### PR TITLE
feat: add reproject_to_instance_crs transform to zarr build pipeline

### DIFF
--- a/climate_api/data/datasets/chirps3.yaml
+++ b/climate_api/data/datasets/chirps3.yaml
@@ -15,6 +15,8 @@
       begin: "1981-01-01"
       trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1D
+  transforms:
+    - climate_api.transforms.reproject_to_instance_crs
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download
   units: mm

--- a/climate_api/data/datasets/era5_land.yaml
+++ b/climate_api/data/datasets/era5_land.yaml
@@ -22,6 +22,7 @@
       variables: ['t2m']
   transforms:
     - climate_api.transforms.convert_units
+    - climate_api.transforms.reproject_to_instance_crs
   units: kelvin
   convert_units: degC
   resolution: 9 km x 9 km
@@ -56,6 +57,7 @@
   transforms:
     - climate_api.transforms.deaccumulate_era5
     - climate_api.transforms.convert_units
+    - climate_api.transforms.reproject_to_instance_crs
   units: m
   convert_units: mm
   resolution: 9 km x 9 km

--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -17,6 +17,8 @@
       end: "2030"
       trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
+  transforms:
+    - climate_api.transforms.reproject_to_instance_crs
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download
     multiscales:

--- a/climate_api/transforms/__init__.py
+++ b/climate_api/transforms/__init__.py
@@ -8,6 +8,7 @@ Functions can be referenced by their dotted module path in the dataset YAML
 """
 
 from .deaccumulate import deaccumulate_era5
+from .reproject import reproject_to_instance_crs
 from .unit_conversion import convert_units
 
-__all__ = ["convert_units", "deaccumulate_era5"]
+__all__ = ["convert_units", "deaccumulate_era5", "reproject_to_instance_crs"]

--- a/climate_api/transforms/reproject.py
+++ b/climate_api/transforms/reproject.py
@@ -1,0 +1,39 @@
+"""Reprojection transform: reproject a dataset to the instance CRS."""
+
+import logging
+from typing import Any
+
+import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # registers the .rio accessor
+import xarray as xr
+
+from climate_api import config as api_config
+
+logger = logging.getLogger(__name__)
+
+
+def reproject_to_instance_crs(
+    ds: xr.Dataset,
+    dataset: dict[str, Any],
+    *,
+    source_crs: str = "EPSG:4326",
+) -> xr.Dataset:
+    """Reproject dataset from source_crs to the instance CRS.
+
+    No-op when the instance CRS matches source_crs (e.g. a WGS84 instance
+    running a WGS84 source dataset). Override source_crs via the transform's
+    ``params`` dict if your source uses a different input CRS.
+
+    The dataset must already have ``x`` and ``y`` as its spatial dimension names,
+    which is guaranteed by ``build_dataset_zarr`` before transforms are run.
+    """
+    target_crs = api_config.get_crs()
+    if target_crs == source_crs:
+        return ds
+
+    varname = dataset["variable"]
+    logger.info("Reprojecting '%s' from %s to %s", varname, source_crs, target_crs)
+
+    ds = ds.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    ds = ds.rio.write_crs(source_crs)
+    reprojected: xr.Dataset = ds.rio.reproject(target_crs)
+    return reprojected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "zarr>=3.1.6,<4",
     "geozarr-toolkit==0.1.*",
     "topozarr==0.0.*",
+    "rioxarray>=0.17",
 ]
 
 [project.urls]

--- a/tests/test_transforms_reproject.py
+++ b/tests/test_transforms_reproject.py
@@ -1,0 +1,77 @@
+"""Tests for the reproject_to_instance_crs transform."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from climate_api.transforms.reproject import reproject_to_instance_crs
+
+_DATASET: dict[str, Any] = {"id": "test", "variable": "value"}
+
+
+def _make_wgs84_dataset() -> xr.Dataset:
+    """Minimal WGS84 raster dataset with x/y dims in degrees."""
+    return xr.Dataset(
+        {"value": (["time", "y", "x"], np.ones((1, 4, 4), dtype="float32"))},
+        coords={
+            "time": ["2024-01-01"],
+            "y": [60.0, 59.0, 58.0, 57.0],
+            "x": [10.0, 11.0, 12.0, 13.0],
+        },
+    )
+
+
+def test_noop_when_instance_crs_matches_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No reprojection when the instance CRS equals the source CRS."""
+    monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
+    ds = _make_wgs84_dataset()
+    result = reproject_to_instance_crs(ds, _DATASET, source_crs="EPSG:4326")
+    # Dataset returned unchanged — same object, no reprojection called
+    assert result is ds
+
+
+def test_noop_returns_dataset_with_original_coords(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Coordinates remain in degrees when no reprojection is needed."""
+    monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
+    ds = _make_wgs84_dataset()
+    result = reproject_to_instance_crs(ds, _DATASET, source_crs="EPSG:4326")
+    assert float(result.x.max()) == pytest.approx(13.0)
+    assert float(result.y.max()) == pytest.approx(60.0)
+
+
+def test_calls_reproject_with_target_crs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When instance CRS differs from source, rio.reproject is called with the target CRS."""
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\ncrs: EPSG:25833\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+
+    ds = _make_wgs84_dataset()
+    reprojected_ds = _make_wgs84_dataset()
+
+    rio_mock = MagicMock()
+    rio_mock.set_spatial_dims.return_value = ds
+    rio_mock.write_crs.return_value = ds
+    rio_mock.reproject.return_value = reprojected_ds
+
+    with patch.object(type(ds), "rio", new_callable=lambda: property(lambda self: rio_mock)):
+        result = reproject_to_instance_crs(ds, _DATASET, source_crs="EPSG:4326")
+
+    rio_mock.set_spatial_dims.assert_called_once_with(x_dim="x", y_dim="y")
+    rio_mock.write_crs.assert_called_once_with("EPSG:4326")
+    rio_mock.reproject.assert_called_once_with("EPSG:25833")
+    assert result is reprojected_ds
+
+
+def test_skips_reproject_when_source_equals_target(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When source_crs is already the instance CRS, reproject is never called."""
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\ncrs: EPSG:25833\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+
+    ds = _make_wgs84_dataset()
+    result = reproject_to_instance_crs(ds, _DATASET, source_crs="EPSG:25833")
+    assert result is ds

