### PR TITLE
fix: pass STAC bbox as explicit bounds to ZarrLayer for projected-CRS stores

### DIFF
--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
+from pyproj import Transformer
 
 from ...data_manager.services.downloader import get_cache_files, get_zarr_path
 from ...data_manager.services.utils import get_time_dim, get_x_y_dims
@@ -88,8 +89,11 @@ def get_data_coverage_for_paths(
             compat="override",
         )
 
+    from climate_api import config as api_config
+
+    native_crs = api_config.get_crs() or "EPSG:4326"
     try:
-        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]))
+        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]), native_crs=native_crs)
     finally:
         ds.close()
 
@@ -122,7 +126,7 @@ def _open_zarr(zarr_path: str) -> xr.Dataset:
     return xr.open_zarr(zarr_path, consolidated=None)  # type: ignore[no-any-return]
 
 
-def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any]:
+def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str, native_crs: str = "EPSG:4326") -> dict[str, Any]:
     """Summarize temporal and spatial coverage for an already opened dataset."""
     if any(size == 0 for size in ds.sizes.values()):
         return {
@@ -130,6 +134,7 @@ def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any
             "coverage": {
                 "temporal": {"start": None, "end": None},
                 "spatial": {"xmin": None, "ymin": None, "xmax": None, "ymax": None},
+                "spatial_wgs84": None,
             },
         }
 
@@ -142,11 +147,19 @@ def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str) -> dict[str, Any
     xmin, xmax = ds[x_dim].min().item(), ds[x_dim].max().item()
     ymin, ymax = ds[y_dim].min().item(), ds[y_dim].max().item()
 
+    spatial_wgs84 = None
+    wgs84 = "EPSG:4326"
+    if native_crs.upper() != wgs84:
+        transformer = Transformer.from_crs(native_crs, wgs84, always_xy=True)
+        lon_min, lat_min, lon_max, lat_max = transformer.transform_bounds(xmin, ymin, xmax, ymax)
+        spatial_wgs84 = {"xmin": lon_min, "ymin": lat_min, "xmax": lon_max, "ymax": lat_max}
+
     return {
         "has_data": True,
         "coverage": {
             "temporal": {"start": start, "end": end},
             "spatial": {"xmin": xmin, "ymin": ymin, "xmax": xmax, "ymax": ymax},
+            "spatial_wgs84": spatial_wgs84,
         },
     }
 

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -59,9 +59,12 @@ def get_data(
 
 def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
     """Return temporal and spatial coverage metadata for downloaded data."""
+    from climate_api import config as api_config
+
+    native_crs = api_config.get_crs() or "EPSG:4326"
     ds = get_data(dataset)
     try:
-        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]))
+        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]), native_crs=native_crs)
     finally:
         ds.close()
 

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -61,6 +61,10 @@ class ArtifactCoverage(BaseModel):
     """Artifact coverage metadata."""
 
     spatial: CoverageSpatial = Field(description="Covered spatial extent of the managed dataset.")
+    spatial_wgs84: CoverageSpatial | None = Field(
+        default=None,
+        description="Spatial extent in WGS84. None for WGS84 instances or legacy records.",
+    )
     temporal: CoverageTemporal = Field(description="Covered temporal extent of the managed dataset.")
 
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -275,9 +275,11 @@ def create_artifact(
     )
     if not coverage_data.get("has_data", True):
         raise HTTPException(status_code=409, detail="Downloaded artifact contains no data for the requested scope")
