### PR TITLE
refactor: rename get_lon_lat_dims to get_x_y_dims

### DIFF
--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -9,7 +9,7 @@ import numpy as np
 import xarray as xr
 
 from ...data_manager.services.downloader import get_cache_files, get_zarr_path
-from ...data_manager.services.utils import get_lon_lat_dims, get_time_dim
+from ...data_manager.services.utils import get_time_dim, get_x_y_dims
 from ...shared.time import numpy_datetime_to_period_string
 
 logger = logging.getLogger(__name__)
@@ -47,11 +47,11 @@ def get_data(
     if bbox is not None:
         logger.info(f"Subsetting xy to {bbox}")
         xmin, ymin, xmax, ymax = list(map(float, bbox))
-        lon_dim, lat_dim = get_lon_lat_dims(ds)
+        x_dim, y_dim = get_x_y_dims(ds)
         # TODO: this assumes y axis increases towards north and is not very stable
         # ...and also does not consider partial pixels at the edges
         # ...should probably switch to rioxarray.clip instead
-        ds = ds.sel(**{lon_dim: slice(xmin, xmax), lat_dim: slice(ymax, ymin)})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        ds = ds.sel(**{x_dim: slice(xmin, xmax), y_dim: slice(ymax, ymin)})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     return ds
 
@@ -134,13 +134,13 @@ def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any
         }
 
     time_dim = get_time_dim(ds)
-    lon_dim, lat_dim = get_lon_lat_dims(ds)
+    x_dim, y_dim = get_x_y_dims(ds)
 
     start = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].min(), period_type))  # type: ignore[arg-type]
     end = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].max(), period_type))  # type: ignore[arg-type]
 