--- a/uv.lock
+++ b/uv.lock
@@ -378,6 +378,7 @@ dependencies = [
     { name = "pygeoapi" },
     { name = "pystac" },
     { name = "python-dotenv" },
+    { name = "rioxarray" },
     { name = "starlette" },
     { name = "topozarr" },
     { name = "uvicorn" },
@@ -408,6 +409,7 @@ requires-dist = [
     { name = "pygeoapi", specifier = ">=0.22.0" },
     { name = "pystac", specifier = ">=1.10,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "rioxarray", specifier = ">=0.17" },
     { name = "starlette", specifier = ">=0.27.0" },
     { name = "topozarr", specifier = "==0.0.*" },
     { name = "uvicorn", specifier = ">=0.41.0" },
@@ -2396,6 +2398,22 @@ wheels = [
 ]
 
 [[package]]
+name = "rioxarray"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyproj" },
+    { name = "rasterio" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/04/9e43477ab0fce7c4c949e1131bfae55ec5228da4ba30f55760660db224b2/rioxarray-0.22.0.tar.gz", hash = "sha256:3f55f23a632ffd9eff13463634227f4afbbcf298947536e161f6cf2ce88d4373", size = 61337, upload-time = "2026-03-06T17:11:00.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/dd/0b2c68495331ba36af783139baaa94693ef310d484d458c11dfa1357287d/rioxarray-0.22.0-py3-none-any.whl", hash = "sha256:db0aa55cd36a95060968f2e6574107829def29d43a563560b90bc642d0bd6a3b", size = 72018, upload-time = "2026-03-06T17:10:58.965Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2802,16 +2820,16 @@ wheels = [
 
 [[package]]
 name = "xarray"
-version = "2025.12.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/af/7b945f331ba8911fdfff2fdfa092763156119f124be1ba4144615c540222/xarray-2025.12.0.tar.gz", hash = "sha256:73f6a6fadccc69c4d45bdd70821a47c72de078a8a0313ff8b1e97cd54ac59fed", size = 3082244, upload-time = "2025-12-05T21:51:22.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/e4/62a677feefde05b12a70a4fc9bdc8558010182a801fbcab68cb56c2b0986/xarray-2025.12.0-py3-none-any.whl", hash = "sha256:9e77e820474dbbe4c6c2954d0da6342aa484e33adaa96ab916b15a786181e970", size = 1381742, upload-time = "2025-12-05T21:51:20.841Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Introduces `climate_api/transforms/reproject.py` with a `reproject_to_instance_crs` transform that reprojects source datasets to the instance CRS using rioxarray during the zarr build pipeline
- The transform is a **no-op** when `source_crs == instance CRS`, so WGS84 instances incur zero overhead
- Wires the transform into `chirps3`, `era5_land` (temperature and precipitation), and `worldpop` dataset YAML templates
- Adds `rioxarray>=0.17` as an explicit dependency (was previously a transitive dep)
- Adds 4 unit tests using a mocked `.rio` accessor to avoid PROJ database conflicts in CI

## Motivation

When an instance is configured with a non-WGS84 CRS (e.g. `EPSG:25833` for Norway), previously ingested datasets would remain in their source CRS (typically WGS84). This PR ensures each ingested zarr is reprojected to the instance CRS at build time, consistent with the `crs` setting introduced in #92.

## Test plan

- [ ] `pytest tests/test_transforms_reproject.py` — all 4 tests pass
- [ ] `make lint` — clean (ruff, mypy, pyright)
- [ ] WGS84 instance: ingest any dataset and confirm no reprojection occurs (no-op path)
- [ ] UTM33 instance (`crs: EPSG:25833`): ingest CHIRPS3 and confirm zarr coordinate values are in metres