### PR TITLE
feat: rename templates_dir to plugins_dir and add sys.path support for custom modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ── Instance configuration ────────────────────────────────────────────────────
-# Path to the instance config file (extent, optional templates_dir).
+# Path to the instance config file (extent, optional plugins_dir).
 # Copy the example before editing: cp climate-api.yaml.example climate-api.yaml
 # climate-api.yaml is gitignored so your local extent stays out of version control.
 # When running via `make run` from the repo root, the relative path below works.

--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -10,4 +10,4 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# plugins_dir: ./plugins/   # optional — root for custom dataset plugins; YAML templates go in plugins/datasets/
+# plugins_dir: ./plugins/   # optional — plugin root: YAML templates in plugins/datasets/, Python modules importable by dotted path

--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -10,4 +10,4 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# templates_dir: ./templates/   # optional — root for custom templates; datasets go in templates/datasets/
+# plugins_dir: ./plugins/   # optional — root for custom dataset plugins; YAML templates go in plugins/datasets/

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -35,17 +35,26 @@ def list_datasets() -> list[dict[str, Any]]:
 
     merged: dict[str, dict[str, Any]] = {d["id"]: d for d in _load_builtin_datasets()}
 
-    config_plugins_dir = api_config.get_config().get("plugins_dir")
+    config = api_config.get_config()
+    if config.get("templates_dir"):
+        raise ValueError(
+            "CLIMATE_API_CONFIG uses the removed 'templates_dir' key. "
+            "Rename it to 'plugins_dir' and rename the directory from 'templates/' to 'plugins/'."
+        )
+    config_plugins_dir = config.get("plugins_dir")
     if config_plugins_dir:
         if not isinstance(config_plugins_dir, (str, Path)):
             raise ValueError(
                 f"plugins_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_plugins_dir).__name__}"
             )
         config_path = api_config.get_config_path()
-        root = (config_path.parent / config_plugins_dir).resolve() if config_path else Path(config_plugins_dir)
+        base = config_path.parent if config_path else Path()
+        root = (base / config_plugins_dir).resolve()
+        if not root.is_dir():
+            raise ValueError(f"plugins_dir '{root}' does not exist or is not a directory")
         root_str = str(root)
         if root_str not in sys.path:
-            sys.path.insert(0, root_str)
+            sys.path.append(root_str)
         datasets_subdir = root / "datasets"
         if datasets_subdir.is_dir():
             for dataset in _load_from_dir(datasets_subdir):

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -2,6 +2,7 @@
 
 import importlib.resources
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,9 @@ def list_datasets() -> list[dict[str, Any]]:
             )
         config_path = api_config.get_config_path()
         root = (config_path.parent / config_templates_dir).resolve() if config_path else Path(config_templates_dir)
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
         datasets_subdir = root / "datasets"
         if datasets_subdir.is_dir():
             for dataset in _load_from_dir(datasets_subdir):

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -24,7 +24,7 @@ def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
 
     Built-in templates from climate_api/data/datasets/ are always loaded. When
-    templates_dir is set in CLIMATE_API_CONFIG, templates from that directory are
+    plugins_dir is set in CLIMATE_API_CONFIG, templates from that directory are
     merged on top — a custom template with the same id overrides the built-in one.
 
     CONFIGS_DIR (test override via monkeypatch) bypasses this and loads only
@@ -35,14 +35,14 @@ def list_datasets() -> list[dict[str, Any]]:
 
     merged: dict[str, dict[str, Any]] = {d["id"]: d for d in _load_builtin_datasets()}
 
-    config_templates_dir = api_config.get_config().get("templates_dir")
-    if config_templates_dir:
-        if not isinstance(config_templates_dir, (str, Path)):
+    config_plugins_dir = api_config.get_config().get("plugins_dir")
+    if config_plugins_dir:
+        if not isinstance(config_plugins_dir, (str, Path)):
             raise ValueError(
-                f"templates_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_templates_dir).__name__}"
+                f"plugins_dir in CLIMATE_API_CONFIG must be a path string, got {type(config_plugins_dir).__name__}"
             )
         config_path = api_config.get_config_path()
