### PR TITLE
feat: support instance-configurable CRS for GeoZarr storage

### DIFF
--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -10,4 +10,5 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# templates_dir: ./templates/   # optional — root for custom templates; datasets go in templates/datasets/
+# plugins_dir: ./plugins/   # optional — root for custom dataset plugins; YAML templates go in plugins/datasets/
+# crs: EPSG:4326             # optional — CRS for stored GeoZarr files (default: EPSG:4326); use e.g. EPSG:25833 for UTM33

--- a/climate_api/config.py
+++ b/climate_api/config.py
@@ -67,12 +67,19 @@ def get_crs() -> str:
     Set `crs: EPSG:25833` in climate-api.yaml to store all GeoZarr files in a
     national projection. All datasets within one instance share the same CRS.
     """
+    import pyproj
+
     raw = get_config().get("crs")
     if raw is None:
         return DEFAULT_CRS
-    if not isinstance(raw, str) or not raw:
+    if not isinstance(raw, str) or not raw.strip():
         raise ValueError(f"crs in CLIMATE_API_CONFIG must be a non-empty string, got {type(raw).__name__}")
-    return raw
+    crs = raw.strip()
+    try:
+        pyproj.CRS.from_user_input(crs)
+    except pyproj.exceptions.CRSError as exc:
+        raise ValueError(f"crs '{crs}' in CLIMATE_API_CONFIG is not a valid CRS: {exc}") from exc
+    return crs
 
 
 def get_data_dir() -> Path | None:

--- a/climate_api/config.py
+++ b/climate_api/config.py
@@ -58,6 +58,23 @@ def _load_config() -> dict[str, Any]:
     return _cache
 
 
+DEFAULT_CRS = "EPSG:4326"
+
+
+def get_crs() -> str:
+    """Return the instance CRS from CLIMATE_API_CONFIG, defaulting to EPSG:4326.
+
+    Set `crs: EPSG:25833` in climate-api.yaml to store all GeoZarr files in a
+    national projection. All datasets within one instance share the same CRS.
+    """
+    raw = get_config().get("crs")
+    if raw is None:
+        return DEFAULT_CRS
+    if not isinstance(raw, str) or not raw:
+        raise ValueError(f"crs in CLIMATE_API_CONFIG must be a non-empty string, got {type(raw).__name__}")
+    return raw
+
+
 def get_data_dir() -> Path | None:
     """Return the data directory declared in CLIMATE_API_CONFIG.
 