-    xmin, xmax = ds[lon_dim].min().item(), ds[lon_dim].max().item()
-    ymin, ymax = ds[lat_dim].min().item(), ds[lat_dim].max().item()
+    xmin, xmax = ds[x_dim].min().item(), ds[x_dim].max().item()
+    ymin, ymax = ds[y_dim].min().item(), ds[y_dim].max().item()
 
     return {
         "has_data": True,

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -19,7 +19,7 @@ from topozarr.coarsen import create_pyramid
 from climate_api import config as api_config
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
-from .utils import get_lon_lat_dims, get_time_dim
+from .utils import get_time_dim, get_x_y_dims
 
 logger = logging.getLogger(__name__)
 
@@ -119,8 +119,8 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
 
-    lon_dim, lat_dim = get_lon_lat_dims(ds)
-    dims = [lon_dim, lat_dim]
+    x_dim, y_dim = get_x_y_dims(ds)
+    dims = [x_dim, y_dim]
 
     # trim to only minimal vars and coords before loading into memory
     logger.info("Trimming unnecessary variables and coordinates")
@@ -133,11 +133,11 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     # Normalise to canonical names so all stored Zarr files are consistent.
     crs = api_config.get_crs()
     time_dim = get_time_dim(ds)
-    rename_map = {k: v for k, v in [(time_dim, "time"), (lon_dim, "x"), (lat_dim, "y")] if k != v}
+    rename_map = {k: v for k, v in [(time_dim, "time"), (x_dim, "x"), (y_dim, "y")] if k != v}
     if rename_map:
         ds = ds.rename(rename_map)
-    lon_dim, lat_dim = "x", "y"
-    dims = [lon_dim, lat_dim]
+    x_dim, y_dim = "x", "y"
+    dims = [x_dim, y_dim]
 
     ds = _select_time_range(ds, dataset=dataset, start=start, end=end)
     ds = _run_transforms(ds, dataset)
@@ -145,12 +145,12 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     source_crs: str = dataset.get("source_crs", "EPSG:4326")
     ds = reproject_to_instance_crs(ds, dataset, source_crs=source_crs)
 
-    xmin = ds[lon_dim].min().item()
-    xmax = ds[lon_dim].max().item()
-    ymin = ds[lat_dim].min().item()
-    ymax = ds[lat_dim].max().item()
+    xmin = ds[x_dim].min().item()
+    xmax = ds[x_dim].max().item()
+    ymin = ds[y_dim].min().item()
+    ymax = ds[y_dim].max().item()
     bbox = [xmin, ymin, xmax, ymax]
-    shape = (ds.sizes[lon_dim], ds.sizes[lat_dim])
+    shape = (ds.sizes[x_dim], ds.sizes[y_dim])
 
     # https://github.com/zarr-developers/geozarr-toolkit/issues/15
     geozarr_attrs = create_geozarr_attrs(
@@ -184,7 +184,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         ds = ds.proj.assign_crs(spatial_ref=crs)
 
         # https://github.com/carbonplan/topozarr/issues/13
-        pyramid = create_pyramid(ds, levels=levels, x_dim=lon_dim, y_dim=lat_dim, method=method)
+        pyramid = create_pyramid(ds, levels=levels, x_dim=x_dim, y_dim=y_dim, method=method)
 
         pyramid.dt.attrs.update(geozarr_attrs)
         pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
@@ -286,9 +286,9 @@ def _compute_time_space_chunks(
     elif period_type == "yearly":
         chunks[dim] = 1
 
-    lon_dim, lat_dim = get_lon_lat_dims(ds)
-    chunks[lon_dim] = min(ds.sizes[lon_dim], max_spatial_chunk)
-    chunks[lat_dim] = min(ds.sizes[lat_dim], max_spatial_chunk)
+    x_dim, y_dim = get_x_y_dims(ds)
+    chunks[x_dim] = min(ds.sizes[x_dim], max_spatial_chunk)
+    chunks[y_dim] = min(ds.sizes[y_dim], max_spatial_chunk)
 
     return chunks
 

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -11,14 +11,14 @@ def get_time_dim(ds: Any) -> str:
     raise ValueError(f"Unable to find time dimension: {getattr(ds, 'coords', repr(ds))}")
 
 
-def get_lon_lat_dims(ds: Any) -> tuple[str, str]:
-    """Return ``(lon, lat)`` dimension names from a dataset.
+def get_x_y_dims(ds: Any) -> tuple[str, str]:
+    """Return ``(x_dim, y_dim)`` spatial dimension names from a dataset.
 
     Only considers names that are actual dimensions (not 2D auxiliary coordinates),
     so datasets with both x/y dimensions and lon/lat auxiliary coords are handled correctly.
     """
     actual_dims: set[str] = set(getattr(ds, "dims", {}) or {})
-    for lon_name, lat_name in [("x", "y"), ("lon", "lat"), ("longitude", "latitude")]:
-        if lon_name in actual_dims and lat_name in actual_dims:
-            return lon_name, lat_name
+    for x_name, y_name in [("x", "y"), ("lon", "lat"), ("longitude", "latitude")]:
+        if x_name in actual_dims and y_name in actual_dims:
+            return x_name, y_name
     raise ValueError(f"Unable to find space dimension: {getattr(ds, 'coords', repr(ds))}")

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -14,7 +14,7 @@ import xarray as xr
 import yaml
 
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
-from climate_api.data_manager.services.utils import get_lon_lat_dims, get_time_dim
+from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 
 
@@ -165,7 +165,7 @@ def _provider_axes(record: ArtifactRecord) -> tuple[str, str, str]:
         ds = xr.open_dataset(data_path)
 
     try:
-        x_field, y_field = get_lon_lat_dims(ds)
+        x_field, y_field = get_x_y_dims(ds)
         time_field = get_time_dim(ds)
         return x_field, y_field, time_field
     finally:

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, Request
 from xstac import xarray_to_stac
 
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
-from climate_api.data_manager.services.utils import get_lon_lat_dims, get_time_dim
+from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
@@ -200,7 +200,7 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
             detail=f"Published Zarr store for artifact '{artifact.artifact_id}' is temporarily unavailable",
         ) from exc
     try:
-        x_dimension, y_dimension = get_lon_lat_dims(ds)
+        x_dimension, y_dimension = get_x_y_dims(ds)
         time_dimension = get_time_dim(ds)
         result = xarray_to_stac(
             ds,

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -428,7 +428,7 @@ def test_build_collection_with_xstac_normalizes_pystac_collection(
     )
     template.add_asset("zarr", pystac.Asset(href="http://example.test/zarr"))
     monkeypatch.setattr(stac_services, "open_zarr_dataset", lambda _: DummyDataset())
-    monkeypatch.setattr(stac_services, "get_lon_lat_dims", lambda _: ("x", "y"))
+    monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
     monkeypatch.setattr(stac_services, "xarray_to_stac", lambda *args, **kwargs: template)
 
@@ -470,7 +470,7 @@ def test_collection_reuses_cached_xstac_payload(
     )
     monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
     monkeypatch.setattr(stac_services, "open_zarr_dataset", fake_open)
-    monkeypatch.setattr(stac_services, "get_lon_lat_dims", lambda _: ("x", "y"))
+    monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
     monkeypatch.setattr(stac_services, "xarray_to_stac", fake_xarray_to_stac)
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
@@ -519,7 +519,7 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
     )
     monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
     monkeypatch.setattr(stac_services, "open_zarr_dataset", lambda _: DummyDataset())
-    monkeypatch.setattr(stac_services, "get_lon_lat_dims", lambda _: ("x", "y"))
+    monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
 
     def fake_xarray_to_stac(*args: object, **kwargs: object) -> pystac.Collection:


### PR DESCRIPTION
## Summary

- Renames `get_lon_lat_dims` → `get_x_y_dims` across all callers
- Updates unpacked variable names from `lon_dim`/`lat_dim` → `x_dim`/`y_dim` in `downloader.py` and `accessor.py`
- Updates monkeypatches in `test_stac.py`

The rename follows the fix in #560ce1b which changed the function to check actual dataset dimensions (not auxiliary coord names) and to prioritise `x`/`y` over `lon`/`lat`. Calling it `get_lon_lat_dims` was misleading — for seNorge and CHIRPS3 it returns `("x", "y")`, not anything lon/lat-named.

No behaviour change.