### PR TITLE
fix: pass native CRS and proj4 string to ZarrLayer for projected stores

### DIFF
--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -25,6 +25,7 @@ CATALOG_TITLE = "DHIS2 Climate API"
 CATALOG_DESCRIPTION = "Published Climate API GeoZarr datasets"
 STAC_VERSION = "1.1.0"
 DATACUBE_EXTENSION = "https://stac-extensions.github.io/datacube/v2.3.0/schema.json"
+PROJECTION_EXTENSION = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
 RENDER_EXTENSION = "https://stac-extensions.github.io/render/v2.0.0/schema.json"
 ZARR_EXTENSION = "https://stac-extensions.github.io/zarr/v1.1.0/schema.json"
 DEFAULT_STAC_LICENSE = "various"
@@ -160,6 +161,7 @@ def _build_collection_template(
         title=artifact.dataset_name,
         stac_extensions=[
             DATACUBE_EXTENSION,
+            PROJECTION_EXTENSION,
             ZARR_EXTENSION,
         ],
         license=DEFAULT_STAC_LICENSE,

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -164,7 +164,11 @@ def _build_collection_template(
         ],
         license=DEFAULT_STAC_LICENSE,
     )
+    from climate_api import config as api_config
+
+    native_crs = api_config.get_crs() or "EPSG:4326"
     template.extra_fields["keywords"] = _keywords(artifact, source_dataset)
+    template.extra_fields["proj:code"] = native_crs
     template.clear_links()
     template.add_link(pystac.Link(rel="self", target=collection_href, media_type="application/json"))
     template.add_link(pystac.Link(rel="root", target=catalog_href, media_type="application/json"))

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -434,13 +434,23 @@
         // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
         // reprojects natively instead of treating coordinates as WGS84 degrees.
         const nativeCrs = collection["proj:code"] ?? "EPSG:4326";
+        const WGS84 = new Set(["EPSG:4326", "OGC:CRS84", "CRS84"]);
+        const isWgs84 = WGS84.has(nativeCrs.toUpperCase());
         let proj4String = null;
-        if (nativeCrs !== "EPSG:4326") {
+        if (!isWgs84) {
           try {
-            const epsgId = nativeCrs.split(":")[1];
-            const p4res = await fetch(`https://epsg.io/${epsgId}.proj4`);
-            if (p4res.ok) proj4String = (await p4res.text()).trim();
-          } catch {}
+            const match = nativeCrs.match(/(\d+)$/);
+            const epsgId = match?.[1];
+            if (epsgId) {
+              const p4res = await fetch(`https://epsg.io/${epsgId}.proj4`);
+              if (p4res.ok) proj4String = (await p4res.text()).trim();
+              else console.warn(`[map] Could not fetch proj4 for ${nativeCrs} (HTTP ${p4res.status})`);
+            } else {
+              console.warn(`[map] Cannot extract EPSG id from CRS "${nativeCrs}" — rendering may be incorrect`);
+            }
+          } catch (err) {
+            console.warn(`[map] Failed to fetch proj4 string for "${nativeCrs}":`, err);
+          }
         }
 
         let cm;
@@ -459,7 +469,7 @@
             selector,
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
-            ...(nativeCrs !== "EPSG:4326" && { crs: nativeCrs }),
+            ...(!isWgs84 && { crs: nativeCrs }),
             ...(proj4String !== null && { proj4: proj4String }),
           });
           map.addLayer(activeLayer);

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -431,6 +431,18 @@
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
 
+        // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
+        // reprojects natively instead of treating coordinates as WGS84 degrees.
+        const nativeCrs = collection["proj:code"] ?? "EPSG:4326";
+        let proj4String = null;
+        if (nativeCrs !== "EPSG:4326") {
+          try {
+            const epsgId = nativeCrs.split(":")[1];
+            const p4res = await fetch(`https://epsg.io/${epsgId}.proj4`);
+            if (p4res.ok) proj4String = (await p4res.text()).trim();
+          } catch {}
+        }
+
         let cm;
         try {
           cm = buildColormap(colormapName);
@@ -447,6 +459,8 @@
             selector,
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
+            ...(nativeCrs !== "EPSG:4326" && { crs: nativeCrs }),
+            ...(proj4String !== null && { proj4: proj4String }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {


### PR DESCRIPTION
## Summary

- Adds `proj:code` to STAC collection `extra_fields` so the map viewer has the native CRS without an extra fetch
- Map viewer reads `collection["proj:code"]`; if not EPSG:4326, fetches the proj4 string from epsg.io and passes `crs` + `proj4` to `ZarrLayer`
- `ZarrLayer` 0.5.0 uses `proj4` to correctly reproject the store's native coordinates to WGS84 during rendering

## Problem

`ZarrLayer` defaults to EPSG:4326 when no `crs` prop is supplied. For Norway's EPSG:25833 store, x/y coordinate arrays contain UTM metre values (~-74 500 to 1 119 500 easting, ~6 466 500 to 7 976 500 northing) which `ZarrLayer` treated as WGS84 degrees, placing the data in the English Channel.

## Test plan

- [ ] Norway instance: seNorge and WorldPop layers render correctly over Norway
- [ ] WGS84 instance (e.g. Sierra Leone): layers continue to render correctly — `epsg.io` fetch is skipped entirely when `proj:code` is EPSG:4326