### PR TITLE
refactor: remove extent_id — single configured extent is always used

### DIFF
--- a/climate-api.yaml.example
+++ b/climate-api.yaml.example
@@ -3,7 +3,6 @@
 # See docs/setup_guide.md for field descriptions.
 
 extent:
-  id: sle
   name: Sierra Leone
   bbox: [-13.5, 6.9, -10.1, 10.0]
   country_code: SLE

--- a/climate_api/extents/routes.py
+++ b/climate_api/extents/routes.py
@@ -20,11 +20,10 @@ def get_extent() -> ExtentRecord:
 def _build_extent_record(extent: dict[str, object]) -> ExtentRecord:
     bbox = extent.get("bbox")
     if not (isinstance(bbox, list) and len(bbox) == 4 and all(isinstance(value, int | float) for value in bbox)):
-        raise ValueError(f"Invalid bbox in extent config for '{extent.get('id')}'")
+        raise ValueError("Invalid bbox in extent config")
     name = extent.get("name")
     description = extent.get("description")
     return ExtentRecord(
-        extent_id=str(extent["id"]),
         name=name if isinstance(name, str) else None,
         description=description if isinstance(description, str) else None,
         bbox=(float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])),

--- a/climate_api/extents/schemas.py
+++ b/climate_api/extents/schemas.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 class ExtentRecord(BaseModel):
     """Configured spatial extent for this Climate API instance."""
 
