### PR TITLE
feat: enable async job management for processes

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -50,10 +50,10 @@ server:
   map:
     url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
     attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-  #    manager:
-  #        name: TinyDB
-  #        connection: /tmp/pygeoapi-process-manager.db
-  #        output_dir: /tmp/
+  manager:
+    name: TinyDB
+    connection: /tmp/pygeoapi-process-manager.db
+    output_dir: /tmp/
   # ogc_schemas_location: /opt/schemas.opengis.net
   admin: false # enable admin api
 

--- a/src/eo_api/routers/ogcapi/plugins/processes/chirps3.py
+++ b/src/eo_api/routers/ogcapi/plugins/processes/chirps3.py
@@ -20,7 +20,7 @@ PROCESS_METADATA = {
     "id": "chirps3",
     "title": "CHIRPS3 Daily Precipitation",
     "description": "Download CHIRPS3 daily precipitation data for a bounding box and date range.",
-    "jobControlOptions": ["sync-execute"],
+    "jobControlOptions": ["sync-execute", "async-execute"],
     "keywords": ["climate", "CHIRPS3", "precipitation", "rainfall"],
     "inputs": {
         "start": {

--- a/src/eo_api/routers/ogcapi/plugins/processes/era5_land.py
+++ b/src/eo_api/routers/ogcapi/plugins/processes/era5_land.py
@@ -20,7 +20,7 @@ PROCESS_METADATA = {
     "id": "era5-land",
     "title": "ERA5-Land Climate Data",
     "description": "Download ERA5-Land hourly climate data for a bounding box and date range.",
-    "jobControlOptions": ["sync-execute"],
+    "jobControlOptions": ["sync-execute", "async-execute"],
     "keywords": ["climate", "ERA5-Land", "temperature", "precipitation"],
     "inputs": {
         "start": {


### PR DESCRIPTION
## Summary

- Enable pygeoapi TinyDB process manager for async execution (uncomment and fix `manager` block in `pygeoapi-config.yml`)
- Add `async-execute` to `jobControlOptions` for both ERA5-Land and CHIRPS3 processors
- Document async workflow and job management endpoints in `docs/ogcapi.md`

## New endpoints (automatic from pygeoapi)

| Method | Path | Description |
|---|---|---|
| GET | `/ogcapi/jobs` | List all jobs |
| GET | `/ogcapi/jobs/{jobId}` | Job status |
| GET | `/ogcapi/jobs/{jobId}/results` | Job results |
| DELETE | `/ogcapi/jobs/{jobId}` | Delete job |

Async execution is triggered by adding the `Prefer: respond-async` header to a process execution request. Sync execution remains the default and is unchanged.

## Test plan

- [ ] `make lint` passes
- [ ] `make openapi` succeeds
- [ ] Sync execution still works (POST without `Prefer` header returns results directly)
- [ ] Async execution works (POST with `Prefer: respond-async` returns 201 with job ID)
- [ ] Job listing works (`GET /ogcapi/jobs`)
- [ ] Job status polling works (`GET /ogcapi/jobs/{jobId}`)
- [ ] Job result retrieval works (`GET /ogcapi/jobs/{jobId}/results`)