--- a/climate_api/config.py
+++ b/climate_api/config.py
@@ -67,7 +67,8 @@ def get_crs() -> str:
     Set `crs: EPSG:25833` in climate-api.yaml to store all GeoZarr files in a
     national projection. All datasets within one instance share the same CRS.
     """
-    import pyproj
+    from pyproj import CRS
+    from pyproj.exceptions import CRSError
 
     raw = get_config().get("crs")
     if raw is None:
@@ -76,8 +77,8 @@ def get_crs() -> str:
         raise ValueError(f"crs in CLIMATE_API_CONFIG must be a non-empty string, got {type(raw).__name__}")
     crs = raw.strip()
     try:
-        pyproj.CRS.from_user_input(crs)
-    except pyproj.exceptions.CRSError as exc:
+        CRS.from_user_input(crs)
+    except CRSError as exc:
         raise ValueError(f"crs '{crs}' in CLIMATE_API_CONFIG is not a valid CRS: {exc}") from exc
     return crs
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -33,8 +33,6 @@ def _resolve_download_dir() -> Path:
 
 DOWNLOAD_DIR = _resolve_download_dir()
 
-CRS = "EPSG:4326"
-
 
 def download_dataset(
     dataset: dict[str, Any],
@@ -131,14 +129,17 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     drop_coords = [c for c in ds.coords if c not in keep_coords]
     ds = ds.drop_vars(drop_coords)
 
-    # Normalise to canonical names (time/longitude/latitude) so all stored Zarr files
-    # are consistent regardless of what the upstream source uses (e.g. lon/lat, x/y).
-    # Downstream readers — pygeoapi, the /zarr endpoint, and the client — rely on this.
+    # Normalise to canonical names so all stored Zarr files are consistent.
+    # For WGS84 instances: rename spatial dims to longitude/latitude (degree values).
+    # For other CRS (e.g. UTM): rename to x/y to reflect projected metre coordinates.
+    crs = api_config.get_crs()
+    target_lon = "longitude" if crs == api_config.DEFAULT_CRS else "x"
+    target_lat = "latitude" if crs == api_config.DEFAULT_CRS else "y"
     time_dim = get_time_dim(ds)
-    rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, "longitude"), (lat_dim, "latitude")] if k != v}
+    rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, target_lon), (lat_dim, target_lat)] if k != v}
     if rename_map:
         ds = ds.rename(rename_map)
-    lon_dim, lat_dim = "longitude", "latitude"
+    lon_dim, lat_dim = target_lon, target_lat
     dims = [lon_dim, lat_dim]
 
     ds = _select_time_range(ds, dataset=dataset, start=start, end=end)
@@ -153,7 +154,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     # https://github.com/zarr-developers/geozarr-toolkit/issues/15
     geozarr_attrs = create_geozarr_attrs(
         dimensions=dims,
-        crs=CRS,
+        crs=crs,
         bbox=bbox,
         shape=shape,
     )
@@ -179,7 +180,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         ds.load()
         ds.close()
 
-        ds = ds.proj.assign_crs(spatial_ref=CRS)
+        ds = ds.proj.assign_crs(spatial_ref=crs)
 
         # https://github.com/carbonplan/topozarr/issues/13
         pyramid = create_pyramid(ds, levels=levels, x_dim=lon_dim, y_dim=lat_dim, method=method)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -130,8 +130,6 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     ds = ds.drop_vars(drop_coords)
 
     # Normalise to canonical names so all stored Zarr files are consistent.
-    # For WGS84 instances: rename spatial dims to longitude/latitude (degree values).
-    # For other CRS (e.g. UTM): rename to x/y to reflect projected metre coordinates.
     crs = api_config.get_crs()
     time_dim = get_time_dim(ds)
     rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, "x"), (lat_dim, "y")] if k != v}

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -133,13 +133,11 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     # For WGS84 instances: rename spatial dims to longitude/latitude (degree values).
     # For other CRS (e.g. UTM): rename to x/y to reflect projected metre coordinates.
     crs = api_config.get_crs()
-    target_lon = "longitude" if crs == api_config.DEFAULT_CRS else "x"
-    target_lat = "latitude" if crs == api_config.DEFAULT_CRS else "y"
     time_dim = get_time_dim(ds)
-    rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, target_lon), (lat_dim, target_lat)] if k != v}
+    rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, "x"), (lat_dim, "y")] if k != v}
     if rename_map:
         ds = ds.rename(rename_map)
-    lon_dim, lat_dim = target_lon, target_lat
+    lon_dim, lat_dim = "x", "y"
     dims = [lon_dim, lat_dim]
 
     ds = _select_time_range(ds, dataset=dataset, start=start, end=end)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -423,7 +423,7 @@ def _crs_to_proj4(crs: str) -> str | None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             return pyproj.CRS.from_user_input(crs).to_proj4()
-    except (pyproj.exceptions.CRSError, Exception):
+    except Exception:
         return None
 
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -12,10 +12,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
 
+import pyproj
 from fastapi import HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from starlette.responses import Response
 
+from climate_api import config as api_config
 from climate_api.data_accessor.services.accessor import get_data_coverage_for_paths
 from climate_api.data_manager.services import downloader
 from climate_api.data_registry.services import datasets as registry_datasets
@@ -398,13 +400,40 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     store_root = _get_zarr_root_or_409(artifact)
 
     entries = _zarr_entries(dataset_id=dataset_id, store_root=store_root, directory=store_root)
+    crs = api_config.get_crs()
     return {
         "kind": "ZarrListing",
         "dataset_id": dataset_id,
         "format": artifact.format,
         "path": ".",
+        "crs": crs,
+        "proj4": _crs_to_proj4(crs),
+        "bounds": _read_zarr_bounds(store_root),
         "entries": entries,
     }
+
+
+def _crs_to_proj4(crs: str) -> str:
+    """Convert an EPSG code or WKT string to a proj4 definition string."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return pyproj.CRS.from_user_input(crs).to_proj4()
+
+
+def _read_zarr_bounds(store_root: Path) -> list[float] | None:
+    """Read the spatial:bbox from the zarr store root attributes, if present."""
+    for attrs_file in (store_root / "zarr.json", store_root / ".zattrs"):
+        if attrs_file.exists():
+            attrs = json.loads(attrs_file.read_text(encoding="utf-8"))
+            # zarr v3 stores root attrs under "attributes" key
+            if attrs_file.name == "zarr.json":
+                attrs = attrs.get("attributes", attrs)
+            bbox = attrs.get("spatial:bbox")
+            if isinstance(bbox, list) and len(bbox) == 4:
+                return [float(v) for v in bbox]
+    return None
 
 
 def get_dataset_zarr_store_file_or_404(

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -400,7 +400,8 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     store_root = _get_zarr_root_or_409(artifact)
 
     entries = _zarr_entries(dataset_id=dataset_id, store_root=store_root, directory=store_root)
-    crs = api_config.get_crs()
+    store_attrs = _read_zarr_attrs(store_root)
+    crs = (store_attrs.get("proj:code") if store_attrs else None) or api_config.get_crs()
     return {
         "kind": "ZarrListing",
         "dataset_id": dataset_id,
@@ -408,31 +409,41 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
         "path": ".",
         "crs": crs,
         "proj4": _crs_to_proj4(crs),
-        "bounds": _read_zarr_bounds(store_root),
+        "bounds": _read_zarr_bounds(store_attrs),
         "entries": entries,
     }
 
 
-def _crs_to_proj4(crs: str) -> str:
-    """Convert an EPSG code or WKT string to a proj4 definition string."""
+def _crs_to_proj4(crs: str) -> str | None:
+    """Convert an EPSG code or WKT string to a proj4 definition string, or None on failure."""
     import warnings
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        return pyproj.CRS.from_user_input(crs).to_proj4()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            return pyproj.CRS.from_user_input(crs).to_proj4()
+    except (pyproj.exceptions.CRSError, Exception):
+        return None
 
 
-def _read_zarr_bounds(store_root: Path) -> list[float] | None:
-    """Read the spatial:bbox from the zarr store root attributes, if present."""
+def _read_zarr_attrs(store_root: Path) -> dict[str, object] | None:
+    """Read the root attributes from a Zarr store, normalising v2/v3 layout differences."""
     for attrs_file in (store_root / "zarr.json", store_root / ".zattrs"):
         if attrs_file.exists():
             attrs = json.loads(attrs_file.read_text(encoding="utf-8"))
-            # zarr v3 stores root attrs under "attributes" key
             if attrs_file.name == "zarr.json":
                 attrs = attrs.get("attributes", attrs)
-            bbox = attrs.get("spatial:bbox")
-            if isinstance(bbox, list) and len(bbox) == 4:
-                return [float(v) for v in bbox]
+            return attrs
+    return None
+
+
+def _read_zarr_bounds(store_attrs: dict[str, object] | None) -> list[float] | None:
+    """Extract the spatial:bbox from pre-read zarr store attributes."""
+    if store_attrs is None:
+        return None
+    bbox = store_attrs.get("spatial:bbox")
+    if isinstance(bbox, list) and len(bbox) == 4:
+        return [float(v) for v in bbox]
     return None
 
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -401,7 +401,8 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
 
     entries = _zarr_entries(dataset_id=dataset_id, store_root=store_root, directory=store_root)
     store_attrs = _read_zarr_attrs(store_root)
-    crs = (store_attrs.get("proj:code") if store_attrs else None) or api_config.get_crs()
+    store_crs = store_attrs.get("proj:code") if store_attrs else None
+    crs = store_crs if isinstance(store_crs, str) and store_crs else api_config.get_crs()
     return {
         "kind": "ZarrListing",
         "dataset_id": dataset_id,
@@ -430,9 +431,9 @@ def _read_zarr_attrs(store_root: Path) -> dict[str, object] | None:
     """Read the root attributes from a Zarr store, normalising v2/v3 layout differences."""
     for attrs_file in (store_root / "zarr.json", store_root / ".zattrs"):
         if attrs_file.exists():
-            attrs = json.loads(attrs_file.read_text(encoding="utf-8"))
+            attrs: dict[str, object] = json.loads(attrs_file.read_text(encoding="utf-8"))
             if attrs_file.name == "zarr.json":
-                attrs = attrs.get("attributes", attrs)
+                attrs = attrs.get("attributes", attrs)  # type: ignore[assignment]
             return attrs
     return None
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -52,7 +52,7 @@ def download(
 
 Any extra keyword arguments from `default_params` in the YAML template are forwarded as additional kwargs.
 
-The API normalises coordinate names at write time: `valid_time` → `time`, `lat`/`y` → `latitude`, `lon`/`x` → `longitude`. Using the canonical names in your output avoids any ambiguity, but upstream names are handled automatically.
+The API normalises coordinate names at write time: `valid_time` → `time`, `lat`/`latitude` → `y`, `lon`/`longitude` → `x`. Using the canonical names in your output avoids any ambiguity, but upstream names are handled automatically.
 
 Install your package in the same environment as the Climate API:
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -58,7 +58,7 @@ dataset_id = list_datasets()[0]["id"]
 ds = open_dataset(dataset_id)
 ```
 
-Each dataset has a `time` dimension, `longitude` and `latitude` spatial dimensions, and a data variable matching the variable (e.g. `precip` for CHIRPS, `t2m` for ERA5-Land temperature).
+Each dataset has a `time` dimension, `x` and `y` spatial dimensions, and a data variable matching the variable (e.g. `precip` for CHIRPS, `t2m` for ERA5-Land temperature).
 
 Select the first time step:
 
@@ -71,16 +71,16 @@ Select a spatial point by sampling the centre of the domain:
 
 ```python
 variable = list(ds.data_vars)[0]  # precip, t2m, tp, or pop_total depending on the dataset
-centre_lat = ds.latitude.mean().item()
-centre_lon = ds.longitude.mean().item()
-point = ds.sel(latitude=centre_lat, longitude=centre_lon, method="nearest")
+centre_y = ds.y.mean().item()
+centre_x = ds.x.mean().item()
+point = ds.sel(y=centre_y, x=centre_x, method="nearest")
 print(point[variable].values)
 ```
 
 Compute the spatial mean over the first 10 time steps (slicing first avoids reading the full dataset over HTTP):
 
 ```python
-spatial_mean = ds[variable].isel(time=slice(10)).mean(dim=["latitude", "longitude"])
+spatial_mean = ds[variable].isel(time=slice(10)).mean(dim=["y", "x"])
 print(spatial_mean.to_dataframe())
 ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,6 +140,14 @@ def test_get_crs_raises_for_invalid_value(monkeypatch: pytest.MonkeyPatch, tmp_p
         get_crs()
 
 
+def test_get_crs_raises_for_unknown_epsg_code(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\ncrs: EPSG:999999\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    with pytest.raises(ValueError, match="not a valid CRS"):
+        get_crs()
+
+
 def test_templates_dir_raises_with_migration_hint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_file = tmp_path / "climate-api.yaml"
     config_file.write_text(f"templates_dir: {tmp_path / 'templates'}\n", encoding="utf-8")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from climate_api.config import get_config, get_data_dir
+from climate_api.config import DEFAULT_CRS, get_config, get_crs, get_data_dir
 from climate_api.data_registry.services import datasets as dataset_registry
 from climate_api.extents import services as extent_services
 
@@ -118,6 +118,26 @@ def test_builtin_datasets_include_chirps_era5_worldpop(monkeypatch: pytest.Monke
     assert "era5land_temperature_hourly" in ids
     assert "era5land_precipitation_hourly" in ids
     assert "worldpop_population_yearly" in ids
+
+
+def test_get_crs_defaults_to_wgs84(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
+    assert get_crs() == DEFAULT_CRS
+
+
+def test_get_crs_reads_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\ncrs: EPSG:25833\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    assert get_crs() == "EPSG:25833"
+
+
+def test_get_crs_raises_for_invalid_value(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\ncrs: 42\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    with pytest.raises(ValueError, match="crs in CLIMATE_API_CONFIG must be a non-empty string"):
+        get_crs()
 
 
 def test_templates_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -409,7 +409,7 @@ def test_build_dataset_zarr_flat_creates_zarr(tmp_path: Path, monkeypatch: pytes
 
 
 def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Source coordinates (lat/lon, valid_time, x/y) are renamed to longitude/latitude/time."""
+    """Source coordinates (lat/lon, valid_time) are renamed to x/y/time."""
     # Simulate ERA5-Land source with valid_time and lon/lat
     ds_era5 = xr.Dataset(
         {"t2m": (["valid_time", "lat", "lon"], np.ones((2, 3, 3), dtype="float32"))},
@@ -436,8 +436,8 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
     result = open_zarr_dataset(str(tmp_path / "era5land_temperature_hourly.zarr"))
     try:
         assert "time" in result.coords
-        assert "longitude" in result.coords
-        assert "latitude" in result.coords
+        assert "x" in result.coords
+        assert "y" in result.coords
         assert "valid_time" not in result.coords
         assert "lat" not in result.coords
         assert "lon" not in result.coords
@@ -446,7 +446,7 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
 
 
 def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Source coordinates using x/y spatial names are renamed to longitude/latitude."""
+    """Source coordinates already named x/y are preserved as x/y."""
     ds_xy = xr.Dataset(
         {"precip": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
         coords={
@@ -472,10 +472,8 @@ def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monke
     result = open_zarr_dataset(str(tmp_path / "chirps3_precipitation_daily.zarr"))
     try:
         assert "time" in result.coords
-        assert "longitude" in result.coords
-        assert "latitude" in result.coords
-        assert "x" not in result.coords
-        assert "y" not in result.coords
+        assert "x" in result.coords
+        assert "y" in result.coords
     finally:
         result.close()
 
@@ -514,7 +512,7 @@ def test_build_dataset_zarr_clips_to_requested_daily_range(
 def _make_fake_pyramid(ds: xr.Dataset, zarr_path: Path) -> Pyramid:
     """Return a Pyramid whose .dt.to_zarr writes a minimal two-level DataTree store."""
     level0 = ds
-    level1 = ds.coarsen(latitude=2, longitude=2, boundary="trim").mean()  # pyright: ignore[reportAttributeAccessIssue]
+    level1 = ds.coarsen(y=2, x=2, boundary="trim").mean()  # pyright: ignore[reportAttributeAccessIssue]
     dt = DataTree.from_dict({"0": level0, "1": level1})
     return Pyramid(datatree=dt, encoding={})
 
@@ -561,7 +559,7 @@ def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monk
 def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Pyramid zarr store uses canonical longitude/latitude/time coordinate names."""
+    """Pyramid zarr store uses canonical x/y/time coordinate names."""
     # Source files use lat/lon (WorldPop-style); canonical names must appear in the written store.
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
@@ -580,8 +578,8 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     # The dataset handed to create_pyramid must already carry canonical names.
     assert len(received) == 1
     ds_in = received[0]
-    assert "longitude" in ds_in.coords
-    assert "latitude" in ds_in.coords
+    assert "x" in ds_in.coords
+    assert "y" in ds_in.coords
     assert "time" in ds_in.coords
     assert "lon" not in ds_in.coords
     assert "lat" not in ds_in.coords
@@ -589,8 +587,8 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     # The written store must also expose canonical names when opened.
     result = open_zarr_dataset(str(tmp_path / "my_dataset.zarr"))
     try:
-        assert "longitude" in result.coords
-        assert "latitude" in result.coords
+        assert "x" in result.coords
+        assert "y" in result.coords
         assert "time" in result.coords
     finally:
         result.close()


### PR DESCRIPTION
Closes #90.

## Summary

- Adds `crs` key to `climate-api.yaml` (defaults to `EPSG:4326`, fully backwards-compatible)
- `build_dataset_zarr` reads the instance CRS and writes it into GeoZarr metadata (`proj:code`, `spatial:bbox`) instead of hardcoding WGS84
- Spatial dimensions are always stored as `x`/`y` regardless of CRS — no special-casing for WGS84
- `GET /zarr/{dataset_id}` response includes three new fields: `crs`, `proj4`, and `bounds`, read from the store's own GeoZarr attributes (falls back to instance config) — so clients like zarr-layer can configure on-the-fly reprojection without hard-coding CRS details

## How to use

For a national instance storing data in Norwegian UTM33:

```yaml
# climate-api.yaml
crs: EPSG:25833
```

Download functions for native-CRS datasets (e.g. seNorge in UTM33) can write `x`/`y` coordinates directly — no reprojection needed before saving.

## Breaking change

None. Instances without a `crs` key continue to use `EPSG:4326` and produce identical output.

Note: all Zarr stores now use `x`/`y` as the canonical spatial dimension names (previously `longitude`/`latitude` for WGS84). If downstream clients select by dim name, they will need updating.

## zarr-layer client

The new `proj4` and `bounds` fields in `GET /zarr/{dataset_id}` let the client build layer props dynamically:

```js
const info = await fetch("/zarr/senorge_temperature_daily_nor").then(r => r.json());
const layer = new ZarrLayer({
  source: `/zarr/senorge_temperature_daily_nor`,
  proj4: info.proj4,
  bounds: info.bounds,
  variable: "tg",
  …
});
```

## Test plan

- [x] `tests/test_config.py` — `get_crs()`: default, explicit value, non-string, unknown EPSG code (e.g. `EPSG:999999`) all fail fast with clear errors
- [x] Full test suite passes
- [ ] Norway instance ingests seNorge data in EPSG:25833 without reprojection step
- [ ] `GET /zarr/{dataset_id}` returns `crs`, `proj4`, and `bounds` for a WGS84 dataset