### PR TITLE
fix: remove bounds prop — rely on ZarrLayer native CRS reprojection

### DIFF
--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -431,12 +431,6 @@
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
 
-        // Pass the STAC spatial bbox as explicit bounds so ZarrLayer positions
-        // the layer correctly for projected-CRS stores (e.g. EPSG:25833).
-        // WGS84 for datasets with spatial_wgs84; legacy projected records fall
-        // back to native-CRS coordinates and may not position correctly.
-        const stacBbox = collection.extent?.spatial?.bbox?.[0];
-
         let cm;
         try {
           cm = buildColormap(colormapName);
@@ -453,7 +447,6 @@
             selector,
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
-            ...(stacBbox !== undefined && { bounds: stacBbox }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {


### PR DESCRIPTION
## Summary

- Removes the `bounds` prop that was added to `ZarrLayer` in PR #100
- Relies on `ZarrLayer` 0.5.0 reading `proj:code` from the zarr store root metadata to reproject natively via `proj4` / `@developmentseed/raster-reproject`

## Problem

PR #100 passed `extent.spatial.bbox` as `bounds` to `ZarrLayer` to fix rendering of projected-CRS stores (e.g. Norway EPSG:25833). The fix did make data visible, but produced a visible skew: the UTM grid's rectangular extent was linearly stretched to fit the WGS84 bounding box corners, causing the data to appear as a rotated rectangle rather than conforming to actual geography.

## Fix

`ZarrLayer` 0.5.0 already imports `proj4` and `@developmentseed/raster-reproject` for untiled multiscale stores. The zarr store written by the Climate API includes `"proj:code": "EPSG:25833"` in root metadata. Removing `bounds` lets the library read that attribute and perform correct client-side CRS reprojection.

## Test plan

- [ ] Verify Norway (EPSG:25833) seNorge and WorldPop layers render correctly aligned to geography with no rectangular skew
- [ ] Verify WGS84 instances continue to render correctly