### PR TITLE
docs: set up Material for MkDocs site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - run: pip install -r docs/requirements.txt
+
+      - run: mkdocs gh-deploy --force --no-history

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <circle cx="16" cy="16" r="15" fill="#147cd7"/>
+  <path d="M5 20 Q8 14 11 18 Q14 22 16 13 Q18 4 21 14 Q23 20 27 16"
+        stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="16" cy="13" r="1.8" fill="white"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+---
+template: home.html
+title: Climate API
+hide:
+  - navigation
+  - toc
+---

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,287 @@
+{% extends "main.html" %}
+
+{% block tabs %}{{ super() }}
+
+<section class="home-hero">
+  <div class="home-hero__inner">
+    <p class="home-hero__eyebrow">Part of the DHIS2 Climate ecosystem</p>
+    <h1 class="home-hero__headline">
+      Climate &amp; Earth Observation<br>
+      data infrastructure for DHIS2
+    </h1>
+    <p class="home-hero__sub">
+      Download, process, and publish climate data through open standards.
+      Built for country deployments. Works with DHIS2, CHAP, QGIS,
+      and any OGC-compatible tool.
+    </p>
+    <div class="home-hero__ctas">
+      <a href="setup_guide/" class="home-btn home-btn--primary">Get started</a>
+      <a href="https://github.com/dhis2/climate-api" class="home-btn home-btn--outline">
+        GitHub
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="home-pipeline">
+  <div class="home-section__inner">
+    <h2 class="home-section__title">How it works</h2>
+    <p class="home-section__sub">
+      One platform connects upstream data sources to the tools your teams already use.
+    </p>
+
+    <div class="pipeline-diagram" role="img" aria-label="Climate API data pipeline: sources feed into Climate API which publishes to storage and consumers">
+      <!-- Sources -->
+      <div class="pipeline-col">
+        <p class="pipeline-col__label">Data sources</p>
+        <div class="pipeline-box pipeline-box--source">
+          <span class="pipeline-box__title">CHIRPS3</span>
+          <span class="pipeline-box__sub">Precipitation</span>
+        </div>
+        <div class="pipeline-box pipeline-box--source">
+          <span class="pipeline-box__title">ERA5-Land</span>
+          <span class="pipeline-box__sub">Temperature · Precipitation</span>
+        </div>
+        <div class="pipeline-box pipeline-box--source">
+          <span class="pipeline-box__title">WorldPop</span>
+          <span class="pipeline-box__sub">Population</span>
+        </div>
+        <div class="pipeline-box pipeline-box--source pipeline-box--dashed">
+          <span class="pipeline-box__title">Custom sources</span>
+          <span class="pipeline-box__sub">Any provider</span>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="pipeline-arrow" aria-hidden="true">
+        <svg viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+          <line x1="2" y1="10" x2="32" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <polyline points="24,4 32,10 24,16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+
+      <!-- Climate API -->
+      <div class="pipeline-col pipeline-col--center">
+        <p class="pipeline-col__label">Climate API</p>
+        <div class="pipeline-box pipeline-box--api">
+          <span class="pipeline-box__title">Ingest</span>
+          <span class="pipeline-box__sub">Download for your extent and time range</span>
+        </div>
+        <div class="pipeline-box pipeline-box--api">
+          <span class="pipeline-box__title">Sync</span>
+          <span class="pipeline-box__sub">Keep datasets up to date automatically</span>
+        </div>
+        <div class="pipeline-box pipeline-box--api">
+          <span class="pipeline-box__title">Transform</span>
+          <span class="pipeline-box__sub">Resample, convert units, derive variables</span>
+        </div>
+        <div class="pipeline-box pipeline-box--api">
+          <span class="pipeline-box__title">Publish</span>
+          <span class="pipeline-box__sub">Expose via STAC, OGC API, and GeoZarr</span>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="pipeline-arrow" aria-hidden="true">
+        <svg viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+          <line x1="2" y1="10" x2="32" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <polyline points="24,4 32,10 24,16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+
+      <!-- Storage & access -->
+      <div class="pipeline-col">
+        <p class="pipeline-col__label">Storage &amp; access</p>
+        <div class="pipeline-box pipeline-box--storage">
+          <span class="pipeline-box__title">GeoZarr</span>
+          <span class="pipeline-box__sub">Cloud-native chunked storage</span>
+        </div>
+        <div class="pipeline-box pipeline-box--storage">
+          <span class="pipeline-box__title">STAC catalogue</span>
+          <span class="pipeline-box__sub">Dataset discovery and metadata</span>
+        </div>
+        <div class="pipeline-box pipeline-box--storage">
+          <span class="pipeline-box__title">OGC API</span>
+          <span class="pipeline-box__sub">Standards-based data access</span>
+        </div>
+      </div>
+
+      <!-- Arrow -->
+      <div class="pipeline-arrow" aria-hidden="true">
+        <svg viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+          <line x1="2" y1="10" x2="32" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <polyline points="24,4 32,10 24,16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+
+      <!-- Consumers -->
+      <div class="pipeline-col">
+        <p class="pipeline-col__label">Consumers</p>
+        <div class="pipeline-box pipeline-box--consumer">
+          <span class="pipeline-box__title">DHIS2 Apps</span>
+          <span class="pipeline-box__sub">Maps, Climate, Analytics</span>
+        </div>
+        <div class="pipeline-box pipeline-box--consumer">
+          <span class="pipeline-box__title">CHAP</span>
+          <span class="pipeline-box__sub">Modelling platform</span>
+        </div>
+        <div class="pipeline-box pipeline-box--consumer">
+          <span class="pipeline-box__title">QGIS · xarray</span>
+          <span class="pipeline-box__sub">Any OGC-compatible tool</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="home-features">
+  <div class="home-section__inner">
+    <h2 class="home-section__title">Key capabilities</h2>
+    <div class="features-grid">
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--blue">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <polyline points="12 6 12 12 16 14"/>
+          </svg>
+        </div>
+        <h3>Ingest &amp; sync</h3>
+        <p>Download datasets for any country extent and keep them current. Temporal sync appends only the missing periods, minimising re-download cost.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--green">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <ellipse cx="12" cy="5" rx="9" ry="3"/>
+            <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/>
+            <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
+          </svg>
+        </div>
+        <h3>GeoZarr storage</h3>
+        <p>Datasets are stored as GeoZarr — cloud-native, chunked, and EPSG:4326. Served via HTTP range requests so any client can access individual chunks without downloading the full store.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--teal">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="2" y1="12" x2="22" y2="12"/>
+            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+          </svg>
+        </div>
+        <h3>OGC API standards</h3>
+        <p>Datasets are published via pygeoapi as OGC API — Coverages, EDR, Features, and Collections. Any OGC-compatible client — QGIS, GDAL, web browsers — can access the data without custom integration.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--indigo">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <line x1="8" y1="21" x2="16" y2="21"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </div>
+        <h3>DHIS2 integration</h3>
+        <p>Aggregates raster data to org unit polygons and pushes data values directly to DHIS2. Works with the DHIS2 Maps App, Climate App, and CHAP Modelling Platform out of the box.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--orange">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+          </svg>
+        </div>
+        <h3>Data sovereignty</h3>
+        <p>Deploy on any infrastructure — local, national cloud, or self-hosted. Storage backend is environment-variable configurable. No dependency on proprietary services. Countries retain full control of their data.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-card__icon feature-card__icon--purple">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="16 18 22 12 16 6"/>
+            <polyline points="8 6 2 12 8 18"/>
+          </svg>
+        </div>
+        <h3>Extensible</h3>
+        <p>Add custom dataset sources by writing a download function and a YAML template. Build derived datasets by resampling to any period type. Integrate as a Python library or via the REST API.</p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="home-personas">
+  <div class="home-section__inner">
+    <h2 class="home-section__title">Where do you want to start?</h2>
+    <div class="personas-grid">
+
+      <a href="setup_guide/" class="persona-card">
+        <div class="persona-card__icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+            <polyline points="9 22 9 12 15 12 15 22"/>
+          </svg>
+        </div>
+        <div class="persona-card__body">
+          <h3>Deploying for my country</h3>
+          <p>Set up a Climate API instance, configure your spatial extent, and ingest your first dataset. Supports Docker and pip install.</p>
+          <span class="persona-card__link">Setup guide &rarr;</span>
+        </div>
+      </a>
+
+      <a href="user_guide/" class="persona-card">
+        <div class="persona-card__icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+          </svg>
+        </div>
+        <div class="persona-card__body">
+          <h3>Accessing data from a running instance</h3>
+          <p>Discover datasets via STAC, open GeoZarr stores with xarray, query via OGC API, or visualise in QGIS — no setup required.</p>
+          <span class="persona-card__link">User guide &rarr;</span>
+        </div>
+      </a>
+
+      <a href="adding_custom_datasets/" class="persona-card">
+        <div class="persona-card__icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3"/>
+            <path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14"/>
+          </svg>
+        </div>
+        <div class="persona-card__body">
+          <h3>Building on the platform</h3>
+          <p>Add custom data sources, write processing transforms, or use Climate API as a dependency in your own application.</p>
+          <span class="persona-card__link">Custom datasets &rarr;</span>
+        </div>
+      </a>
+
+    </div>
+  </div>
+</section>
+
+<section class="home-ecosystem">
+  <div class="home-section__inner">
+    <p class="home-ecosystem__label">Part of the DHIS2 Climate ecosystem</p>
+    <div class="ecosystem-links">
+      <a href="https://climate-tools.dhis2.org/" class="ecosystem-link">
+        <span class="ecosystem-link__name">Climate Tools</span>
+        <span class="ecosystem-link__desc">Python tools for climate data access and processing</span>
+      </a>
+      <a href="https://chap.dhis2.org/" class="ecosystem-link">
+        <span class="ecosystem-link__name">CHAP</span>
+        <span class="ecosystem-link__desc">Climate-informed health analytics and modelling</span>
+      </a>
+      <a href="https://dhis2.org/climate/" class="ecosystem-link">
+        <span class="ecosystem-link__name">DHIS2 Climate</span>
+        <span class="ecosystem-link__desc">Climate and health data integration for DHIS2</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+{% endblock %}
+
+{% block content %}{% endblock %}
+{% block footer %}{{ super() }}{% endblock %}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,462 @@
+/* ── DHIS2 brand colours ──────────────────────────────────────────────── */
+
+:root {
+  --dhis2-blue: #147cd7;
+  --dhis2-blue-dark: #0c5fa3;
+  --dhis2-blue-light: #e8f3fc;
+  --dhis2-navy: #1a2741;
+
+  --md-primary-fg-color: var(--dhis2-blue);
+  --md-primary-fg-color--light: #4da3e8;
+  --md-primary-fg-color--dark: var(--dhis2-blue-dark);
+  --md-accent-fg-color: var(--dhis2-blue);
+  --md-accent-fg-color--transparent: rgba(20, 124, 215, 0.1);
+}
+
+[data-md-color-scheme="slate"] {
+  --dhis2-blue-light: rgba(20, 124, 215, 0.15);
+  --dhis2-navy: #0d1b2e;
+}
+
+/* ── Hero section ────────────────────────────────────────────────────── */
+
+.home-hero {
+  background: linear-gradient(150deg, var(--dhis2-navy) 0%, #1a3a5c 60%, #0c5fa3 100%);
+  padding: 5rem 1rem 4rem;
+  text-align: center;
+  color: white;
+}
+
+.home-hero__inner {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.home-hero__eyebrow {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 1.2rem;
+}
+
+.home-hero__headline {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 1.2rem;
+  color: white;
+  border: none;
+}
+
+.home-hero__sub {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.8);
+  margin: 0 auto 2.2rem;
+  max-width: 600px;
+}
+
+.home-hero__ctas {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.home-btn {
+  display: inline-block;
+  padding: 0.7rem 1.8rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.home-btn--primary {
+  background: var(--dhis2-blue);
+  color: white;
+  border: 2px solid var(--dhis2-blue);
+}
+
+.home-btn--primary:hover {
+  background: var(--dhis2-blue-dark);
+  border-color: var(--dhis2-blue-dark);
+  color: white;
+}
+
+.home-btn--outline {
+  background: transparent;
+  color: white;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+
+.home-btn--outline:hover {
+  border-color: white;
+  color: white;
+}
+
+/* ── Shared section styles ───────────────────────────────────────────── */
+
+.home-section__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.home-section__title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 0.6rem;
+  border: none;
+}
+
+.home-section__sub {
+  text-align: center;
+  color: var(--md-default-fg-color--light);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+
+/* ── Pipeline diagram ────────────────────────────────────────────────── */
+
+.home-pipeline {
+  padding: 4rem 1rem;
+  background: var(--md-default-bg-color);
+}
+
+.pipeline-diagram {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.pipeline-col {
+  flex: 1;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pipeline-col__label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--light);
+  text-align: center;
+  margin-bottom: 0.2rem;
+}
+
+.pipeline-arrow {
+  flex-shrink: 0;
+  width: 36px;
+  margin-top: 3.2rem;
+  color: var(--dhis2-blue);
+  opacity: 0.6;
+}
+
+.pipeline-arrow svg {
+  width: 100%;
+  height: auto;
+}
+
+.pipeline-box {
+  display: flex;
+  flex-direction: column;
+  padding: 0.7rem 0.9rem;
+  border-radius: 6px;
+  border: 1.5px solid transparent;
+}
+
+.pipeline-box__title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.pipeline-box__sub {
+  font-size: 0.72rem;
+  line-height: 1.4;
+  margin-top: 0.2rem;
+  opacity: 0.75;
+}
+
+.pipeline-box--source {
+  background: var(--dhis2-blue-light);
+  border-color: rgba(20, 124, 215, 0.3);
+  color: var(--dhis2-blue-dark);
+}
+
+[data-md-color-scheme="slate"] .pipeline-box--source {
+  color: #7ec3f5;
+}
+
+.pipeline-box--source.pipeline-box--dashed {
+  border-style: dashed;
+  opacity: 0.7;
+}
+
+.pipeline-box--api {
+  background: var(--dhis2-blue);
+  border-color: var(--dhis2-blue-dark);
+  color: white;
+}
+
+.pipeline-box--api .pipeline-box__sub {
+  color: rgba(255, 255, 255, 0.8);
+  opacity: 1;
+}
+
+.pipeline-box--storage {
+  background: #f0fdf4;
+  border-color: rgba(22, 163, 74, 0.35);
+  color: #15803d;
+}
+
+[data-md-color-scheme="slate"] .pipeline-box--storage {
+  background: rgba(22, 163, 74, 0.1);
+  color: #4ade80;
+}
+
+.pipeline-box--consumer {
+  background: var(--md-code-bg-color);
+  border-color: var(--md-default-fg-color--lightest);
+  color: var(--md-default-fg-color);
+}
+
+/* ── Feature cards ───────────────────────────────────────────────────── */
+
+.home-features {
+  padding: 4rem 1rem;
+  background: var(--md-code-bg-color);
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.2rem;
+  margin-top: 0.5rem;
+}
+
+.feature-card {
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 1.4rem;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.feature-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  border-color: var(--dhis2-blue);
+}
+
+.feature-card__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.feature-card__icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.feature-card__icon--blue   { background: #e8f3fc; color: var(--dhis2-blue); }
+.feature-card__icon--green  { background: #f0fdf4; color: #16a34a; }
+.feature-card__icon--teal   { background: #f0fdfa; color: #0d9488; }
+.feature-card__icon--indigo { background: #eef2ff; color: #4f46e5; }
+.feature-card__icon--orange { background: #fff7ed; color: #ea580c; }
+.feature-card__icon--purple { background: #faf5ff; color: #9333ea; }
+
+[data-md-color-scheme="slate"] .feature-card__icon--blue   { background: rgba(20, 124, 215, 0.15); }
+[data-md-color-scheme="slate"] .feature-card__icon--green  { background: rgba(22, 163, 74, 0.15); }
+[data-md-color-scheme="slate"] .feature-card__icon--teal   { background: rgba(13, 148, 136, 0.15); }
+[data-md-color-scheme="slate"] .feature-card__icon--indigo { background: rgba(79, 70, 229, 0.15); }
+[data-md-color-scheme="slate"] .feature-card__icon--orange { background: rgba(234, 88, 12, 0.15); }
+[data-md-color-scheme="slate"] .feature-card__icon--purple { background: rgba(147, 51, 234, 0.15); }
+
+.feature-card h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.feature-card p {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+  margin: 0;
+}
+
+/* ── Personas ────────────────────────────────────────────────────────── */
+
+.home-personas {
+  padding: 4rem 1rem;
+  background: var(--md-default-bg-color);
+}
+
+.personas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2rem;
+  margin-top: 0.5rem;
+}
+
+.persona-card {
+  display: flex;
+  gap: 1.1rem;
+  background: var(--md-code-bg-color);
+  border: 1.5px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 1.4rem;
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.persona-card:hover {
+  border-color: var(--dhis2-blue);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  color: var(--md-default-fg-color);
+  text-decoration: none;
+}
+
+.persona-card__icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  background: var(--dhis2-blue-light);
+  color: var(--dhis2-blue);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+[data-md-color-scheme="slate"] .persona-card__icon {
+  background: rgba(20, 124, 215, 0.15);
+}
+
+.persona-card__icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.persona-card__body h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+}
+
+.persona-card__body p {
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+  margin: 0 0 0.8rem;
+}
+
+.persona-card__link {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--dhis2-blue);
+}
+
+/* ── Ecosystem links ─────────────────────────────────────────────────── */
+
+.home-ecosystem {
+  padding: 3rem 1rem;
+  background: var(--dhis2-navy);
+  text-align: center;
+}
+
+[data-md-color-scheme="slate"] .home-ecosystem {
+  background: #0d1b2e;
+}
+
+.home-ecosystem__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 1.5rem;
+}
+
+.ecosystem-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.ecosystem-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-decoration: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  min-width: 180px;
+}
+
+.ecosystem-link:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.ecosystem-link__name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 0.3rem;
+}
+
+.ecosystem-link__desc {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.45);
+  text-align: center;
+  line-height: 1.4;
+}
+
+/* ── Responsive: collapse pipeline on small screens ──────────────────── */
+
+@media (max-width: 768px) {
+  .pipeline-diagram {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pipeline-arrow {
+    display: none;
+  }
+
+  .pipeline-col {
+    border-left: 3px solid var(--dhis2-blue);
+    padding-left: 1rem;
+    margin-left: 0.5rem;
+  }
+
+  .pipeline-col__label {
+    text-align: left;
+  }
+}
+
+/* ── Remove default MkDocs nav bottom padding on home page ───────────── */
+
+.md-content__inner:has(> :first-child:empty) {
+  padding-top: 0;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: Climate API
+site_description: Climate and Earth Observation data infrastructure for DHIS2
+site_url: https://dhis2.github.io/climate-api/
+repo_url: https://github.com/dhis2/climate-api
+repo_name: dhis2/climate-api
+docs_dir: docs
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  icon:
+    repo: fontawesome/brands/github
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+validation:
+  links:
+    not_found: warn
+
+nav:
+  - Home: index.md
+  - Get started: setup_guide.md
+  - Concepts:
+      - Project overview: project_description.md
+      - Implementation status: implementation-status.md
+      - OGC API: ogcapi.md
+  - Guides:
+      - Accessing data: user_guide.md
+      - Adding custom datasets: adding_custom_datasets.md
+      - API reference: managed_data_api_guide.md
+  - Roadmap: roadmap.md


### PR DESCRIPTION
Closes #83

## What's in this PR

Sets up a full documentation site using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/), deployable to GitHub Pages via GitHub Actions.

### New files

| File | Purpose |
|------|---------|
| `mkdocs.yml` | Site config — theme, nav, extensions, DHIS2 brand colours |
| `docs/index.md` | Landing page (uses custom home template) |
| `docs/overrides/home.html` | Custom home template: hero, pipeline diagram, feature cards, persona entry points, ecosystem links |
| `docs/stylesheets/extra.css` | DHIS2 brand colours, all custom layout CSS |
| `docs/assets/logo.svg` | Minimal climate waveform logo |
| `docs/requirements.txt` | Docs dependencies for CI |
| `.github/workflows/docs.yml` | Deploys to GitHub Pages on push to `main` |

### Landing page sections

1. **Hero** — dark navy gradient, headline + tagline + Get started / GitHub CTAs
2. **Pipeline diagram** — five-column layout: Sources → Climate API → Storage & access → Consumers, showing the full data flow as labelled boxes
3. **Feature cards** — six capability cards: Ingest & sync, GeoZarr storage, OGC API standards, DHIS2 integration, Data sovereignty, Extensible
4. **Personas** — three entry points: Deploying for my country, Accessing data, Building on the platform
5. **Ecosystem** — links to Climate Tools, CHAP, and dhis2.org/climate

### Existing docs

All 8 existing `/docs` markdown files are incorporated into the nav under Get started, Concepts, Guides, and Roadmap — no content is duplicated.

### Before this is live on GitHub Pages

Enable GitHub Pages in the repo settings (`Settings → Pages → Source: Deploy from a branch → gh-pages`). The workflow creates the `gh-pages` branch automatically on the first push to `main`.

## Preview

Build locally with:
```bash
pip install -r docs/requirements.txt
mkdocs serve
```