### PR TITLE
fix: scope cache files by extent_id and validate spatial coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,6 @@ CLIMATE_API_CONFIG=./climate-api.yaml
 # See docs/setup_guide.md for registration and .netrc setup instructions.
 
 # ── Download and ingestion ────────────────────────────────────────────────────
-# Legacy override for the download cache directory. Prefer setting data_dir in
-# climate-api.yaml instead. CACHE_OVERRIDE is kept for Docker/CI compatibility.
-# CACHE_OVERRIDE=/path/to/cache
-
 # Fallback bounding box used when a request does not include an explicit bbox.
 # Format: xmin,ymin,xmax,ymax
 # DOWNLOAD_BBOX=-13.5,6.9,-10.1,10.0

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ CLIMATE_API_CONFIG=./climate-api.yaml
 # See docs/setup_guide.md for registration and .netrc setup instructions.
 
 # ── Download and ingestion ────────────────────────────────────────────────────
-# Override the download cache directory (default: data/downloads).
+# Legacy override for the download cache directory. Prefer setting data_dir in
+# climate-api.yaml instead. CACHE_OVERRIDE is kept for Docker/CI compatibility.
 # CACHE_OVERRIDE=/path/to/cache
 
 # Fallback bounding box used when a request does not include an explicit bbox.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ── Instance configuration ────────────────────────────────────────────────────
-# Path to the instance config file (extent, optional datasets_dir).
+# Path to the instance config file (extent, optional templates_dir).
 # Copy the example before editing: cp climate-api.yaml.example climate-api.yaml
 # climate-api.yaml is gitignored so your local extent stays out of version control.
 # When running via `make run` from the repo root, the relative path below works.

--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -10,4 +10,4 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# datasets_dir: ./datasets/   # optional — custom templates merged with built-ins
+# templates_dir: ./templates/   # optional — custom dataset/processing templates merged with built-ins

--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -10,4 +10,4 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# templates_dir: ./templates/   # optional — custom dataset/processing templates merged with built-ins
+# templates_dir: ./templates/   # optional — root for custom templates; datasets go in templates/datasets/

--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -8,4 +8,6 @@ extent:
   bbox: [-13.5, 6.9, -10.1, 10.0]
   country_code: SLE
 
+data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
+
 # datasets_dir: ./datasets/   # optional — custom templates merged with built-ins

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -124,6 +124,22 @@ sync_availability:
 
 `latest_available_function` must accept a `dataset` dict and return a `datetime`. Omit `sync_availability` entirely for `static` datasets or when you always want to sync up to the requested end date.
 
+**Spatial and temporal extents** — declares what the source dataset covers. Used to validate ingest requests before hitting the provider:
+
+```yaml
+extents:
+  spatial:
+    bbox: [-180, -50, 180, 50]   # [xmin, ymin, xmax, ymax] in WGS84
+    crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+  temporal:
+    begin: "1981-01-01"
+    end: "2030-12-31"            # omit if ongoing
+    trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+    resolution: P1D              # ISO 8601 duration: PT1H, P1D, P1M, P1Y
+```
+
+If an ingest request's bounding box has no overlap with `extents.spatial.bbox`, the API returns HTTP 400 immediately. Partial overlap is allowed — the provider will return data for the intersecting area.
+
 **Units**
 
 | Field           | Required | Description |
@@ -151,6 +167,7 @@ extent:
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
 
+data_dir: ./data
 datasets_dir: ./datasets/
 ```
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -2,7 +2,7 @@
 
 This guide explains how to add a new dataset source to your Climate API instance — for example a national meteorological service, a regional satellite product, or a custom model output.
 
-The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `datasets_dir` in your `climate-api.yaml` at a directory containing your own YAML template files.
+The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `templates_dir` in your `climate-api.yaml` at a directory containing your own YAML template files.
 
 ## Overview
 
@@ -159,7 +159,7 @@ ingestion:
 
 ## Step 3: Point the instance at your templates directory
 
-Add `datasets_dir` to your `climate-api.yaml`:
+Add `templates_dir` to your `climate-api.yaml`:
 
 ```yaml
 extent:
@@ -168,10 +168,10 @@ extent:
   bbox: [28.8, -2.9, 30.9, -1.0]
 
 data_dir: ./data
-datasets_dir: ./datasets/
+templates_dir: ./datasets/
 ```
 
-All `*.yaml` and `*.yml` files in `datasets_dir` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
+All `*.yaml` and `*.yml` files in `templates_dir` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
 
 ## Step 4: Ingest and publish
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -159,7 +159,13 @@ ingestion:
 
 ## Step 3: Point the instance at your templates directory
 
-Add `templates_dir` to your `climate-api.yaml`:
+Add `templates_dir` to your `climate-api.yaml` and place your YAML file in the `datasets/` subfolder:
+
+```
+templates/
+└── datasets/
+    └── enacts_rainfall.yaml
+```
 
 ```yaml
 extent:
@@ -168,10 +174,10 @@ extent:
   bbox: [28.8, -2.9, 30.9, -1.0]
 
 data_dir: ./data
-templates_dir: ./datasets/
+templates_dir: ./templates/
 ```
 
-All `*.yaml` and `*.yml` files in `templates_dir` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
+All `*.yaml` and `*.yml` files in `templates_dir/datasets/` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
 
 ## Step 4: Ingest and publish
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -32,6 +32,8 @@ extent:
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
   country_code: RWA
+
+data_dir: ./data
 ```
 
 Field reference:
@@ -42,6 +44,8 @@ Field reference:
 | `name`         | No  | Human-readable name shown in API responses |
 | `bbox`         | Yes | Bounding box as `[xmin, ymin, xmax, ymax]` in WGS84 decimal degrees |
 | `country_code` | No  | ISO 3166-1 alpha-3 code — required for WorldPop downloads |
+
+`data_dir` sets the directory where downloaded NetCDF files and Zarr stores are kept. It is required when a config file is present and is resolved relative to the config file. Each instance must have its own `data_dir` to avoid mixing data between deployments.
 
 To find the bounding box for a country, [bboxfinder.com](http://bboxfinder.com) is a useful tool.
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -200,7 +200,7 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
   }' | jq
 ```
 
-ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by supplying a custom `era5_land.yaml` via `datasets_dir` in your `climate-api.yaml`.
+ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by supplying a custom `era5_land.yaml` via `templates_dir` in your `climate-api.yaml`.
 
 ---
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -200,7 +200,7 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
   }' | jq
 ```
 
-ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by supplying a custom `era5_land.yaml` via `templates_dir` in your `climate-api.yaml`.
+ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by placing a custom `era5_land.yaml` in `templates_dir/datasets/` — see `adding_custom_datasets.md`.
 
 ---
 

--- a/src/climate_api/config.py
+++ b/src/climate_api/config.py
@@ -59,9 +59,12 @@ def _load_config() -> dict[str, Any]:
 
 
 def get_data_dir() -> Path | None:
-    """Return the data directory declared in CLIMATE_API_CONFIG, or None if no config is present.
+    """Return the data directory declared in CLIMATE_API_CONFIG.
 
-    Raises ValueError if a config file is present but data_dir is not set, so
+    Returns None when CLIMATE_API_CONFIG is unset or points to a file that does
+    not exist (e.g. CI environments where the config is gitignored).
+
+    Raises ValueError if the config file exists but data_dir is not set, so
     misconfigured instances fail fast at startup rather than silently sharing
     a default directory with other instances.
 

--- a/src/climate_api/config.py
+++ b/src/climate_api/config.py
@@ -65,8 +65,6 @@ def get_data_dir() -> Path | None:
     misconfigured instances fail fast at startup rather than silently sharing
     a default directory with other instances.
 