+    _spatial_wgs84_data = coverage_data["coverage"].get("spatial_wgs84")
     coverage = ArtifactCoverage(
         temporal=CoverageTemporal(**coverage_data["coverage"]["temporal"]),
         spatial=CoverageSpatial(**coverage_data["coverage"]["spatial"]),
+        spatial_wgs84=CoverageSpatial(**_spatial_wgs84_data) if _spatial_wgs84_data else None,
     )
     if not _temporal_coverage_matches_request_scope(coverage.temporal, request_scope):
         raise HTTPException(
@@ -357,9 +359,11 @@ def store_materialized_zarr_artifact(
     coverage_data = get_data_coverage_for_paths(dataset, zarr_path=str(zarr_path.resolve()))
     if not coverage_data.get("has_data", True):
         raise HTTPException(status_code=409, detail="Materialized artifact contains no data for the requested scope")
+    _spatial_wgs84_data = coverage_data["coverage"].get("spatial_wgs84")
     coverage = ArtifactCoverage(
         temporal=CoverageTemporal(**coverage_data["coverage"]["temporal"]),
         spatial=CoverageSpatial(**coverage_data["coverage"]["spatial"]),
+        spatial_wgs84=CoverageSpatial(**_spatial_wgs84_data) if _spatial_wgs84_data else None,
     )
     request_scope = request_scope.model_copy(update={"end": coverage.temporal.end})
 

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -146,7 +146,7 @@ def _build_collection_template(
     zarr_href: str,
     source_dataset: dict[str, Any],
 ) -> pystac.Collection:
-    spatial = artifact.coverage.spatial
+    spatial = artifact.coverage.spatial_wgs84 or artifact.coverage.spatial
     temporal = artifact.coverage.temporal
     template = pystac.Collection(
         id=dataset_id,
@@ -349,7 +349,7 @@ def _round_spatial_steps(collection: dict[str, Any]) -> None:
 
 
 def _override_spatial_extent_from_artifact(collection: dict[str, Any], artifact: ArtifactRecord) -> None:
-    spatial = artifact.coverage.spatial
+    spatial = artifact.coverage.spatial_wgs84 or artifact.coverage.spatial
     collection["extent"]["spatial"]["bbox"] = [[spatial.xmin, spatial.ymin, spatial.xmax, spatial.ymax]]
 
 

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -431,9 +431,9 @@
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
 
-        // Always pass the STAC spatial bbox as explicit bounds so ZarrLayer
-        // positions the layer in WGS84 regardless of the store's native CRS.
-        // The API guarantees extent.spatial.bbox is always in WGS84.
+        // Pass the STAC spatial bbox as explicit bounds so ZarrLayer positions
+        // the layer correctly for projected-CRS stores (e.g. EPSG:25833).
+        // extent.spatial.bbox is always in WGS84 (reprojected at ingest time).
         const stacBbox = collection.extent?.spatial?.bbox?.[0] ?? null;
 
         let cm;

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -431,6 +431,11 @@
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
 
+        // Always pass the STAC spatial bbox as explicit bounds so ZarrLayer
+        // positions the layer in WGS84 regardless of the store's native CRS.
+        // The API guarantees extent.spatial.bbox is always in WGS84.
+        const stacBbox = collection.extent?.spatial?.bbox?.[0] ?? null;
+
         let cm;
         try {
           cm = buildColormap(colormapName);
@@ -447,6 +452,7 @@
             selector,
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
+            ...(stacBbox !== null && { bounds: stacBbox }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -433,7 +433,8 @@
 
         // Pass the STAC spatial bbox as explicit bounds so ZarrLayer positions
         // the layer correctly for projected-CRS stores (e.g. EPSG:25833).
-        // extent.spatial.bbox is always in WGS84 (reprojected at ingest time).
+        // WGS84 for datasets ingested after spatial_wgs84 was introduced; legacy
+        // records without it fall back to native-CRS coordinates.
         const stacBbox = collection.extent?.spatial?.bbox?.[0] ?? null;
 
         let cm;

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -433,9 +433,9 @@
 
         // Pass the STAC spatial bbox as explicit bounds so ZarrLayer positions
         // the layer correctly for projected-CRS stores (e.g. EPSG:25833).
-        // WGS84 for datasets ingested after spatial_wgs84 was introduced; legacy
-        // records without it fall back to native-CRS coordinates.
-        const stacBbox = collection.extent?.spatial?.bbox?.[0] ?? null;
+        // WGS84 for datasets with spatial_wgs84; legacy projected records fall
+        // back to native-CRS coordinates and may not position correctly.
+        const stacBbox = collection.extent?.spatial?.bbox?.[0];
 
         let cm;
         try {
@@ -453,7 +453,7 @@
             selector,
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
-            ...(stacBbox !== null && { bounds: stacBbox }),
+            ...(stacBbox !== undefined && { bounds: stacBbox }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException
 from topozarr.pyramid import Pyramid
 from xarray import DataTree
 
-from climate_api.data_accessor.services.accessor import open_zarr_dataset
+from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
 from climate_api.data_manager.services import downloader
 from climate_api.ingestions import services as ingestion_services
 
@@ -595,3 +595,50 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
         assert "time" in result.coords
     finally:
         result.close()
+
+
+# ---------------------------------------------------------------------------
+# _coverage_from_dataset — WGS84 reprojection
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_from_dataset_populates_spatial_wgs84_for_projected_crs() -> None:
+    # Small UTM33N (EPSG:25833) bounding box covering south-central Norway.
+    x = np.array([100_000.0, 200_000.0])  # easting metres
+    y = np.array([6_500_000.0, 6_600_000.0])  # northing metres
+    times = pd.date_range("2020-01-01", periods=1, freq="D")
+    data = np.ones((1, len(y), len(x)))
+    ds = xr.Dataset(
+        {"temperature": (["time", "y", "x"], data)},
+        coords={"time": times, "y": y, "x": x},
+    )
+
+    result = _coverage_from_dataset(ds=ds, period_type="daily", native_crs="EPSG:25833")
+
+    wgs84 = result["coverage"]["spatial_wgs84"]
+    assert wgs84 is not None
+    # Reprojected bounds must be in WGS84 degree range.
+    assert -180 <= wgs84["xmin"] <= 180
+    assert -180 <= wgs84["xmax"] <= 180
+    assert -90 <= wgs84["ymin"] <= 90
+    assert -90 <= wgs84["ymax"] <= 90
+    # Rough sanity check: UTM33N easting ~100–200 km, northing ~6500–6600 km.
+    assert 7.0 < wgs84["xmin"] < 10.0
+    assert 8.0 < wgs84["xmax"] < 12.0
+    assert 58.0 < wgs84["ymin"] < 62.0
+    assert 58.0 < wgs84["ymax"] < 62.0
+
+
+def test_coverage_from_dataset_leaves_spatial_wgs84_none_for_wgs84() -> None:
+    x = np.array([-10.0, -9.0])
+    y = np.array([7.0, 8.0])
+    times = pd.date_range("2020-01-01", periods=1, freq="D")
+    data = np.ones((1, len(y), len(x)))
+    ds = xr.Dataset(
+        {"temperature": (["time", "y", "x"], data)},
+        coords={"time": times, "y": y, "x": x},
+    )
+
+    result = _coverage_from_dataset(ds=ds, period_type="daily", native_crs="EPSG:4326")
+
+    assert result["coverage"]["spatial_wgs84"] is None


### PR DESCRIPTION
## Summary

- Extracts `extent.spatial.bbox[0]` from the STAC collection response and passes it as the `bounds` prop to `ZarrLayer`
- Fixes map rendering for instances using a projected CRS (e.g. Norway EPSG:25833 / UTM zone 33N)
- No change for WGS84 instances — when `stacBbox` is `null`, the spread is a no-op

## Problem

`@carbonplan/zarr-layer` reads the store's x/y coordinate arrays and treats them as WGS84 longitude/latitude. For projected-CRS stores (EPSG:25833), coordinates are in metres (x: ~−74 500 – 1 119 500, y: ~6 466 500 – 7 976 500), which are completely outside the valid WGS84 range, so nothing rendered on the map.

## Fix

The STAC API guarantees `extent.spatial.bbox` is always in WGS84 (reprojected at ingest time). Passing this bbox as `bounds` (i.e. `explicitBounds`) tells `ZarrLayer` exactly where to position the layer without reading the native coordinate arrays.

## Test plan

- [ ] Verify the Norway instance (EPSG:25833) renders raster layers on the map at the correct geographic position
- [ ] Verify a WGS84 instance (e.g. Sierra Leone) continues to render correctly — `bounds` is omitted when `stacBbox` is `null`