-    extent_id: str = Field(description="Stable identifier for the configured extent.")
     name: str | None = Field(default=None, description="Human-readable name of the extent.")
     description: str | None = Field(default=None, description="Optional descriptive text for the extent.")
     bbox: tuple[float, float, float, float] = Field(

--- a/climate_api/extents/services.py
+++ b/climate_api/extents/services.py
@@ -21,9 +21,9 @@ def get_extent() -> dict[str, Any] | None:
     return extent
 
 
-def get_extent_or_404(extent_id: str) -> dict[str, Any]:
-    """Return the configured extent if its id matches, or raise 404."""
+def get_extent_or_404() -> dict[str, Any]:
+    """Return the configured extent or raise 404 if none is configured."""
     extent = get_extent()
-    if extent is not None and extent.get("id") == extent_id:
+    if extent is not None:
         return extent
-    raise HTTPException(status_code=404, detail=f"Extent '{extent_id}' not found")
+    raise HTTPException(status_code=404, detail="No extent is configured for this Climate API instance")

--- a/climate_api/extents/services.py
+++ b/climate_api/extents/services.py
@@ -14,8 +14,6 @@ def get_extent() -> dict[str, Any] | None:
         return None
     if not isinstance(extent, dict):
         raise ValueError("extent in CLIMATE_API_CONFIG must be a mapping")
-    if not isinstance(extent.get("id"), str) or not extent["id"]:
-        raise ValueError("extent.id in CLIMATE_API_CONFIG must be a non-empty string")
     if not isinstance(extent.get("bbox"), list) or len(extent["bbox"]) != 4:
         raise ValueError("extent.bbox in CLIMATE_API_CONFIG must be a list of four numbers [xmin, ymin, xmax, ymax]")
     return extent

--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -5,7 +5,7 @@ from fastapi.responses import FileResponse
 from starlette.responses import Response
 
 from climate_api.data_registry.routes import _get_dataset_or_404
-from climate_api.extents.services import get_extent_or_404
+from climate_api.extents.services import get_extent
 from climate_api.ingestions import services
 from climate_api.ingestions.schemas import (
     CreateIngestionRequest,
@@ -28,19 +28,13 @@ sync_router = APIRouter()
 def create_ingestion(request: CreateIngestionRequest) -> IngestionResponse:
     """Create or update a managed dataset from a dataset template and configured extent."""
     dataset = _get_dataset_or_404(request.dataset_id)
-    resolved_bbox: list[float] | None = None
-    resolved_country_code: str | None = None
-    if request.extent_id is not None:
-        extent = get_extent_or_404(request.extent_id)
-        bbox = extent.get("bbox")
-        country_code = extent.get("country_code")
-        resolved_bbox = list(bbox) if isinstance(bbox, list) else resolved_bbox
-        resolved_country_code = country_code if isinstance(country_code, str) else resolved_country_code
+    extent = get_extent()
+    resolved_bbox = list(extent["bbox"]) if extent else None
+    resolved_country_code = extent.get("country_code") if extent else None
     artifact = services.create_artifact(
         dataset=dataset,
         start=request.start,
         end=request.end,
-        extent_id=request.extent_id,
         bbox=resolved_bbox,
         country_code=resolved_country_code,
         overwrite=request.overwrite,

--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -5,7 +5,7 @@ from fastapi.responses import FileResponse
 from starlette.responses import Response
 
 from climate_api.data_registry.routes import _get_dataset_or_404
-from climate_api.extents.services import get_extent
+from climate_api.extents.services import get_extent_or_404
 from climate_api.ingestions import services
 from climate_api.ingestions.schemas import (
     CreateIngestionRequest,
@@ -28,9 +28,9 @@ sync_router = APIRouter()
 def create_ingestion(request: CreateIngestionRequest) -> IngestionResponse:
     """Create or update a managed dataset from a dataset template and configured extent."""
     dataset = _get_dataset_or_404(request.dataset_id)
-    extent = get_extent()
-    resolved_bbox = list(extent["bbox"]) if extent else None
-    resolved_country_code = extent.get("country_code") if extent else None
+    extent = get_extent_or_404()
+    resolved_bbox = list(extent["bbox"])
+    resolved_country_code = extent.get("country_code")
     artifact = services.create_artifact(
         dataset=dataset,
         start=request.start,

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -69,13 +69,9 @@ class ArtifactRequestScope(BaseModel):
 
     start: str = Field(description="Requested start period for the ingestion or sync operation.")
     end: str | None = Field(default=None, description="Requested end period for the ingestion or sync operation.")
-    extent_id: str | None = Field(
-        default=None,
-        description="Configured Climate API extent identifier used to resolve spatial scope for this request.",
-    )
     bbox: tuple[float, float, float, float] | None = Field(
         default=None,
-        description="Requested bounding box when the artifact was created from an explicit bbox.",
+        description="Requested bounding box when the artifact was created.",
     )
 
 
@@ -111,10 +107,6 @@ class CreateIngestionRequest(BaseModel):
     dataset_id: str = Field(description="Source dataset template id from the Climate API registry.")
     start: str = Field(description="Start period to ingest.")
     end: str | None = Field(default=None, description="Optional end period to ingest.")
-    extent_id: str | None = Field(
-        default=None,
-        description="Configured Climate API extent identifier used to resolve spatial scope for this ingestion.",
-    )
     overwrite: bool = Field(
         default=False,
         description="Whether to force regeneration of an existing matching artifact.",
@@ -287,7 +279,6 @@ class SyncDetail(BaseModel):
     """
 
     source_dataset_id: str = Field(description="Source dataset template id used to plan the sync.")
-    extent_id: str | None = Field(default=None, description="Configured extent id used to scope the managed dataset.")
     sync_kind: SyncKind = Field(description="Sync planning mode declared by the dataset template.")
     action: SyncAction = Field(description="Planner-selected sync action.")
     reason: str = Field(description="Stable machine-readable reason for the selected action.")

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -21,7 +21,7 @@ from climate_api import config as api_config
 from climate_api.data_accessor.services.accessor import get_data_coverage_for_paths
 from climate_api.data_manager.services import downloader
 from climate_api.data_registry.services import datasets as registry_datasets
-from climate_api.extents.services import get_extent_or_404
+from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import (
     ArtifactCoverage,
     ArtifactFormat,
@@ -150,7 +150,6 @@ def create_artifact(
     dataset: dict[str, object],
     start: str,
     end: str | None,
-    extent_id: str | None,
     bbox: list[float] | None,
     country_code: str | None,
     overwrite: bool,
@@ -180,7 +179,6 @@ def create_artifact(
     request_scope = ArtifactRequestScope(
         start=start,
         end=end,
-        extent_id=extent_id,
         bbox=(bbox[0], bbox[1], bbox[2], bbox[3]) if bbox is not None else None,
     )
     existing = _find_existing_artifact(
@@ -338,7 +336,6 @@ def store_materialized_zarr_artifact(
     dataset: dict[str, object],
     start: str,
     end: str | None,
-    extent_id: str | None,
     bbox: list[float] | None,
     zarr_path: Path,
     overwrite: bool,
@@ -351,7 +348,6 @@ def store_materialized_zarr_artifact(
     request_scope = ArtifactRequestScope(
         start=normalized_start,
         end=normalized_end,
-        extent_id=extent_id,
         bbox=(bbox[0], bbox[1], bbox[2], bbox[3]) if bbox is not None else None,
     )
     coverage_data = get_data_coverage_for_paths(dataset, zarr_path=str(zarr_path.resolve()))
@@ -400,11 +396,8 @@ def sync_dataset(
     source_dataset = registry_datasets.get_dataset(latest_artifact.dataset_id)
     if source_dataset is None:
         raise HTTPException(status_code=404, detail=f"Source dataset '{latest_artifact.dataset_id}' not found")
-    resolved_country_code: str | None = None
-    if latest_artifact.request_scope.extent_id is not None:
-        extent = get_extent_or_404(latest_artifact.request_scope.extent_id)
-        country_code = extent.get("country_code")
-        resolved_country_code = country_code if isinstance(country_code, str) else None
+    extent = get_extent()
+    resolved_country_code = extent.get("country_code") if extent else None
     try:
         return run_sync(
             latest_artifact=latest_artifact,
@@ -926,7 +919,6 @@ def _upgrade_legacy_record(item: dict[str, object]) -> dict[str, object]:
             item["request_scope"] = {
                 "start": start,
                 "end": end,
-                "extent_id": None,
                 "bbox": bbox,
             }
     return item

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -66,7 +66,6 @@ def plan_sync(
     if sync_kind == SyncKind.STATIC:
         return SyncDetail(
             source_dataset_id=latest_artifact.dataset_id,
-            extent_id=latest_artifact.request_scope.extent_id,
             sync_kind=sync_kind,
             action=SyncAction.NOT_SYNCABLE,
             reason="static_dataset",
@@ -96,7 +95,6 @@ def plan_sync(
         if next_period_start > latest_available_end:
             return SyncDetail(
                 source_dataset_id=latest_artifact.dataset_id,
-                extent_id=latest_artifact.request_scope.extent_id,
                 sync_kind=sync_kind,
                 action=SyncAction.NO_OP,
                 reason="no_new_period",
@@ -113,7 +111,6 @@ def plan_sync(
         reason = "new_periods_available_for_append" if action == SyncAction.APPEND else "new_periods_available"
         return SyncDetail(
             source_dataset_id=latest_artifact.dataset_id,
-            extent_id=latest_artifact.request_scope.extent_id,
             sync_kind=sync_kind,
             action=action,
             reason=reason,
@@ -135,7 +132,6 @@ def plan_sync(
     if current_end >= latest_available_end:
         return SyncDetail(
             source_dataset_id=latest_artifact.dataset_id,
-            extent_id=latest_artifact.request_scope.extent_id,
             sync_kind=sync_kind,
             action=SyncAction.NO_OP,
             reason="no_new_release",
@@ -151,7 +147,6 @@ def plan_sync(
 
     return SyncDetail(
         source_dataset_id=latest_artifact.dataset_id,
-        extent_id=latest_artifact.request_scope.extent_id,
         sync_kind=sync_kind,
         action=SyncAction.REMATERIALIZE,
         reason="new_release_available",
@@ -246,7 +241,6 @@ def run_sync(
         end=sync_detail.target_end,
         download_start=download_start,
         download_end=sync_detail.delta_end if download_start is not None else None,
-        extent_id=latest_artifact.request_scope.extent_id,
         bbox=list(latest_artifact.request_scope.bbox) if latest_artifact.request_scope.bbox is not None else None,
         country_code=country_code,
         overwrite=False,

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -66,8 +66,6 @@ def materialize_resampled_artifact(
     method: str,
     start: str,
     end: str | None,
-    extent_id: str | None,
-    bbox: list[float] | None,
     overwrite: bool,
     publish: bool,
 ) -> ArtifactRecord:
@@ -77,12 +75,7 @@ def materialize_resampled_artifact(
 
     existing = ingestion_services._find_existing_artifact(
         dataset_id=target_dataset_id,
-        request_scope=ArtifactRequestScope(
-            start=start,
-            end=resolved_end,
-            extent_id=extent_id,
-            bbox=(bbox[0], bbox[1], bbox[2], bbox[3]) if bbox is not None and extent_id is None else None,
-        ),
+        request_scope=ArtifactRequestScope(start=start, end=resolved_end),
         prefer_zarr=True,
     )
     if existing is not None and not overwrite:
@@ -94,18 +87,11 @@ def materialize_resampled_artifact(
     if source_dataset is None:
         raise HTTPException(status_code=404, detail=f"Source dataset template '{source_dataset_id}' not found")
 
-    source_artifact = _resolve_source_artifact(source_dataset_id=source_dataset_id, extent_id=extent_id, bbox=bbox)
+    source_artifact = _resolve_source_artifact(source_dataset_id=source_dataset_id)
     if source_artifact.format != ArtifactFormat.ZARR:
         raise HTTPException(status_code=409, detail="Resampling currently requires a Zarr-backed source artifact")
 
-    source_bbox = bbox
-    if source_bbox is None and source_artifact.request_scope.bbox is not None:
-        source_bbox = list(source_artifact.request_scope.bbox)
-    target_managed_dataset_id = managed_dataset_id_for_scope(
-        target_dataset_id,
-        extent_id=extent_id,
-        bbox=source_bbox if extent_id is None else None,
-    )
+    target_managed_dataset_id = managed_dataset_id_for_scope(target_dataset_id)
     zarr_path = DERIVED_DATA_DIR / f"{target_managed_dataset_id}.zarr"
 
     source_ds = open_zarr_dataset(source_artifact.path or source_artifact.asset_paths[0])
@@ -122,8 +108,6 @@ def materialize_resampled_artifact(
             raise HTTPException(status_code=409, detail="Source artifact does not contain any complete target periods")
         existing_realized = _find_existing_resampled_artifact(
             target_dataset_id=target_dataset_id,
-            extent_id=extent_id,
-            bbox=source_bbox if extent_id is None else None,
             start=start,
             resampled=resampled,
         )
@@ -145,21 +129,15 @@ def materialize_resampled_artifact(
         dataset=target_dataset,
         start=start,
         end=resolved_end,
-        extent_id=extent_id,
-        bbox=source_bbox if extent_id is None else None,
+        bbox=None,
         zarr_path=zarr_path,
         overwrite=overwrite,
         publish=publish,
     )
 
 
-def _resolve_source_artifact(
-    *,
-    source_dataset_id: str,
-    extent_id: str | None,
-    bbox: list[float] | None,
-) -> ArtifactRecord:
-    managed_dataset_id = managed_dataset_id_for_scope(source_dataset_id, extent_id=extent_id, bbox=bbox)
+def _resolve_source_artifact(*, source_dataset_id: str) -> ArtifactRecord:
+    managed_dataset_id = managed_dataset_id_for_scope(source_dataset_id)
     return ingestion_services.get_latest_artifact_for_dataset_or_404(managed_dataset_id)
 
 
@@ -230,8 +208,6 @@ def _drop_incomplete_edge_periods(
 def _find_existing_resampled_artifact(
     *,
     target_dataset_id: str,
-    extent_id: str | None,
-    bbox: list[float] | None,
     start: str,
     resampled: xr.Dataset,
 ) -> ArtifactRecord | None:
@@ -239,12 +215,7 @@ def _find_existing_resampled_artifact(
     realized_end = _coerce_numpy_datetime(resampled[time_dim].values[-1]).strftime("%Y-%m-%d")
     return ingestion_services._find_existing_artifact(
         dataset_id=target_dataset_id,
-        request_scope=ArtifactRequestScope(
-            start=start,
-            end=realized_end,
-            extent_id=extent_id,
-            bbox=(bbox[0], bbox[1], bbox[2], bbox[3]) if bbox is not None else None,
-        ),
+        request_scope=ArtifactRequestScope(start=start, end=realized_end),
         prefer_zarr=True,
     )
 

--- a/climate_api/processing/services.py
+++ b/climate_api/processing/services.py
@@ -21,7 +21,6 @@ def execute_resample(
     method: str,
     start: str,
     end: str | None = None,
-    extent_id: str | None = None,
     overwrite: bool = False,
     publish: bool = True,
     **_ignored: Any,
@@ -47,7 +46,6 @@ def execute_resample(
         method=method,
         start=start,
         end=end,
-        extent_id=extent_id,
         overwrite=overwrite,
         publish=publish,
     )
@@ -65,7 +63,6 @@ def run_resample_process(
     method: str,
     start: str,
     end: str | None,
-    extent_id: str | None,
     overwrite: bool,
     publish: bool,
 ) -> tuple[str, DatasetRecord]:
@@ -76,8 +73,6 @@ def run_resample_process(
         method=method,
         start=start,
         end=end,
-        extent_id=extent_id,
-        bbox=None,
         overwrite=overwrite,
         publish=publish,
     )

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -8,13 +8,13 @@ from datetime import UTC, datetime
 from importlib import import_module
 from pathlib import Path
 from typing import Any, cast
-from zlib import adler32
 
 import xarray as xr
 import yaml
 
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
+from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 
 
@@ -172,31 +172,16 @@ def _provider_axes(record: ArtifactRecord) -> tuple[str, str, str]:
         ds.close()
 
 
-def managed_dataset_id_for_scope(
-    dataset_id: str,
-    *,
-    extent_id: str | None,
-    bbox: tuple[float, float, float, float] | list[float] | None,
-) -> str:
-    """Build a stable managed dataset identifier from dataset scope inputs."""
-    if extent_id:
-        scope_key = extent_id
-    elif bbox:
-        bbox_str = ",".join(f"{value:.6f}" for value in bbox)
-        scope_hash = f"{adler32(bbox_str.encode('utf-8')):08x}"
-        scope_key = f"bbox_{scope_hash}"
-    else:
-        scope_key = "global"
+def managed_dataset_id_for_scope(dataset_id: str) -> str:
+    """Build a stable managed dataset identifier for the configured extent."""
+    extent = get_extent()
+    scope_key = extent["id"] if extent else "global"
     return f"{dataset_id}_{scope_key}"
 
 
 def _collection_id_for(record: ArtifactRecord) -> str:
     """Build a stable collection identifier for a logical dataset scope."""
-    return managed_dataset_id_for_scope(
-        record.dataset_id,
-        extent_id=record.request_scope.extent_id,
-        bbox=record.request_scope.bbox,
-    )
+    return managed_dataset_id_for_scope(record.dataset_id)
 
 
 def managed_dataset_id_for(record: ArtifactRecord) -> str:

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -173,10 +173,8 @@ def _provider_axes(record: ArtifactRecord) -> tuple[str, str, str]:
 
 
 def managed_dataset_id_for_scope(dataset_id: str) -> str:
-    """Build a stable managed dataset identifier for the configured extent."""
-    extent = get_extent()
-    scope_key = extent["id"] if extent else "global"
-    return f"{dataset_id}_{scope_key}"
+    """Return a stable managed dataset identifier for the single configured extent."""
+    return dataset_id
 
 
 def _collection_id_for(record: ArtifactRecord) -> str:

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -183,7 +183,7 @@ def _collection_id_for(record: ArtifactRecord) -> str:
 
 def managed_dataset_id_for(record: ArtifactRecord) -> str:
     """Return the stable managed dataset id for a stored record."""
-    return record.publication.collection_id or _collection_id_for(record)
+    return _collection_id_for(record)
 
 
 def _native_dataset_href(dataset_id: str) -> str:

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -14,7 +14,6 @@ import yaml
 
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
-from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 
 

--- a/climate_api/system/routes.py
+++ b/climate_api/system/routes.py
@@ -66,14 +66,12 @@ async def manage_ingest(request: Request) -> RedirectResponse:
 
         extent = get_extent()
         resolved_bbox = list(extent["bbox"]) if extent else None
-        extent_id = extent["id"] if extent else None
         country_code = extent.get("country_code") if extent else None
 
         create_artifact(
             dataset=template,
             start=start,
             end=end,
-            extent_id=extent_id,
             bbox=resolved_bbox,
             country_code=country_code,
             overwrite=overwrite,

--- a/climate_api/system/routes.py
+++ b/climate_api/system/routes.py
@@ -47,7 +47,7 @@ async def manage_ingest(request: Request) -> RedirectResponse:
     from fastapi import HTTPException
 
     from climate_api.data_registry.services.datasets import get_dataset
-    from climate_api.extents.services import get_extent
+    from climate_api.extents.services import get_extent_or_404
     from climate_api.ingestions.services import create_artifact
 
     base = str(request.base_url).rstrip("/")
@@ -64,9 +64,9 @@ async def manage_ingest(request: Request) -> RedirectResponse:
             msg = urllib.parse.quote(f"Dataset template '{dataset_id}' not found")
             return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
 
-        extent = get_extent()
-        resolved_bbox = list(extent["bbox"]) if extent else None
-        country_code = extent.get("country_code") if extent else None
+        extent = get_extent_or_404()
+        resolved_bbox = list(extent["bbox"])
+        country_code = extent.get("country_code")
 
         create_artifact(
             dataset=template,

--- a/climate_api/templates/landing_page.html
+++ b/climate_api/templates/landing_page.html
@@ -196,7 +196,7 @@
         {% if extent %}
         <dl class="status-grid">
           <dt>Extent</dt>
-          <dd>{{ extent.name or extent.id }} <code>{{ extent.id }}</code></dd>
+          <dd>{{ extent.name or "Unnamed extent" }}</dd>
           <dt>Bounding box</dt>
           <dd><code>{{ extent.bbox | join(", ") }}</code></dd>
           {% if extent.country_code %}

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -88,7 +88,7 @@ Create a directory for your custom templates and add a YAML file. Each file cont
 
 | Field        | Required | Description |
 | ------------ | -------- | ----------- |
-| `id`         | Yes | Unique template identifier. Dataset IDs in the API are `{id}_{extent_id}`, e.g. `enacts_rainfall_daily_rwa` |
+| `id`         | Yes | Unique template identifier. This becomes the dataset ID in the API, e.g. `enacts_rainfall_daily` |
 | `name`       | Yes | Full human-readable name shown in API responses and STAC metadata |
 | `short_name` | No  | Short label used in compact displays |
 | `variable`   | Yes | Name of the data variable in the Zarr store (e.g. `precip`, `t2m`, `rainfall`) |
@@ -200,7 +200,6 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
     "dataset_id": "enacts_rainfall_daily",
     "start": "2024-01-01",
     "end": "2024-01-31",
-    "extent_id": "rwa",
     "prefer_zarr": true,
     "publish": true
   }' | jq

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -180,7 +180,6 @@ plugins/
 
 ```yaml
 extent:
-  id: rwa
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -40,7 +40,7 @@ Operational note:
 
 ## 1. Discover the configured extent
 
-The configured extent is setup-time Climate API configuration. It is read-only at runtime and is identified by `extent_id`.
+The configured extent is setup-time Climate API configuration. It is read-only at runtime.
 
 Example:
 
@@ -52,7 +52,6 @@ Example response:
 
 ```json
 {
-  "extent_id": "sle",
   "name": "Sierra Leone",
   "description": null,
   "bbox": [-13.5, 6.9, -10.1, 10.0]
@@ -61,23 +60,21 @@ Example response:
 
 What this means:
 
-- `extent_id` is the public Climate API handle for a configured spatial extent
 - `bbox` is the resolved spatial extent exposed publicly
 - provider-specific hints may exist internally in extent config, but they are not part of the public extent response
 
 ## 2. Ingest a dataset
 
-The public ingestion contract now takes:
+The public ingestion contract takes:
 
 - `dataset_id`
 - `start`
 - optional `end`
-- optional `extent_id`
 - `overwrite`
 - `prefer_zarr`
 - `publish`
 
-Raw `bbox` and `country_code` are no longer part of the public ingestion payload.
+Raw `bbox` and `country_code` are not part of the public ingestion payload — the API resolves them from the configured extent.
 
 ### Example: CHIRPS3
 
@@ -88,7 +85,6 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
     "dataset_id": "chirps3_precipitation_daily",
     "start": "2024-01-01",
     "end": "2024-01-31",
-    "extent_id": "sle",
     "overwrite": false,
     "prefer_zarr": true,
     "publish": true
@@ -104,7 +100,6 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
     "dataset_id": "worldpop_population_yearly",
     "start": "2020",
     "end": "2020",
-    "extent_id": "sle",
     "overwrite": false,
     "prefer_zarr": true,
     "publish": true
@@ -118,7 +113,7 @@ Example response:
   "ingestion_id": "a7e06c93-ba78-4c74-b772-160927fdb463",
   "status": "completed",
   "dataset": {
-    "dataset_id": "chirps3_precipitation_daily_sle",
+    "dataset_id": "chirps3_precipitation_daily",
     "source_dataset_id": "chirps3_precipitation_daily",
     "dataset_name": "Total precipitation (CHIRPS3)",
     "short_name": "Total precipitation",
@@ -143,22 +138,22 @@ Example response:
     "last_updated": "2026-04-01T09:03:28.691120Z",
     "links": [
       {
-        "href": "/datasets/chirps3_precipitation_daily_sle",
+        "href": "/datasets/chirps3_precipitation_daily",
         "rel": "self",
         "title": "Dataset detail"
       },
       {
-        "href": "/zarr/chirps3_precipitation_daily_sle",
+        "href": "/zarr/chirps3_precipitation_daily",
         "rel": "zarr",
         "title": "Zarr store"
       },
       {
-        "href": "/stac/collections/chirps3_precipitation_daily_sle",
+        "href": "/stac/collections/chirps3_precipitation_daily",
         "rel": "stac",
         "title": "STAC collection"
       },
       {
-        "href": "/ogcapi/collections/chirps3_precipitation_daily_sle",
+        "href": "/ogcapi/collections/chirps3_precipitation_daily",
         "rel": "ogc-collection",
         "title": "OGC collection"
       }
@@ -235,7 +230,7 @@ Example response:
   "kind": "DatasetList",
   "items": [
     {
-      "dataset_id": "chirps3_precipitation_daily_sle",
+      "dataset_id": "chirps3_precipitation_daily",
       "source_dataset_id": "chirps3_precipitation_daily",
       "dataset_name": "Total precipitation (CHIRPS3)",
       "short_name": "Total precipitation",
@@ -260,17 +255,17 @@ Example response:
       "last_updated": "2026-04-01T09:03:28.691120Z",
       "links": [
         {
-          "href": "/datasets/chirps3_precipitation_daily_sle",
+          "href": "/datasets/chirps3_precipitation_daily",
           "rel": "self",
           "title": "Dataset detail"
         },
         {
-          "href": "/zarr/chirps3_precipitation_daily_sle",
+          "href": "/zarr/chirps3_precipitation_daily",
           "rel": "zarr",
           "title": "Zarr store"
         },
         {
-          "href": "/ogcapi/collections/chirps3_precipitation_daily_sle",
+          "href": "/ogcapi/collections/chirps3_precipitation_daily",
           "rel": "ogc-collection",
           "title": "OGC collection"
         }
@@ -298,7 +293,7 @@ What this means:
 Example:
 
 ```bash
-curl -s http://127.0.0.1:8000/datasets/chirps3_precipitation_daily_sle | jq
+curl -s http://127.0.0.1:8000/datasets/chirps3_precipitation_daily | jq
 ```
 
 What this adds beyond the list response:
@@ -316,8 +311,8 @@ If the latest managed dataset version is Zarr-backed, the canonical native raw-d
 Examples:
 
 ```bash
-curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily_sle | jq
-curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily_sle/zarr.json | jq
+curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily | jq
+curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily/zarr.json | jq
 ```
 
 The listing response exposes:
@@ -343,15 +338,15 @@ STAC examples:
 
 ```bash
 curl -s "http://127.0.0.1:8000/stac/catalog.json" | jq
-curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily_sle" | jq
+curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily" | jq
 ```
 
 Examples:
 
 ```bash
 curl -s "http://127.0.0.1:8000/ogcapi/collections?f=json" | jq
-curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily_sle?f=json" | jq
-curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily_sle/coverage?f=json" | jq
+curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily?f=json" | jq
+curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily/coverage?f=json" | jq
 ```
 
 What this means:
@@ -396,13 +391,13 @@ Configured availability policies:
 Example dry-run plan:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle/plan?end=2024-02-10" | jq
+curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
 ```
 
 Example execution:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle" \
+curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{"end":"2024-02-10","prefer_zarr":true,"publish":true}' | jq
 ```
@@ -418,9 +413,6 @@ These commands assume the API is running on `http://127.0.0.1:8000` and that
 curl -s "http://127.0.0.1:8000/extent" | jq
 ```
 
-Use an extent that has enough spatial metadata for the selected dataset. The
-examples below use `sle`.
-
 ### 2. Create an initial CHIRPS3 managed dataset
 
 ```bash
@@ -428,7 +420,6 @@ curl -s -X POST "http://127.0.0.1:8000/ingestions" \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "chirps3_precipitation_daily",
-    "extent_id": "sle",
     "start": "2024-01-01",
     "end": "2024-01-31",
     "prefer_zarr": true,
@@ -439,23 +430,23 @@ curl -s -X POST "http://127.0.0.1:8000/ingestions" \
 Expected:
 
 - `status` is `completed`
-- `dataset.dataset_id` is `chirps3_precipitation_daily_sle`
+- `dataset.dataset_id` is `chirps3_precipitation_daily`
 - `dataset.extent.temporal.end` is `2024-01-31`
 
 ### 3. Inspect the managed dataset and publication
 
 ```bash
-curl -s "http://127.0.0.1:8000/datasets/chirps3_precipitation_daily_sle" | jq
-curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily_sle" | jq
-curl -s "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily_sle" | jq
-curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily_sle?f=json" | jq
-curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily_sle/coverage?f=json" | jq
+curl -s "http://127.0.0.1:8000/datasets/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily?f=json" | jq
+curl -s "http://127.0.0.1:8000/ogcapi/collections/chirps3_precipitation_daily/coverage?f=json" | jq
 ```
 
 ### 4. Dry-run a CHIRPS3 append sync
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle/plan?end=2024-02-10" | jq
+curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
 ```
 
 Expected planning response:
@@ -483,7 +474,7 @@ Where these timestamps come from:
 - `delta_end` is the resolved target period after any availability clamping
 
 If `end` is omitted, the planner defaults to the current date. For example, calling
-`/sync/chirps3_precipitation_daily_sle/plan` on `2026-04-20` after ingesting
+`/sync/chirps3_precipitation_daily/plan` on `2026-04-20` after ingesting
 through `2024-01-31` first resolves the target from today's date, then applies
 CHIRPS3 availability. Because CHIRPS3 daily sync is configured to use complete
 released source months, the target may be clamped below today's date and
@@ -499,7 +490,7 @@ If CHIRPS3 currently has complete released data through `2026-03-31` and you ask
 for:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle/plan?end=2026-04-21" | jq
+curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2026-04-21" | jq
 ```
 
 Expected:
@@ -511,7 +502,7 @@ Expected:
 ### 5. Execute the CHIRPS3 sync
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle" \
+curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2024-02-10",
@@ -528,14 +519,14 @@ Expected:
 - `sync_detail.delta_start` is `2024-02-01`
 - `sync_detail.delta_end` is `2024-02-10`
 - `sync_detail.target_end` is `2024-02-10`
-- the returned `dataset.dataset_id` is still `chirps3_precipitation_daily_sle`
+- the returned `dataset.dataset_id` is still `chirps3_precipitation_daily`
 - the returned dataset has a newer version in `versions`
 - the returned dataset coverage ends at `2024-02-10`, even if the upstream downloader cached the full February source month
 
 You can then extend the same managed dataset again:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle" \
+curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2024-02-20",
@@ -557,7 +548,7 @@ Expected:
 Run the same plan again with the current end:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_sle/plan?end=2024-02-20" | jq
+curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-20" | jq
 ```
 
 Expected:
@@ -575,7 +566,6 @@ curl -s -X POST "http://127.0.0.1:8000/ingestions" \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "worldpop_population_yearly",
-    "extent_id": "sle",
     "start": "2020",
     "end": "2020",
     "prefer_zarr": true,
@@ -586,7 +576,7 @@ curl -s -X POST "http://127.0.0.1:8000/ingestions" \
 Plan a later release:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/worldpop_population_yearly_sle/plan?end=2021" | jq
+curl -s "http://127.0.0.1:8000/sync/worldpop_population_yearly/plan?end=2021" | jq
 ```
 
 Expected:
@@ -599,7 +589,7 @@ Expected:
 Execute the release sync:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/worldpop_population_yearly_sle" \
+curl -s -X POST "http://127.0.0.1:8000/sync/worldpop_population_yearly" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2021",
@@ -612,7 +602,7 @@ Expected:
 
 - `status` is `completed`
 - `sync_detail.action` is `rematerialize`
-- the managed dataset id remains `worldpop_population_yearly_sle`
+- `dataset.dataset_id` is `worldpop_population_yearly`
 
 ## Summary
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -97,7 +97,6 @@ Expected response:
 
 ```json
 {
-  "extent_id": "rwa",
   "name": "Rwanda",
   "description": null,
   "bbox": [28.8, -2.9, 30.9, -1.0]
@@ -108,8 +107,6 @@ Expected response:
 
 CHIRPS3 (daily precipitation) requires no API key and is a good first dataset to verify the setup.
 
-Replace `rwa` with the `id` you set in Step 2.
-
 ```bash
 curl -s -X POST http://127.0.0.1:8000/ingestions \
   -H "Content-Type: application/json" \
@@ -117,13 +114,12 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
     "dataset_id": "chirps3_precipitation_daily",
     "start": "2024-01-01",
     "end": "2024-01-31",
-    "extent_id": "rwa",
     "prefer_zarr": true,
     "publish": true
   }' | jq
 ```
 
-A successful response returns `"status": "completed"` and a `dataset` object with `dataset_id` matching `chirps3_precipitation_daily_{extent_id}` (e.g. `chirps3_precipitation_daily_rwa`).
+A successful response returns `"status": "completed"` and a `dataset` object with `dataset_id` of `chirps3_precipitation_daily`.
 
 ## Step 7: Access the data
 
@@ -191,7 +187,6 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
     "dataset_id": "era5land_temperature_hourly",
     "start": "2024-01-01T00",
     "end": "2024-01-31T23",
-    "extent_id": "rwa",
     "prefer_zarr": true,
     "publish": true
   }' | jq
@@ -203,14 +198,14 @@ ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner w
 
 ## Keeping datasets up to date
 
-Use the sync endpoint to advance an existing dataset to the latest available data. Replace `rwa` with your extent `id` from Step 2:
+Use the sync endpoint to advance an existing dataset to the latest available data:
 
 ```bash
 # Check what would be downloaded without executing
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_rwa/plan" | jq
+curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan" | jq
 
 # Execute the sync
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily_rwa" \
+curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{"prefer_zarr": true, "publish": true}' | jq
 ```

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -28,7 +28,6 @@ cp climate-api.yaml.example climate-api.yaml
 
 ```yaml
 extent:
-  id: rwa
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
   country_code: RWA
@@ -40,7 +39,6 @@ Field reference:
 
 | Field          | Required | Description |
 | -------------- | -------- | ----------- |
-| `id`           | Yes | Short identifier used in dataset IDs and API paths (e.g. `chirps3_precipitation_daily_rwa`) |
 | `name`         | No  | Human-readable name shown in API responses |
 | `bbox`         | Yes | Bounding box as `[xmin, ymin, xmax, ymax]` in WGS84 decimal degrees |
 | `country_code` | No  | ISO 3166-1 alpha-3 code — required for WorldPop downloads |
@@ -53,7 +51,6 @@ Values can reference environment variables using `${VAR:-default}` syntax:
 
 ```yaml
 extent:
-  id: ${EXTENT_ID:-rwa}
   name: ${EXTENT_NAME:-Rwanda}
   bbox: [28.8, -2.9, 30.9, -1.0]
 ```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -15,7 +15,7 @@ curl -s http://127.0.0.1:8000/stac/catalog.json | jq
 Each entry in `links` with `"rel": "child"` points to one dataset collection. Use the `href` from the catalog to fetch it:
 
 ```bash
-# Replace {dataset_id} with any id from the catalog above, e.g. chirps3_precipitation_daily_sle
+# Replace {dataset_id} with any id from the catalog above, e.g. chirps3_precipitation_daily
 curl -s http://127.0.0.1:8000/stac/collections/{dataset_id} | jq
 ```
 
@@ -25,7 +25,7 @@ The `assets.zarr` field contains everything needed to open the dataset:
 {
   "assets": {
     "zarr": {
-      "href": "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily_rwa",
+      "href": "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily",
       "xarray:open_kwargs": { "consolidated": true }
     }
   }
@@ -86,11 +86,9 @@ print(spatial_mean.to_dataframe())
 
 ## Dataset IDs
 
-Dataset IDs follow the pattern `{source_dataset_id}_{extent_id}`, for example `chirps3_precipitation_daily_sle` for CHIRPS3 daily precipitation over Sierra Leone (`sle`).
+Dataset IDs match the template `id` field from the dataset YAML. Available datasets in the built-in catalogue:
 
-Available datasets in the built-in catalogue:
-
-| Dataset ID prefix               | Variable    | Period | Source    |
+| Dataset ID                      | Variable    | Period | Source    |
 | ------------------------------- | ----------- | ------ | --------- |
 | `chirps3_precipitation_daily`   | `precip`    | Daily  | CHIRPS v3 |
 | `era5land_temperature_hourly`   | `t2m`       | Hourly | ERA5-Land |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from climate_api.main import app
 
 _TEST_CONFIG = """\
 extent:
-  id: sle
   name: Sierra Leone
   bbox: [-13.5, 6.9, -10.1, 10.0]
   country_code: SLE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ def test_get_data_dir_raises_when_config_present_but_no_data_dir(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     config_file = tmp_path / "climate-api.yaml"
-    config_file.write_text("extent:\n  id: nor\n", encoding="utf-8")
+    config_file.write_text("extent:\n  name: Norway\n", encoding="utf-8")
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
     with pytest.raises(ValueError, match="data_dir is required"):
         get_data_dir()
@@ -52,7 +52,6 @@ def test_get_config_loads_extent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     config_file.write_text(
         """
 extent:
-  id: rwa
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
   country_code: RWA
@@ -62,7 +61,7 @@ extent:
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
 
     config = get_config()
-    assert config["extent"]["id"] == "rwa"
+    assert config["extent"]["name"] == "Rwanda"
     assert config["extent"]["bbox"] == [28.8, -2.9, 30.9, -1.0]
 
 
@@ -71,17 +70,14 @@ def test_get_config_substitutes_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_pa
     config_file.write_text(
         """
 extent:
-  id: ${EXTENT_ID:-sle}
   name: ${EXTENT_NAME:-Sierra Leone}
 """,
         encoding="utf-8",
     )
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
-    monkeypatch.setenv("EXTENT_ID", "rwa")
     monkeypatch.delenv("EXTENT_NAME", raising=False)
 
     config = get_config()
-    assert config["extent"]["id"] == "rwa"
     assert config["extent"]["name"] == "Sierra Leone"
 
 
@@ -90,7 +86,6 @@ def test_extents_service_reads_from_config(monkeypatch: pytest.MonkeyPatch, tmp_
     config_file.write_text(
         """
 extent:
-  id: rwa
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
 """,
@@ -100,7 +95,7 @@ extent:
 
     extent = extent_services.get_extent()
     assert extent is not None
-    assert extent["id"] == "rwa"
+    assert extent["name"] == "Rwanda"
 
 
 def test_extent_service_returns_none_when_config_unset(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -122,9 +122,7 @@ def test_list_datasets_groups_artifacts_by_managed_dataset_id(monkeypatch: pytes
 def test_dataset_links_include_stac_for_published_zarr() -> None:
     links = services._dataset_links("chirps3_precipitation_daily", _artifact(artifact_id="a1"))
 
-    assert any(
-        link.rel == "stac" and link.href == "/stac/collections/chirps3_precipitation_daily" for link in links
-    )
+    assert any(link.rel == "stac" and link.href == "/stac/collections/chirps3_precipitation_daily" for link in links)
 
 
 def test_dataset_links_omit_stac_for_unpublished_or_netcdf() -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -44,7 +44,6 @@ def _artifact(
         request_scope=ArtifactRequestScope(
             start="2026-01-01",
             end=end,
-            extent_id="sle",
             bbox=(1.0, 2.0, 3.0, 4.0),
         ),
         coverage=ArtifactCoverage(
@@ -168,7 +167,7 @@ def test_list_ingestions_returns_most_recent_first(monkeypatch: pytest.MonkeyPat
     assert result.items[0].dataset.dataset_id == "chirps3_precipitation_daily_sle"
 
 
-def test_managed_dataset_id_prefers_extent_id_when_present() -> None:
+def test_managed_dataset_id_uses_stored_collection_id(monkeypatch: pytest.MonkeyPatch) -> None:
     artifact = _artifact(artifact_id="a1")
 
     assert managed_dataset_id_for(artifact) == "chirps3_precipitation_daily_sle"
@@ -178,7 +177,6 @@ def test_find_existing_artifact_ignores_record_with_overwide_coverage() -> None:
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
         end="2026-02-10",
-        extent_id="sle",
         bbox=(1.0, 2.0, 3.0, 4.0),
     )
     stale_artifact = _artifact(artifact_id="stale", end="2026-02-29")
@@ -200,7 +198,6 @@ def test_find_existing_artifact_ignores_stale_record(monkeypatch: pytest.MonkeyP
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
         end="2026-02-10",
-        extent_id="sle",
         bbox=(1.0, 2.0, 3.0, 4.0),
     )
     stale_artifact = _artifact(artifact_id="stale", end="2026-02-10")
@@ -256,7 +253,6 @@ def test_temporal_coverage_matches_request_scope_allows_open_ended_reuse() -> No
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
         end=None,
-        extent_id="sle",
         bbox=(1.0, 2.0, 3.0, 4.0),
     )
 
@@ -307,7 +303,6 @@ def test_create_artifact_computes_coverage_from_created_artifact_paths(
         dataset=dataset,
         start="2020",
         end="2020",
-        extent_id="sle",
         bbox=[-13.5, 6.9, -10.1, 10.0],
         country_code="SLE",
         overwrite=False,
@@ -368,7 +363,6 @@ def test_create_artifact_normalizes_request_scope_to_dataset_period(
         dataset=dataset,
         start="2026-04-21T12:15:00",
         end="2026-04-21T13:45:00",
-        extent_id="sle",
         bbox=[1.0, 2.0, 3.0, 4.0],
         country_code=None,
         overwrite=False,
@@ -437,7 +431,6 @@ def test_create_artifact_defaults_omitted_end_to_dataset_native_period_for_downl
         dataset=dataset,
         start="2026-04-21T12:15:00",
         end=None,
-        extent_id="sle",
         bbox=[1.0, 2.0, 3.0, 4.0],
         country_code=None,
         overwrite=False,
@@ -485,7 +478,6 @@ def test_create_artifact_returns_409_when_downloaded_artifact_has_no_data(
             dataset=dataset,
             start="2020",
             end="2020",
-            extent_id="sle",
             bbox=[-13.5, 6.9, -10.1, 10.0],
             country_code="SLE",
             overwrite=False,
@@ -547,7 +539,6 @@ def test_create_artifact_can_download_delta_while_recording_full_request_scope(
         end="2026-02-10",
         download_start="2026-02-01",
         download_end="2026-02-10",
-        extent_id="sle",
         bbox=[1.0, 2.0, 3.0, 4.0],
         country_code=None,
         overwrite=False,
@@ -581,7 +572,6 @@ def test_create_artifact_rejects_partial_download_scope(monkeypatch: pytest.Monk
             end="2026-02-10",
             download_start=None,
             download_end="2026-02-10",
-            extent_id="sle",
             bbox=[1.0, 2.0, 3.0, 4.0],
             country_code=None,
             overwrite=False,
@@ -610,7 +600,6 @@ def test_create_artifact_rejects_download_scope_outside_request_scope(monkeypatc
             end="2026-02-10",
             download_start="2026-02-01",
             download_end="2026-02-11",
-            extent_id="sle",
             bbox=[1.0, 2.0, 3.0, 4.0],
             country_code=None,
             overwrite=False,
@@ -642,7 +631,6 @@ def test_create_artifact_delta_does_not_reuse_netcdf_artifact_when_canonical_zar
     netcdf_existing.request_scope = ArtifactRequestScope(
         start="2026-01-01",
         end="2026-02-10",
-        extent_id="sle",
         bbox=(1.0, 2.0, 3.0, 4.0),
     )
 
@@ -675,7 +663,6 @@ def test_create_artifact_delta_does_not_reuse_netcdf_artifact_when_canonical_zar
         end="2026-02-10",
         download_start="2026-02-01",
         download_end="2026-02-10",
-        extent_id="sle",
         bbox=[1.0, 2.0, 3.0, 4.0],
         country_code=None,
         overwrite=False,
@@ -731,7 +718,6 @@ def test_create_artifact_delta_requires_canonical_zarr_when_prefer_zarr_is_false
         end="2026-02-10",
         download_start="2026-02-01",
         download_end="2026-02-10",
-        extent_id="sle",
         bbox=[1.0, 2.0, 3.0, 4.0],
         country_code=None,
         overwrite=False,
@@ -775,7 +761,6 @@ def test_create_artifact_delta_fails_when_canonical_zarr_build_fails(
             end="2026-02-10",
             download_start="2026-02-01",
             download_end="2026-02-10",
-            extent_id="sle",
             bbox=[1.0, 2.0, 3.0, 4.0],
             country_code=None,
             overwrite=False,
@@ -824,7 +809,6 @@ def test_create_artifact_delta_rejects_short_rebuilt_coverage(
             end="2026-02-10",
             download_start="2026-02-01",
             download_end="2026-02-10",
-            extent_id="sle",
             bbox=[1.0, 2.0, 3.0, 4.0],
             country_code=None,
             overwrite=False,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -28,7 +28,7 @@ def _artifact(
     *,
     artifact_id: str,
     source_dataset_id: str = "chirps3_precipitation_daily",
-    managed_dataset_id: str = "chirps3_precipitation_daily_sle",
+    managed_dataset_id: str = "chirps3_precipitation_daily",
     created_at: str = "2026-01-10T00:00:00+00:00",
     end: str = "2026-01-10",
 ) -> ArtifactRecord:
@@ -109,7 +109,7 @@ def test_list_datasets_groups_artifacts_by_managed_dataset_id(monkeypatch: pytes
 
     assert len(result.items) == 1
     dataset = result.items[0]
-    assert dataset.dataset_id == "chirps3_precipitation_daily_sle"
+    assert dataset.dataset_id == "chirps3_precipitation_daily"
     assert dataset.source_dataset_id == "chirps3_precipitation_daily"
     assert dataset.period_type == "daily"
     assert dataset.units == "mm"
@@ -120,10 +120,10 @@ def test_list_datasets_groups_artifacts_by_managed_dataset_id(monkeypatch: pytes
 
 
 def test_dataset_links_include_stac_for_published_zarr() -> None:
-    links = services._dataset_links("chirps3_precipitation_daily_sle", _artifact(artifact_id="a1"))
+    links = services._dataset_links("chirps3_precipitation_daily", _artifact(artifact_id="a1"))
 
     assert any(
-        link.rel == "stac" and link.href == "/stac/collections/chirps3_precipitation_daily_sle" for link in links
+        link.rel == "stac" and link.href == "/stac/collections/chirps3_precipitation_daily" for link in links
     )
 
 
@@ -133,8 +133,8 @@ def test_dataset_links_omit_stac_for_unpublished_or_netcdf() -> None:
     netcdf = _artifact(artifact_id="a2")
     netcdf.format = ArtifactFormat.NETCDF
 
-    unpublished_links = services._dataset_links("chirps3_precipitation_daily_sle", unpublished)
-    netcdf_links = services._dataset_links("chirps3_precipitation_daily_sle", netcdf)
+    unpublished_links = services._dataset_links("chirps3_precipitation_daily", unpublished)
+    netcdf_links = services._dataset_links("chirps3_precipitation_daily", netcdf)
 
     assert all(link.rel != "stac" for link in unpublished_links)
     assert all(link.rel != "stac" for link in netcdf_links)
@@ -164,13 +164,13 @@ def test_list_ingestions_returns_most_recent_first(monkeypatch: pytest.MonkeyPat
 
     assert result.kind == "IngestionList"
     assert [item.ingestion_id for item in result.items] == ["a2", "a1"]
-    assert result.items[0].dataset.dataset_id == "chirps3_precipitation_daily_sle"
+    assert result.items[0].dataset.dataset_id == "chirps3_precipitation_daily"
 
 
-def test_managed_dataset_id_uses_stored_collection_id(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_managed_dataset_id_is_derived_from_dataset_id(monkeypatch: pytest.MonkeyPatch) -> None:
     artifact = _artifact(artifact_id="a1")
 
-    assert managed_dataset_id_for(artifact) == "chirps3_precipitation_daily_sle"
+    assert managed_dataset_id_for(artifact) == "chirps3_precipitation_daily"
 
 
 def test_find_existing_artifact_ignores_record_with_overwide_coverage() -> None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -44,7 +44,6 @@ def _artifact(
         request_scope=ArtifactRequestScope(
             start="2026-01-01",
             end=end,
-            extent_id="sle",
             bbox=(1.0, 2.0, 3.0, 4.0),
         ),
         coverage=ArtifactCoverage(
@@ -142,7 +141,6 @@ def test_sync_dataset_creates_new_version_from_next_period(monkeypatch: pytest.M
 
     assert captured["start"] == "2026-01-01"
     assert captured["end"] == "2026-02-10"
-    assert captured["extent_id"] == "sle"
     assert captured["bbox"] == [1.0, 2.0, 3.0, 4.0]
     assert captured["country_code"] == "SLE"
     assert result.sync_id == "a2"
@@ -488,7 +486,6 @@ def test_sync_plan_route_returns_plan_without_creating_artifact(
     assert response.status_code == 200
     assert response.json() == {
         "source_dataset_id": "chirps3_precipitation_daily",
-        "extent_id": "sle",
         "sync_kind": "temporal",
         "action": "rematerialize",
         "reason": "new_periods_available",
@@ -790,7 +787,6 @@ def test_run_sync_raises_clear_error_when_append_invariants_are_missing(monkeypa
 
     broken_plan = SyncDetail(
         source_dataset_id="chirps3_precipitation_daily",
-        extent_id="sle",
         sync_kind=SyncKind.TEMPORAL,
         action=SyncAction.APPEND,
         reason="new_periods_available_for_append",
@@ -833,8 +829,8 @@ def test_sync_dataset_forwards_country_code_from_extent(monkeypatch: pytest.Monk
     )
     monkeypatch.setattr(
         services,
-        "get_extent_or_404",
-        lambda _: {"id": "sle", "bbox": [-13.5, 6.9, -10.1, 10.0], "country_code": "SLE"},
+        "get_extent",
+        lambda: {"id": "sle", "bbox": [-13.5, 6.9, -10.1, 10.0], "country_code": "SLE"},
     )
 
     captured: dict[str, object] = {}
@@ -848,7 +844,6 @@ def test_sync_dataset_forwards_country_code_from_extent(monkeypatch: pytest.Monk
             dataset=_dataset_detail(dataset_id),
             sync_detail=SyncDetail(
                 source_dataset_id="worldpop_population_yearly",
-                extent_id="sle",
                 sync_kind=SyncKind.RELEASE,
                 action=SyncAction.REMATERIALIZE,
                 reason="new_release_available",

--- a/tests/test_extents.py
+++ b/tests/test_extents.py
@@ -6,6 +6,7 @@ def test_get_extent_returns_configured_extent(client: TestClient) -> None:
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["extent_id"] == "sle"
+    assert payload["name"] == "Sierra Leone"
     assert payload["bbox"] == [-13.5, 6.9, -10.1, 10.0]
+    assert "extent_id" not in payload
     assert "country_code" not in payload

--- a/tests/test_processing_resample.py
+++ b/tests/test_processing_resample.py
@@ -48,7 +48,6 @@ def _artifact(
         request_scope=ArtifactRequestScope(
             start=start,
             end=end,
-            extent_id="sle",
             bbox=(1.0, 2.0, 3.0, 4.0),
         ),
         coverage=ArtifactCoverage(
@@ -104,8 +103,6 @@ def test_materialize_resampled_artifact_builds_daily_dataset_from_hourly_source(
         method="mean",
         start="2026-01-01",
         end="2026-01-02",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -161,8 +158,6 @@ def test_materialize_resampled_artifact_supports_custom_frequency_dekadal(
         method="sum",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -184,8 +179,6 @@ def test_materialize_resampled_artifact_returns_404_when_source_dataset_template
             method="sum",
             start="2026-01-05",
             end="2026-01-12",
-            extent_id="sle",
-            bbox=None,
             overwrite=False,
             publish=False,
         )
@@ -231,8 +224,6 @@ def test_materialize_resampled_artifact_drops_incomplete_trailing_week(
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -287,8 +278,6 @@ def test_materialize_resampled_artifact_drops_incomplete_leading_week(
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -347,8 +336,6 @@ def test_materialize_resampled_artifact_returns_409_when_source_has_no_data_in_r
             method="sum",
             start="2026-03-02",  # 2026-W10 — well beyond source data
             end="2026-03-02",
-            extent_id="sle",
-            bbox=None,
             overwrite=False,
             publish=False,
         )
@@ -394,8 +381,6 @@ def test_materialize_resampled_artifact_builds_monthly_dataset_from_daily_source
         method="sum",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -450,8 +435,6 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -467,8 +450,6 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -516,8 +497,6 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -527,8 +506,6 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -576,8 +553,6 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -601,8 +576,6 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=True,
     )
@@ -651,8 +624,6 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=False,
         publish=False,
     )
@@ -669,8 +640,6 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
-        extent_id="sle",
-        bbox=None,
         overwrite=True,
         publish=False,
     )

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -58,7 +58,6 @@ def test_post_resample_execution_returns_completed_response(
             "method": "sum",
             "start": "2026-01-05",
             "end": "2026-01-12",
-            "extent_id": "sle",
             "publish": True,
         },
     )
@@ -90,7 +89,6 @@ def test_post_resample_execution_passes_params_to_service(
             "method": "sum",
             "start": "2026-01-05",
             "end": "2026-01-12",
-            "extent_id": "sle",
             "overwrite": True,
             "publish": False,
         },
@@ -102,7 +100,6 @@ def test_post_resample_execution_passes_params_to_service(
     assert captured["method"] == "sum"
     assert captured["start"] == "2026-01-05"
     assert captured["end"] == "2026-01-12"
-    assert captured["extent_id"] == "sle"
     assert captured["overwrite"] is True
     assert captured["publish"] is False
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -15,7 +15,6 @@ def test_root_returns_html_by_default(client: TestClient) -> None:
 def test_root_html_shows_extent(client: TestClient) -> None:
     response = client.get("/")
     assert "Sierra Leone" in response.text
-    assert "sle" in response.text
 
 
 def test_root_html_links_to_key_endpoints(client: TestClient) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -34,7 +34,7 @@ def _artifact(
     dataset_id: str = "chirps3_precipitation_daily",
     dataset_name: str = "CHIRPS3 precipitation",
     variable: str = "precip",
-    managed_dataset_id: str = "chirps3_precipitation_daily_sle",
+    managed_dataset_id: str = "chirps3_precipitation_daily",
     status: PublicationStatus = PublicationStatus.PUBLISHED,
     format: ArtifactFormat = ArtifactFormat.ZARR,
     path: str | None = "/tmp/chirps3_precipitation_daily.zarr",
@@ -135,7 +135,7 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
         "_build_collection_with_xstac",
         lambda **_: {
             "type": "Collection",
-            "id": "chirps3_precipitation_daily_sle",
+            "id": "chirps3_precipitation_daily",
             "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
             "cube:dimensions": {
                 "x": {
@@ -176,13 +176,13 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     )
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["type"] == "Collection"
     assert payload["description"] == "Published GeoZarr dataset for CHIRPS3 precipitation"
-    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily_sle")
+    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily")
     assert payload["assets"]["zarr"]["xarray:open_kwargs"] == {"consolidated": True}
     assert payload["extent"]["temporal"]["interval"] == [["2026-01-01T00:00:00Z", "2026-01-10T00:00:00Z"]]
     assert payload["cube:dimensions"]["x"]["step"] == 0.05
@@ -214,7 +214,7 @@ def test_collection_uses_configured_base_url(client: TestClient, monkeypatch: py
         "_build_collection_with_xstac",
         lambda **_: {
             "type": "Collection",
-            "id": "chirps3_precipitation_daily_sle",
+            "id": "chirps3_precipitation_daily",
             "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
             "cube:dimensions": {"time": {"type": "temporal", "extent": ["2026-01-01", "2026-01-10"]}},
             "cube:variables": {"precip": {"type": "data", "dimensions": ["time", "y", "x"]}},
@@ -224,11 +224,11 @@ def test_collection_uses_configured_base_url(client: TestClient, monkeypatch: py
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["links"][0]["href"] == "https://climate.example.org/stac/collections/chirps3_precipitation_daily_sle"
+    assert payload["links"][0]["href"] == "https://climate.example.org/stac/collections/chirps3_precipitation_daily"
 
 
 def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -237,7 +237,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
         dataset_id="era5land_temperature_hourly",
         dataset_name="ERA5-Land temperature",
         variable="t2m",
-        managed_dataset_id="era5land_temperature_hourly_sle",
+        managed_dataset_id="era5land_temperature_hourly",
         path="/tmp/era5land_temperature_hourly.zarr",
         temporal_start="2026-01-01T00",
         temporal_end="2026-01-01T12",
@@ -257,7 +257,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
         "_build_collection_with_xstac",
         lambda **_: {
             "type": "Collection",
-            "id": "era5land_temperature_hourly_sle",
+            "id": "era5land_temperature_hourly",
             "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
             "cube:dimensions": {
                 "valid_time": {"type": "temporal", "extent": ["2026-01-01T00", "2026-01-01T12"]},
@@ -269,7 +269,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
 
-    response = client.get("/stac/collections/era5land_temperature_hourly_sle")
+    response = client.get("/stac/collections/era5land_temperature_hourly")
 
     assert response.status_code == 200
     payload = response.json()
@@ -297,7 +297,7 @@ def test_collection_uses_level0_href_for_pyramid_zarr_store(
         "_build_collection_with_xstac",
         lambda **_: {
             "type": "Collection",
-            "id": "chirps3_precipitation_daily_sle",
+            "id": "chirps3_precipitation_daily",
             "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
             "cube:dimensions": {"time": {"type": "temporal", "extent": ["2026-01-01", "2026-01-10"]}},
             "cube:variables": {"precip": {"type": "data", "dimensions": ["time", "y", "x"]}},
@@ -307,11 +307,11 @@ def test_collection_uses_level0_href_for_pyramid_zarr_store(
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": None})
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily_sle/0")
+    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily/0")
 
 
 def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
@@ -333,7 +333,7 @@ def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
         "_build_collection_with_xstac",
         lambda **_: {
             "type": "Collection",
-            "id": "chirps3_precipitation_daily_sle",
+            "id": "chirps3_precipitation_daily",
             "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
             "cube:dimensions": {"time": {"type": "temporal", "extent": ["2026-01-01", "2026-01-10"]}},
             "cube:variables": {"precip": {"type": "data", "dimensions": ["time", "y", "x"]}},
@@ -344,11 +344,11 @@ def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": None})
     monkeypatch.setattr(stac_services, "_is_pyramid_zarr", lambda _: True)
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily_sle/0")
+    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily/0")
 
 
 def test_collection_returns_404_for_unknown_dataset(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -380,7 +380,7 @@ def test_catalog_prefers_latest_artifact_per_managed_dataset(
     payload = response.json()
     child_links = [link for link in payload["links"] if link["rel"] == "child"]
     assert len(child_links) == 1
-    assert "chirps3_precipitation_daily_sle" in child_links[0]["href"]
+    assert "chirps3_precipitation_daily" in child_links[0]["href"]
 
 
 def test_catalog_sorts_child_links_by_managed_dataset_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -389,13 +389,13 @@ def test_catalog_sorts_child_links_by_managed_dataset_id(client: TestClient, mon
         "list_artifacts",
         lambda: SimpleNamespace(
             items=[
-                _artifact(artifact_id="a1", managed_dataset_id="worldpop_population_yearly_sle"),
+                _artifact(artifact_id="a1", managed_dataset_id="worldpop_population_yearly"),
                 _artifact(
                     artifact_id="a2",
                     dataset_id="aa_dataset",
                     dataset_name="AA Dataset",
                     variable="value",
-                    managed_dataset_id="aa_dataset_sle",
+                    managed_dataset_id="aa_dataset",
                     path="/tmp/aa_dataset.zarr",
                 ),
             ]
@@ -419,7 +419,7 @@ def test_build_collection_with_xstac_normalizes_pystac_collection(
 
     artifact = _artifact(artifact_id="a1")
     template = pystac.Collection(
-        id="chirps3_precipitation_daily_sle",
+        id="chirps3_precipitation_daily",
         description="template",
         extent=pystac.Extent(
             spatial=pystac.SpatialExtent([[1.0, 2.0, 3.0, 4.0]]),
@@ -438,7 +438,7 @@ def test_build_collection_with_xstac_normalizes_pystac_collection(
 
     assert isinstance(payload, dict)
     assert payload["type"] == "Collection"
-    assert payload["id"] == "chirps3_precipitation_daily_sle"
+    assert payload["id"] == "chirps3_precipitation_daily"
 
 
 def test_collection_reuses_cached_xstac_payload(
@@ -478,8 +478,8 @@ def test_collection_reuses_cached_xstac_payload(
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
 
-    first_response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
-    second_response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    first_response = client.get("/stac/collections/chirps3_precipitation_daily")
+    second_response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert first_response.status_code == 200
     assert second_response.status_code == 200
@@ -537,15 +537,15 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 200
     payload = response.json()
     links = {link["rel"]: link["href"] for link in payload["links"]}
-    assert links["self"].endswith("/stac/collections/chirps3_precipitation_daily_sle")
+    assert links["self"].endswith("/stac/collections/chirps3_precipitation_daily")
     assert links["root"].endswith("/stac/catalog.json")
     assert links["parent"].endswith("/stac/catalog.json")
-    assert links["alternate"].endswith("/datasets/chirps3_precipitation_daily_sle")
+    assert links["alternate"].endswith("/datasets/chirps3_precipitation_daily")
 
 
 def test_collection_returns_500_for_missing_artifact_store_metadata(
@@ -555,7 +555,7 @@ def test_collection_returns_500_for_missing_artifact_store_metadata(
     monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
     monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 500
     assert "no readable storage path metadata" in response.json()["detail"]
@@ -579,7 +579,7 @@ def test_collection_returns_503_when_zarr_store_cannot_be_opened(
         raise_file_not_found,
     )
 
-    response = client.get("/stac/collections/chirps3_precipitation_daily_sle")
+    response = client.get("/stac/collections/chirps3_precipitation_daily")
 
     assert response.status_code == 503
     assert "temporarily unavailable" in response.json()["detail"]
@@ -587,7 +587,7 @@ def test_collection_returns_503_when_zarr_store_cannot_be_opened(
 
 def test_build_collection_with_xstac_reads_normalised_zarr_coordinates(tmp_path: Path) -> None:
     """STAC collection metadata is derived correctly from a normalised longitude/latitude/time store."""
-    zarr_path = tmp_path / "chirps3_precipitation_daily_sle.zarr"
+    zarr_path = tmp_path / "chirps3_precipitation_daily.zarr"
     ds = xr.Dataset(
         {"precip": (["time", "latitude", "longitude"], np.ones((5, 3, 3), dtype="float32"))},
         coords={
@@ -601,7 +601,7 @@ def test_build_collection_with_xstac_reads_normalised_zarr_coordinates(tmp_path:
     artifact = _artifact(artifact_id="a1", path=str(zarr_path))
 
     template = pystac.Collection(
-        id="chirps3_precipitation_daily_sle",
+        id="chirps3_precipitation_daily",
         description="test",
         extent=pystac.Extent(
             spatial=pystac.SpatialExtent([[1.0, 2.0, 3.0, 4.0]]),

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -55,7 +55,6 @@ def _artifact(
         request_scope=ArtifactRequestScope(
             start=temporal_start,
             end=temporal_end,
-            extent_id="sle",
             bbox=(1.0, 2.0, 3.0, 4.0),
         ),
         coverage=ArtifactCoverage(


### PR DESCRIPTION
## Summary

- `extent_id` was threaded through ingestion requests, artifact scopes, sync plans, and processing services to support selecting among multiple named extents. Since only one extent is ever configured per instance, it added indirection without benefit.
- `ArtifactRequestScope`, `CreateIngestionRequest`, and `SyncDetail` schemas drop the `extent_id` field
- `get_extent_or_404()` no longer takes an ID argument — it just returns the single configured extent or 404
- `managed_dataset_id_for_scope` reads the extent ID from config directly; the `adler32` bbox-hash fallback is removed
- Ingestion route, sync service, system UI, and all processing/resample functions resolve the extent from config rather than accepting it as a parameter
- Resampled artifact scopes store only `start/end` — bbox is implicit from the single configured extent

## Breaking changes

- `POST /ingestion` no longer accepts `extent_id` in the request body. The configured extent is always used.
- `SyncDetail` response no longer includes `extent_id`.

## Test plan

- [ ] 211 passing, 0 failing (`make test`)
- [ ] `POST /ingestion` uses the configured extent without requiring `extent_id`
- [ ] `GET /sync/{id}/plan` response no longer contains `extent_id`
- [ ] `GET /extent` still returns the configured extent with its `id`