### PR TITLE
feat: auto-detect pyramid zarr from data dimensions, remove multiscales YAML config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,9 @@ Each YAML in `data/datasets/` defines a dataset template. The `ingestion` block 
 ingestion:
   function: dhis2eo.data.worldpop.pop_total.yearly.download
   default_params: {} # passed to the download function
-  multiscales: # optional — triggers pyramid build
-    levels: 4
-    method: mean
 ```
 
-If `multiscales` is present, `build_dataset_zarr` builds a multiscale Zarr pyramid. Otherwise it writes a flat chunked zarr with auto-computed chunk sizes tuned to the dataset's `period_type`.
+`build_dataset_zarr` automatically builds a multiscale Zarr pyramid when the spatial dimensions exceed 2048×2048 pixels. Otherwise it writes a flat chunked zarr with auto-computed chunk sizes tuned to the dataset's `period_type`.
 
 ## pygeoapi
 

--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -20,8 +20,6 @@
       resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download
-    multiscales:
-      levels: 4
     default_params:
       version: global2
   units: people

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -114,7 +114,6 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     """Collect dataset cache files into one optimised Zarr archive, clipped to request scope."""
     logger.info(f"Optimizing cache for dataset {dataset['id']}")
 
-    ingestion = dataset["ingestion"]
     files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
     ds = xr.open_mfdataset(files)
@@ -166,7 +165,6 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     if _needs_pyramid(ds, lon_dim, lat_dim):
         levels = _pyramid_levels(ds, lon_dim, lat_dim)
-        method = ingestion.get("pyramid_method", "mean")
         logger.info("Building %d-level pyramid (max dim %d pixels)", levels, max(ds.sizes[lon_dim], ds.sizes[lat_dim]))
 
         # Add multiscales convention metadata to the zarr attributes
@@ -183,7 +181,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         ds = ds.proj.assign_crs(spatial_ref=crs)
 
         # https://github.com/carbonplan/topozarr/issues/13
-        pyramid = create_pyramid(ds, levels=levels, x_dim=lon_dim, y_dim=lat_dim, method=method)
+        pyramid = create_pyramid(ds, levels=levels, x_dim=lon_dim, y_dim=lat_dim, method="mean")
 
         pyramid.dt.attrs.update(geozarr_attrs)
         pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -164,11 +164,10 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     logger.info("Saving to optimized zarr file")
     zarr_path = DOWNLOAD_DIR / f"{_get_cache_prefix(dataset)}.zarr"
 
-    multiscales = dict(ingestion.get("multiscales", {}))
-
-    if multiscales:
-        levels = multiscales.get("levels", 4)
-        method = multiscales.get("method", "mean")
+    if _needs_pyramid(ds, lon_dim, lat_dim):
+        levels = _pyramid_levels(ds, lon_dim, lat_dim)
+        method = ingestion.get("pyramid_method", "mean")
+        logger.info("Building %d-level pyramid (max dim %d pixels)", levels, max(ds.sizes[lon_dim], ds.sizes[lat_dim]))
 
         # Add multiscales convention metadata to the zarr attributes
         zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
@@ -202,8 +201,8 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         pyramid.dt.close()
 
     else:
+        logger.info("Building flat zarr (max dim %d pixels)", max(ds.sizes[lon_dim], ds.sizes[lat_dim]))
         # determine optimal chunk sizes
-        logger.info("Determining optimal chunk size for zarr archive")
         ds_autochunk = ds.chunk("auto").unify_chunks()
         uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
         time_space_chunks = _compute_time_space_chunks(ds, dataset)
@@ -217,6 +216,25 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     ds.close()
     logger.info("Finished cache optimization")
+
+
+_PYRAMID_PIXEL_THRESHOLD = 2048 * 2048
+_PYRAMID_MAX_LEVELS = 8
+_PYRAMID_TARGET_TILE_SIZE = 512
+
+
+def _needs_pyramid(ds: xr.Dataset, x_dim: str, y_dim: str) -> bool:
+    """Return True when the spatial extent is large enough to benefit from a pyramid."""
+    return ds.sizes[x_dim] * ds.sizes[y_dim] > _PYRAMID_PIXEL_THRESHOLD
+
+
+def _pyramid_levels(ds: xr.Dataset, x_dim: str, y_dim: str) -> int:
+    """Compute the number of pyramid levels needed to reach a manageable tile size."""
+    import math
+
+    max_dim = max(ds.sizes[x_dim], ds.sizes[y_dim])
+    levels = math.ceil(math.log2(max_dim / _PYRAMID_TARGET_TILE_SIZE))
+    return max(2, min(levels, _PYRAMID_MAX_LEVELS))
 
 
 def _select_time_range(

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -109,7 +109,7 @@ def plan_sync(
                 target_end=latest_available_end,
                 target_end_source=target_end_source,
             )
-        action = SyncAction.APPEND if _supports_append(source_dataset) else SyncAction.REMATERIALIZE
+        action = SyncAction.APPEND if _supports_append(source_dataset, latest_artifact) else SyncAction.REMATERIALIZE
         reason = "new_periods_available_for_append" if action == SyncAction.APPEND else "new_periods_available"
         return SyncDetail(
             source_dataset_id=latest_artifact.dataset_id,
@@ -365,18 +365,18 @@ def _latest_available_end(*, source_dataset: dict[str, Any], requested_end: str)
     )
 
 
-def _supports_append(source_dataset: dict[str, Any]) -> bool:
+def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRecord) -> bool:
     """Return whether this template opts into V1 delta-download sync execution."""
+    from pathlib import Path
+
     if source_dataset.get("sync", {}).get("execution") != SyncAction.APPEND.value:
         return False
-    ingestion = source_dataset.get("ingestion")
-    if not isinstance(ingestion, dict):
-        return False
-    # Multiscale stores are rebuilt as pyramids today; keep append opt-in to flat
-    # canonical stores until pyramid delta behavior is explicitly designed.
-    if ingestion.get("multiscales"):
+    # Pyramid zarr stores cannot be appended to — they must be rebuilt in full.
+    # Detect this from the existing artifact's on-disk structure rather than YAML.
+    artifact_path = latest_artifact.path
+    if artifact_path and (Path(artifact_path) / "0").exists():
         logger.warning(
-            "Sync append execution is not supported for multiscale dataset '%s'; falling back to rematerialize",
+            "Sync append execution is not supported for pyramid zarr dataset '%s'; falling back to rematerialize",
             source_dataset.get("id", "<unknown>"),
         )
         return False

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -292,12 +292,17 @@ def _public_zarr_asset_href(
     artifact: ArtifactRecord,
     source_dataset: dict[str, Any],
 ) -> str:
-    ingestion = source_dataset.get("ingestion")
-    # Use dataset-template multiscale metadata so local and remote stores map to
-    # the same public href contract without filesystem probing.
-    if isinstance(ingestion, dict) and ingestion.get("multiscales"):
+    artifact_path = _artifact_store_path(artifact)
+    if _is_pyramid_zarr(artifact_path):
         return _abs_url(request, f"/zarr/{dataset_id}/0")
     return _abs_url(request, f"/zarr/{dataset_id}")
+
+
+def _is_pyramid_zarr(artifact_path: str) -> bool:
+    """Return True if artifact_path is a multiscale pyramid zarr store."""
+    if "://" in artifact_path:
+        return False
+    return (Path(artifact_path) / "0").is_dir()
 
 
 def _abs_url(request: Request, path: str) -> str:

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -129,7 +129,6 @@ Omit `sync.availability` entirely for `static` datasets or when you always want 
 | ----- | -------- | ----------- |
 | `ingestion.function` | Yes | Dotted path to the download function |
 | `ingestion.default_params` | No | Extra keyword arguments forwarded to the download function |
-| `ingestion.multiscales` | No | Build a multi-resolution Zarr pyramid (see below) |
 
 **Transforms** — applied after download, before writing to Zarr:
 
@@ -167,15 +166,7 @@ If an ingest request's bounding box has no overlap with `extents.spatial.bbox`, 
 | `display.range` | No | `[min, max]` display range for the colormap |
 | `display.nodata` | No | No-data / fill value |
 
-**Multiscale pyramid** — for high-resolution raster datasets rendered in map viewers:
-
-```yaml
-ingestion:
-  function: mypackage.sources.enacts.download
-  multiscales:
-    levels: 4    # number of pyramid levels (default: 4)
-    method: mean # aggregation method (default: mean)
-```
+**Multiscale pyramid** — pyramid Zarr stores are built automatically when the ingested dataset's spatial dimensions exceed 2048×2048 pixels. No YAML configuration is required; the pyramid level count is derived from the data shape and coarsening always uses mean aggregation.
 
 ## Step 3: Point the instance at your plugins directory
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -153,7 +153,7 @@ Published Zarr-backed managed datasets appear there as one STAC Collection per d
 
 Current STAC details:
 
-- multiscale datasets can expose `/zarr/{dataset_id}/0` as the canonical asset href when declared in template metadata
+- pyramid Zarr stores (detected by the presence of a `0/` level on disk) expose `/zarr/{dataset_id}/0` as the canonical asset href
 - temporal extents are normalized to RFC 3339 in both STAC and Datacube temporal extent fields
 - STAC collection `license` currently defaults to `various`
 - spatial `step` values are rounded for readability while preserving axis direction

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime, tzinfo
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -29,6 +30,7 @@ def _artifact(
     managed_dataset_id: str = "chirps3_precipitation_daily_sle",
     created_at: str = "2026-01-10T00:00:00+00:00",
     end: str = "2026-01-10",
+    path: str = "/tmp/chirps3_precipitation_daily.zarr",
 ) -> ArtifactRecord:
     return ArtifactRecord(
         artifact_id=artifact_id,
@@ -36,8 +38,8 @@ def _artifact(
         dataset_name="CHIRPS3 precipitation",
         variable="precip",
         format=ArtifactFormat.ZARR,
-        path="/tmp/chirps3_precipitation_daily.zarr",
-        asset_paths=["/tmp/chirps3_precipitation_daily.zarr"],
+        path=path,
+        asset_paths=[path],
         variables=["precip"],
         request_scope=ArtifactRequestScope(
             start="2026-01-01",
@@ -207,15 +209,21 @@ def test_sync_dataset_append_policy_downloads_only_delta_but_preserves_full_scop
     assert result.sync_detail.delta_end == "2026-02-10"
 
 
-def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_multiscales(
+def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_pyramid_zarr(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    # Simulate a pyramid zarr on disk by creating a "0/" subdirectory.
+    zarr_path = tmp_path / "worldpop_population_yearly.zarr"  # type: ignore[operator]
+    (zarr_path / "0").mkdir(parents=True)
+
     dataset_id = "worldpop_population_yearly_sle"
     latest = _artifact(
         artifact_id="a1",
         source_dataset_id="worldpop_population_yearly",
         managed_dataset_id=dataset_id,
         end="2024",
+        path=str(zarr_path),
     )
     monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: latest)
     monkeypatch.setattr(
@@ -225,7 +233,7 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_multiscales(
             "id": "worldpop_population_yearly",
             "period_type": "yearly",
             "sync": {"kind": "temporal", "execution": "append"},
-            "ingestion": {"multiscales": {"levels": 4}},
+            "ingestion": {},
         },
     )
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -324,7 +324,7 @@ _PYRAMID_DATASET: dict[str, Any] = {
     "id": "my_dataset",
     "variable": "pop_total",
     "period_type": "yearly",
-    "ingestion": {"multiscales": {"levels": 2, "method": "mean"}},
+    "ingestion": {},
 }
 
 
@@ -522,6 +522,7 @@ def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypa
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
     monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "_needs_pyramid", lambda *_: True)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -540,6 +541,7 @@ def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monk
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
     monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "_needs_pyramid", lambda *_: True)
 
     def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> Pyramid:
         return _make_fake_pyramid(ds, tmp_path / "my_dataset.zarr")
@@ -564,6 +566,7 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     nc_files = _write_nc_files(tmp_path)
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
     monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "_needs_pyramid", lambda *_: True)
 
     received: list[xr.Dataset] = []
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -280,7 +280,9 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
 def test_collection_uses_level0_href_for_multiscale_store(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    artifact = _artifact(artifact_id="a1", path=str(tmp_path / "chirps3_precipitation_daily.zarr"))
+    zarr_path = tmp_path / "chirps3_precipitation_daily.zarr"
+    (zarr_path / "0").mkdir(parents=True)
+    artifact = _artifact(artifact_id="a1", path=str(zarr_path))
     monkeypatch.setattr(
         ingestion_services,
         "list_artifacts",
@@ -289,7 +291,7 @@ def test_collection_uses_level0_href_for_multiscale_store(
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {"multiscales": {"levels": 2}}},
+        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -325,7 +327,7 @@ def test_collection_uses_level0_href_for_remote_multiscale_store(
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {"multiscales": {"levels": 2}}},
+        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -341,6 +343,7 @@ def test_collection_uses_level0_href_for_remote_multiscale_store(
     )
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": None})
+    monkeypatch.setattr(stac_services, "_is_pyramid_zarr", lambda _: True)
 
     response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
 


### PR DESCRIPTION
## Summary

- Removes the `multiscales` block from dataset YAML templates; pyramid zarr is now built automatically when spatial dimensions exceed the 2048×2048 pixel threshold
- Pyramid level count is derived at build time using `ceil(log2(max_dim / 512))`, capped between 2 and 8 levels; coarsening always uses `mean`
- Sync append detection switches from the removed `ingestion.multiscales` YAML key to checking whether the on-disk artifact has a `0/` subdirectory
- STAC href detection uses the same `(path)/0` filesystem probe for local stores; `_is_pyramid_zarr` is monkeypatchable for remote-store tests

## Breaking changes

- `ingestion.multiscales` and `ingestion.pyramid_method` in dataset YAML templates are no longer read. Remove them from any custom templates — pyramid creation is now fully automatic.

## Test plan

- [ ] 211 passing, 0 failing (`make test`)
- [ ] Ingest a high-resolution dataset (e.g. WorldPop global) and confirm a pyramid zarr is built
- [ ] Ingest a small dataset and confirm a flat zarr is built
- [ ] Verify sync plan correctly detects pyramid zarr on-disk and falls back to rematerialize instead of append