-    Callers should check CACHE_OVERRIDE themselves before calling this function;
-    CACHE_OVERRIDE is a legacy escape hatch that bypasses config-level validation.
     """
     config_path = get_config_path()
     if config_path is None or not config_path.exists():

--- a/src/climate_api/config.py
+++ b/src/climate_api/config.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+_MISSING = object()
+
 
 def _substitute_env_vars(text: str) -> str:
     """Replace ${VAR:-default} patterns with values from the environment."""
@@ -54,3 +56,30 @@ def _load_config() -> dict[str, Any]:
         raise ValueError(f"CLIMATE_API_CONFIG must be a YAML mapping at the top level: {path}")
     _cache = dict(loaded or {})
     return _cache
+
+
+def get_data_dir() -> Path | None:
+    """Return the data directory declared in CLIMATE_API_CONFIG, or None if no config is present.
+
+    Raises ValueError if a config file is present but data_dir is not set, so
+    misconfigured instances fail fast at startup rather than silently sharing
+    a default directory with other instances.
+
+    Callers should check CACHE_OVERRIDE themselves before calling this function;
+    CACHE_OVERRIDE is a legacy escape hatch that bypasses config-level validation.
+    """
+    config_path = get_config_path()
+    if config_path is None:
+        return None
+
+    config = get_config()
+    raw = config.get("data_dir", _MISSING)
+    if raw is _MISSING:
+        raise ValueError(
+            "data_dir is required in CLIMATE_API_CONFIG when a config file is present. "
+            "Set it to the directory where downloaded data should be stored, "
+            "e.g. data_dir: ./data"
+        )
+    if not isinstance(raw, (str, Path)):
+        raise ValueError(f"data_dir in CLIMATE_API_CONFIG must be a path string, got {type(raw).__name__}")
+    return (config_path.parent / raw).resolve()

--- a/src/climate_api/config.py
+++ b/src/climate_api/config.py
@@ -69,7 +69,7 @@ def get_data_dir() -> Path | None:
     CACHE_OVERRIDE is a legacy escape hatch that bypasses config-level validation.
     """
     config_path = get_config_path()
-    if config_path is None:
+    if config_path is None or not config_path.exists():
         return None
 
     config = get_config()

--- a/src/climate_api/data/datasets/chirps3.yaml
+++ b/src/climate_api/data/datasets/chirps3.yaml
@@ -7,6 +7,8 @@
   sync_execution: append
   sync_availability:
     latest_available_function: climate_api.providers.availability.chirps3_daily_latest_available
+  coverage:
+    lat: [-50, 50]
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download
   units: mm

--- a/src/climate_api/data/datasets/chirps3.yaml
+++ b/src/climate_api/data/datasets/chirps3.yaml
@@ -13,6 +13,7 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1981-01-01"
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1D
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download

--- a/src/climate_api/data/datasets/chirps3.yaml
+++ b/src/climate_api/data/datasets/chirps3.yaml
@@ -13,8 +13,6 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1981-01-01"
-      end:
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1D
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download

--- a/src/climate_api/data/datasets/chirps3.yaml
+++ b/src/climate_api/data/datasets/chirps3.yaml
@@ -7,8 +7,15 @@
   sync_execution: append
   sync_availability:
     latest_available_function: climate_api.providers.availability.chirps3_daily_latest_available
-  coverage:
-    lat: [-50, 50]
+  extents:
+    spatial:
+      bbox: [-180, -50, 180, 50]
+      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    temporal:
+      begin: "1981-01-01"
+      end:
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+      resolution: P1D
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download
   units: mm

--- a/src/climate_api/data/datasets/era5_land.yaml
+++ b/src/climate_api/data/datasets/era5_land.yaml
@@ -14,8 +14,6 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      end:
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
@@ -46,8 +44,6 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      end:
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download

--- a/src/climate_api/data/datasets/era5_land.yaml
+++ b/src/climate_api/data/datasets/era5_land.yaml
@@ -8,7 +8,16 @@
   sync_availability:
     latest_available_function: climate_api.providers.availability.lagged_latest_available
     lag_hours: 120
-  ingestion: 
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    temporal:
+      begin: "1950-01-01"
+      end:
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+      resolution: PT1H
+  ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
     default_params:
       variables: ['t2m']
@@ -31,7 +40,16 @@
   sync_availability:
     latest_available_function: climate_api.providers.availability.lagged_latest_available
     lag_hours: 120
-  ingestion: 
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    temporal:
+      begin: "1950-01-01"
+      end:
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+      resolution: PT1H
+  ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
     default_params:
       variables: ['tp']

--- a/src/climate_api/data/datasets/era5_land.yaml
+++ b/src/climate_api/data/datasets/era5_land.yaml
@@ -14,6 +14,7 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
@@ -44,6 +45,7 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download

--- a/src/climate_api/data/datasets/worldpop.yaml
+++ b/src/climate_api/data/datasets/worldpop.yaml
@@ -8,6 +8,15 @@
     latest_available_function: climate_api.providers.availability.worldpop_release_latest_available
     # WorldPop projections are intentionally request-driven for future years.
     allow_future: true
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    temporal:
+      begin: "2000"
+      end:
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+      resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download
     multiscales:

--- a/src/climate_api/data/datasets/worldpop.yaml
+++ b/src/climate_api/data/datasets/worldpop.yaml
@@ -14,8 +14,6 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "2000"
-      end:
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download

--- a/src/climate_api/data/datasets/worldpop.yaml
+++ b/src/climate_api/data/datasets/worldpop.yaml
@@ -14,6 +14,7 @@
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "2000"
+      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download

--- a/src/climate_api/data/datasets/worldpop.yaml
+++ b/src/climate_api/data/datasets/worldpop.yaml
@@ -13,7 +13,8 @@
       bbox: [-180, -90, 180, 90]
       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
-      begin: "2000"
+      begin: "2015"
+      end: "2030"
       trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
   ingestion:

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -47,7 +47,6 @@ def download_dataset(
     country_code: str | None,
     overwrite: bool,
     background_tasks: BackgroundTasks | None,
-    extent_id: str | None = None,
 ) -> list[Path]:
     """Download dataset files and return the NetCDF paths created or modified by this run.
 
@@ -60,7 +59,7 @@ def download_dataset(
     ingestion = dataset["ingestion"]
     eo_download_func_path = ingestion["function"]
     eo_download_func = _get_dynamic_function(eo_download_func_path)
-    before_files = {path.resolve(): path.stat().st_mtime_ns for path in get_cache_files(dataset, extent_id=extent_id)}
+    before_files = {path.resolve(): path.stat().st_mtime_ns for path in get_cache_files(dataset)}
 
     params = dict(ingestion.get("default_params", {}))
     params.update(
@@ -68,7 +67,7 @@ def download_dataset(
             "start": start,
             "end": end or datetime.date.today().isoformat(),
             "dirname": DOWNLOAD_DIR,
-            "prefix": _get_cache_prefix(dataset, extent_id=extent_id),
+            "prefix": _get_cache_prefix(dataset),
             "overwrite": overwrite,
         }
     )
@@ -108,21 +107,19 @@ def download_dataset(
         message = str(exc).strip() or "Unexpected error from upstream data provider"
         raise HTTPException(status_code=502, detail=f"Upstream dataset download failed: {message}") from exc
 
-    after_files = [path.resolve() for path in get_cache_files(dataset, extent_id=extent_id)]
+    after_files = [path.resolve() for path in get_cache_files(dataset)]
     changed_files = [
         path for path in after_files if path not in before_files or path.stat().st_mtime_ns != before_files[path]
     ]
     return changed_files
 
 
-def build_dataset_zarr(
-    dataset: dict[str, Any], *, start: str | None = None, end: str | None = None, extent_id: str | None = None
-) -> None:
+def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end: str | None = None) -> None:
     """Collect dataset cache files into one optimised Zarr archive, clipped to request scope."""
     logger.info(f"Optimizing cache for dataset {dataset['id']}")
 
     ingestion = dataset["ingestion"]
-    files = get_cache_files(dataset, extent_id=extent_id)
+    files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
 
@@ -166,7 +163,7 @@ def build_dataset_zarr(
 
     # save as zarr
     logger.info("Saving to optimized zarr file")
-    zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset, extent_id=extent_id)}.zarr"
+    zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
 
     multiscales = dict(ingestion.get("multiscales", {}))
 
@@ -274,21 +271,20 @@ def _compute_time_space_chunks(
     return chunks
 
 
-def _get_cache_prefix(dataset: dict[str, Any], extent_id: str | None = None) -> str:
-    base = str(dataset["id"])
-    return f"{base}_{extent_id}" if extent_id else base
+def _get_cache_prefix(dataset: dict[str, Any]) -> str:
+    return str(dataset["id"])
 
 
-def get_cache_files(dataset: dict[str, Any], extent_id: str | None = None) -> list[Path]:
+def get_cache_files(dataset: dict[str, Any]) -> list[Path]:
     """Return all NetCDF cache files matching this dataset's prefix."""
     # TODO: not bulletproof -- e.g. 2m_temperature matches 2m_temperature_modified
