### PR TITLE
GeoZarr multiscale pyramid support

### DIFF
--- a/data/datasets/worldpop.yaml
+++ b/data/datasets/worldpop.yaml
@@ -3,8 +3,10 @@
   short_name: Total population
   variable: pop_total
   period_type: yearly
-  cache_info: 
+  cache_info:
     eo_function: dhis2eo.data.worldpop.pop_total.yearly.download
+    multiscales:
+      levels: 4
     default_params:
       version: global2
   units: people

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "prefect>=3.6",
     "earthkit-transforms==0.5.*",
     "metpy>=1.7,<2",
-    "zarr==3.1.5",
+    "zarr>=3.1.6",
+    "geozarr-toolkit>=0.1.2",
+    "topozarr>=0.0.6"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["dhis2eo.*", "dhis2_client.*", "pygeoapi.*", "titiler.*", "rasterio.*", "pygeofilter.*", "prefect.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml"]
+module = ["dhis2eo.*", "dhis2_client.*", "pygeoapi.*", "titiler.*", "rasterio.*", "pygeofilter.*", "prefect.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit"]
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "prefect>=3.6",
     "earthkit-transforms==0.5.*",
     "metpy>=1.7,<2",
-    "zarr>=3.1.6",
+    "zarr>=3.1.6,<4",
     "geozarr-toolkit>=0.1.2",
     "topozarr>=0.0.6"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "earthkit-transforms==0.5.*",
     "metpy>=1.7,<2",
     "zarr>=3.1.6,<4",
-    "geozarr-toolkit>=0.1.2",
-    "topozarr>=0.0.6"
+    "geozarr-toolkit==0.1.*",
+    "topozarr==0.0.*"
 ]
 
 [tool.ruff]

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import tempfile
-from pathlib import Path
 from typing import Any
 
 import xarray as xr