-        root = (config_path.parent / config_templates_dir).resolve() if config_path else Path(config_templates_dir)
+        root = (config_path.parent / config_plugins_dir).resolve() if config_path else Path(config_plugins_dir)
         root_str = str(root)
         if root_str not in sys.path:
             sys.path.insert(0, root_str)

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -2,7 +2,7 @@
 
 This guide explains how to add a new dataset source to your Climate API instance — for example a national meteorological service, a regional satellite product, or a custom model output.
 
-The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `templates_dir` in your `climate-api.yaml` at a directory containing your own YAML template files.
+The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `plugins_dir` in your `climate-api.yaml` at a directory containing your own YAML template files.
 
 ## Overview
 
@@ -157,12 +157,12 @@ ingestion:
     method: mean # aggregation method (default: mean)
 ```
 
-## Step 3: Point the instance at your templates directory
+## Step 3: Point the instance at your plugins directory
 
-Add `templates_dir` to your `climate-api.yaml` and place your YAML file in the `datasets/` subfolder:
+Add `plugins_dir` to your `climate-api.yaml` and place your YAML file in the `datasets/` subfolder:
 
 ```
-templates/
+plugins/
 └── datasets/
     └── enacts_rainfall.yaml
 ```
@@ -174,10 +174,10 @@ extent:
   bbox: [28.8, -2.9, 30.9, -1.0]
 
 data_dir: ./data
-templates_dir: ./templates/
+plugins_dir: ./plugins/
 ```
 
-All `*.yaml` and `*.yml` files in `templates_dir/datasets/` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
+All `*.yaml` and `*.yml` files in `plugins_dir/datasets/` are loaded and merged with the built-in templates (CHIRPS3, ERA5-Land, WorldPop). Custom templates are additive — the built-ins remain available unless you deliberately override one by using the same `id`.
 
 ## Step 4: Ingest and publish
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -2,7 +2,7 @@
 
 This guide explains how to add a new dataset source to your Climate API instance — for example a national meteorological service, a regional satellite product, or a custom model output.
 