-    prefix = _get_cache_prefix(dataset, extent_id=extent_id)
+    prefix = _get_cache_prefix(dataset)
     return list(DOWNLOAD_DIR.glob(f"{prefix}*.nc"))
 
 
-def get_zarr_path(dataset: dict[str, Any], extent_id: str | None = None) -> Path | None:
+def get_zarr_path(dataset: dict[str, Any]) -> Path | None:
     """Return the optimised zarr archive path if it exists."""
-    prefix = _get_cache_prefix(dataset, extent_id=extent_id)
+    prefix = _get_cache_prefix(dataset)
     optimized = DOWNLOAD_DIR / f"{prefix}.zarr"
     if optimized.exists():
         return optimized

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -46,6 +46,7 @@ def download_dataset(
     country_code: str | None,
     overwrite: bool,
     background_tasks: BackgroundTasks | None,
+    extent_id: str | None = None,
 ) -> list[Path]:
     """Download dataset files and return the NetCDF paths created or modified by this run.
 
@@ -54,10 +55,11 @@ def download_dataset(
     When running in the background-task path, the download is deferred and this function
     returns an empty list because no files have been created yet.
     """
+    _validate_spatial_coverage(dataset, bbox)
     ingestion = dataset["ingestion"]
     eo_download_func_path = ingestion["function"]
     eo_download_func = _get_dynamic_function(eo_download_func_path)
-    before_files = {path.resolve(): path.stat().st_mtime_ns for path in get_cache_files(dataset)}
+    before_files = {path.resolve(): path.stat().st_mtime_ns for path in get_cache_files(dataset, extent_id=extent_id)}
 
     params = dict(ingestion.get("default_params", {}))
     params.update(
@@ -65,7 +67,7 @@ def download_dataset(
             "start": start,
             "end": end or datetime.date.today().isoformat(),
             "dirname": DOWNLOAD_DIR,
-            "prefix": _get_cache_prefix(dataset),
+            "prefix": _get_cache_prefix(dataset, extent_id=extent_id),
             "overwrite": overwrite,
         }
     )
@@ -105,19 +107,21 @@ def download_dataset(
         message = str(exc).strip() or "Unexpected error from upstream data provider"
         raise HTTPException(status_code=502, detail=f"Upstream dataset download failed: {message}") from exc
 
-    after_files = [path.resolve() for path in get_cache_files(dataset)]
+    after_files = [path.resolve() for path in get_cache_files(dataset, extent_id=extent_id)]
     changed_files = [
         path for path in after_files if path not in before_files or path.stat().st_mtime_ns != before_files[path]
     ]
     return changed_files
 
 
-def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end: str | None = None) -> None:
+def build_dataset_zarr(
+    dataset: dict[str, Any], *, start: str | None = None, end: str | None = None, extent_id: str | None = None
+) -> None:
     """Collect dataset cache files into one optimised Zarr archive, clipped to request scope."""
     logger.info(f"Optimizing cache for dataset {dataset['id']}")
 
     ingestion = dataset["ingestion"]
-    files = get_cache_files(dataset)
+    files = get_cache_files(dataset, extent_id=extent_id)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
 
@@ -161,7 +165,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     # save as zarr
     logger.info("Saving to optimized zarr file")
-    zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
+    zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset, extent_id=extent_id)}.zarr"
 
     multiscales = dict(ingestion.get("multiscales", {}))
 
@@ -269,24 +273,57 @@ def _compute_time_space_chunks(
     return chunks
 
 
-def _get_cache_prefix(dataset: dict[str, Any]) -> str:
-    return str(dataset["id"])
+def _get_cache_prefix(dataset: dict[str, Any], extent_id: str | None = None) -> str:
+    base = str(dataset["id"])
+    return f"{base}_{extent_id}" if extent_id else base
 
 
-def get_cache_files(dataset: dict[str, Any]) -> list[Path]:
+def get_cache_files(dataset: dict[str, Any], extent_id: str | None = None) -> list[Path]:
     """Return all NetCDF cache files matching this dataset's prefix."""
     # TODO: not bulletproof -- e.g. 2m_temperature matches 2m_temperature_modified
-    prefix = _get_cache_prefix(dataset)
+    prefix = _get_cache_prefix(dataset, extent_id=extent_id)
     return list(DOWNLOAD_DIR.glob(f"{prefix}*.nc"))
 
 
-def get_zarr_path(dataset: dict[str, Any]) -> Path | None:
+def get_zarr_path(dataset: dict[str, Any], extent_id: str | None = None) -> Path | None:
     """Return the optimised zarr archive path if it exists."""
-    prefix = _get_cache_prefix(dataset)
+    prefix = _get_cache_prefix(dataset, extent_id=extent_id)
     optimized = DOWNLOAD_DIR / f"{prefix}.zarr"
     if optimized.exists():
         return optimized
     return None
+
+
+def _validate_spatial_coverage(dataset: dict[str, Any], bbox: list[float] | None) -> None:
+    """Raise HTTP 400 if the request bbox falls outside the dataset's declared coverage."""
+    coverage = dataset.get("coverage")
+    if not coverage or bbox is None:
+        return
+    xmin, ymin, xmax, ymax = bbox
+    lat_bounds = coverage.get("lat")
+    if lat_bounds is not None:
+        cov_lat_min, cov_lat_max = lat_bounds
+        if ymin > cov_lat_max or ymax < cov_lat_min:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Dataset '{dataset['id']}' does not cover this extent. "
+                    f"Latitude coverage: {cov_lat_min}°–{cov_lat_max}°, "
+                    f"requested: {ymin}°–{ymax}°."
+                ),
+            )
+    lon_bounds = coverage.get("lon")
+    if lon_bounds is not None:
+        cov_lon_min, cov_lon_max = lon_bounds
+        if xmin > cov_lon_max or xmax < cov_lon_min:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Dataset '{dataset['id']}' does not cover this extent. "
+                    f"Longitude coverage: {cov_lon_min}°–{cov_lon_max}°, "
+                    f"requested: {xmin}°–{xmax}°."
+                ),
+            )
 
 
 def _get_dynamic_function(full_path: str) -> Callable[..., Any]:

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -52,7 +52,7 @@ def download_dataset(
     When running in the background-task path, the download is deferred and this function
     returns an empty list because no files have been created yet.
     """
-    _validate_spatial_coverage(dataset, bbox)
+    _validate_spatial_coverage(dataset, bbox if bbox is not None else _bbox_from_env())
     ingestion = dataset["ingestion"]
     eo_download_func_path = ingestion["function"]
     eo_download_func = _get_dynamic_function(eo_download_func_path)
@@ -297,7 +297,7 @@ def _validate_spatial_coverage(dataset: dict[str, Any], bbox: list[float] | None
     if not spatial:
         return
     cov_bbox = spatial.get("bbox")
-    if not cov_bbox:
+    if not isinstance(cov_bbox, (list, tuple)) or len(cov_bbox) != 4:
         return
     cov_xmin, cov_ymin, cov_xmax, cov_ymax = cov_bbox
     xmin, ymin, xmax, ymax = bbox

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -24,9 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_download_dir() -> Path:
-    override = os.getenv("CACHE_OVERRIDE")
-    if override:
-        return Path(override)
     data_dir = api_config.get_data_dir()
     if data_dir is not None:
         return data_dir / "downloads"

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -16,19 +16,20 @@ from fastapi import BackgroundTasks, HTTPException
 from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
+from climate_api import config as api_config
+
 from .utils import get_lon_lat_dims, get_time_dim
 
 logger = logging.getLogger(__name__)
 
 
 def _resolve_download_dir() -> Path:
-    # CACHE_OVERRIDE keeps existing Docker/dev deployments working unchanged.
     override = os.getenv("CACHE_OVERRIDE")
     if override:
         return Path(override)
-    # Default to an XDG-compliant user-writable location so the package works
-    # when installed with pip (where a package-relative path would land inside
-    # site-packages and typically be non-writable).
+    data_dir = api_config.get_data_dir()
+    if data_dir is not None:
+        return data_dir / "downloads"
     xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     return xdg_data / "climate-api" / "downloads"
 

--- a/src/climate_api/data_manager/services/downloader.py
+++ b/src/climate_api/data_manager/services/downloader.py
@@ -295,35 +295,36 @@ def get_zarr_path(dataset: dict[str, Any], extent_id: str | None = None) -> Path
 
 
 def _validate_spatial_coverage(dataset: dict[str, Any], bbox: list[float] | None) -> None:
-    """Raise HTTP 400 if the request bbox falls outside the dataset's declared coverage."""
-    coverage = dataset.get("coverage")
-    if not coverage or bbox is None:
+    """Raise HTTP 400 if the request bbox falls outside the dataset's declared extents."""
+    extents = dataset.get("extents")
+    if not extents or bbox is None:
         return
+    spatial = extents.get("spatial")
+    if not spatial:
+        return
+    cov_bbox = spatial.get("bbox")
+    if not cov_bbox:
+        return
+    cov_xmin, cov_ymin, cov_xmax, cov_ymax = cov_bbox
     xmin, ymin, xmax, ymax = bbox
-    lat_bounds = coverage.get("lat")
-    if lat_bounds is not None:
-        cov_lat_min, cov_lat_max = lat_bounds
-        if ymin > cov_lat_max or ymax < cov_lat_min:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Dataset '{dataset['id']}' does not cover this extent. "
-                    f"Latitude coverage: {cov_lat_min}°–{cov_lat_max}°, "
-                    f"requested: {ymin}°–{ymax}°."
-                ),
-            )
-    lon_bounds = coverage.get("lon")
-    if lon_bounds is not None:
-        cov_lon_min, cov_lon_max = lon_bounds
-        if xmin > cov_lon_max or xmax < cov_lon_min:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Dataset '{dataset['id']}' does not cover this extent. "
-                    f"Longitude coverage: {cov_lon_min}°–{cov_lon_max}°, "
-                    f"requested: {xmin}°–{xmax}°."
-                ),
-            )
+    if ymin > cov_ymax or ymax < cov_ymin:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Dataset '{dataset['id']}' does not cover this extent. "
+                f"Latitude coverage: {cov_ymin}°–{cov_ymax}°, "
+                f"requested: {ymin}°–{ymax}°."
+            ),
+        )
+    if xmin > cov_xmax or xmax < cov_xmin:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Dataset '{dataset['id']}' does not cover this extent. "
+                f"Longitude coverage: {cov_xmin}°–{cov_xmax}°, "
+                f"requested: {xmin}°–{xmax}°."
+            ),
+        )
 
 
 def _get_dynamic_function(full_path: str) -> Callable[..., Any]:

