### PR TITLE
fix: preserve NaN fill values when writing flat zarr stores

### DIFF
--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -209,6 +209,12 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
         ds.attrs.update(geozarr_attrs)
         ds_chunked = ds.chunk(uniform_chunks)
+        # Remove _FillValue from each variable's encoding so that in-memory NaN values
+        # are stored as IEEE NaN in zarr rather than re-encoded as a sentinel (e.g.
+        # -999.99). ZarrLayer uses the zarr fill_value attribute (nan for floats) to
+        # render missing pixels as transparent — not a separately specified fillValue.
+        for var in ds_chunked.data_vars:
+            ds_chunked[var].encoding.pop("_FillValue", None)
         ds_chunked.to_zarr(zarr_path, mode="w", consolidated=True)
         ds_chunked.close()
 


### PR DESCRIPTION
## Summary

- xarray inherits `_FillValue` from netCDF source encoding and re-encodes in-memory NaN values back to the sentinel (e.g. `-999.99` for seNorge) when writing to zarr
- ZarrLayer reads the zarr array's `fill_value` attribute (`nan` for floats) for pixel transparency — it does not compare against a separate `_FillValue` attribute
- Out-of-Norway pixels (originally masked in the netCDF) were being stored as `-999.99` and rendered as opaque dark blue instead of transparent

## Fix

Remove `_FillValue` from each variable's xarray encoding before calling `to_zarr()`. This preserves the in-memory NaN values as IEEE NaN in the zarr chunks, matching the zarr array's `fill_value: nan` declaration. ZarrLayer then masks those pixels automatically with no extra configuration needed.

## Test plan

- [ ] Rebuild seNorge temperature zarr and verify `zarr store['tg'].fill_value == nan` and `np.any(np.isnan(data[0]))` is True
- [ ] Confirm out-of-Norway pixels are transparent in the map viewer
- [ ] Verify other datasets (WorldPop, CHIRPS) still ingest correctly