### PR TITLE
fix: restrict local zarr browser access to allowed origins

### DIFF
--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -34,7 +34,13 @@ def download_dataset(
     overwrite: bool,
     background_tasks: BackgroundTasks | None,
 ) -> list[Path]:
-    """Download dataset from source and store as local NetCDF cache files."""
+    """Download dataset files and return the NetCDF paths created or modified by this run.
+
+    The download still happens primarily through side effects in the provider function.
+    This return value is used to identify the concrete files created for this invocation.
+    When running in the background-task path, the download is deferred and this function
+    returns an empty list because no files have been created yet.
+    """
     cache_info = dataset["cache_info"]
     eo_download_func_path = cache_info["eo_function"]
     eo_download_func = _get_dynamic_function(eo_download_func_path)

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -1,5 +1,6 @@
 """DHIS2 EO API -- Earth observation data API for DHIS2."""
 
+import os
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request
@@ -24,31 +25,51 @@ app.add_middleware(
 )
 
 
+def _zarr_browser_access_origins() -> set[str]:
+    """Return allowlisted remote origins permitted to inspect local Zarr endpoints."""
+    raw = os.getenv("EO_API_ZARR_BROWSER_ORIGINS", "https://inspect.geozarr.org")
+    return {origin.strip() for origin in raw.split(",") if origin.strip()}
+
+
+def _append_vary_value(response: Response, value: str) -> None:
+    """Append one token to the Vary header without clobbering existing values."""
+    existing = response.headers.get("Vary")
+    if existing is None:
+        response.headers["Vary"] = value
+        return
+
+    values = [item.strip() for item in existing.split(",") if item.strip()]
+    if value not in values:
+        response.headers["Vary"] = ", ".join([*values, value])
+
+
 @app.middleware("http")
 async def add_zarr_browser_access_headers(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     """Add browser access headers needed by remote Zarr inspectors calling localhost."""
+    origin = request.headers.get("origin")
+    allowed_origin = origin if origin in _zarr_browser_access_origins() else None
     if (
         request.method == "OPTIONS"
         and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/"))
         and request.headers.get("access-control-request-private-network") == "true"
+        and allowed_origin is not None
     ):
         response = Response(status_code=200)
     else:
         response = await call_next(request)
     if request.url.path == "/zarr" or request.url.path.startswith("/zarr/"):
-        origin = request.headers.get("origin")
-        if origin is not None:
-            response.headers["Access-Control-Allow-Origin"] = origin
-            response.headers["Vary"] = "Origin"
+        if allowed_origin is not None:
+            response.headers["Access-Control-Allow-Origin"] = allowed_origin
+            _append_vary_value(response, "Origin")
             response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
                 request.headers.get("access-control-request-headers", "*"),
             )
-        if request.headers.get("access-control-request-private-network") == "true":
+        if allowed_origin is not None and request.headers.get("access-control-request-private-network") == "true":
             response.headers["Access-Control-Allow-Private-Network"] = "true"
     return response
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -51,6 +51,19 @@ def test_zarr_route_echoes_origin_for_browser_access(client: TestClient, monkeyp
     assert response.headers["access-control-allow-origin"] == "https://inspect.geozarr.org"
 
 
+def test_zarr_route_does_not_allow_unconfigured_origin(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_dataset_zarr_store_info_or_404",
+        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+    )
+
+    response = client.get("/zarr/dataset-1", headers={"Origin": "https://example.org"})
+
+    assert response.status_code == 200
+    assert "access-control-allow-private-network" not in response.headers
+
+
 def test_zarr_route_allows_private_network_preflight(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,
@@ -70,3 +83,25 @@ def test_zarr_route_allows_private_network_preflight(client: TestClient, monkeyp
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "https://inspect.geozarr.org"
     assert response.headers["access-control-allow-private-network"] == "true"
+
+
+def test_zarr_route_preserves_existing_vary_values(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_dataset_zarr_store_info_or_404",
+        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+    )
+
+    response = client.options(
+        "/zarr/dataset-1",
+        headers={
+            "Origin": "https://inspect.geozarr.org",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-Test",
+            "Access-Control-Request-Private-Network": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    vary_values = {value.strip() for value in response.headers["vary"].split(",")}
+    assert "Origin" in vary_values


### PR DESCRIPTION
This PR tightens the recent `/zarr` browser-access support.

Changes:
- restrict special browser/PNA access for local `/zarr` endpoints to an explicit origin allowlist
- default allowlist to `https://inspect.geozarr.org`
- preserve existing `Vary` header values correctly
- clarify the `download_dataset()` return contract in the downloader docstring

This keeps GeoZarr inspection support for approved origins while avoiding reflecting arbitrary origins.