--- a/src/climate_api/data_registry/services/datasets.py
+++ b/src/climate_api/data_registry/services/datasets.py
@@ -23,7 +23,7 @@ def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
 
     Built-in templates from climate_api/data/datasets/ are always loaded. When
-    datasets_dir is set in CLIMATE_API_CONFIG, templates from that directory are
+    templates_dir is set in CLIMATE_API_CONFIG, templates from that directory are
     merged on top — a custom template with the same id overrides the built-in one.
 
     CONFIGS_DIR (test override via monkeypatch) bypasses this and loads only
@@ -34,14 +34,14 @@ def list_datasets() -> list[dict[str, Any]]:
 
     merged: dict[str, dict[str, Any]] = {d["id"]: d for d in _load_builtin_datasets()}
 
-    config_datasets_dir = api_config.get_config().get("datasets_dir")
-    if config_datasets_dir:
-        if not isinstance(config_datasets_dir, (str, Path)):
+    config_templates_dir = api_config.get_config().get("templates_dir")
+    if config_templates_dir:
+        if not isinstance(config_templates_dir, (str, Path)):
             raise ValueError(
-                f"datasets_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_datasets_dir).__name__}"
+                f"templates_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_templates_dir).__name__}"
             )
         config_path = api_config.get_config_path()
-        resolved = (config_path.parent / config_datasets_dir).resolve() if config_path else Path(config_datasets_dir)
+        resolved = (config_path.parent / config_templates_dir).resolve() if config_path else Path(config_templates_dir)
         for dataset in _load_from_dir(resolved):
             merged[dataset["id"]] = dataset
 

--- a/src/climate_api/data_registry/services/datasets.py
+++ b/src/climate_api/data_registry/services/datasets.py
@@ -41,9 +41,11 @@ def list_datasets() -> list[dict[str, Any]]:
                 f"templates_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_templates_dir).__name__}"
             )
         config_path = api_config.get_config_path()
-        resolved = (config_path.parent / config_templates_dir).resolve() if config_path else Path(config_templates_dir)
-        for dataset in _load_from_dir(resolved):
-            merged[dataset["id"]] = dataset
+        root = (config_path.parent / config_templates_dir).resolve() if config_path else Path(config_templates_dir)
+        datasets_subdir = root / "datasets"
+        if datasets_subdir.is_dir():
+            for dataset in _load_from_dir(datasets_subdir):
+                merged[dataset["id"]] = dataset
 
     return list(merged.values())
 

--- a/src/climate_api/ingestions/services.py
+++ b/src/climate_api/ingestions/services.py
@@ -51,9 +51,6 @@ logger = logging.getLogger(__name__)
 def _resolve_artifacts_dir() -> Path:
     from climate_api import config as api_config
 
-    override = os.getenv("CACHE_OVERRIDE")
-    if override:
-        return Path(override) / "artifacts"
     data_dir = api_config.get_data_dir()
     if data_dir is not None:
         return data_dir / "artifacts"

--- a/src/climate_api/ingestions/services.py
+++ b/src/climate_api/ingestions/services.py
@@ -215,13 +215,14 @@ def create_artifact(
         country_code=country_code,
         overwrite=overwrite,
         background_tasks=None,
+        extent_id=extent_id,
     )
     logger.info("Download finished for dataset '%s': changed_files=%d", dataset["id"], len(downloaded_files))
 
     if prefer_zarr or requires_canonical_zarr:
         try:
             logger.info("Building canonical Zarr artifact for dataset '%s'", dataset["id"])
-            downloader.build_dataset_zarr(dataset, start=start, end=end)
+            downloader.build_dataset_zarr(dataset, start=start, end=end, extent_id=extent_id)
             logger.info("Canonical Zarr artifact built for dataset '%s'", dataset["id"])
         except Exception as exc:
             if requires_canonical_zarr:
@@ -241,16 +242,16 @@ def create_artifact(
                 exc_info=True,
             )
 
-    zarr_path = downloader.get_zarr_path(dataset)
+    zarr_path = downloader.get_zarr_path(dataset, extent_id=extent_id)
     if requires_canonical_zarr and zarr_path is None:
         raise HTTPException(
             status_code=500,
             detail="Append sync requires a canonical Zarr artifact, but no Zarr store was produced.",
         )
     cache_files = (
-        downloader.get_cache_files(dataset)
+        downloader.get_cache_files(dataset, extent_id=extent_id)
         if requires_canonical_zarr
-        else downloaded_files or downloader.get_cache_files(dataset)
+        else downloaded_files or downloader.get_cache_files(dataset, extent_id=extent_id)
     )
     primary_path: str | None
 

--- a/src/climate_api/ingestions/services.py
+++ b/src/climate_api/ingestions/services.py
@@ -219,14 +219,13 @@ def create_artifact(
         country_code=country_code,
         overwrite=overwrite,
         background_tasks=None,
-        extent_id=extent_id,
     )
     logger.info("Download finished for dataset '%s': changed_files=%d", dataset["id"], len(downloaded_files))
 
     if prefer_zarr or requires_canonical_zarr:
         try:
             logger.info("Building canonical Zarr artifact for dataset '%s'", dataset["id"])
-            downloader.build_dataset_zarr(dataset, start=start, end=end, extent_id=extent_id)
+            downloader.build_dataset_zarr(dataset, start=start, end=end)
             logger.info("Canonical Zarr artifact built for dataset '%s'", dataset["id"])
         except Exception as exc:
             if requires_canonical_zarr:
