### PR TITLE
pygeoapi skelethon plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ sync:
 
 run:
 	uv run uvicorn main:app --reload
+
+openapi:
+	PYTHONPATH="$(PWD)" uv run pygeoapi openapi generate ./pygeoapi-config.yml > pygeoapi-openapi.yml

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ uvicorn main:app --reload
 - `make sync` — install dependencies with uv
 - `make run` — start the app with uv
 
-### Update pygeoapi-openapi.yml
+### pygeoapi instructions
+
+To validate the configuration:
+
+```
+pygeoapi config validate -c pygeoapi-config.yml`
+```
 
 Run after changes are made in pygeoapi-config.yml:
 
@@ -50,12 +56,6 @@ Run after changes are made in pygeoapi-config.yml:
 
 ```
 PYTHONPATH="$(pwd)" uv run pygeoapi openapi generate ./pygeoapi-config.yml > pygeoapi-openapi.yml
-```
-
-Or use:
-
-```
-make openapi
 ```
 
 ### Endpoints

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ uvicorn main:app --reload
 - `make sync` — install dependencies with uv
 - `make run` — start the app with uv
 
+### Update pygeoapi-openapi.yml
+
+Run after changes are made in pygeoapi-config.yml:
+
+`make openapi` or
+
+```
+PYTHONPATH="$(pwd)" uv run pygeoapi openapi generate ./pygeoapi-config.yml > pygeoapi-openapi.yml
+```
+
+Or use:
+
+```
+make openapi
+```
+
+### Endpoints
+
 Root endpoint:
 
 http://127.0.0.1:8000/ -> Welcome to DHIS2 EO API
@@ -49,6 +67,10 @@ http://127.0.0.1:8000/ -> Welcome to DHIS2 EO API
 Docs:
 
 http://127.0.0.1:8000/docs
+
+OGC API
+
+http://127.0.0.1:8000/ogcapi
 
 Examples:
 

--- a/plugins/dhis2eo.py
+++ b/plugins/dhis2eo.py
@@ -1,0 +1,96 @@
+from pygeoapi.provider.base import BaseProvider
+
+
+class DHIS2EOProvider(BaseProvider):
+    """DHIS2 EO Provider"""
+
+    def __init__(self, provider_def):
+        """Inherit from parent class"""
+
+        super().__init__(provider_def)
+        self._coverage_properties = self._get_coverage_properties()
+        self.axes = self._coverage_properties['axes']
+        self.crs = self._coverage_properties['bbox_crs']
+        self.num_bands = self._coverage_properties['num_bands']
+        self.get_fields()
+
+    def _get_coverage_properties(self) -> dict:
+        return {
+            'bbox': [-180.0, -60.0, 180.0, 60.0],
+            'bbox_crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            'crs_type': 'GeographicCRS',
+            'bbox_units': 'deg',
+            'x_axis_label': 'Long',
+            'y_axis_label': 'Lat',
+            'width': 2400,
+            'height': 800,
+            'resx': 0.15,
+            'resy': 0.15,
+            'num_bands': 1,
+            'tags': {},
+            'axes': ['Long', 'Lat'],
+        }
+
+    def get_fields(self):
+        # generate a JSON Schema of coverage band metadata
+        self._fields = {
+            'testfield': {
+                'type': 'number'
+            }
+        }
+        return self._fields
+
+    def query(self, bands=None, subsets=None, format_='json', **kwargs):
+        # process bands and subsets parameters
+        # query/extract coverage data
+
+        if bands is None:
+            bands = []
+        if subsets is None:
+            subsets = {}
+
+        # optionally specify the output filename pygeoapi can use as part of the response (HTTP Content-Disposition header)
+        self.filename = 'my-cool-filename.dat'
+
+        if format_ == 'json':
+            # return a CoverageJSON representation
+            return {
+                'type': 'Coverage',
+                'domain': {
+                    'type': 'Domain',
+                    'domainType': 'Grid',
+                    'axes': {
+                        'Long': {'start': -180.0, 'stop': 180.0, 'num': 2},
+                        'Lat': {'start': -60.0, 'stop': 60.0, 'num': 2},
+                    },
+                    'referencing': [{
+                        'coordinates': ['Long', 'Lat'],
+                        'system': {
+                            'type': 'GeographicCRS',
+                            'id': self.crs,
+                        },
+                    }],
+                },
+                'parameters': {
+                    'testfield': {
+                        'type': 'Parameter',
+                        'description': {'en': 'Test field'},
+                        'unit': {
+                            'label': {'en': 'mm/day'},
+                            'symbol': {'value': 'mm/day', 'type': 'http://www.opengis.net/def/uom/UCUM/'},
+                        },
+                    }
+                },
+                'ranges': {
+                    'testfield': {
+                        'type': 'NdArray',
+                        'dataType': 'float',
+                        'axisNames': ['Lat', 'Long'],
+                        'shape': [2, 2],
+                        'values': [10.0, 12.5, 8.2, 9.1],
+                    }
+                },
+            }
+        else:
+            # return default (likely binary) representation
+            return bytes(112)

--- a/plugins/dhis2eo.py
+++ b/plugins/dhis2eo.py
@@ -1,96 +1,39 @@
-from pygeoapi.provider.base import BaseProvider
+from pygeoapi.provider.base_edr import BaseEDRProvider
 
 
-class DHIS2EOProvider(BaseProvider):
-    """DHIS2 EO Provider"""
-
-    def __init__(self, provider_def):
-        """Inherit from parent class"""
-
-        super().__init__(provider_def)
-        self._coverage_properties = self._get_coverage_properties()
-        self.axes = self._coverage_properties['axes']
-        self.crs = self._coverage_properties['bbox_crs']
-        self.num_bands = self._coverage_properties['num_bands']
-        self.get_fields()
-
-    def _get_coverage_properties(self) -> dict:
-        return {
-            'bbox': [-180.0, -60.0, 180.0, 60.0],
-            'bbox_crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
-            'crs_type': 'GeographicCRS',
-            'bbox_units': 'deg',
-            'x_axis_label': 'Long',
-            'y_axis_label': 'Lat',
-            'width': 2400,
-            'height': 800,
-            'resx': 0.15,
-            'resy': 0.15,
-            'num_bands': 1,
-            'tags': {},
-            'axes': ['Long', 'Lat'],
-        }
+class DHIS2EOProvider(BaseEDRProvider):
+    """Minimal EDR provider example."""
 
     def get_fields(self):
-        # generate a JSON Schema of coverage band metadata
-        self._fields = {
-            'testfield': {
-                'type': 'number'
+        return {
+            'value': {
+                'type': 'number',
+                'title': 'Value',
+                'x-ogc-unit': 'mm/day',
             }
         }
-        return self._fields
 
-    def query(self, bands=None, subsets=None, format_='json', **kwargs):
-        # process bands and subsets parameters
-        # query/extract coverage data
-
-        if bands is None:
-            bands = []
-        if subsets is None:
-            subsets = {}
-
-        # optionally specify the output filename pygeoapi can use as part of the response (HTTP Content-Disposition header)
-        self.filename = 'my-cool-filename.dat'
-
-        if format_ == 'json':
-            # return a CoverageJSON representation
-            return {
-                'type': 'Coverage',
-                'domain': {
-                    'type': 'Domain',
-                    'domainType': 'Grid',
-                    'axes': {
-                        'Long': {'start': -180.0, 'stop': 180.0, 'num': 2},
-                        'Lat': {'start': -60.0, 'stop': 60.0, 'num': 2},
-                    },
-                    'referencing': [{
-                        'coordinates': ['Long', 'Lat'],
-                        'system': {
-                            'type': 'GeographicCRS',
-                            'id': self.crs,
-                        },
-                    }],
+    def position(self, **kwargs):
+        return {
+            'type': 'Coverage',
+            'domain': {
+                'type': 'Domain',
+                'domainType': 'Point',
+                'axes': {
+                    'Long': {'values': [0.0]},
+                    'Lat': {'values': [0.0]},
                 },
-                'parameters': {
-                    'testfield': {
-                        'type': 'Parameter',
-                        'description': {'en': 'Test field'},
-                        'unit': {
-                            'label': {'en': 'mm/day'},
-                            'symbol': {'value': 'mm/day', 'type': 'http://www.opengis.net/def/uom/UCUM/'},
-                        },
-                    }
-                },
-                'ranges': {
-                    'testfield': {
-                        'type': 'NdArray',
-                        'dataType': 'float',
-                        'axisNames': ['Lat', 'Long'],
-                        'shape': [2, 2],
-                        'values': [10.0, 12.5, 8.2, 9.1],
-                    }
-                },
-            }
-        else:
-            # return default (likely binary) representation
-            return bytes(112)
+            },
+            'parameters': {
+                'value': {'type': 'Parameter'}
+            },
+            'ranges': {
+                'value': {
+                    'type': 'NdArray',
+                    'dataType': 'float',
+                    'axisNames': ['Long', 'Lat'],
+                    'shape': [1, 1],
+                    'values': [10.0],
+                }
+            },
+        }

--- a/plugins/dhis2orgUnits.py
+++ b/plugins/dhis2orgUnits.py
@@ -1,0 +1,47 @@
+from pygeoapi.provider.base import BaseProvider
+
+class DHIS2OrgUnitsProvider(BaseProvider):
+    """DHIS2 Organization Units Provider"""
+
+    def __init__(self, provider_def):
+        """Inherit from parent class"""
+
+        super().__init__(provider_def)
+
+    def get_fields(self):
+
+        # open dat file and return fields and their datatypes
+        return {
+            'field1': 'string',
+            'field2': 'string'
+        }
+
+    def query(self, offset=0, limit=10, resulttype='results',
+              bbox=[], datetime_=None, properties=[], sortby=[],
+              select_properties=[], skip_geometry=False, **kwargs):
+
+        # optionally specify the output filename pygeoapi can use as part
+        # of the response (HTTP Content-Disposition header)
+        self.filename = 'my-cool-filename.dat'
+
+        # open data file (self.data) and process, return
+        return {
+            'type': 'FeatureCollection',
+            'features': [{
+                'type': 'Feature',
+                'id': '371',
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': [ -75, 45 ]
+                },
+                'properties': {
+                    'stn_id': '35',
+                    'datetime': '2001-10-30T14:24:55Z',
+                    'value': '89.9'
+                }
+            }]
+        }
+
+    def get_schema():
+        # return a `dict` of a JSON schema (inline or reference)
+        return ('application/geo+json', {'$ref': 'https://geojson.org/schema/Feature.json'})

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -121,7 +121,7 @@ resources:
         href: https://www.chc.ucsb.edu/data/chirps3
         hreflang: en-EN
     providers:
-      - type: coverage
+      - type: edr
         name: plugins.dhis2eo.DHIS2EOProvider
         data: tests/data/
 
@@ -142,7 +142,7 @@ resources:
         href: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land
         hreflang: en-EN
     providers:
-      - type: coverage
+      - type: edr
         name: plugins.dhis2eo.DHIS2EOProvider
         data: tests/data/
 

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -89,13 +89,62 @@ metadata:
 resources:
   dhis2-org-units:
     type: collection
-    title: DHIS2 Org Units
+    title: DHIS2 organization units
     description: Get organization units from DHIS2
+    keywords:
+      - dhis2
+    extents:
+      spatial:
+        bbox: [-180, -90, 180, 90]
+        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     providers:
       - type: feature
         name: plugins.dhis2orgUnits.DHIS2OrgUnitsProvider
         data: tests/data/
         id_field: id
+
+  chirps-precipitation:
+    type: collection
+    title: CHIRPS v3 daily precipitation
+    description: CHIRPS v3 daily precipitation
+    keywords:
+      - chirps
+      - precipitation
+    extents:
+      spatial:
+        bbox: [-180, -60, 180, 60]
+        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    links:
+      - type: text/html
+        rel: canonical
+        title: information
+        href: https://www.chc.ucsb.edu/data/chirps3
+        hreflang: en-EN
+    providers:
+      - type: coverage
+        name: plugins.dhis2eo.DHIS2EOProvider
+        data: tests/data/
+
+  era5-land:
+    type: collection
+    title: ERA5-Land hourly
+    description: ERA5-Land hourly data on single levels from 1981 to present
+    keywords:
+      - era5
+    extents:
+      spatial:
+        bbox: [-180, -90, 180, 90]
+        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    links:
+      - type: text/html
+        rel: canonical
+        title: information
+        href: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land
+        hreflang: en-EN
+    providers:
+      - type: coverage
+        name: plugins.dhis2eo.DHIS2EOProvider
+        data: tests/data/
 
   obs:
     type: collection

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -87,6 +87,16 @@ metadata:
     role: pointOfContact
 
 resources:
+  dhis2-org-units:
+    type: collection
+    title: DHIS2 Org Units
+    description: Get organization units from DHIS2
+    providers:
+      - type: feature
+        name: plugins.dhis2orgUnits.DHIS2OrgUnitsProvider
+        data: tests/data/
+        id_field: id
+
   obs:
     type: collection
     title: Observations

--- a/pygeoapi-openapi.yml
+++ b/pygeoapi-openapi.yml
@@ -277,25 +277,78 @@ paths:
       summary: Get CHIRPS v3 daily precipitation metadata
       tags:
       - chirps-precipitation
-  /collections/chirps-precipitation/coverage:
+  /collections/chirps-precipitation/area:
     get:
       description: CHIRPS v3 daily precipitation
-      operationId: getChirps-precipitationCoverage
+      operationId: queryAreaChirps-precipitation
       parameters:
-      - $ref: '#/components/parameters/lang'
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/areaCoords.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
       - $ref: '#/components/parameters/f'
-      - $ref: '#/components/parameters/bbox'
-      - $ref: '#/components/parameters/bbox-crs'
       responses:
         '200':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
-        '400':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
-        '404':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
-        '500':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get CHIRPS v3 daily precipitation coverage
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query CHIRPS v3 daily precipitation by area
+      tags:
+      - chirps-precipitation
+  /collections/chirps-precipitation/cube:
+    get:
+      description: CHIRPS v3 daily precipitation
+      operationId: queryCubeChirps-precipitation
+      parameters:
+      - description: Only features that have a geometry that intersects the bounding
+          box are selected.The bounding box is provided as four or six numbers, depending
+          on whether the coordinate reference system includes a vertical axis (height
+          or depth).
+        explode: false
+        in: query
+        name: bbox
+        required: true
+        schema:
+          items:
+            type: number
+          maxItems: 6
+          minItems: 4
+          type: array
+        style: form
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query CHIRPS v3 daily precipitation by cube
+      tags:
+      - chirps-precipitation
+  /collections/chirps-precipitation/position:
+    get:
+      description: CHIRPS v3 daily precipitation
+      operationId: queryPositionChirps-precipitation
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/positionCoords.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query CHIRPS v3 daily precipitation by position
       tags:
       - chirps-precipitation
   /collections/dhis2-org-units:
@@ -447,25 +500,81 @@ paths:
       summary: Get ERA5-Land hourly metadata
       tags:
       - era5-land
-  /collections/era5-land/coverage:
+  /collections/era5-land/area:
     get:
       description: ERA5-Land hourly data on single levels from 1981 to present
-      operationId: getEra5-landCoverage
+      operationId: queryAreaEra5-land
       parameters:
-      - $ref: '#/components/parameters/lang'
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/areaCoords.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
       - $ref: '#/components/parameters/f'
-      - $ref: '#/components/parameters/bbox'
-      - $ref: '#/components/parameters/bbox-crs'
       responses:
         '200':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
-        '400':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
-        '404':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
-        '500':
-          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get ERA5-Land hourly coverage
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query ERA5-Land hourly data on single levels from 1981 to present by
+        area
+      tags:
+      - era5-land
+  /collections/era5-land/cube:
+    get:
+      description: ERA5-Land hourly data on single levels from 1981 to present
+      operationId: queryCubeEra5-land
+      parameters:
+      - description: Only features that have a geometry that intersects the bounding
+          box are selected.The bounding box is provided as four or six numbers, depending
+          on whether the coordinate reference system includes a vertical axis (height
+          or depth).
+        explode: false
+        in: query
+        name: bbox
+        required: true
+        schema:
+          items:
+            type: number
+          maxItems: 6
+          minItems: 4
+          type: array
+        style: form
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query ERA5-Land hourly data on single levels from 1981 to present by
+        cube
+      tags:
+      - era5-land
+  /collections/era5-land/position:
+    get:
+      description: ERA5-Land hourly data on single levels from 1981 to present
+      operationId: queryPositionEra5-land
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/positionCoords.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/parameter-name.yaml
+      - $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/parameters/z.yaml
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          content:
+            application/prs.coverage+json:
+              schema:
+                $ref: https://schemas.opengis.net/ogcapi/edr/1.0/openapi/schemas/coverageJSON.yaml
+          description: Response
+      summary: query ERA5-Land hourly data on single levels from 1981 to present by
+        position
       tags:
       - era5-land
   /collections/gdps-temperature:

--- a/pygeoapi-openapi.yml
+++ b/pygeoapi-openapi.yml
@@ -258,6 +258,46 @@ paths:
       summary: Collections
       tags:
       - server
+  /collections/chirps-precipitation:
+    get:
+      description: CHIRPS v3 daily precipitation
+      operationId: describeChirps-precipitationCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get CHIRPS v3 daily precipitation metadata
+      tags:
+      - chirps-precipitation
+  /collections/chirps-precipitation/coverage:
+    get:
+      description: CHIRPS v3 daily precipitation
+      operationId: getChirps-precipitationCoverage
+      parameters:
+      - $ref: '#/components/parameters/lang'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/bbox'
+      - $ref: '#/components/parameters/bbox-crs'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get CHIRPS v3 daily precipitation coverage
+      tags:
+      - chirps-precipitation
   /collections/dhis2-org-units:
     get:
       description: Get organization units from DHIS2
@@ -274,7 +314,7 @@ paths:
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
         '500':
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get DHIS2 Org Units metadata
+      summary: Get DHIS2 organization units metadata
       tags:
       - dhis2-org-units
   /collections/dhis2-org-units/items:
@@ -324,7 +364,7 @@ paths:
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
         '500':
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get DHIS2 Org Units items
+      summary: Get DHIS2 organization units items
       tags:
       - dhis2-org-units
     options:
@@ -333,7 +373,7 @@ paths:
       responses:
         '200':
           description: options response
-      summary: Options for DHIS2 Org Units items
+      summary: Options for DHIS2 organization units items
       tags:
       - dhis2-org-units
     post:
@@ -353,7 +393,7 @@ paths:
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
         '500':
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get DHIS2 Org Units items with CQL2
+      summary: Get DHIS2 organization units items with CQL2
       tags:
       - dhis2-org-units
   /collections/dhis2-org-units/items/{featureId}:
@@ -374,7 +414,7 @@ paths:
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
         '500':
           $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
-      summary: Get DHIS2 Org Units item by id
+      summary: Get DHIS2 organization units item by id
       tags:
       - dhis2-org-units
     options:
@@ -385,9 +425,49 @@ paths:
       responses:
         '200':
           description: options response
-      summary: Options for DHIS2 Org Units item by id
+      summary: Options for DHIS2 organization units item by id
       tags:
       - dhis2-org-units
+  /collections/era5-land:
+    get:
+      description: ERA5-Land hourly data on single levels from 1981 to present
+      operationId: describeEra5-landCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get ERA5-Land hourly metadata
+      tags:
+      - era5-land
+  /collections/era5-land/coverage:
+    get:
+      description: ERA5-Land hourly data on single levels from 1981 to present
+      operationId: getEra5-landCoverage
+      parameters:
+      - $ref: '#/components/parameters/lang'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/bbox'
+      - $ref: '#/components/parameters/bbox-crs'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get ERA5-Land hourly coverage
+      tags:
+      - era5-land
   /collections/gdps-temperature:
     get:
       description: Global Deterministic Prediction System sample
@@ -1139,6 +1219,10 @@ tags:
   name: server
 - description: Get organization units from DHIS2
   name: dhis2-org-units
+- description: CHIRPS v3 daily precipitation
+  name: chirps-precipitation
+- description: ERA5-Land hourly data on single levels from 1981 to present
+  name: era5-land
 - description: My cool observations
   name: obs
 - description: lakes of the world, public domain

--- a/pygeoapi-openapi.yml
+++ b/pygeoapi-openapi.yml
@@ -99,7 +99,7 @@ components:
       name: resourceId
       required: true
       schema:
-        default: obs
+        default: dhis2-org-units
         type: string
     skipGeometry:
       description: This option can be used to skip response geometries for each feature.
@@ -258,6 +258,136 @@ paths:
       summary: Collections
       tags:
       - server
+  /collections/dhis2-org-units:
+    get:
+      description: Get organization units from DHIS2
+      operationId: describeDhis2-org-unitsCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get DHIS2 Org Units metadata
+      tags:
+      - dhis2-org-units
+  /collections/dhis2-org-units/items:
+    get:
+      description: Get organization units from DHIS2
+      operationId: getDhis2-org-unitsFeatures
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      - $ref: '#/components/parameters/bbox'
+      - description: The optional limit parameter limits the number of items that
+          are presented in the response document (maximum=50, default=20).
+        explode: false
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 20
+          maximum: 50
+          minimum: 1
+          type: integer
+        style: form
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/bbox-crs'
+      - description: The properties that should be included for each feature. The
+          parameter value is a comma-separated list of property names.
+        explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          items:
+            enum: []
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/vendorSpecificParameters'
+      - $ref: '#/components/parameters/skipGeometry'
+      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/parameters/sortby.yaml
+      - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get DHIS2 Org Units items
+      tags:
+      - dhis2-org-units
+    options:
+      description: Get organization units from DHIS2
+      operationId: optionsDhis2-org-unitsFeatures
+      responses:
+        '200':
+          description: options response
+      summary: Options for DHIS2 Org Units items
+      tags:
+      - dhis2-org-units
+    post:
+      description: Get organization units from DHIS2
+      operationId: getCQL2Dhis2-org-unitsFeatures
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: https://schemas.opengis.net/cql2/1.0/cql2.json
+        description: Get items with CQL2
+        required: true
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get DHIS2 Org Units items with CQL2
+      tags:
+      - dhis2-org-units
+  /collections/dhis2-org-units/items/{featureId}:
+    get:
+      description: Get organization units from DHIS2
+      operationId: getDhis2-org-unitsFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Feature
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get DHIS2 Org Units item by id
+      tags:
+      - dhis2-org-units
+    options:
+      description: Get organization units from DHIS2
+      operationId: optionsDhis2-org-unitsFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      responses:
+        '200':
+          description: options response
+      summary: Options for DHIS2 Org Units item by id
+      tags:
+      - dhis2-org-units
   /collections/gdps-temperature:
     get:
       description: Global Deterministic Prediction System sample
@@ -1007,6 +1137,8 @@ tags:
     description: information
     url: https://example.org
   name: server
+- description: Get organization units from DHIS2
+  name: dhis2-org-units
 - description: My cool observations
   name: obs
 - description: lakes of the world, public domain


### PR DESCRIPTION
This PR adds two pygeoapi skelethon data provider plugins:

- dhis2orgUnits -> for retrieving org units from DHIS2
- dhis2eo.py -> for retrieving data from dhis2eo

3 collections were added to reference the plugins: 
- dhis2-org-units -> dhis2orgUnits plugin
- chirps-precipitation -> dhis2eo plugin
- era5land -> dhis2eo plugin

See: https://docs.pygeoapi.io/en/stable/plugins.html