-The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `plugins_dir` in your `climate-api.yaml` at a directory containing your own YAML template files.
+The built-in dataset templates (CHIRPS3, ERA5-Land, WorldPop) ship as package data. Custom datasets are layered on top by pointing `plugins_dir` in your `climate-api.yaml` at a plugins directory. That directory serves two purposes: YAML dataset templates go in its `datasets/` subfolder, and Python download modules placed directly under it are importable by their dotted path (e.g. `mypackage.sources.download`) without installing them as a package.
 
 ## Overview
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -200,7 +200,7 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
   }' | jq
 ```
 
-ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by placing a custom `era5_land.yaml` in `templates_dir/datasets/` — see `adding_custom_datasets.md`.
+ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by placing a custom `era5_land.yaml` in `plugins_dir/datasets/` — see `adding_custom_datasets.md`.
 
 ---
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,6 +120,55 @@ def test_builtin_datasets_include_chirps_era5_worldpop(monkeypatch: pytest.Monke
     assert "worldpop_population_yearly" in ids
 
 
+def test_templates_dir_raises_with_migration_hint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")
+    monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+
+    with pytest.raises(ValueError, match="templates_dir"):
+        dataset_registry.list_datasets()
+
+
+def test_plugins_dir_adds_root_to_sys_path_and_makes_modules_importable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plugins_dir = tmp_path / "plugins"
+    pkg_dir = plugins_dir / "myplugin"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "source.py").write_text("VALUE = 42\n", encoding="utf-8")
+    (plugins_dir / "datasets").mkdir()
+    (plugins_dir / "datasets" / "custom.yaml").write_text(
+        """
+- id: plugin_dataset
+  name: Plugin dataset
+  variable: val
+  period_type: daily
+  sync_kind: static
+  ingestion:
+    function: myplugin.source.download
+""",
+        encoding="utf-8",
+    )
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text(f"plugins_dir: {plugins_dir}\n", encoding="utf-8")
+    monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    root_str = str(plugins_dir.resolve())
+    monkeypatch.syspath_prepend("")  # ensure clean sys.path state without the plugins root
+
+    dataset_registry.list_datasets()
+
+    import sys
+
+    assert root_str in sys.path
+    import importlib
+
+    mod = importlib.import_module("myplugin.source")
+    assert mod.VALUE == 42
+
+
 def test_plugins_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     datasets_subdir = tmp_path / "plugins" / "datasets"
     datasets_subdir.mkdir(parents=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,8 +120,8 @@ def test_builtin_datasets_include_chirps_era5_worldpop(monkeypatch: pytest.Monke
     assert "worldpop_population_yearly" in ids
 
 
-def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    datasets_subdir = tmp_path / "templates" / "datasets"
+def test_plugins_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    datasets_subdir = tmp_path / "plugins" / "datasets"
     datasets_subdir.mkdir(parents=True)
     (datasets_subdir / "custom.yaml").write_text(
         """
@@ -136,7 +136,7 @@ def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")
+    config_file.write_text(f"plugins_dir: {tmp_path / 'plugins'}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -146,15 +146,15 @@ def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch
     assert "chirps3_precipitation_daily" in ids
 
 
-def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """templates_dir is resolved relative to the config file, not CWD.
+def test_plugins_dir_resolved_relative_to_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """plugins_dir is resolved relative to the config file, not CWD.
 
     This matters when running the installed `climate-api` CLI from a directory
-    other than the repo root, where a relative templates_dir in the config must
+    other than the repo root, where a relative plugins_dir in the config must
     still point at the correct sibling directory.
     """
     deployment_dir = tmp_path / "deployment"
-    datasets_subdir = deployment_dir / "templates" / "datasets"
+    datasets_subdir = deployment_dir / "plugins" / "datasets"
     datasets_subdir.mkdir(parents=True)
     (datasets_subdir / "custom.yaml").write_text(
         """
@@ -168,7 +168,7 @@ def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monk
         encoding="utf-8",
     )
     config_file = deployment_dir / "climate-api.yaml"
-    config_file.write_text("templates_dir: ./templates\n", encoding="utf-8")
+    config_file.write_text("plugins_dir: ./plugins\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
@@ -177,8 +177,8 @@ def test_templates_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monk
     assert "deployed_dataset" in ids
 
 
-def test_templates_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    datasets_subdir = tmp_path / "templates" / "datasets"
+def test_plugins_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    datasets_subdir = tmp_path / "plugins" / "datasets"
     datasets_subdir.mkdir(parents=True)
     (datasets_subdir / "chirps3.yaml").write_text(
         """
@@ -193,7 +193,7 @@ def test_templates_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.Mon
         encoding="utf-8",
     )
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")
+    config_file.write_text(f"plugins_dir: {tmp_path / 'plugins'}\n", encoding="utf-8")
 
     monkeypatch.setattr(dataset_registry, "CONFIGS_DIR", None)
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))


### PR DESCRIPTION
## Summary

- Renames the `templates_dir` instance config key to `plugins_dir` (and the conventional directory from `templates/` to `plugins/`) to better reflect that the directory holds plugin code and dataset definitions, not Jinja2 templates.
- When `plugins_dir` is set in `CLIMATE_API_CONFIG`, the resolved plugins root is added to `sys.path` (once, idempotently) so that Python can import ingestion functions defined in custom modules under that directory — e.g. `senorge.daily.download` resolves when `senorge/` lives under `plugins/`.

## Breaking change

Rename `templates_dir` to `plugins_dir` in your `climate-api.yaml`, and rename the directory on disk:

```yaml
# before
templates_dir: ./templates/

# after
plugins_dir: ./plugins/
```

Instances that do not use a custom plugins directory are unaffected.

## How the sys.path addition works

The plugins root is resolved in `list_datasets()` when a `plugins_dir` config is present. Adding it to `sys.path` at that point means any dotted module path in an `ingestion.function` field (e.g. `senorge.daily.download`) resolves correctly via the standard import system — no changes required to the ingestion runner or the dynamic function loader.

## Test plan

- [ ] Dataset registry and config tests pass (`tests/test_dataset_registry.py`, `tests/test_config.py`)
- [ ] A custom module placed at `{plugins_dir}/senorge/daily.py` is importable as `senorge.daily` when the Norway instance config is active