@@ -246,16 +245,16 @@ def create_artifact(
                 exc_info=True,
             )
 
-    zarr_path = downloader.get_zarr_path(dataset, extent_id=extent_id)
+    zarr_path = downloader.get_zarr_path(dataset)
     if requires_canonical_zarr and zarr_path is None:
         raise HTTPException(
             status_code=500,
             detail="Append sync requires a canonical Zarr artifact, but no Zarr store was produced.",
         )
     cache_files = (
-        downloader.get_cache_files(dataset, extent_id=extent_id)
+        downloader.get_cache_files(dataset)
         if requires_canonical_zarr
-        else downloaded_files or downloader.get_cache_files(dataset, extent_id=extent_id)
+        else downloaded_files or downloader.get_cache_files(dataset)
     )
     primary_path: str | None
 

--- a/src/climate_api/ingestions/services.py
+++ b/src/climate_api/ingestions/services.py
@@ -49,10 +49,14 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_artifacts_dir() -> Path:
-    # CACHE_OVERRIDE keeps existing Docker/dev deployments working unchanged.
+    from climate_api import config as api_config
+
     override = os.getenv("CACHE_OVERRIDE")
     if override:
         return Path(override) / "artifacts"
+    data_dir = api_config.get_data_dir()
+    if data_dir is not None:
+        return data_dir / "artifacts"
     xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     return xdg_data / "climate-api" / "artifacts"
 

--- a/src/climate_api/publications/services.py
+++ b/src/climate_api/publications/services.py
@@ -19,9 +19,11 @@ from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, Publi
 
 
 def _resolve_pygeoapi_dir() -> Path:
-    override = os.getenv("CACHE_OVERRIDE")
-    if override:
-        return Path(override) / "pygeoapi"
+    from climate_api import config as api_config
+
+    data_dir = api_config.get_data_dir()
+    if data_dir is not None:
+        return data_dir / "pygeoapi"
     xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     return xdg_data / "climate-api" / "pygeoapi"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ extent:
   name: Sierra Leone
   bbox: [-13.5, 6.9, -10.1, 10.0]
   country_code: SLE
+data_dir: ./data
 """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,13 @@ def test_get_data_dir_returns_none_when_no_config(monkeypatch: pytest.MonkeyPatc
     assert get_data_dir() is None
 
 
+def test_get_data_dir_returns_none_when_config_path_set_but_file_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(tmp_path / "nonexistent.yaml"))
+    assert get_data_dir() is None
+
+
 def test_get_data_dir_raises_when_config_present_but_no_data_dir(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,10 +120,10 @@ def test_builtin_datasets_include_chirps_era5_worldpop(monkeypatch: pytest.Monke
     assert "worldpop_population_yearly" in ids
 
 
-def test_datasets_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    datasets_dir = tmp_path / "datasets"
-    datasets_dir.mkdir()
-    (datasets_dir / "custom.yaml").write_text(
+def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    templates_dir = tmp_path / "datasets"
+    templates_dir.mkdir()
+    (templates_dir / "custom.yaml").write_text(
         """
 - id: custom_dataset
   name: Custom dataset
@@ -136,7 +136,7 @@ def test_datasets_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch,
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"datasets_dir: {datasets_dir}\n", encoding="utf-8")
+    config_file.write_text(f"templates_dir: {templates_dir}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -146,18 +146,18 @@ def test_datasets_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch,
     assert "chirps3_precipitation_daily" in ids
 
 
-def test_datasets_dir_resolved_relative_to_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """datasets_dir is resolved relative to the config file, not CWD.
+def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """templates_dir is resolved relative to the config file, not CWD.
 
     This matters when running the installed `climate-api` CLI from a directory
-    other than the repo root, where a relative datasets_dir in the config must
+    other than the repo root, where a relative templates_dir in the config must
     still point at the correct sibling directory.
     """
     deployment_dir = tmp_path / "deployment"
     deployment_dir.mkdir()
-    datasets_dir = deployment_dir / "datasets"
-    datasets_dir.mkdir()
-    (datasets_dir / "custom.yaml").write_text(
+    templates_dir = deployment_dir / "datasets"
+    templates_dir.mkdir()
+    (templates_dir / "custom.yaml").write_text(
         """
 - id: deployed_dataset
   variable: val
@@ -169,7 +169,7 @@ def test_datasets_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monke
         encoding="utf-8",
     )
     config_file = deployment_dir / "climate-api.yaml"