@@ -95,11 +94,21 @@ def get_data_coverage_for_paths(
 
 
 def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
-    """Open a zarr store, handling pyramid stores by opening the base resolution level."""
+    """Open a zarr store, handling pyramid stores by opening the base resolution level.
+
+    When the root group has no data variables (as in a multiscale pyramid store),
+    attempts to open level 0 instead. This works for any store backend — local
+    paths, S3 URIs, GCS URIs, fsspec mappers — without filesystem-specific checks.
+    """
     ds = _open_zarr(zarr_path)
-    if not ds.data_vars and (Path(zarr_path) / "0").is_dir():
+    if not ds.data_vars:
+        level0_path = zarr_path.rstrip("/") + "/0"
+        try:
+            level0 = _open_zarr(level0_path)
+        except Exception:
+            return ds
         ds.close()
-        ds = _open_zarr(f"{zarr_path}/0")
+        ds = level0
     return ds
 
 

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -105,8 +105,12 @@ def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
         level0_path = zarr_path.rstrip("/") + "/0"
         try:
             level0 = _open_zarr(level0_path)
-        except Exception:
-            return ds
+        except Exception as exc:
+            ds.close()
+            raise ValueError(
+                f"Zarr store at {zarr_path!r} has no data variables at the root "
+                f"and base pyramid level {level0_path!r} could not be opened"
+            ) from exc
         ds.close()
         ds = level0
     return ds

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -96,7 +96,7 @@ def get_data_coverage_for_paths(
 def _open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     """Open a zarr store, handling pyramid stores by opening the base resolution level."""
     ds = xr.open_zarr(zarr_path, consolidated=False)
-    if not ds.dims:
+    if not ds.data_vars:
         ds.close()
         ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
     return ds

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -117,16 +117,8 @@ def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
 
 
 def _open_zarr(zarr_path: str) -> xr.Dataset:
-    """Open a zarr store, preferring consolidated metadata when available."""
-    try:
-        return xr.open_zarr(zarr_path, consolidated=True)  # type: ignore[no-any-return]
-    except Exception as exc:
-        logger.debug(
-            "Could not open zarr store with consolidated metadata at %s; falling back to non-consolidated open: %s",
-            zarr_path,
-            exc,
-        )
-        return xr.open_zarr(zarr_path, consolidated=False)  # type: ignore[no-any-return]
+    """Open a zarr store with automatic consolidated metadata detection."""
+    return xr.open_zarr(zarr_path, consolidated=None)  # type: ignore[no-any-return]
 
 
 def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -97,7 +97,7 @@ def get_data_coverage_for_paths(
 def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     """Open a zarr store, handling pyramid stores by opening the base resolution level."""
     ds = _open_zarr(zarr_path)
-    if not ds.data_vars and Path(f"{zarr_path}/0").exists():
+    if not ds.data_vars and (Path(zarr_path) / "0").is_dir():
         ds.close()
         ds = _open_zarr(f"{zarr_path}/0")
     return ds

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -25,7 +25,7 @@ def get_data(
     zarr_path = get_zarr_path(dataset)
     if zarr_path:
         logger.info(f"Using optimized zarr file: {zarr_path}")
-        ds = xr.open_zarr(zarr_path, consolidated=True)
+        ds = _open_zarr_dataset(str(zarr_path))
     else:
         logger.warning(
             f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
@@ -77,7 +77,7 @@ def get_data_coverage_for_paths(
         raise ValueError("Coverage calculation requires either zarr_path or at least one netcdf path")
 
     if zarr_path is not None:
-        ds = xr.open_zarr(zarr_path, consolidated=True)
+        ds = _open_zarr_dataset(zarr_path)
     else:
         assert netcdf_paths is not None
         ds = xr.open_mfdataset(
@@ -91,6 +91,15 @@ def get_data_coverage_for_paths(
         return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]))
     finally:
         ds.close()
+
+
+def _open_zarr_dataset(zarr_path: str) -> xr.Dataset:
+    """Open a zarr store, handling pyramid stores by opening the base resolution level."""
+    ds = xr.open_zarr(zarr_path, consolidated=False)
+    if not ds.dims:
+        ds.close()
+        ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
+    return ds
 
 
 def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -96,11 +96,24 @@ def get_data_coverage_for_paths(
 
 def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     """Open a zarr store, handling pyramid stores by opening the base resolution level."""
-    ds = xr.open_zarr(zarr_path, consolidated=False)
+    ds = _open_zarr(zarr_path)
     if not ds.data_vars and Path(f"{zarr_path}/0").exists():
         ds.close()
-        ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
-    return ds  # type: ignore[no-any-return]
+        ds = _open_zarr(f"{zarr_path}/0")
+    return ds
+
+
+def _open_zarr(zarr_path: str) -> xr.Dataset:
+    """Open a zarr store, preferring consolidated metadata when available."""
+    try:
+        return xr.open_zarr(zarr_path, consolidated=True)  # type: ignore[no-any-return]
+    except Exception as exc:
+        logger.debug(
+            "Could not open zarr store with consolidated metadata at %s; falling back to non-consolidated open: %s",
+            zarr_path,
+            exc,
+        )
+        return xr.open_zarr(zarr_path, consolidated=False)  # type: ignore[no-any-return]
 
 
 def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -42,7 +42,7 @@ def get_data(
     if start and end:
         logger.info(f"Subsetting time to {start} and {end}")
         time_dim = get_time_dim(ds)
-        ds = ds.sel(**{time_dim: slice(start, end)})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        ds = ds.sel(**{time_dim: slice(start, end)})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     if bbox is not None:
         logger.info(f"Subsetting xy to {bbox}")
@@ -51,7 +51,7 @@ def get_data(
         # TODO: this assumes y axis increases towards north and is not very stable
         # ...and also does not consider partial pixels at the edges
         # ...should probably switch to rioxarray.clip instead
-        ds = ds.sel(**{lon_dim: slice(xmin, xmax), lat_dim: slice(ymax, ymin)})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        ds = ds.sel(**{lon_dim: slice(xmin, xmax), lat_dim: slice(ymax, ymin)})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     return ds
 
@@ -100,7 +100,7 @@ def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     if not ds.data_vars and Path(f"{zarr_path}/0").exists():
         ds.close()
         ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
-    return ds  # type: ignore[return-value]
+    return ds  # type: ignore[no-any-return]
 
 
 def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import xarray as xr
@@ -41,7 +42,7 @@ def get_data(
     if start and end:
         logger.info(f"Subsetting time to {start} and {end}")
         time_dim = get_time_dim(ds)
-        ds = ds.sel(**{time_dim: slice(start, end)})  # pyright: ignore[reportArgumentType]
+        ds = ds.sel(**{time_dim: slice(start, end)})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
 
     if bbox is not None:
         logger.info(f"Subsetting xy to {bbox}")
@@ -50,9 +51,9 @@ def get_data(
         # TODO: this assumes y axis increases towards north and is not very stable
         # ...and also does not consider partial pixels at the edges
         # ...should probably switch to rioxarray.clip instead
-        ds = ds.sel(**{lon_dim: slice(xmin, xmax), lat_dim: slice(ymax, ymin)})  # pyright: ignore[reportArgumentType]
+        ds = ds.sel(**{lon_dim: slice(xmin, xmax), lat_dim: slice(ymax, ymin)})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
 
-    return ds  # type: ignore[no-any-return]
+    return ds
 
 
 def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
@@ -95,12 +96,11 @@ def get_data_coverage_for_paths(
 
 def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     """Open a zarr store, handling pyramid stores by opening the base resolution level."""
-    from pathlib import Path
     ds = xr.open_zarr(zarr_path, consolidated=False)
     if not ds.data_vars and Path(f"{zarr_path}/0").exists():
         ds.close()
         ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
-    return ds
+    return ds  # type: ignore[return-value]
 
 
 def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:

--- a/src/eo_api/data_accessor/services/accessor.py
+++ b/src/eo_api/data_accessor/services/accessor.py
@@ -25,7 +25,7 @@ def get_data(
     zarr_path = get_zarr_path(dataset)
     if zarr_path:
         logger.info(f"Using optimized zarr file: {zarr_path}")
-        ds = _open_zarr_dataset(str(zarr_path))
+        ds = open_zarr_dataset(str(zarr_path))
     else:
         logger.warning(
             f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
@@ -77,7 +77,7 @@ def get_data_coverage_for_paths(
         raise ValueError("Coverage calculation requires either zarr_path or at least one netcdf path")
 
     if zarr_path is not None:
-        ds = _open_zarr_dataset(zarr_path)
+        ds = open_zarr_dataset(zarr_path)
     else:
         assert netcdf_paths is not None
         ds = xr.open_mfdataset(
@@ -93,10 +93,11 @@ def get_data_coverage_for_paths(
         ds.close()
 
 
-def _open_zarr_dataset(zarr_path: str) -> xr.Dataset:
+def open_zarr_dataset(zarr_path: str) -> xr.Dataset:
     """Open a zarr store, handling pyramid stores by opening the base resolution level."""
+    from pathlib import Path
     ds = xr.open_zarr(zarr_path, consolidated=False)
-    if not ds.data_vars:
+    if not ds.data_vars and Path(f"{zarr_path}/0").exists():
         ds.close()
         ds = xr.open_zarr(f"{zarr_path}/0", consolidated=False)
     return ds

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -5,12 +5,16 @@ import importlib
 import inspect
 import logging
 import os
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import xarray as xr
+import xproj # pyright: ignore[reportUnusedImport]
 from fastapi import BackgroundTasks, HTTPException
+from geozarr_toolkit import create_geozarr_attrs, create_multiscales_layout
+from topozarr.coarsen import create_pyramid
 
 from ...shared.dhis2_adapter import create_client, get_org_units_geojson
 from .utils import get_lon_lat_dims, get_time_dim
@@ -24,6 +28,7 @@ if CACHE_OVERRIDE:
     _download_dir = Path(CACHE_OVERRIDE)
 DOWNLOAD_DIR = _download_dir
 
+CRS ="EPSG:4326"
 
 def download_dataset(
     dataset: dict[str, Any],
@@ -101,28 +106,121 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
 
+    lon_dim, lat_dim = get_lon_lat_dims(ds)
+    dims = [lon_dim, lat_dim]
+
     # trim to only minimal vars and coords
     logger.info("Trimming unnecessary variables and coordinates")
     varname = dataset["variable"]
     ds = ds[[varname]]
-    keep_coords = [get_time_dim(ds)] + list(get_lon_lat_dims(ds))
+    keep_coords = [get_time_dim(ds)] + dims
     drop_coords = [c for c in ds.coords if c not in keep_coords]
     ds = ds.drop_vars(drop_coords)
 
+    lon_dim, lat_dim = get_lon_lat_dims(ds)
+    dims = [lon_dim, lat_dim]
+
+    xmin, xmax = ds[lon_dim].min().item(), ds[lon_dim].max().item()
+    ymin, ymax = ds[lat_dim].min().item(), ds[lat_dim].max().item()
+    bbox = [xmin, ymin, xmax, ymax]
+    shape = (ds.sizes[lon_dim], ds.sizes[lat_dim]) 
+
+    geozarr_attrs =  create_geozarr_attrs(
+        dimensions=dims,
+        crs=CRS,
+        bbox=bbox,
+        shape=shape,
+    )
+
+    print("########");
+
+    print(json.dumps(geozarr_attrs, indent=2))
+
+    print("########");
+
+    zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
+
+    # Fix stale org name in convention metadata
+    # for convention in zarr_conventions:
+    #     if convention.get("name") == "proj:":
+    #        convention["schema_url"] = convention["schema_url"].replace(
+    #            "zarr-experimental", "zarr-conventions"
+    #        )
+    #        convention["spec_url"] = convention["spec_url"].replace(
+    #            "zarr-experimental", "zarr-conventions"
+    #        )
+
+    multiscales_convention = {
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+    }
+
+    zarr_conventions.append(multiscales_convention)
+    geozarr_attrs["zarr_conventions"] = zarr_conventions
+
+    ds.attrs.update(geozarr_attrs)
+
+    print(json.dumps(geozarr_attrs, indent=2))
+
+    ds = ds.proj.assign_crs(spatial_ref=CRS)
+
+    pyramid = create_pyramid(
+        ds,
+        levels=5,
+        x_dim=lon_dim,
+        y_dim=lat_dim,
+        method="mean",  # "mean" (default) | "max" | "min" | "sum"
+    )
+    # print(pyramid.encoding)
+    # print(pyramid.dt)
+
+    # print(json.dumps(pyramid.dt.attrs, indent=2))
+
+    # levels = []
+    # for i, level in enumerate(pyramid.dt.levels):  # or pyramid.dt.levels, depending on your object
+    #    entry = {"asset": str(i)}
+    #    if i > 0:
+    #        entry["derived_from"] = str(i - 1)
+    #        entry["transform"] = {"scale": [2.0, 2.0]}  # or actual scale for your data
+    #    levels.append(entry)
+    # multiscales = create_multiscales_layout(pyramid)
+
     # determine optimal chunk sizes
-    logger.info("Determining optimal chunk size for zarr archive")
-    ds_autochunk = ds.chunk("auto").unify_chunks()
-    uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
-    time_space_chunks = _compute_time_space_chunks(ds, dataset)
-    uniform_chunks.update(time_space_chunks)
-    logging.info(f"--> {uniform_chunks}")
+    # logger.info("Determining optimal chunk size for zarr archive")
+    # ds_autochunk = ds.chunk("auto").unify_chunks()
+    # uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
+    # time_space_chunks = _compute_time_space_chunks(ds, dataset)
+    # uniform_chunks.update(time_space_chunks)
+    #logging.info(f"--> {uniform_chunks}")
 
     # save as zarr
     logger.info("Saving to optimized zarr file")
     zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
-    ds_chunked = ds.chunk(uniform_chunks)
-    ds_chunked.to_zarr(zarr_path, mode="w")
-    ds_chunked.close()
+    # ds_chunked = ds.chunk(uniform_chunks)
+    # ds_chunked.to_zarr(zarr_path, mode="w")
+    # ds_chunked.close()
+
+    pyramid.dt.attrs.update(geozarr_attrs)
+
+    pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
+
+    # 
+    # multiscales = pyramid.dt.attrs.get("multiscales", None)
+
+    # print(json.dumps(multiscales, indent=2))
+
+    # --- Add multiscales attribute to each pyramid level group ---
+    # import zarr
+    # store = zarr.open_group(str(zarr_path), mode='a')
+    # Write to root
+    # if multiscales is not None:
+    #    store.attrs['multiscales'] = multiscales
+        # Write to each pyramid level group (e.g., '0', '1', ...)
+    #    for level in store.group_keys():
+    #        store[level].attrs['multiscales'] = multiscales
 
     logger.info("Finished cache optimization")
 

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -149,8 +149,11 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
         zarr_conventions.append(MultiscalesConventionMetadata().model_dump())
         geozarr_attrs["zarr_conventions"] = zarr_conventions
 
-        # load into memory to release netCDF file handles before multiprocessing in create_pyramid
+        # Load into memory then close to deterministically release netCDF file handles
+        # before create_pyramid spawns multiprocessing workers. After load() the data
+        # lives in numpy arrays and no longer needs the underlying file objects.
         ds.load()
+        ds.close()
 
         ds = ds.proj.assign_crs(spatial_ref=CRS)
 

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -14,7 +14,7 @@ from typing import Any
 import xarray as xr
 import xproj # pyright: ignore[reportUnusedImport]
 from fastapi import BackgroundTasks, HTTPException
-from geozarr_toolkit import create_geozarr_attrs, create_multiscales_layout
+from geozarr_toolkit import create_geozarr_attrs, MultiscalesConventionMetadata
 from topozarr.coarsen import create_pyramid
 
 from ...shared.dhis2_adapter import create_client, get_org_units_geojson
@@ -103,6 +103,9 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     """Collect all dataset files into a single optimised zarr archive."""
     logger.info(f"Optimizing cache for dataset {dataset['id']}")
 
+    print(json.dumps(dataset, indent=2))
+
+    cache_info = dataset["cache_info"]
     files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
@@ -119,14 +122,18 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     drop_coords = [c for c in ds.coords if c not in keep_coords]
     ds = ds.drop_vars(drop_coords)
 
-    lon_dim, lat_dim = get_lon_lat_dims(ds)
-    dims = [lon_dim, lat_dim]
-
-    xmin, xmax = ds[lon_dim].min().item(), ds[lon_dim].max().item()
-    ymin, ymax = ds[lat_dim].min().item(), ds[lat_dim].max().item()
+    xmin = ds[lon_dim].min().item() 
+    xmax = ds[lon_dim].max().item()
+    ymin = ds[lat_dim].min().item() 
+    ymax = ds[lat_dim].max().item()
+    
     bbox = [xmin, ymin, xmax, ymax]
+    
     shape = (ds.sizes[lon_dim], ds.sizes[lat_dim]) 
 
+    multiscales = dict(cache_info.get("multiscales", {}))
+
+    # https://github.com/zarr-developers/geozarr-toolkit/issues/15
     geozarr_attrs =  create_geozarr_attrs(
         dimensions=dims,
         crs=CRS,
@@ -134,107 +141,60 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
         shape=shape,
     )
 
-    print("########");
-
-    print(json.dumps(geozarr_attrs, indent=2))
-
-    print("########");
-
-    zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
-
-    # Fix stale org name in convention metadata
-    # for convention in zarr_conventions:
-    #     if convention.get("name") == "proj:":
-    #        convention["schema_url"] = convention["schema_url"].replace(
-    #            "zarr-experimental", "zarr-conventions"
-    #        )
-    #        convention["spec_url"] = convention["spec_url"].replace(
-    #            "zarr-experimental", "zarr-conventions"
-    #        )
-
-    multiscales_convention = {
-        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-        "name": "multiscales",
-        "description": "Multiscale layout of zarr datasets"
-    }
-
-    zarr_conventions.append(multiscales_convention)
-    geozarr_attrs["zarr_conventions"] = zarr_conventions
-
-    ds.attrs.update(geozarr_attrs)
-
-    print(json.dumps(geozarr_attrs, indent=2))
-
-    ds = ds.proj.assign_crs(spatial_ref=CRS)
-
-    pyramid = create_pyramid(
-        ds,
-        levels=5,
-        x_dim=lon_dim,
-        y_dim=lat_dim,
-        method="mean",  # "mean" (default) | "max" | "min" | "sum"
-    )
-    # print(pyramid.encoding)
-    # print(pyramid.dt)
-
-    # print(json.dumps(pyramid.dt.attrs, indent=2))
-
-    # levels = []
-    # for i, level in enumerate(pyramid.dt.levels):  # or pyramid.dt.levels, depending on your object
-    #    entry = {"asset": str(i)}
-    #    if i > 0:
-    #        entry["derived_from"] = str(i - 1)
-    #        entry["transform"] = {"scale": [2.0, 2.0]}  # or actual scale for your data
-    #    levels.append(entry)
-    # multiscales = create_multiscales_layout(pyramid)
-
-    # determine optimal chunk sizes
-    # logger.info("Determining optimal chunk size for zarr archive")
-    # ds_autochunk = ds.chunk("auto").unify_chunks()
-    # uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
-    # time_space_chunks = _compute_time_space_chunks(ds, dataset)
-    # uniform_chunks.update(time_space_chunks)
-    #logging.info(f"--> {uniform_chunks}")
-
     # save as zarr
     logger.info("Saving to optimized zarr file")
     zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
-    # ds_chunked = ds.chunk(uniform_chunks)
-    # ds_chunked.to_zarr(zarr_path, mode="w")
-    # ds_chunked.close()
 
-    pyramid.dt.attrs.update(geozarr_attrs)
+
+    if (multiscales):
+        levels = multiscales.get("levels", 4)
+        method = multiscales.get("method", "mean")
+
+        # Add multiscales convention metadata to the zarr attributes
+        zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
+        zarr_conventions.append(MultiscalesConventionMetadata().model_dump())
+        geozarr_attrs["zarr_conventions"] = zarr_conventions
+
+        ds = ds.proj.assign_crs(spatial_ref=CRS)
+
+        # https://github.com/carbonplan/topozarr/issues/13
+        pyramid = create_pyramid(
+            ds,
+            levels=levels,
+            x_dim=lon_dim,
+            y_dim=lat_dim,
+            method=method
+        )
+
+        pyramid.dt.attrs.update(geozarr_attrs)
+        pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
+
+        # zarr-layer looks for the time coordinate at the root of the store, not inside each level.
+        # Copy it from level 0 so browser clients can discover it without knowing the level structure.
+        time_src = zarr_path / "0" / "time"
+        time_dst = zarr_path / "time"
+        if time_src.exists():
+            if time_dst.exists():
+                shutil.rmtree(time_dst)
+            shutil.copytree(time_src, time_dst)
+
+        pyramid.dt.close()
+
+    else:    
+        # determine optimal chunk sizes
+        logger.info("Determining optimal chunk size for zarr archive")
+        ds_autochunk = ds.chunk("auto").unify_chunks()
+        uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
+        time_space_chunks = _compute_time_space_chunks(ds, dataset)
+        uniform_chunks.update(time_space_chunks)
+        logging.info(f"--> {uniform_chunks}")
+
+        ds.attrs.update(geozarr_attrs)
+        ds_chunked = ds.chunk(uniform_chunks)
+        ds_chunked.to_zarr(zarr_path, mode="w")
+        ds_chunked.close()
 
     ds.close()
-
-    pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
-
-    # zarr-layer looks for the time coordinate at the root of the store, not inside each level.
-    # Copy it from level 0 so browser clients can discover it without knowing the level structure.
-    time_src = zarr_path / "0" / "time"
-    time_dst = zarr_path / "time"
-    if time_src.exists():
-        if time_dst.exists():
-            shutil.rmtree(time_dst)
-        shutil.copytree(time_src, time_dst)
-
-    #
-    # multiscales = pyramid.dt.attrs.get("multiscales", None)
-
-    # print(json.dumps(multiscales, indent=2))
-
-    # --- Add multiscales attribute to each pyramid level group ---
-    # import zarr
-    # store = zarr.open_group(str(zarr_path), mode='a')
-    # Write to root
-    # if multiscales is not None:
-    #    store.attrs['multiscales'] = multiscales
-        # Write to each pyramid level group (e.g., '0', '1', ...)
-    #    for level in store.group_keys():
-    #        store[level].attrs['multiscales'] = multiscales
-
     logger.info("Finished cache optimization")
 
 

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -105,6 +105,7 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
+    ds.load()
 
     lon_dim, lat_dim = get_lon_lat_dims(ds)
     dims = [lon_dim, lat_dim]
@@ -205,9 +206,11 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
 
     pyramid.dt.attrs.update(geozarr_attrs)
 
+    ds.close()
+
     pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
 
-    # 
+    #
     # multiscales = pyramid.dt.attrs.get("multiscales", None)
 
     # print(json.dumps(multiscales, indent=2))

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -183,7 +183,7 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
 
         ds.attrs.update(geozarr_attrs)
         ds_chunked = ds.chunk(uniform_chunks)
-        ds_chunked.to_zarr(zarr_path, mode="w")
+        ds_chunked.to_zarr(zarr_path, mode="w", consolidated=True)
         ds_chunked.close()
 
     ds.close()

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -5,16 +5,15 @@ import importlib
 import inspect
 import logging
 import os
-import json
 import shutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import xarray as xr
-import xproj # pyright: ignore[reportUnusedImport]
+import xproj  # noqa: F401  # type: ignore[import-untyped]  # pyright: ignore[reportUnusedImport]
 from fastapi import BackgroundTasks, HTTPException
-from geozarr_toolkit import create_geozarr_attrs, MultiscalesConventionMetadata
+from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from ...shared.dhis2_adapter import create_client, get_org_units_geojson
@@ -29,7 +28,8 @@ if CACHE_OVERRIDE:
     _download_dir = Path(CACHE_OVERRIDE)
 DOWNLOAD_DIR = _download_dir
 
-CRS ="EPSG:4326"
+CRS = "EPSG:4326"
+
 
 def download_dataset(
     dataset: dict[str, Any],
@@ -103,18 +103,15 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     """Collect all dataset files into a single optimised zarr archive."""
     logger.info(f"Optimizing cache for dataset {dataset['id']}")
 
-    print(json.dumps(dataset, indent=2))
-
     cache_info = dataset["cache_info"]
     files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
-    ds.load()
 
     lon_dim, lat_dim = get_lon_lat_dims(ds)
     dims = [lon_dim, lat_dim]
 
-    # trim to only minimal vars and coords
+    # trim to only minimal vars and coords before loading into memory
     logger.info("Trimming unnecessary variables and coordinates")
     varname = dataset["variable"]
     ds = ds[[varname]]
@@ -122,15 +119,18 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     drop_coords = [c for c in ds.coords if c not in keep_coords]
     ds = ds.drop_vars(drop_coords)
 
-    xmin = ds[lon_dim].min().item() 
+    # load into memory to release netCDF file handles before multiprocessing in create_pyramid
+    ds.load()
+
+    xmin = ds[lon_dim].min().item()
     xmax = ds[lon_dim].max().item()
-    ymin = ds[lat_dim].min().item() 
+    ymin = ds[lat_dim].min().item()
     ymax = ds[lat_dim].max().item()
     bbox = [xmin, ymin, xmax, ymax]
-    shape = (ds.sizes[lon_dim], ds.sizes[lat_dim]) 
+    shape = (ds.sizes[lon_dim], ds.sizes[lat_dim])
 
     # https://github.com/zarr-developers/geozarr-toolkit/issues/15
-    geozarr_attrs =  create_geozarr_attrs(
+    geozarr_attrs = create_geozarr_attrs(
         dimensions=dims,
         crs=CRS,
         bbox=bbox,
@@ -143,7 +143,7 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
 
     multiscales = dict(cache_info.get("multiscales", {}))
 
-    if (multiscales):
+    if multiscales:
         levels = multiscales.get("levels", 4)
         method = multiscales.get("method", "mean")
 
@@ -155,21 +155,16 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
         ds = ds.proj.assign_crs(spatial_ref=CRS)
 
         # https://github.com/carbonplan/topozarr/issues/13
-        pyramid = create_pyramid(
-            ds,
-            levels=levels,
-            x_dim=lon_dim,
-            y_dim=lat_dim,
-            method=method
-        )
+        pyramid = create_pyramid(ds, levels=levels, x_dim=lon_dim, y_dim=lat_dim, method=method)
 
         pyramid.dt.attrs.update(geozarr_attrs)
         pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
 
         # zarr-layer looks for the time coordinate at the root of the store, not inside each level.
         # Copy it from level 0 so browser clients can discover it without knowing the level structure.
-        time_src = zarr_path / "0" / "time"
-        time_dst = zarr_path / "time"
+        time_dim = get_time_dim(ds)
+        time_src = zarr_path / "0" / time_dim
+        time_dst = zarr_path / time_dim
         if time_src.exists():
             if time_dst.exists():
                 shutil.rmtree(time_dst)
@@ -177,14 +172,14 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
 
         pyramid.dt.close()
 
-    else:    
+    else:
         # determine optimal chunk sizes
         logger.info("Determining optimal chunk size for zarr archive")
         ds_autochunk = ds.chunk("auto").unify_chunks()
         uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
         time_space_chunks = _compute_time_space_chunks(ds, dataset)
         uniform_chunks.update(time_space_chunks)
-        logging.info(f"--> {uniform_chunks}")
+        logger.info(f"--> {uniform_chunks}")
 
         ds.attrs.update(geozarr_attrs)
         ds_chunked = ds.chunk(uniform_chunks)

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -126,12 +126,8 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     xmax = ds[lon_dim].max().item()
     ymin = ds[lat_dim].min().item() 
     ymax = ds[lat_dim].max().item()
-    
     bbox = [xmin, ymin, xmax, ymax]
-    
     shape = (ds.sizes[lon_dim], ds.sizes[lat_dim]) 
-
-    multiscales = dict(cache_info.get("multiscales", {}))
 
     # https://github.com/zarr-developers/geozarr-toolkit/issues/15
     geozarr_attrs =  create_geozarr_attrs(
@@ -145,6 +141,7 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     logger.info("Saving to optimized zarr file")
     zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
 
+    multiscales = dict(cache_info.get("multiscales", {}))
 
     if (multiscales):
         levels = multiscales.get("levels", 4)

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import os
 import json
+import shutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -209,6 +210,15 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     ds.close()
 
     pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
+
+    # zarr-layer looks for the time coordinate at the root of the store, not inside each level.
+    # Copy it from level 0 so browser clients can discover it without knowing the level structure.
+    time_src = zarr_path / "0" / "time"
+    time_dst = zarr_path / "time"
+    if time_src.exists():
+        if time_dst.exists():
+            shutil.rmtree(time_dst)
+        shutil.copytree(time_src, time_dst)
 
     #
     # multiscales = pyramid.dt.attrs.get("multiscales", None)

--- a/src/eo_api/data_manager/services/downloader.py
+++ b/src/eo_api/data_manager/services/downloader.py
@@ -119,9 +119,6 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
     drop_coords = [c for c in ds.coords if c not in keep_coords]
     ds = ds.drop_vars(drop_coords)
 
-    # load into memory to release netCDF file handles before multiprocessing in create_pyramid
-    ds.load()
-
     xmin = ds[lon_dim].min().item()
     xmax = ds[lon_dim].max().item()
     ymin = ds[lat_dim].min().item()
@@ -151,6 +148,9 @@ def build_dataset_zarr(dataset: dict[str, Any]) -> None:
         zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
         zarr_conventions.append(MultiscalesConventionMetadata().model_dump())
         geozarr_attrs["zarr_conventions"] = zarr_conventions
+
+        # load into memory to release netCDF file handles before multiprocessing in create_pyramid
+        ds.load()
 
         ds = ds.proj.assign_crs(spatial_ref=CRS)
 

--- a/src/eo_api/data_manager/services/utils.py
+++ b/src/eo_api/data_manager/services/utils.py
@@ -8,7 +8,7 @@ def get_time_dim(ds: Any) -> str:
     for time_name in ["valid_time", "time"]:
         if hasattr(ds, time_name):
             return time_name
-    raise ValueError(f"Unable to find time dimension: {ds.coordinates}")
+    raise ValueError(f"Unable to find time dimension: {ds.coords}")
 
 
 def get_lon_lat_dims(ds: Any) -> tuple[str, str]:
@@ -16,4 +16,4 @@ def get_lon_lat_dims(ds: Any) -> tuple[str, str]:
     for lon_name, lat_name in [("lon", "lat"), ("longitude", "latitude"), ("x", "y")]:
         if hasattr(ds, lat_name):
             return lon_name, lat_name
-    raise ValueError(f"Unable to find space dimension: {ds.coordinates}")
+    raise ValueError(f"Unable to find space dimension: {ds.coords}")

--- a/src/eo_api/data_manager/services/utils.py
+++ b/src/eo_api/data_manager/services/utils.py
@@ -8,7 +8,7 @@ def get_time_dim(ds: Any) -> str:
     for time_name in ["valid_time", "time"]:
         if hasattr(ds, time_name):
             return time_name
-    raise ValueError(f"Unable to find time dimension: {ds.coords}")
+    raise ValueError(f"Unable to find time dimension: {getattr(ds, 'coords', repr(ds))}")
 
 
 def get_lon_lat_dims(ds: Any) -> tuple[str, str]:
@@ -16,4 +16,4 @@ def get_lon_lat_dims(ds: Any) -> tuple[str, str]:
     for lon_name, lat_name in [("lon", "lat"), ("longitude", "latitude"), ("x", "y")]:
         if hasattr(ds, lat_name):
             return lon_name, lat_name
-    raise ValueError(f"Unable to find space dimension: {ds.coords}")
+    raise ValueError(f"Unable to find space dimension: {getattr(ds, 'coords', repr(ds))}")

--- a/src/eo_api/ingestions/routes.py
+++ b/src/eo_api/ingestions/routes.py
@@ -92,13 +92,13 @@ def download_artifact_file(dataset_id: str) -> FileResponse:
     return FileResponse(artifact.path, media_type=media_type, filename=filename)
 
 
-@zarr_router.get("/{dataset_id}")
+@zarr_router.api_route("/{dataset_id}", methods=["GET", "HEAD"])
 def get_canonical_zarr_store_info(dataset_id: str) -> dict[str, object]:
     """Return canonical Zarr store listing for a managed dataset."""
     return services.get_dataset_zarr_store_info_or_404(dataset_id)
 
 
-@zarr_router.get("/{dataset_id}/{relative_path:path}", response_model=None)
+@zarr_router.api_route("/{dataset_id}/{relative_path:path}", methods=["GET", "HEAD"], response_model=None)
 def get_canonical_zarr_store_file(dataset_id: str, relative_path: str) -> FileResponse | Response | dict[str, object]:
     """Serve canonical Zarr store content for a managed dataset."""
     return services.get_dataset_zarr_store_file_or_404(dataset_id, relative_path)

--- a/src/eo_api/ingestions/services.py
+++ b/src/eo_api/ingestions/services.py
@@ -296,35 +296,16 @@ def get_dataset_zarr_store_file_or_404(
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
-        logger.warning(f"Zarr chunk/file not found: dataset_id={dataset_id}, relative_path={relative_path}, resolved={target}")
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
     if target.is_dir():
         return _zarr_directory_listing(dataset_id=dataset_id, store_root=store_root, directory=target)
     if target.name in {".zarray", ".zattrs", ".zgroup", "zarr.json"}:
         return JSONResponse(content=json.loads(target.read_text(encoding="utf-8")))
 
-    # Check file type and readability before serving
-    if not target.is_file():
-        logger.warning(f"Target exists but is not a file: {target}")
-        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' is not a file")
-    if not os.access(target, os.R_OK):
-        logger.warning(f"Target file is not readable: {target}")
-        raise HTTPException(status_code=403, detail=f"Zarr path '{relative_path}' is not readable")
-
     media_type, _ = mimetypes.guess_type(target.name)
     if media_type is None:
         media_type = "application/octet-stream"
-    try:
-        # print(f"Serving file: {target} (size: {target.stat().st_size})")
-        # Try direct Response for diagnosis
-        with open(target, "rb") as f:
-            data = f.read()
-        return Response(content=data, media_type=media_type)
-        # Uncomment below to try FileResponse again if needed
-        # return FileResponse(target, media_type=media_type, filename=target.name)
-    except Exception as exc:
-        logger.error(f"Error serving Zarr chunk: {target} -- {exc}")
-        raise HTTPException(status_code=500, detail=f"Error serving Zarr chunk: {exc}")
+    return FileResponse(target, media_type=media_type, filename=target.name)
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/src/eo_api/ingestions/services.py
+++ b/src/eo_api/ingestions/services.py
@@ -296,16 +296,35 @@ def get_dataset_zarr_store_file_or_404(
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
+        logger.warning(f"Zarr chunk/file not found: dataset_id={dataset_id}, relative_path={relative_path}, resolved={target}")
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
     if target.is_dir():
         return _zarr_directory_listing(dataset_id=dataset_id, store_root=store_root, directory=target)
     if target.name in {".zarray", ".zattrs", ".zgroup", "zarr.json"}:
         return JSONResponse(content=json.loads(target.read_text(encoding="utf-8")))
 
+    # Check file type and readability before serving
+    if not target.is_file():
+        logger.warning(f"Target exists but is not a file: {target}")
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' is not a file")
+    if not os.access(target, os.R_OK):
+        logger.warning(f"Target file is not readable: {target}")
+        raise HTTPException(status_code=403, detail=f"Zarr path '{relative_path}' is not readable")
+
     media_type, _ = mimetypes.guess_type(target.name)
     if media_type is None:
         media_type = "application/octet-stream"
-    return FileResponse(target, media_type=media_type, filename=target.name)
+    try:
+        # print(f"Serving file: {target} (size: {target.stat().st_size})")
+        # Try direct Response for diagnosis
+        with open(target, "rb") as f:
+            data = f.read()
+        return Response(content=data, media_type=media_type)
+        # Uncomment below to try FileResponse again if needed
+        # return FileResponse(target, media_type=media_type, filename=target.name)
+    except Exception as exc:
+        logger.error(f"Error serving Zarr chunk: {target} -- {exc}")
+        raise HTTPException(status_code=500, detail=f"Error serving Zarr chunk: {exc}")
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -30,21 +30,12 @@ async def add_zarr_browser_access_headers(
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     """Add browser access headers needed by remote Zarr inspectors calling localhost."""
-    # Handle CORS preflight for private network
     if (
         request.method == "OPTIONS"
         and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/"))
         and request.headers.get("access-control-request-private-network") == "true"
     ):
         response = Response(status_code=200)
-    # Handle HEAD requests for /zarr and /zarr/*, even if no route is defined
-    elif (
-        request.method == "HEAD"
-        and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/"))
-    ):
-        response = Response(status_code=200)
-        response.body = b""
-        response.headers["Content-Length"] = "0"
     else:
         response = await call_next(request)
     if request.url.path == "/zarr" or request.url.path.startswith("/zarr/"):
@@ -52,7 +43,7 @@ async def add_zarr_browser_access_headers(
         if origin is not None:
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Vary"] = "Origin"
-            response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS, HEAD")
+            response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
                 request.headers.get("access-control-request-headers", "*"),

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -23,6 +23,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.middleware("http")
 async def add_zarr_browser_access_headers(
     request: Request,

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -23,7 +23,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
 @app.middleware("http")
 async def add_zarr_browser_access_headers(
     request: Request,

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -30,12 +30,21 @@ async def add_zarr_browser_access_headers(
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     """Add browser access headers needed by remote Zarr inspectors calling localhost."""
+    # Handle CORS preflight for private network
     if (
         request.method == "OPTIONS"
         and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/"))
         and request.headers.get("access-control-request-private-network") == "true"
     ):
         response = Response(status_code=200)
+    # Handle HEAD requests for /zarr and /zarr/*, even if no route is defined
+    elif (
+        request.method == "HEAD"
+        and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/"))
+    ):
+        response = Response(status_code=200)
+        response.body = b""
+        response.headers["Content-Length"] = "0"
     else:
         response = await call_next(request)
     if request.url.path == "/zarr" or request.url.path.startswith("/zarr/"):
@@ -43,7 +52,7 @@ async def add_zarr_browser_access_headers(
         if origin is not None:
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Vary"] = "Origin"
-            response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS")
+            response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS, HEAD")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
                 request.headers.get("access-control-request-headers", "*"),

--- a/src/eo_api/main.py
+++ b/src/eo_api/main.py
@@ -43,7 +43,7 @@ async def add_zarr_browser_access_headers(
         if origin is not None:
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Vary"] = "Origin"
-            response.headers.setdefault("Access-Control-Allow-Methods", "GET, OPTIONS")
+            response.headers.setdefault("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
                 request.headers.get("access-control-request-headers", "*"),

--- a/src/eo_api/publications/services.py
+++ b/src/eo_api/publications/services.py
@@ -12,6 +12,7 @@ from zlib import adler32
 import xarray as xr
 import yaml
 
+from eo_api.data_accessor.services.accessor import open_zarr_dataset
 from eo_api.data_manager.services.utils import get_lon_lat_dims, get_time_dim
 from eo_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 
@@ -56,6 +57,9 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
         active = published_record if artifact.artifact_id == record.artifact_id else artifact
         if active.publication.status != PublicationStatus.PUBLISHED:
             continue
+        data_path = active.path or active.asset_paths[0]
+        if active.format == ArtifactFormat.ZARR and Path(f"{data_path}/0").exists():
+            continue  # pyramid zarr: not served via pygeoapi, use /zarr endpoint instead
         assert active.publication.collection_id is not None
         resources[active.publication.collection_id] = _build_collection_resource(active)
 
@@ -108,7 +112,7 @@ def _build_collection_resource(record: ArtifactRecord) -> dict[str, Any]:
         "format": _provider_format(record.format),
     }
     if record.format == ArtifactFormat.ZARR:
-        provider["options"] = {"zarr": {"consolidated": True}, "squeeze": True}
+        provider["options"] = {"zarr": {"consolidated": False}, "squeeze": True}
 
     return {
         "type": "collection",
@@ -144,7 +148,7 @@ def _provider_axes(record: ArtifactRecord) -> tuple[str, str, str]:
     """Inspect an artifact and return provider axis field names."""
     data_path = record.path or record.asset_paths[0]
     if record.format == ArtifactFormat.ZARR:
-        ds = xr.open_zarr(data_path, consolidated=True)
+        ds = open_zarr_dataset(data_path)
     else:
         ds = xr.open_dataset(data_path)
 

--- a/src/eo_api/publications/services.py
+++ b/src/eo_api/publications/services.py
@@ -39,6 +39,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
     from eo_api.ingestions.services import list_artifacts
 
     collection_id = managed_dataset_id_for(record)
+    data_path = record.path or record.asset_paths[0]
+    is_pyramid_zarr = record.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir()
     published_record = record.model_copy(
         update={
             "publication": record.publication.model_copy(
@@ -46,7 +48,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
                     "status": PublicationStatus.PUBLISHED,
                     "collection_id": collection_id,
                     "published_at": datetime.now(UTC),
-                    "pygeoapi_path": f"/ogcapi/collections/{collection_id}",
+                    # Pyramid zarr stores are served via the /zarr endpoint, not pygeoapi.
+                    "pygeoapi_path": None if is_pyramid_zarr else f"/ogcapi/collections/{collection_id}",
                 }
             )
         }

--- a/src/eo_api/publications/services.py
+++ b/src/eo_api/publications/services.py
@@ -58,7 +58,7 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
         if active.publication.status != PublicationStatus.PUBLISHED:
             continue
         data_path = active.path or active.asset_paths[0]
-        if active.format == ArtifactFormat.ZARR and Path(f"{data_path}/0").exists():
+        if active.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir():
             continue  # pyramid zarr: not served via pygeoapi, use /zarr endpoint instead
         assert active.publication.collection_id is not None
         resources[active.publication.collection_id] = _build_collection_resource(active)
@@ -112,7 +112,7 @@ def _build_collection_resource(record: ArtifactRecord) -> dict[str, Any]:
         "format": _provider_format(record.format),
     }
     if record.format == ArtifactFormat.ZARR:
-        provider["options"] = {"zarr": {"consolidated": False}, "squeeze": True}
+        provider["options"] = {"zarr": {"consolidated": True}, "squeeze": True}
 
     return {
         "type": "collection",

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -193,7 +193,7 @@ def test_open_zarr_dataset_pyramid_falls_back_to_level_0(tmp_path: Path) -> None
     """Pyramid zarr with no data vars at root falls back to opening /0."""
     zarr_path = tmp_path / "pyramid.zarr"
     zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
-    _make_dataset().to_zarr(str(zarr_path / "0"), mode="w")
+    _make_dataset().to_zarr(str(zarr_path / "0"), mode="w", zarr_format=3)
 
     result = open_zarr_dataset(str(zarr_path))
     try:
@@ -212,7 +212,7 @@ def test_open_zarr_dataset_pyramid_with_root_time_still_opens_level_0(tmp_path: 
     ds = _make_dataset()
     zarr_path = tmp_path / "pyramid.zarr"
     zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
-    ds.to_zarr(str(zarr_path / "0"), mode="w")
+    ds.to_zarr(str(zarr_path / "0"), mode="w", zarr_format=3)
     # Simulate what build_dataset_zarr does: copy time to root
     import shutil
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,8 +1,16 @@
+from pathlib import Path
 from typing import Any
 
+import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
+import zarr
 from fastapi import HTTPException
+from topozarr.pyramid import Pyramid
+from xarray import DataTree
 
+from eo_api.data_accessor.services.accessor import open_zarr_dataset
 from eo_api.data_manager.services import downloader
 
 
@@ -112,3 +120,183 @@ def test_download_dataset_returns_502_for_upstream_provider_failure(monkeypatch:
 
 def _raise_default_bbox_error() -> list[float]:
     raise RuntimeError("missing default bbox")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset() -> xr.Dataset:
+    return xr.Dataset(
+        {"pop_total": (["time", "lat", "lon"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2020-01-01", periods=2, freq="YS"),
+            "lat": [10.0, 9.0, 8.0],
+            "lon": [30.0, 31.0, 32.0],
+        },
+    )
+
+
+def _write_nc_files(tmp_path: Path) -> list[Path]:
+    paths = []
+    for year in (2020, 2021):
+        ds = xr.Dataset(
+            {"pop_total": (["time", "lat", "lon"], np.ones((1, 3, 3), dtype="float32"))},
+            coords={
+                "time": [pd.Timestamp(f"{year}-01-01")],
+                "lat": [10.0, 9.0, 8.0],
+                "lon": [30.0, 31.0, 32.0],
+            },
+        )
+        path = tmp_path / f"my_dataset_{year}.nc"
+        ds.to_netcdf(path)
+        paths.append(path)
+    return paths
+
+
+_FLAT_DATASET: dict[str, Any] = {
+    "id": "my_dataset",
+    "variable": "pop_total",
+    "period_type": "yearly",
+    "cache_info": {},
+}
+
+_PYRAMID_DATASET: dict[str, Any] = {
+    "id": "my_dataset",
+    "variable": "pop_total",
+    "period_type": "yearly",
+    "cache_info": {"multiscales": {"levels": 2, "method": "mean"}},
+}
+
+
+# ---------------------------------------------------------------------------
+# open_zarr_dataset
+# ---------------------------------------------------------------------------
+
+
+def test_open_zarr_dataset_flat(tmp_path: Path) -> None:
+    """Flat zarr store is opened directly and exposes its data variables."""
+    ds = _make_dataset()
+    zarr_path = tmp_path / "flat.zarr"
+    ds.to_zarr(str(zarr_path), mode="w")
+
+    result = open_zarr_dataset(str(zarr_path))
+    try:
+        assert "pop_total" in result.data_vars
+        assert result.sizes["time"] == 2
+    finally:
+        result.close()
+
+
+def test_open_zarr_dataset_pyramid_falls_back_to_level_0(tmp_path: Path) -> None:
+    """Pyramid zarr with no data vars at root falls back to opening /0."""
+    zarr_path = tmp_path / "pyramid.zarr"
+    zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
+    _make_dataset().to_zarr(str(zarr_path / "0"), mode="w")
+
+    result = open_zarr_dataset(str(zarr_path))
+    try:
+        assert "pop_total" in result.data_vars
+        assert result.sizes["time"] == 2
+    finally:
+        result.close()
+
+
+def test_open_zarr_dataset_pyramid_with_root_time_still_opens_level_0(tmp_path: Path) -> None:
+    """Root-level time coord (copied for zarr-layer) does not confuse the fallback.
+
+    The fallback triggers on empty data_vars, not empty dims, so a root group
+    that only has a 'time' coordinate array still falls back to /0.
+    """
+    ds = _make_dataset()
+    zarr_path = tmp_path / "pyramid.zarr"
+    zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
+    ds.to_zarr(str(zarr_path / "0"), mode="w")
+    # Simulate what build_dataset_zarr does: copy time to root
+    import shutil
+
+    shutil.copytree(str(zarr_path / "0" / "time"), str(zarr_path / "time"))
+
+    result = open_zarr_dataset(str(zarr_path))
+    try:
+        assert "pop_total" in result.data_vars
+    finally:
+        result.close()
+
+
+# ---------------------------------------------------------------------------
+# build_dataset_zarr — flat path
+# ---------------------------------------------------------------------------
+
+
+def test_build_dataset_zarr_flat_creates_zarr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flat zarr is written with the correct variable and no pyramid level dirs."""
+    nc_files = _write_nc_files(tmp_path)
+    monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+
+    downloader.build_dataset_zarr(_FLAT_DATASET)
+
+    zarr_path = tmp_path / "my_dataset.zarr"
+    assert zarr_path.exists()
+    assert not (zarr_path / "0").exists()
+
+    result = open_zarr_dataset(str(zarr_path))
+    try:
+        assert "pop_total" in result.data_vars
+        assert result.sizes["time"] == 2
+    finally:
+        result.close()
+
+
+# ---------------------------------------------------------------------------
+# build_dataset_zarr — pyramid path
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_pyramid(ds: xr.Dataset, zarr_path: Path) -> Pyramid:
+    """Return a Pyramid whose .dt.to_zarr writes a minimal two-level DataTree store."""
+    level0 = ds
+    level1 = ds.coarsen(lat=2, lon=2, boundary="trim").mean()  # pyright: ignore[reportAttributeAccessIssue]
+    dt = DataTree.from_dict({"0": level0, "1": level1})
+    return Pyramid(datatree=dt, encoding={})
+
+
+def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pyramid zarr build copies the time coordinate to the store root for zarr-layer."""
+    nc_files = _write_nc_files(tmp_path)
+    monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+
+    def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
+        return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
+
+    monkeypatch.setattr(downloader, "create_pyramid", fake_create_pyramid)
+
+    downloader.build_dataset_zarr(_PYRAMID_DATASET)
+
+    zarr_path = tmp_path / "my_dataset.zarr"
+    assert (zarr_path / "0").exists(), "pyramid level 0 should exist"
+    assert (zarr_path / "time").exists(), "time coordinate must be copied to zarr root"
+
+
+def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """open_zarr_dataset returns the dataset from level 0 of the pyramid store."""
+    nc_files = _write_nc_files(tmp_path)
+    monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+
+    def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
+        return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
+
+    monkeypatch.setattr(downloader, "create_pyramid", fake_create_pyramid)
+
+    downloader.build_dataset_zarr(_PYRAMID_DATASET)
+
+    result = open_zarr_dataset(str(tmp_path / "my_dataset.zarr"))
+    try:
+        assert "pop_total" in result.data_vars
+        assert result.sizes["time"] == 2
+    finally:
+        result.close()

--- a/uv.lock
+++ b/uv.lock
@@ -808,12 +808,14 @@ dependencies = [
     { name = "dhis2eo" },
     { name = "earthkit-transforms" },
     { name = "geojson-pydantic" },
+    { name = "geozarr-toolkit" },
     { name = "httpx" },
     { name = "metpy" },
     { name = "prefect" },
     { name = "pygeoapi" },
     { name = "python-dotenv" },
     { name = "titiler-core" },
+    { name = "topozarr" },
     { name = "uvicorn" },
     { name = "zarr" },
 ]
@@ -835,14 +837,16 @@ requires-dist = [
     { name = "dhis2eo", git = "https://github.com/dhis2/dhis2eo.git?rev=v1.1.0" },
     { name = "earthkit-transforms", specifier = "==0.5.*" },
     { name = "geojson-pydantic", specifier = ">=2.1.0" },
+    { name = "geozarr-toolkit", specifier = ">=0.1.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "metpy", specifier = ">=1.7,<2" },
     { name = "prefect", specifier = ">=3.6" },
     { name = "pygeoapi", specifier = ">=0.22.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "titiler-core", specifier = ">=1.2.0" },
+    { name = "topozarr", specifier = ">=0.0.6" },
     { name = "uvicorn", specifier = ">=0.41.0" },
-    { name = "zarr", specifier = "==3.1.5" },
+    { name = "zarr", specifier = ">=3.1.6" },
 ]
 
 [package.metadata.requires-dev]
@@ -959,6 +963,23 @@ wheels = [
 ]
 
 [[package]]
+name = "flox"
+version = "0.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "numpy-groupies" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/fd/94b6e6dba647c062434f21b40efe800ca3fed2292856f82c816a8a626b97/flox-0.11.2.tar.gz", hash = "sha256:ca48d391e4a06cdf1c24368bf73114191851149611a5b318d82436fa713efdf0", size = 956626, upload-time = "2026-02-26T05:41:53.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/7b/4ce04d96cb4538ab3eab6bbcc06e624bbbc3661011bfab0b536f4fb026ab/flox-0.11.2-py3-none-any.whl", hash = "sha256:d3932bfe9e26729dd7e471c4d448abeaee7a62272621f584de0e704b3c0665cb", size = 89143, upload-time = "2026-02-26T05:41:54.725Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.61.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1030,6 +1051,21 @@ wheels = [
 ]
 
 [[package]]
+name = "geozarr-toolkit"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyproj" },
+    { name = "structlog" },
+    { name = "zarr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/00/eb0acfacf70c23c26ec84730234657279645be24de289de1a865fcad8a7e/geozarr_toolkit-0.1.2.tar.gz", hash = "sha256:04b4196245210bfc854051729d0c3a92865bc47cf258f70227ae39a5ff40576b", size = 26324, upload-time = "2026-04-01T01:45:03.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/2b/fb54fdbad8041ca7ffa8332b29afd3697580c8884656540b7ab6a8c56096/geozarr_toolkit-0.1.2-py3-none-any.whl", hash = "sha256:6d4317b791da7fcb19fce9df345f8f9ee3a1a822eb3bb3aad448ec41b73b526e", size = 19719, upload-time = "2026-04-01T01:45:02.146Z" },
+]
+
+[[package]]
 name = "google-crc32c"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1098,6 +1134,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -1110,6 +1147,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -1118,6 +1156,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -1906,6 +1945,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
     { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
     { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
+name = "numpy-groupies"
+version = "0.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ff/0559b586423d9a59feac52c2261501106dcd61e45214862de5fbb03b78cb/numpy_groupies-0.11.3.tar.gz", hash = "sha256:aed4afdad55e856b9e737fe4b4673c77e47c2f887c3663a18baaa200407c23e0", size = 159159, upload-time = "2025-05-22T11:47:58.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e0/760e73c111193db5ca37712a148e4807d1b0c60302ab31e4ada6528ca34d/numpy_groupies-0.11.3-py3-none-any.whl", hash = "sha256:d4065dd5d56fda941ad5a7c80a7f80b49f671ed148aaa3e243a0e4caa71adcb3", size = 40784, upload-time = "2025-05-22T11:47:56.997Z" },
 ]
 
 [[package]]
@@ -3286,6 +3337,15 @@ wheels = [
 ]
 
 [[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3340,6 +3400,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "topozarr"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask" },
+    { name = "flox" },
+    { name = "xarray" },
+    { name = "xproj" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/ca/583de433bc37128e431aba336a09642a9f6834988cd2021ca81216b3d63a/topozarr-0.0.6.tar.gz", hash = "sha256:8fc6728c7796da9c71a68f6026a78743dcedd6296e400206264487b5abf37dfe", size = 6349, upload-time = "2026-04-02T19:33:51.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/b5/628461bf9f08944dd4f5f8204de4cb798e34c4affc6bd05c2c3d0e0f0ff0/topozarr-0.0.6-py3-none-any.whl", hash = "sha256:76c58b784d1272ecaf0b73a649f186c62799e8176b7a6d5a3d5fb834d333ad15", size = 7994, upload-time = "2026-04-02T19:33:52.404Z" },
 ]
 
 [[package]]
@@ -3595,8 +3670,21 @@ wheels = [
 ]
 
 [[package]]
+name = "xproj"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyproj" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/33/8c2bcceedfa13122916b6a582eedf9581682dbee329d95bcfb4c69542ade/xproj-0.2.1.tar.gz", hash = "sha256:d520c7a0df402f6a5922108ed614c8ea0ce6b04bec12c91aceb75fe3c1d3c5c3", size = 31781, upload-time = "2025-07-07T09:05:48.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/b9/b6a9cf72aef69c3e6db869dcc130e19452a658366dac9377f9cd32a76b80/xproj-0.2.1-py3-none-any.whl", hash = "sha256:d762c540c1bc4abc5955b4034b409b9b2f7733c3e49285f3aeb71f9a2dd6bf34", size = 23837, upload-time = "2025-07-07T09:05:46.889Z" },
+]
+
+[[package]]
 name = "zarr"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "donfig" },
@@ -3606,9 +3694,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/5a/b8a0cf39a14c770c30bd1f2d120c54000c8cd9e84e8e79f38d9a7ce58071/zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb", size = 386531, upload-time = "2026-03-23T17:25:18.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/15/bb13b4913ef95ad5448490821eee4671d0e67673342e4d4070854e5fe081/zarr-3.1.5-py3-none-any.whl", hash = "sha256:29cd905afb6235b94c09decda4258c888fcb79bb6c862ef7c0b8fe009b5c8563", size = 284067, upload-time = "2025-11-21T14:05:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e", size = 295655, upload-time = "2026-03-23T17:25:17.189Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -846,7 +846,7 @@ requires-dist = [
     { name = "titiler-core", specifier = ">=1.2.0" },
     { name = "topozarr", specifier = ">=0.0.6" },
     { name = "uvicorn", specifier = ">=0.41.0" },
-    { name = "zarr", specifier = ">=3.1.6" },
+    { name = "zarr", specifier = ">=3.1.6,<4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Adds GeoZarr-oriented Zarr handling to eo-api, including multiscale (pyramid) store creation and serving adjustments, to better support Zarr browser/clients and GeoZarr metadata conventions.

Adds optional multiscale pyramid output for datasets configured with `cache_info.multiscales`, using topozarr for coarsening and geozarr-toolkit for spatial metadata. Flat zarr stores now also carry GeoZarr attributes (CRS, bbox, shape).

I've checked that borh worldpop (multiscale) and chirps show in Climate Tools and on a map using zarr-layer:

<img width="722" height="555" alt="Screenshot 2026-04-14 at 21 57 21" src="https://github.com/user-attachments/assets/e0402f44-3d85-40a6-9bb7-bcedef727f83" />
<img width="726" height="696" alt="Screenshot 2026-04-14 at 22 17 06" src="https://github.com/user-attachments/assets/44e8ef20-920c-47fb-b72e-3c6180391d98" />
<img width="714" height="511" alt="Screenshot 2026-04-14 at 21 57 44" src="https://github.com/user-attachments/assets/661c2bc7-e0c2-487b-a0d4-5913fdc7b4bb" />
<img width="803" height="698" alt="Screenshot 2026-04-14 at 21 59 44" src="https://github.com/user-attachments/assets/95171ef1-9434-491b-98c8-b95504130b86" />

## Changes

**Pyramid builds (`build_dataset_zarr`)**
- New `multiscales` branch: builds a zarr v3 pyramid via `topozarr.create_pyramid` with configurable levels and aggregation method
- Attaches GeoZarr + OGC Multiscales convention metadata to the store root
- Copies the time coordinate to the zarr root so browser clients (zarr-layer) can discover it without traversing level paths
- `ds.load()` is scoped to the pyramid branch only, keeping the flat path fully lazy to avoid unnecessary RAM usage on large rasters

**Zarr open helpers (`accessor.py`)**
- New public `open_zarr_dataset`: opens flat and pyramid stores uniformly, falling back to `/0` when the root group has no data variables
- New private `_open_zarr`: tries consolidated metadata first (fast for remote stores), falls back to non-consolidated on failure

**pygeoapi publication**
- Pyramid zarr stores are skipped from the pygeoapi config (the xarray provider does not support zarr groups); they are served via the `/zarr` endpoint instead

**Routes**
- Zarr store endpoints now accept HEAD in addition to GET (required by zarr-layer for preflight requests)

**Dataset config**
- WorldPop configured with `multiscales.levels: 4`

## Tests
- New tests covering flat and pyramid zarr builds, time-coordinate root copy, and `open_zarr_dataset` pyramid fallback behaviour