-    config_file.write_text("datasets_dir: ./datasets\n", encoding="utf-8")
+    config_file.write_text("templates_dir: ./datasets\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -178,10 +178,10 @@ def test_datasets_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monke
     assert "deployed_dataset" in ids
 
 
-def test_datasets_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    datasets_dir = tmp_path / "datasets"
-    datasets_dir.mkdir()
-    (datasets_dir / "chirps3.yaml").write_text(
+def test_templates_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    templates_dir = tmp_path / "datasets"
+    templates_dir.mkdir()
+    (templates_dir / "chirps3.yaml").write_text(
         """
 - id: chirps3_precipitation_daily
   name: Custom CHIRPS override
@@ -194,7 +194,7 @@ def test_datasets_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.Monk
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"datasets_dir: {datasets_dir}\n", encoding="utf-8")
+    config_file.write_text(f"templates_dir: {templates_dir}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,31 @@ from pathlib import Path
 
 import pytest
 
-from climate_api.config import get_config
+from climate_api.config import get_config, get_data_dir
 from climate_api.data_registry.services import datasets as dataset_registry
 from climate_api.extents import services as extent_services
+
+
+def test_get_data_dir_returns_none_when_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
+    assert get_data_dir() is None
+
+
+def test_get_data_dir_raises_when_config_present_but_no_data_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("extent:\n  id: nor\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    with pytest.raises(ValueError, match="data_dir is required"):
+        get_data_dir()
+
+
+def test_get_data_dir_resolves_relative_to_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    assert get_data_dir() == tmp_path / "data"
 
 
 def test_get_config_returns_empty_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,9 +121,9 @@ def test_builtin_datasets_include_chirps_era5_worldpop(monkeypatch: pytest.Monke
 
 
 def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    templates_dir = tmp_path / "datasets"
-    templates_dir.mkdir()
-    (templates_dir / "custom.yaml").write_text(
+    datasets_subdir = tmp_path / "templates" / "datasets"
+    datasets_subdir.mkdir(parents=True)
+    (datasets_subdir / "custom.yaml").write_text(
         """
 - id: custom_dataset
   name: Custom dataset
@@ -136,7 +136,7 @@ def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"templates_dir: {templates_dir}\n", encoding="utf-8")
+    config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -154,10 +154,9 @@ def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monk
     still point at the correct sibling directory.
     """
     deployment_dir = tmp_path / "deployment"
-    deployment_dir.mkdir()
-    templates_dir = deployment_dir / "datasets"
-    templates_dir.mkdir()
-    (templates_dir / "custom.yaml").write_text(
+    datasets_subdir = deployment_dir / "templates" / "datasets"
+    datasets_subdir.mkdir(parents=True)
+    (datasets_subdir / "custom.yaml").write_text(
         """
 - id: deployed_dataset
   variable: val
@@ -169,7 +168,7 @@ def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monk
         encoding="utf-8",
     )
     config_file = deployment_dir / "climate-api.yaml"
-    config_file.write_text("templates_dir: ./datasets\n", encoding="utf-8")
+    config_file.write_text("templates_dir: ./templates\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -179,9 +178,9 @@ def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monk
 
 
 def test_templates_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    templates_dir = tmp_path / "datasets"
-    templates_dir.mkdir()
-    (templates_dir / "chirps3.yaml").write_text(
+    datasets_subdir = tmp_path / "templates" / "datasets"
+    datasets_subdir.mkdir(parents=True)
+    (datasets_subdir / "chirps3.yaml").write_text(
         """
 - id: chirps3_precipitation_daily
   name: Custom CHIRPS override
@@ -194,7 +193,7 @@ def test_templates_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.Mon
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"templates_dir: {templates_dir}\n", encoding="utf-8")
+    config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -279,7 +279,7 @@ def test_create_artifact_computes_coverage_from_created_artifact_paths(
     created_file.write_text("dummy", encoding="utf-8")
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     captured: dict[str, object] = {}
@@ -350,7 +350,7 @@ def test_create_artifact_normalizes_request_scope_to_dataset_period(
         return [created_file]
 
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -419,7 +419,7 @@ def test_create_artifact_defaults_omitted_end_to_dataset_native_period_for_downl
 
     monkeypatch.setattr(services, "utc_now", lambda: FixedDateTime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -466,7 +466,7 @@ def test_create_artifact_returns_409_when_downloaded_artifact_has_no_data(
     created_file.write_text("dummy", encoding="utf-8")
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -527,7 +527,7 @@ def test_create_artifact_can_download_delta_while_recording_full_request_scope(
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
     zarr_path_chirps = tmp_path / "chirps3_precipitation_daily.zarr"
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path_chirps)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path_chirps)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -655,8 +655,8 @@ def test_create_artifact_delta_does_not_reuse_netcdf_artifact_when_canonical_zar
     monkeypatch.setattr(services, "_find_existing_artifact", fake_find_existing_artifact)
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
     monkeypatch.setattr(
         services,
         "get_data_coverage_for_paths",
@@ -703,17 +703,15 @@ def test_create_artifact_delta_requires_canonical_zarr_when_prefer_zarr_is_false
 
     captured_build: dict[str, object] = {}
 
-    def fake_build_dataset_zarr(
-        dataset_arg: dict[str, object], *, start: str | None, end: str | None, extent_id: str | None = None
-    ) -> None:
+    def fake_build_dataset_zarr(dataset_arg: dict[str, object], *, start: str | None, end: str | None) -> None:
         captured_build["dataset_id"] = dataset_arg["id"]
         captured_build["start"] = start
         captured_build["end"] = end
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", fake_build_dataset_zarr)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -767,7 +765,7 @@ def test_create_artifact_delta_fails_when_canonical_zarr_build_fails(
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", fail_build_dataset_zarr)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     with pytest.raises(services.HTTPException) as exc_info:
@@ -805,8 +803,8 @@ def test_create_artifact_delta_rejects_short_rebuilt_coverage(
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -526,7 +526,8 @@ def test_create_artifact_can_download_delta_while_recording_full_request_scope(
 
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: tmp_path / "chirps3_precipitation_daily.zarr")
+    zarr_path_chirps = tmp_path / "chirps3_precipitation_daily.zarr"
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path_chirps)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -279,7 +279,7 @@ def test_create_artifact_computes_coverage_from_created_artifact_paths(
     created_file.write_text("dummy", encoding="utf-8")
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     captured: dict[str, object] = {}
@@ -350,7 +350,7 @@ def test_create_artifact_normalizes_request_scope_to_dataset_period(
         return [created_file]
 
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -419,7 +419,7 @@ def test_create_artifact_defaults_omitted_end_to_dataset_native_period_for_downl
 
     monkeypatch.setattr(services, "utc_now", lambda: FixedDateTime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -466,7 +466,7 @@ def test_create_artifact_returns_409_when_downloaded_artifact_has_no_data(
     created_file.write_text("dummy", encoding="utf-8")
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -526,7 +526,7 @@ def test_create_artifact_can_download_delta_while_recording_full_request_scope(
 
     monkeypatch.setattr(services.downloader, "download_dataset", fake_download_dataset)
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: tmp_path / "chirps3_precipitation_daily.zarr")
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: tmp_path / "chirps3_precipitation_daily.zarr")
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -654,8 +654,8 @@ def test_create_artifact_delta_does_not_reuse_netcdf_artifact_when_canonical_zar
     monkeypatch.setattr(services, "_find_existing_artifact", fake_find_existing_artifact)
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
     monkeypatch.setattr(
         services,
         "get_data_coverage_for_paths",
@@ -702,15 +702,17 @@ def test_create_artifact_delta_requires_canonical_zarr_when_prefer_zarr_is_false
 
     captured_build: dict[str, object] = {}
 
-    def fake_build_dataset_zarr(dataset_arg: dict[str, object], *, start: str | None, end: str | None) -> None:
+    def fake_build_dataset_zarr(
+        dataset_arg: dict[str, object], *, start: str | None, end: str | None, extent_id: str | None = None
+    ) -> None:
         captured_build["dataset_id"] = dataset_arg["id"]
         captured_build["start"] = start
         captured_build["end"] = end
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", fake_build_dataset_zarr)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,
@@ -764,7 +766,7 @@ def test_create_artifact_delta_fails_when_canonical_zarr_build_fails(
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", fail_build_dataset_zarr)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: None)
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: None)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     with pytest.raises(services.HTTPException) as exc_info:
@@ -802,8 +804,8 @@ def test_create_artifact_delta_rejects_short_rebuilt_coverage(
 
     monkeypatch.setattr(services.downloader, "download_dataset", lambda *_, **__: [created_file])
     monkeypatch.setattr(services.downloader, "build_dataset_zarr", lambda *_, **__: None)
-    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda _: zarr_path)
-    monkeypatch.setattr(services.downloader, "get_cache_files", lambda _: [created_file])
+    monkeypatch.setattr(services.downloader, "get_zarr_path", lambda dataset, extent_id=None: zarr_path)
+    monkeypatch.setattr(services.downloader, "get_cache_files", lambda dataset, extent_id=None: [created_file])
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(
         services,

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -23,9 +23,19 @@ def test_resolve_download_dir_uses_cache_override(monkeypatch: pytest.MonkeyPatc
         assert downloader._resolve_download_dir() == Path(override)
 
 
-def test_resolve_download_dir_uses_xdg_data_home(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_download_dir_uses_data_dir_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nextent:\n  id: test\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    assert downloader._resolve_download_dir() == tmp_path / "data" / "downloads"
+
+
+def test_resolve_download_dir_uses_xdg_when_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     with tempfile.TemporaryDirectory() as xdg:
         monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
+        monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", xdg)
         assert downloader._resolve_download_dir() == Path(xdg) / "climate-api" / "downloads"
 
@@ -37,9 +47,19 @@ def test_resolve_artifacts_dir_uses_cache_override(monkeypatch: pytest.MonkeyPat
         assert ingestion_services._resolve_artifacts_dir() == Path(override) / "artifacts"
 
 
-def test_resolve_artifacts_dir_uses_xdg_data_home(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_artifacts_dir_uses_data_dir_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nextent:\n  id: test\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    assert ingestion_services._resolve_artifacts_dir() == tmp_path / "data" / "artifacts"
+
+
+def test_resolve_artifacts_dir_uses_xdg_when_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     with tempfile.TemporaryDirectory() as xdg:
         monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
+        monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", xdg)
         assert ingestion_services._resolve_artifacts_dir() == Path(xdg) / "climate-api" / "artifacts"
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -167,26 +167,34 @@ def test_get_cache_prefix_with_extent_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_validate_spatial_coverage_passes_when_no_coverage_declared() -> None:
+_CHIRPS3_EXTENTS: dict[str, Any] = {
+    "spatial": {"bbox": [-180, -50, 180, 50], "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"}
+}
+_LIMITED_LON_EXTENTS: dict[str, Any] = {
+    "spatial": {"bbox": [-180, -90, 60, 90], "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"}
+}
+
+
+def test_validate_spatial_coverage_passes_when_no_extents_declared() -> None:
     dataset: dict[str, Any] = {"id": "worldpop_population_yearly", "ingestion": {}}
     downloader._validate_spatial_coverage(dataset, bbox=[4.5, 57.9, 31.1, 71.2])
 
 
 def test_validate_spatial_coverage_passes_when_no_bbox() -> None:
-    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "coverage": {"lat": [-50, 50]}}
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "extents": _CHIRPS3_EXTENTS}
     downloader._validate_spatial_coverage(dataset, bbox=None)
 
 
-def test_validate_spatial_coverage_passes_when_bbox_inside_coverage() -> None:
-    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "coverage": {"lat": [-50, 50]}}
+def test_validate_spatial_coverage_passes_when_bbox_inside_extents() -> None:
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "extents": _CHIRPS3_EXTENTS}
     downloader._validate_spatial_coverage(dataset, bbox=[-10.0, -10.0, 10.0, 10.0])
 
 
-def test_validate_spatial_coverage_raises_when_bbox_outside_lat_coverage() -> None:
+def test_validate_spatial_coverage_raises_when_bbox_outside_lat_extents() -> None:
     dataset: dict[str, Any] = {
         "id": "chirps3_precipitation_daily",
         "ingestion": {},
-        "coverage": {"lat": [-50, 50]},
+        "extents": _CHIRPS3_EXTENTS,
     }
     with pytest.raises(HTTPException) as exc_info:
         downloader._validate_spatial_coverage(dataset, bbox=[4.5, 57.9, 31.1, 71.2])
@@ -195,11 +203,11 @@ def test_validate_spatial_coverage_raises_when_bbox_outside_lat_coverage() -> No
     assert "Latitude" in str(exc_info.value.detail)
 
 
-def test_validate_spatial_coverage_raises_when_bbox_outside_lon_coverage() -> None:
+def test_validate_spatial_coverage_raises_when_bbox_outside_lon_extents() -> None:
     dataset: dict[str, Any] = {
         "id": "some_dataset",
         "ingestion": {},
-        "coverage": {"lon": [-180, 60]},
+        "extents": _LIMITED_LON_EXTENTS,
     }
     with pytest.raises(HTTPException) as exc_info:
         downloader._validate_spatial_coverage(dataset, bbox=[70.0, -10.0, 90.0, 10.0])
@@ -207,13 +215,13 @@ def test_validate_spatial_coverage_raises_when_bbox_outside_lon_coverage() -> No
     assert "Longitude" in str(exc_info.value.detail)
 
 
-def test_download_dataset_returns_400_when_bbox_outside_dataset_coverage(
+def test_download_dataset_returns_400_when_bbox_outside_dataset_extents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dataset: dict[str, Any] = {
         "id": "chirps3_precipitation_daily",
         "ingestion": {"function": "ignored.path"},
-        "coverage": {"lat": [-50, 50]},
+        "extents": _CHIRPS3_EXTENTS,
     }
 
     with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -182,6 +182,12 @@ def test_validate_spatial_coverage_passes_when_no_bbox() -> None:
     downloader._validate_spatial_coverage(dataset, bbox=None)
 
 
+def test_validate_spatial_coverage_passes_when_template_bbox_malformed() -> None:
+    extents: dict[str, Any] = {"spatial": {"bbox": "not-a-list"}}
+    dataset: dict[str, Any] = {"id": "bad_template", "ingestion": {}, "extents": extents}
+    downloader._validate_spatial_coverage(dataset, bbox=[-10.0, -10.0, 10.0, 10.0])
+
+
 def test_validate_spatial_coverage_passes_when_bbox_inside_extents() -> None:
     dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "extents": _CHIRPS3_EXTENTS}
     downloader._validate_spatial_coverage(dataset, bbox=[-10.0, -10.0, 10.0, 10.0])
@@ -210,6 +216,31 @@ def test_validate_spatial_coverage_raises_when_bbox_outside_lon_extents() -> Non
         downloader._validate_spatial_coverage(dataset, bbox=[70.0, -10.0, 90.0, 10.0])
     assert exc_info.value.status_code == 400
     assert "Longitude" in str(exc_info.value.detail)
+
+
+def test_download_dataset_validates_env_bbox_against_extents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coverage validation uses the env fallback bbox when no bbox is passed in the request."""
+    dataset: dict[str, Any] = {
+        "id": "chirps3_precipitation_daily",
+        "ingestion": {"function": "ignored.path"},
+        "extents": _CHIRPS3_EXTENTS,
+    }
+    monkeypatch.setenv("DOWNLOAD_BBOX", "4.5,57.9,31.1,71.2")
+
+    with pytest.raises(HTTPException) as exc_info:
+        downloader.download_dataset(
+            dataset=dataset,
+            start="2020-01-01",
+            end="2020-01-31",
+            bbox=None,
+            country_code=None,
+            overwrite=False,
+            background_tasks=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "does not cover this extent" in str(exc_info.value.detail)
 
 
 def test_download_dataset_returns_400_when_bbox_outside_dataset_extents(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -168,18 +168,13 @@ def test_download_dataset_returns_502_for_upstream_provider_failure(monkeypatch:
 
 
 # ---------------------------------------------------------------------------
-# _get_cache_prefix — extent_id isolation
+# _get_cache_prefix
 # ---------------------------------------------------------------------------
 
 
-def test_get_cache_prefix_without_extent_id() -> None:
+def test_get_cache_prefix_uses_dataset_id() -> None:
     dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}}
     assert downloader._get_cache_prefix(dataset) == "chirps3_precipitation_daily"
-
-
-def test_get_cache_prefix_with_extent_id() -> None:
-    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}}
-    assert downloader._get_cache_prefix(dataset, extent_id="nor") == "chirps3_precipitation_daily_nor"
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +379,7 @@ def test_build_dataset_zarr_flat_creates_zarr(tmp_path: Path, monkeypatch: pytes
     """Flat zarr is written with the correct variable and no pyramid level dirs."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
 
     downloader.build_dataset_zarr(_FLAT_DATASET)
 
@@ -421,7 +416,7 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: [path])
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: [path])
 
     downloader.build_dataset_zarr(dataset)
 
@@ -457,7 +452,7 @@ def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monke
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: [path])
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: [path])
 
     downloader.build_dataset_zarr(dataset)
 
@@ -485,7 +480,7 @@ def test_build_dataset_zarr_clips_to_requested_daily_range(
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
 
     downloader.build_dataset_zarr(dataset, start="2024-02-01", end="2024-02-10")
 
@@ -515,7 +510,7 @@ def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypa
     """Pyramid zarr build copies the time coordinate to the store root for zarr-layer."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -533,7 +528,7 @@ def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monk
     """open_zarr_dataset returns the dataset from level 0 of the pyramid store."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -557,7 +552,7 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     # Source files use lat/lon (WorldPop-style); canonical names must appear in the written store.
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
 
     received: list[xr.Dataset] = []
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -16,49 +16,31 @@ from climate_api.data_manager.services import downloader
 from climate_api.ingestions import services as ingestion_services
 
 
-def test_resolve_download_dir_uses_cache_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    with tempfile.TemporaryDirectory() as override:
-        monkeypatch.setenv("CACHE_OVERRIDE", override)
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        assert downloader._resolve_download_dir() == Path(override)
-
-
 def test_resolve_download_dir_uses_data_dir_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "climate-api.yaml"
     config_file.write_text("data_dir: ./data\nextent:\n  id: test\n", encoding="utf-8")
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
-    monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     assert downloader._resolve_download_dir() == tmp_path / "data" / "downloads"
 
 
 def test_resolve_download_dir_uses_xdg_when_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     with tempfile.TemporaryDirectory() as xdg:
-        monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
         monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", xdg)
         assert downloader._resolve_download_dir() == Path(xdg) / "climate-api" / "downloads"
-
-
-def test_resolve_artifacts_dir_uses_cache_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    with tempfile.TemporaryDirectory() as override:
-        monkeypatch.setenv("CACHE_OVERRIDE", override)
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        assert ingestion_services._resolve_artifacts_dir() == Path(override) / "artifacts"
 
 
 def test_resolve_artifacts_dir_uses_data_dir_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "climate-api.yaml"
     config_file.write_text("data_dir: ./data\nextent:\n  id: test\n", encoding="utf-8")
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
-    monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     assert ingestion_services._resolve_artifacts_dir() == tmp_path / "data" / "artifacts"
 
 
 def test_resolve_artifacts_dir_uses_xdg_when_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     with tempfile.TemporaryDirectory() as xdg:
-        monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
         monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", xdg)
         assert ingestion_services._resolve_artifacts_dir() == Path(xdg) / "climate-api" / "artifacts"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -148,6 +148,89 @@ def test_download_dataset_returns_502_for_upstream_provider_failure(monkeypatch:
 
 
 # ---------------------------------------------------------------------------
+# _get_cache_prefix — extent_id isolation
+# ---------------------------------------------------------------------------
+
+
+def test_get_cache_prefix_without_extent_id() -> None:
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}}
+    assert downloader._get_cache_prefix(dataset) == "chirps3_precipitation_daily"
+
+
+def test_get_cache_prefix_with_extent_id() -> None:
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}}
+    assert downloader._get_cache_prefix(dataset, extent_id="nor") == "chirps3_precipitation_daily_nor"
+
+
+# ---------------------------------------------------------------------------
+# _validate_spatial_coverage
+# ---------------------------------------------------------------------------
+
+
+def test_validate_spatial_coverage_passes_when_no_coverage_declared() -> None:
+    dataset: dict[str, Any] = {"id": "worldpop_population_yearly", "ingestion": {}}
+    downloader._validate_spatial_coverage(dataset, bbox=[4.5, 57.9, 31.1, 71.2])
+
+
+def test_validate_spatial_coverage_passes_when_no_bbox() -> None:
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "coverage": {"lat": [-50, 50]}}
+    downloader._validate_spatial_coverage(dataset, bbox=None)
+
+
+def test_validate_spatial_coverage_passes_when_bbox_inside_coverage() -> None:
+    dataset: dict[str, Any] = {"id": "chirps3_precipitation_daily", "ingestion": {}, "coverage": {"lat": [-50, 50]}}
+    downloader._validate_spatial_coverage(dataset, bbox=[-10.0, -10.0, 10.0, 10.0])
+
+
+def test_validate_spatial_coverage_raises_when_bbox_outside_lat_coverage() -> None:
+    dataset: dict[str, Any] = {
+        "id": "chirps3_precipitation_daily",
+        "ingestion": {},
+        "coverage": {"lat": [-50, 50]},
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        downloader._validate_spatial_coverage(dataset, bbox=[4.5, 57.9, 31.1, 71.2])
+    assert exc_info.value.status_code == 400
+    assert "does not cover this extent" in str(exc_info.value.detail)
+    assert "Latitude" in str(exc_info.value.detail)
+
+
+def test_validate_spatial_coverage_raises_when_bbox_outside_lon_coverage() -> None:
+    dataset: dict[str, Any] = {
+        "id": "some_dataset",
+        "ingestion": {},
+        "coverage": {"lon": [-180, 60]},
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        downloader._validate_spatial_coverage(dataset, bbox=[70.0, -10.0, 90.0, 10.0])
+    assert exc_info.value.status_code == 400
+    assert "Longitude" in str(exc_info.value.detail)
+
+
+def test_download_dataset_returns_400_when_bbox_outside_dataset_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset: dict[str, Any] = {
+        "id": "chirps3_precipitation_daily",
+        "ingestion": {"function": "ignored.path"},
+        "coverage": {"lat": [-50, 50]},
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        downloader.download_dataset(
+            dataset=dataset,
+            start="2020-01-01",
+            end="2020-01-31",
+            bbox=[4.5, 57.9, 31.1, 71.2],
+            country_code=None,
+            overwrite=False,
+            background_tasks=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "does not cover this extent" in str(exc_info.value.detail)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -273,7 +356,7 @@ def test_build_dataset_zarr_flat_creates_zarr(tmp_path: Path, monkeypatch: pytes
     """Flat zarr is written with the correct variable and no pyramid level dirs."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
 
     downloader.build_dataset_zarr(_FLAT_DATASET)
 
@@ -310,7 +393,7 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: [path])
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: [path])
 
     downloader.build_dataset_zarr(dataset)
 
@@ -346,7 +429,7 @@ def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monke
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: [path])
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: [path])
 
     downloader.build_dataset_zarr(dataset)
 
@@ -374,7 +457,7 @@ def test_build_dataset_zarr_clips_to_requested_daily_range(
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
 
     downloader.build_dataset_zarr(dataset, start="2024-02-01", end="2024-02-10")
 
@@ -404,7 +487,7 @@ def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypa
     """Pyramid zarr build copies the time coordinate to the store root for zarr-layer."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -422,7 +505,7 @@ def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monk
     """open_zarr_dataset returns the dataset from level 0 of the pyramid store."""
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -446,7 +529,7 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     # Source files use lat/lon (WorldPop-style); canonical names must appear in the written store.
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
-    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda dataset, extent_id=None: nc_files)
 
     received: list[xr.Dataset] = []
 

--- a/tests/test_publications.py
+++ b/tests/test_publications.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from climate_api.publications import services
@@ -9,21 +11,21 @@ def test_load_base_config_returns_mapping() -> None:
     assert "server" in config
 
 
-def test_resolve_pygeoapi_dir_uses_cache_override(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+def test_resolve_pygeoapi_dir_uses_data_dir_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from climate_api import config as api_config
+
+    monkeypatch.setattr(api_config, "get_data_dir", lambda: tmp_path / "data")
+    result = services._resolve_pygeoapi_dir()
+    assert result == tmp_path / "data" / "pygeoapi"
+
+
+def test_resolve_pygeoapi_dir_uses_xdg_data_home(monkeypatch: pytest.MonkeyPatch) -> None:
     import tempfile
 
-    with tempfile.TemporaryDirectory() as override:
-        monkeypatch.setenv("CACHE_OVERRIDE", override)
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        result = services._resolve_pygeoapi_dir()
-        assert str(result) == f"{override}/pygeoapi"
+    from climate_api import config as api_config
 
-
-def test_resolve_pygeoapi_dir_uses_xdg_data_home(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
-    import tempfile
-
+    monkeypatch.setattr(api_config, "get_data_dir", lambda: None)
     with tempfile.TemporaryDirectory() as xdg:
-        monkeypatch.delenv("CACHE_OVERRIDE", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", xdg)
         result = services._resolve_pygeoapi_dir()
         assert str(result) == f"{xdg}/climate-api/pygeoapi"


### PR DESCRIPTION
## Breaking changes

- **\`CACHE_OVERRIDE\` env var removed** — deployments using \`CACHE_OVERRIDE\` to set the data directory must migrate to \`data_dir\` in \`climate-api.yaml\`.
- **\`data_dir\` required in \`climate-api.yaml\`** — the API raises \`ValueError\` at startup if a config file is present but \`data_dir\` is not set.
- **\`datasets_dir\` renamed to \`templates_dir\`** — any \`climate-api.yaml\` files using \`datasets_dir\` must be updated.

## Summary

- **Directory isolation per instance**: Each deployment must now declare \`data_dir\` in \`climate-api.yaml\`. This prevents silent data reuse across instances (e.g. WorldPop data for Sierra Leone being served to a Norway instance).
- **Data directory resolution**: \`data_dir\` from config → XDG default (\`~/.local/share/climate-api\`). \`CACHE_OVERRIDE\` is gone.
- **\`templates_dir\` (renamed from \`datasets_dir\`)**: Points at user-supplied YAML templates. The new name reflects that it will cover both dataset and processing templates going forward.
- **Spatial coverage validation**: \`download_dataset\` validates the request bbox against \`extents.spatial.bbox\` before hitting the provider, returning HTTP 400 with a clear message instead of a confusing provider error. Partial overlap is allowed; only fully outside requests are rejected.
- **OGC-aligned extents in dataset templates**: Replaced the custom \`coverage:\` field with an \`extents:\` block matching OGC API Collections (\`extents.spatial.bbox\` in \`[xmin, ymin, xmax, ymax]\` format, \`extents.temporal\` with \`begin\`, \`trs\`, and \`resolution\`). CHIRPS3 gets a restricted spatial bbox of \`[-180, -50, 180, 50]\`.

## Background

Discovered during Norway instance setup: WorldPop data downloaded for Sierra Leone was silently reused for Norway (wrong bounding box), and a CHIRPS3 ingest for Norway returned an HTTP 403 with no clear message. The root fix is directory isolation per instance via \`data_dir\`.

## Test plan

- [x] \`test_get_data_dir_*\` — required field, relative path resolution, no-config fallback
- [x] \`test_resolve_download_dir_*\` / \`test_resolve_artifacts_dir_*\` — config data_dir, XDG fallback
- [x] \`test_get_cache_prefix_uses_dataset_id\`
- [x] \`test_validate_spatial_coverage_*\` — OGC bbox validation cases
- [x] \`test_download_dataset_returns_400_when_bbox_outside_dataset_extents\`
- [x] \`test_templates_dir_*\` — custom template loading, relative path resolution, override by id
- [x] All existing tests pass (164 passed, 1 skipped)