### PR TITLE
refactor: derive period_type from extents.temporal.resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ data/derived
 data/pygeoapi
 docs/internal/
 site/
+.claude/

--- a/climate_api/data/datasets/chirps3.yaml
+++ b/climate_api/data/datasets/chirps3.yaml
@@ -10,10 +10,8 @@
   extents:
     spatial:
       bbox: [-180, -50, 180, 50]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1981-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1D
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download

--- a/climate_api/data/datasets/chirps3.yaml
+++ b/climate_api/data/datasets/chirps3.yaml
@@ -2,7 +2,6 @@
   name: Total precipitation (CHIRPS3)
   short_name: Total precipitation
   variable: precip
-  period_type: daily
   sync:
     kind: temporal
     execution: append

--- a/climate_api/data/datasets/era5_land.yaml
+++ b/climate_api/data/datasets/era5_land.yaml
@@ -2,7 +2,6 @@
   name: 2m temperature (ERA5-Land)
   short_name: 2m temperature
   variable: t2m
-  period_type: hourly
   sync:
     kind: temporal
     execution: append
@@ -35,7 +34,6 @@
   name: Total precipitation (ERA5-Land)
   short_name: Total precipitation
   variable: tp
-  period_type: hourly
   sync:
     kind: temporal
     execution: append

--- a/climate_api/data/datasets/era5_land.yaml
+++ b/climate_api/data/datasets/era5_land.yaml
@@ -11,10 +11,8 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
@@ -43,10 +41,8 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download

--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -2,7 +2,6 @@
   name: Total population (WorldPop Global2)
   short_name: Total population
   variable: pop_total
-  period_type: yearly
   sync:
     kind: release
     availability:

--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -11,11 +11,9 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "2015"
       end: "2030"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download

--- a/climate_api/data/processes/resample.yaml
+++ b/climate_api/data/processes/resample.yaml
@@ -1,4 +1,4 @@
 - id: resample
   name: Temporal resampling
-  description: Aggregate a source dataset to a coarser temporal resolution using pandas frequency aliases (e.g. 1D, W-MON, MS).
+  description: Aggregate a source dataset to a coarser temporal resolution using an ISO 8601 duration (e.g. P1M, P1W, P1D, PT1H).
   execution_function: climate_api.processing.services.execute_resample

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -11,7 +11,6 @@ from pyproj import Transformer
 
 from ...data_manager.services.downloader import get_cache_files, get_zarr_path
 from ...data_manager.services.utils import get_time_dim, get_x_y_dims
-from ...data_registry.services.datasets import get_period_type
 from ...shared.time import numpy_datetime_to_period_string
 
 logger = logging.getLogger(__name__)
@@ -65,7 +64,8 @@ def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
     native_crs = api_config.get_crs() or "EPSG:4326"
     ds = get_data(dataset)
     try:
-        return _coverage_from_dataset(ds=ds, period_type=get_period_type(dataset), native_crs=native_crs)
+        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        return _coverage_from_dataset(ds=ds, resolution=resolution, native_crs=native_crs)
     finally:
         ds.close()
 
@@ -97,7 +97,8 @@ def get_data_coverage_for_paths(
 
     native_crs = api_config.get_crs() or "EPSG:4326"
     try:
-        return _coverage_from_dataset(ds=ds, period_type=get_period_type(dataset), native_crs=native_crs)
+        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        return _coverage_from_dataset(ds=ds, resolution=resolution, native_crs=native_crs)
     finally:
         ds.close()
 
@@ -130,7 +131,7 @@ def _open_zarr(zarr_path: str) -> xr.Dataset:
     return xr.open_zarr(zarr_path, consolidated=None)  # type: ignore[no-any-return]
 
 
-def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str, native_crs: str = "EPSG:4326") -> dict[str, Any]:
+def _coverage_from_dataset(*, ds: xr.Dataset, resolution: str, native_crs: str = "EPSG:4326") -> dict[str, Any]:
     """Summarize temporal and spatial coverage for an already opened dataset."""
     if any(size == 0 for size in ds.sizes.values()):
         return {
@@ -145,8 +146,8 @@ def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str, native_crs: str 
     time_dim = get_time_dim(ds)
     x_dim, y_dim = get_x_y_dims(ds)
 
-    start = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].min(), period_type))  # type: ignore[arg-type]
-    end = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].max(), period_type))  # type: ignore[arg-type]
+    start = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].min(), resolution))  # type: ignore[arg-type]
+    end = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].max(), resolution))  # type: ignore[arg-type]
 
     xmin, xmax = ds[x_dim].min().item(), ds[x_dim].max().item()
     ymin, ymax = ds[y_dim].min().item(), ds[y_dim].max().item()

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -11,6 +11,7 @@ from pyproj import Transformer
 
 from ...data_manager.services.downloader import get_cache_files, get_zarr_path
 from ...data_manager.services.utils import get_time_dim, get_x_y_dims
+from ...data_registry.services.datasets import get_period_type
 from ...shared.time import numpy_datetime_to_period_string
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
     native_crs = api_config.get_crs() or "EPSG:4326"
     ds = get_data(dataset)
     try:
-        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str = get_period_type(dataset)
         return _coverage_from_dataset(ds=ds, period_type=period_type, native_crs=native_crs)
     finally:
         ds.close()
@@ -97,7 +98,7 @@ def get_data_coverage_for_paths(
 
     native_crs = api_config.get_crs() or "EPSG:4326"
     try:
-        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str = get_period_type(dataset)
         return _coverage_from_dataset(ds=ds, period_type=period_type, native_crs=native_crs)
     finally:
         ds.close()

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -64,8 +64,8 @@ def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
     native_crs = api_config.get_crs() or "EPSG:4326"
     ds = get_data(dataset)
     try:
-        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
-        return _coverage_from_dataset(ds=ds, resolution=resolution, native_crs=native_crs)
+        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        return _coverage_from_dataset(ds=ds, period_type=period_type, native_crs=native_crs)
     finally:
         ds.close()
 
@@ -97,8 +97,8 @@ def get_data_coverage_for_paths(
 
     native_crs = api_config.get_crs() or "EPSG:4326"
     try:
-        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
-        return _coverage_from_dataset(ds=ds, resolution=resolution, native_crs=native_crs)
+        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        return _coverage_from_dataset(ds=ds, period_type=period_type, native_crs=native_crs)
     finally:
         ds.close()
 
@@ -131,7 +131,7 @@ def _open_zarr(zarr_path: str) -> xr.Dataset:
     return xr.open_zarr(zarr_path, consolidated=None)  # type: ignore[no-any-return]
 
 
-def _coverage_from_dataset(*, ds: xr.Dataset, resolution: str, native_crs: str = "EPSG:4326") -> dict[str, Any]:
+def _coverage_from_dataset(*, ds: xr.Dataset, period_type: str, native_crs: str = "EPSG:4326") -> dict[str, Any]:
     """Summarize temporal and spatial coverage for an already opened dataset."""
     if any(size == 0 for size in ds.sizes.values()):
         return {
@@ -146,8 +146,8 @@ def _coverage_from_dataset(*, ds: xr.Dataset, resolution: str, native_crs: str =
     time_dim = get_time_dim(ds)
     x_dim, y_dim = get_x_y_dims(ds)
 
-    start = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].min(), resolution))  # type: ignore[arg-type]
-    end = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].max(), resolution))  # type: ignore[arg-type]
+    start = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].min(), period_type))  # type: ignore[arg-type]
+    end = _period_string_scalar(numpy_datetime_to_period_string(ds[time_dim].max(), period_type))  # type: ignore[arg-type]
 
     xmin, xmax = ds[x_dim].min().item(), ds[x_dim].max().item()
     ymin, ymax = ds[y_dim].min().item(), ds[y_dim].max().item()

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -11,6 +11,7 @@ from pyproj import Transformer
 
 from ...data_manager.services.downloader import get_cache_files, get_zarr_path
 from ...data_manager.services.utils import get_time_dim, get_x_y_dims
+from ...data_registry.services.datasets import get_period_type
 from ...shared.time import numpy_datetime_to_period_string
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def get_data_coverage(dataset: dict[str, Any]) -> dict[str, Any]:
     native_crs = api_config.get_crs() or "EPSG:4326"
     ds = get_data(dataset)
     try:
-        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]), native_crs=native_crs)
+        return _coverage_from_dataset(ds=ds, period_type=get_period_type(dataset), native_crs=native_crs)
     finally:
         ds.close()
 
@@ -96,7 +97,7 @@ def get_data_coverage_for_paths(
 
     native_crs = api_config.get_crs() or "EPSG:4326"
     try:
-        return _coverage_from_dataset(ds=ds, period_type=str(dataset["period_type"]), native_crs=native_crs)
+        return _coverage_from_dataset(ds=ds, period_type=get_period_type(dataset), native_crs=native_crs)
     finally:
         ds.close()
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -304,6 +304,8 @@ def _compute_time_space_chunks(
         chunks[dim] = 24 * 7
     elif period_type == "P1D":  # daily
         chunks[dim] = 30
+    elif period_type == "P1W":  # weekly
+        chunks[dim] = 52
     elif period_type == "P1M":  # monthly
         chunks[dim] = 12
     elif period_type == "P1Y":  # yearly

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -300,13 +300,13 @@ def _compute_time_space_chunks(
 
     dim = get_time_dim(ds)
     period_type: str = get_period_type(dataset)
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         chunks[dim] = 24 * 7
-    elif period_type == "P1D":
+    elif period_type == "P1D":  # daily
         chunks[dim] = 30
-    elif period_type == "P1M":
+    elif period_type == "P1M":  # monthly
         chunks[dim] = 12
-    elif period_type == "P1Y":
+    elif period_type == "P1Y":  # yearly
         chunks[dim] = 1
 
     x_dim, y_dim = get_x_y_dims(ds)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,6 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -298,7 +299,7 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    period_type = dataset["period_type"]
+    period_type = get_period_type(dataset)
     if period_type == "hourly":
         chunks[dim] = 24 * 7
     elif period_type == "daily":

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,7 +17,6 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -299,14 +298,14 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    period_type = get_period_type(dataset)
-    if period_type == "hourly":
+    resolution: str = str(dataset.get("extents", {}).get("temporal", {}).get("resolution", ""))  # type: ignore[union-attr]
+    if "T" in resolution.upper():
         chunks[dim] = 24 * 7
-    elif period_type == "daily":
+    elif resolution == "P1D":
         chunks[dim] = 30
-    elif period_type == "monthly":
+    elif resolution == "P1M":
         chunks[dim] = 12
-    elif period_type == "yearly":
+    elif resolution == "P1Y":
         chunks[dim] = 1
 
     x_dim, y_dim = get_x_y_dims(ds)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -298,7 +298,7 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    period_type: str = str(dataset.get("extents", {}).get("temporal", {}).get("resolution", ""))  # type: ignore[union-attr]
+    period_type: str = str(dataset["extents"]["temporal"]["resolution"])
     if "T" in period_type.upper():
         chunks[dim] = 24 * 7
     elif period_type == "P1D":

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -298,14 +298,14 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    resolution: str = str(dataset.get("extents", {}).get("temporal", {}).get("resolution", ""))  # type: ignore[union-attr]
-    if "T" in resolution.upper():
+    period_type: str = str(dataset.get("extents", {}).get("temporal", {}).get("resolution", ""))  # type: ignore[union-attr]
+    if "T" in period_type.upper():
         chunks[dim] = 24 * 7
-    elif resolution == "P1D":
+    elif period_type == "P1D":
         chunks[dim] = 30
-    elif resolution == "P1M":
+    elif period_type == "P1M":
         chunks[dim] = 12
-    elif resolution == "P1Y":
+    elif period_type == "P1Y":
         chunks[dim] = 1
 
     x_dim, y_dim = get_x_y_dims(ds)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,8 +17,8 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.transforms.reproject import reproject_to_instance_crs
 from climate_api.data_registry.services.datasets import get_period_type
+from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -300,7 +300,7 @@ def _compute_time_space_chunks(
 
     dim = get_time_dim(ds)
     period_type: str = get_period_type(dataset)
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         chunks[dim] = 24 * 7
     elif period_type == "P1D":
         chunks[dim] = 30

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -18,6 +18,7 @@ from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
 from climate_api.transforms.reproject import reproject_to_instance_crs
+from climate_api.data_registry.services.datasets import get_period_type
 
 from .utils import get_time_dim, get_x_y_dims
 
@@ -298,7 +299,7 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    period_type: str = str(dataset["extents"]["temporal"]["resolution"])
+    period_type: str = get_period_type(dataset)
     if "T" in period_type.upper():
         chunks[dim] = 24 * 7
     elif period_type == "P1D":

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -18,6 +18,7 @@ from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
 from climate_api.data_registry.services.datasets import get_period_type
+from climate_api.shared.time import _period_family
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -299,16 +300,16 @@ def _compute_time_space_chunks(
     chunks: dict[str, int] = {}
 
     dim = get_time_dim(ds)
-    period_type: str = get_period_type(dataset)
-    if period_type == "PT1H":  # hourly
+    family = _period_family(get_period_type(dataset))
+    if family == "PT1H":  # hourly
         chunks[dim] = 24 * 7
-    elif period_type == "P1D":  # daily
+    elif family == "P1D":  # daily
         chunks[dim] = 30
-    elif period_type == "P1W":  # weekly
+    elif family == "P1W":  # weekly
         chunks[dim] = 52
-    elif period_type == "P1M":  # monthly
+    elif family == "P1M":  # monthly
         chunks[dim] = 12
-    elif period_type == "P1Y":  # yearly
+    elif family == "P1Y":  # yearly
         chunks[dim] = 1
 
     x_dim, y_dim = get_x_y_dims(ds)

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -19,6 +19,15 @@ CONFIGS_DIR: Path | None = None
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
+_ISO_RESOLUTION_TO_PERIOD_TYPE: dict[str, str] = {
+    "PT1H": "hourly",
+    "P1D": "daily",
+    "P1W": "weekly",
+    "P1M": "monthly",
+    "P1Y": "yearly",
+}
+SUPPORTED_PERIOD_TYPES: frozenset[str] = frozenset(_ISO_RESOLUTION_TO_PERIOD_TYPE.values())
+
 
 def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
@@ -159,6 +168,24 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     sync_availability = sync_block.get("availability") if isinstance(sync_block, dict) else None
     if sync_availability is not None:
         _validate_sync_availability(sync_availability, dataset_id=dataset_id, source=source)
+
+    extents = dataset.get("extents")
+    temporal = extents.get("temporal") if isinstance(extents, dict) else None
+    resolution = temporal.get("resolution") if isinstance(temporal, dict) else None
+    if not isinstance(resolution, str) or not resolution:
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define extents.temporal.resolution")
+    dataset["period_type"] = _resolution_to_period_type(resolution, dataset_id=dataset_id, source=source)
+
+
+def _resolution_to_period_type(resolution: str, *, dataset_id: str, source: str) -> str:
+    period_type = _ISO_RESOLUTION_TO_PERIOD_TYPE.get(resolution.strip())
+    if period_type is None:
+        supported = ", ".join(sorted(_ISO_RESOLUTION_TO_PERIOD_TYPE))
+        raise ValueError(
+            f"Dataset template '{dataset_id}' in {source} has unrecognised "
+            f"extents.temporal.resolution '{resolution}'. Supported values: {supported}"
+        )
+    return period_type
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -19,14 +19,6 @@ CONFIGS_DIR: Path | None = None
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
-_ISO_RESOLUTION_TO_PERIOD_TYPE: dict[str, str] = {
-    "PT1H": "hourly",
-    "P1D": "daily",
-    "P1W": "weekly",
-    "P1M": "monthly",
-    "P1Y": "yearly",
-}
-SUPPORTED_PERIOD_TYPES: frozenset[str] = frozenset(_ISO_RESOLUTION_TO_PERIOD_TYPE.values())
 
 
 def list_datasets() -> list[dict[str, Any]]:
@@ -178,14 +170,21 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
 
 
 def _resolution_to_period_type(resolution: str, *, dataset_id: str, source: str) -> str:
-    period_type = _ISO_RESOLUTION_TO_PERIOD_TYPE.get(resolution.strip())
-    if period_type is None:
-        supported = ", ".join(sorted(_ISO_RESOLUTION_TO_PERIOD_TYPE))
-        raise ValueError(
-            f"Dataset template '{dataset_id}' in {source} has unrecognised "
-            f"extents.temporal.resolution '{resolution}'. Supported values: {supported}"
-        )
-    return period_type
+    r = resolution.strip().upper()
+    if "T" in r:
+        return "hourly"
+    if "Y" in r:
+        return "yearly"
+    if "M" in r:
+        return "monthly"
+    if "W" in r:
+        return "weekly"
+    if "D" in r:
+        return "daily"
+    raise ValueError(
+        f"Dataset template '{dataset_id}' in {source} has unrecognised "
+        f"extents.temporal.resolution '{resolution}'"
+    )
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -20,7 +20,6 @@ SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
 
-
 def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
 
@@ -166,40 +165,6 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     resolution = temporal.get("resolution") if isinstance(temporal, dict) else None
     if not isinstance(resolution, str) or not resolution:
         raise ValueError(f"Dataset template '{dataset_id}' in {source} must define extents.temporal.resolution")
-    try:
-        _iso_resolution_to_period_type(resolution)
-    except ValueError:
-        raise ValueError(
-            f"Dataset template '{dataset_id}' in {source} has unrecognised "
-            f"extents.temporal.resolution '{resolution}'"
-        )
-
-
-def _iso_resolution_to_period_type(resolution: str) -> str:
-    """Map an ISO 8601 duration string to a Climate API period-class string."""
-    r = resolution.strip().upper()
-    if "T" in r:
-        return "hourly"
-    if "Y" in r:
-        return "yearly"
-    if "M" in r:
-        return "monthly"
-    if "W" in r:
-        return "weekly"
-    if "D" in r:
-        return "daily"
-    raise ValueError(f"Cannot determine period type from resolution '{resolution}'")
-
-
-def get_period_type(dataset: dict[str, Any]) -> str:
-    """Return the period-class string derived from extents.temporal.resolution."""
-    try:
-        resolution: object = dataset["extents"]["temporal"]["resolution"]
-    except (KeyError, TypeError):
-        raise ValueError(f"Dataset '{dataset.get('id')}' is missing extents.temporal.resolution")
-    if not isinstance(resolution, str):
-        raise ValueError(f"Dataset '{dataset.get('id')}' extents.temporal.resolution must be a string")
-    return _iso_resolution_to_period_type(resolution)
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -167,6 +167,11 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
         raise ValueError(f"Dataset template '{dataset_id}' in {source} must define extents.temporal.resolution")
 
 
+def get_period_type(dataset: dict[str, Any]) -> str:
+    """Return the ISO 8601 temporal resolution from a dataset dict."""
+    return str(dataset["extents"]["temporal"]["resolution"])
+
+
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:
     """Validate optional source availability policy metadata."""
     if not isinstance(sync_availability, dict):

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -166,10 +166,17 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     resolution = temporal.get("resolution") if isinstance(temporal, dict) else None
     if not isinstance(resolution, str) or not resolution:
         raise ValueError(f"Dataset template '{dataset_id}' in {source} must define extents.temporal.resolution")
-    dataset["period_type"] = _resolution_to_period_type(resolution, dataset_id=dataset_id, source=source)
+    try:
+        _iso_resolution_to_period_type(resolution)
+    except ValueError:
+        raise ValueError(
+            f"Dataset template '{dataset_id}' in {source} has unrecognised "
+            f"extents.temporal.resolution '{resolution}'"
+        )
 
 
-def _resolution_to_period_type(resolution: str, *, dataset_id: str, source: str) -> str:
+def _iso_resolution_to_period_type(resolution: str) -> str:
+    """Map an ISO 8601 duration string to a Climate API period-class string."""
     r = resolution.strip().upper()
     if "T" in r:
         return "hourly"
@@ -181,10 +188,18 @@ def _resolution_to_period_type(resolution: str, *, dataset_id: str, source: str)
         return "weekly"
     if "D" in r:
         return "daily"
-    raise ValueError(
-        f"Dataset template '{dataset_id}' in {source} has unrecognised "
-        f"extents.temporal.resolution '{resolution}'"
-    )
+    raise ValueError(f"Cannot determine period type from resolution '{resolution}'")
+
+
+def get_period_type(dataset: dict[str, Any]) -> str:
+    """Return the period-class string derived from extents.temporal.resolution."""
+    try:
+        resolution: object = dataset["extents"]["temporal"]["resolution"]
+    except (KeyError, TypeError):
+        raise ValueError(f"Dataset '{dataset.get('id')}' is missing extents.temporal.resolution")
+    if not isinstance(resolution, str):
+        raise ValueError(f"Dataset '{dataset.get('id')}' extents.temporal.resolution must be a string")
+    return _iso_resolution_to_period_type(resolution)
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -2,6 +2,7 @@
 
 import importlib.resources
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -165,6 +166,11 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     resolution = temporal.get("resolution") if isinstance(temporal, dict) else None
     if not isinstance(resolution, str) or not resolution:
         raise ValueError(f"Dataset template '{dataset_id}' in {source} must define extents.temporal.resolution")
+    if not re.fullmatch(r"P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?", resolution):
+        raise ValueError(
+            f"Dataset template '{dataset_id}' in {source} has invalid extents.temporal.resolution '{resolution}'"
+            " — must be a valid ISO 8601 duration (e.g. P1D, PT1H, P1M)"
+        )
 
 
 def get_period_type(dataset: dict[str, Any]) -> str:

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -162,7 +162,7 @@ class DatasetRecord(BaseModel):
     dataset_name: str = Field(description="Full display name of the dataset.")
     short_name: str | None = Field(default=None, description="Short display name of the dataset.")
     variable: str = Field(description="Primary raster variable stored in the dataset.")
-    period_type: str = Field(description="Temporal period type of the dataset, for example daily or yearly.")
+    period_type: str = Field(description="ISO 8601 duration string representing the temporal resolution of the dataset, for example P1D or P1Y.")
     units: str | None = Field(default=None, description="Units of the primary variable.")
     resolution: str | None = Field(default=None, description="Native spatial resolution summary.")
     source: str | None = Field(default=None, description="Upstream source name.")
@@ -237,7 +237,7 @@ class DatasetListResponse(BaseModel):
                     "dataset_name": "Total precipitation (CHIRPS3)",
                     "short_name": "Total precipitation",
                     "variable": "precip",
-                    "period_type": "daily",
+                    "period_type": "P1D",
                     "units": "mm",
                     "resolution": "5 km x 5 km",
                     "source": "CHIRPS v3",

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -162,7 +162,7 @@ class DatasetRecord(BaseModel):
     dataset_name: str = Field(description="Full display name of the dataset.")
     short_name: str | None = Field(default=None, description="Short display name of the dataset.")
     variable: str = Field(description="Primary raster variable stored in the dataset.")
-    period_type: str = Field(description="ISO 8601 duration string representing the temporal resolution of the dataset, for example P1D or P1Y.")
+    period_type: str = Field(description="ISO 8601 duration string for the temporal resolution (e.g. P1D, P1Y).")
     units: str | None = Field(default=None, description="Units of the primary variable.")
     resolution: str | None = Field(default=None, description="Native spatial resolution summary.")
     source: str | None = Field(default=None, description="Upstream source name.")

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -22,7 +22,6 @@ from climate_api import config as api_config
 from climate_api.data_accessor.services.accessor import get_data_coverage_for_paths
 from climate_api.data_manager.services import downloader
 from climate_api.data_registry.services import datasets as registry_datasets
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import (
     ArtifactCoverage,
@@ -161,13 +160,13 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
-    period_type = get_period_type(dataset)
-    start = _normalize_request_period(start, period_type=period_type, field_name="start")
-    end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
+    resolution = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    start = _normalize_request_period(start, resolution=resolution, field_name="start")
+    end = _normalize_optional_request_period(end, resolution=resolution, field_name="end")
     download_start = _normalize_optional_request_period(
-        download_start, period_type=period_type, field_name="download_start"
+        download_start, resolution=resolution, field_name="download_start"
     )
-    download_end = _normalize_optional_request_period(download_end, period_type=period_type, field_name="download_end")
+    download_end = _normalize_optional_request_period(download_end, resolution=resolution, field_name="download_end")
     _validate_download_scope(
         start=start,
         end=end,
@@ -177,7 +176,7 @@ def create_artifact(
     requires_canonical_zarr = download_start is not None
     resolved_download_end = download_end if download_end is not None else end
     if resolved_download_end is None:
-        resolved_download_end = _default_request_end(period_type)
+        resolved_download_end = _default_request_end(resolution)
     request_scope = ArtifactRequestScope(
         start=start,
         end=end,
@@ -346,9 +345,9 @@ def store_materialized_zarr_artifact(
     publish: bool,
 ) -> ArtifactRecord:
     """Store metadata for a locally materialized Zarr artifact."""
-    period_type = get_period_type(dataset)
-    normalized_start = _normalize_request_period(start, period_type=period_type, field_name="start")
-    normalized_end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
+    resolution = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    normalized_start = _normalize_request_period(start, resolution=resolution, field_name="start")
+    normalized_end = _normalize_optional_request_period(end, resolution=resolution, field_name="end")
     request_scope = ArtifactRequestScope(
         start=normalized_start,
         end=normalized_end,
@@ -685,10 +684,10 @@ def _find_existing_artifact(
     )
 
 
-def _normalize_request_period(value: str, *, period_type: str, field_name: str) -> str:
+def _normalize_request_period(value: str, *, resolution: str, field_name: str) -> str:
     """Normalize a required request period or raise a clear client error."""
     try:
-        return normalize_period_string(value, period_type)
+        return normalize_period_string(value, resolution)
     except (TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=400,
@@ -696,27 +695,27 @@ def _normalize_request_period(value: str, *, period_type: str, field_name: str) 
         ) from exc
 
 
-def _normalize_optional_request_period(value: str | None, *, period_type: str, field_name: str) -> str | None:
+def _normalize_optional_request_period(value: str | None, *, resolution: str, field_name: str) -> str | None:
     """Normalize an optional request period or raise a clear client error."""
     if value is None:
         return None
-    return _normalize_request_period(value, period_type=period_type, field_name=field_name)
+    return _normalize_request_period(value, resolution=resolution, field_name=field_name)
 
 
-def _default_request_end(period_type: str) -> str:
+def _default_request_end(resolution: str) -> str:
     """Return the current dataset-native period string for omitted ingestion end values."""
-    if period_type == "hourly":
-        return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "daily":
+    if "T" in resolution.upper():
+        return datetime_to_period_string(utc_now(), resolution)
+    if resolution == "P1D":
         return utc_today().isoformat()
-    if period_type == "weekly":
-        return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "monthly":
+    if resolution == "P1W":
+        return datetime_to_period_string(utc_now(), resolution)
+    if resolution == "P1M":
         today = utc_today()
         return f"{today.year:04d}-{today.month:02d}"
-    if period_type == "yearly":
+    if resolution == "P1Y":
         return str(utc_today().year)
-    raise HTTPException(status_code=400, detail=f"Invalid period_type '{period_type}' for request end defaulting")
+    raise HTTPException(status_code=400, detail=f"Invalid resolution '{resolution}' for request end defaulting")
 
 
 def _validate_download_scope(
@@ -828,7 +827,7 @@ def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> D
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
         variable=latest.variable,
-        period_type=_period_type_for_artifact(source_dataset),
+        period_type=_resolution_for_artifact(source_dataset),
         units=_as_optional_str(source_dataset.get("units")),
         resolution=_as_optional_str(source_dataset.get("resolution")),
         source=_as_optional_str(source_dataset.get("source")),
@@ -887,11 +886,12 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
     return links
 
 
-def _period_type_for_artifact(dataset: dict[str, Any]) -> str:
-    """Return the period-class string for a dataset dict, falling back to 'unknown'."""
+def _resolution_for_artifact(dataset: dict[str, Any]) -> str:
+    """Return the ISO 8601 resolution for a dataset dict, falling back to 'unknown'."""
     try:
-        return get_period_type(dataset)
-    except (KeyError, ValueError):
+        resolution: object = dataset["extents"]["temporal"]["resolution"]
+        return str(resolution) if isinstance(resolution, str) else "unknown"
+    except (KeyError, TypeError):
         return "unknown"
 
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -822,13 +822,17 @@ def _temporal_coverage_matches_request_scope(
 def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> DatasetRecord:
     latest = max(artifacts, key=lambda artifact: artifact.created_at)
     source_dataset = registry_datasets.get_dataset(latest.dataset_id) or {}
+    try:
+        period_type = get_period_type(source_dataset)
+    except (KeyError, TypeError):
+        period_type = "unknown"
     return DatasetRecord(
         dataset_id=dataset_id,
         source_dataset_id=latest.dataset_id,
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
         variable=latest.variable,
-        period_type=_resolution_for_artifact(source_dataset),
+        period_type=period_type,
         units=_as_optional_str(source_dataset.get("units")),
         resolution=_as_optional_str(source_dataset.get("resolution")),
         source=_as_optional_str(source_dataset.get("source")),
@@ -886,13 +890,6 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
         )
     return links
 
-
-def _resolution_for_artifact(dataset: dict[str, Any]) -> str:
-    """Return the ISO 8601 resolution for a dataset dict, falling back to 'unknown'."""
-    try:
-        return get_period_type(dataset)
-    except (KeyError, TypeError):
-        return "unknown"
 
 
 def _as_optional_str(value: object) -> str | None:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -160,13 +160,13 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
-    resolution = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
-    start = _normalize_request_period(start, resolution=resolution, field_name="start")
-    end = _normalize_optional_request_period(end, resolution=resolution, field_name="end")
+    period_type = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    start = _normalize_request_period(start, period_type=period_type, field_name="start")
+    end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     download_start = _normalize_optional_request_period(
-        download_start, resolution=resolution, field_name="download_start"
+        download_start, period_type=period_type, field_name="download_start"
     )
-    download_end = _normalize_optional_request_period(download_end, resolution=resolution, field_name="download_end")
+    download_end = _normalize_optional_request_period(download_end, period_type=period_type, field_name="download_end")
     _validate_download_scope(
         start=start,
         end=end,
@@ -176,7 +176,7 @@ def create_artifact(
     requires_canonical_zarr = download_start is not None
     resolved_download_end = download_end if download_end is not None else end
     if resolved_download_end is None:
-        resolved_download_end = _default_request_end(resolution)
+        resolved_download_end = _default_request_end(period_type)
     request_scope = ArtifactRequestScope(
         start=start,
         end=end,
@@ -345,9 +345,9 @@ def store_materialized_zarr_artifact(
     publish: bool,
 ) -> ArtifactRecord:
     """Store metadata for a locally materialized Zarr artifact."""
-    resolution = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
-    normalized_start = _normalize_request_period(start, resolution=resolution, field_name="start")
-    normalized_end = _normalize_optional_request_period(end, resolution=resolution, field_name="end")
+    period_type = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    normalized_start = _normalize_request_period(start, period_type=period_type, field_name="start")
+    normalized_end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     request_scope = ArtifactRequestScope(
         start=normalized_start,
         end=normalized_end,
@@ -684,10 +684,10 @@ def _find_existing_artifact(
     )
 
 
-def _normalize_request_period(value: str, *, resolution: str, field_name: str) -> str:
+def _normalize_request_period(value: str, *, period_type: str, field_name: str) -> str:
     """Normalize a required request period or raise a clear client error."""
     try:
-        return normalize_period_string(value, resolution)
+        return normalize_period_string(value, period_type)
     except (TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=400,
@@ -695,27 +695,27 @@ def _normalize_request_period(value: str, *, resolution: str, field_name: str) -
         ) from exc
 
 
-def _normalize_optional_request_period(value: str | None, *, resolution: str, field_name: str) -> str | None:
+def _normalize_optional_request_period(value: str | None, *, period_type: str, field_name: str) -> str | None:
     """Normalize an optional request period or raise a clear client error."""
     if value is None:
         return None
-    return _normalize_request_period(value, resolution=resolution, field_name=field_name)
+    return _normalize_request_period(value, period_type=period_type, field_name=field_name)
 
 
-def _default_request_end(resolution: str) -> str:
+def _default_request_end(period_type: str) -> str:
     """Return the current dataset-native period string for omitted ingestion end values."""
-    if "T" in resolution.upper():
-        return datetime_to_period_string(utc_now(), resolution)
-    if resolution == "P1D":
+    if "T" in period_type.upper():
+        return datetime_to_period_string(utc_now(), period_type)
+    if period_type == "P1D":
         return utc_today().isoformat()
-    if resolution == "P1W":
-        return datetime_to_period_string(utc_now(), resolution)
-    if resolution == "P1M":
+    if period_type == "P1W":
+        return datetime_to_period_string(utc_now(), period_type)
+    if period_type == "P1M":
         today = utc_today()
         return f"{today.year:04d}-{today.month:02d}"
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         return str(utc_today().year)
-    raise HTTPException(status_code=400, detail=f"Invalid resolution '{resolution}' for request end defaulting")
+    raise HTTPException(status_code=400, detail=f"Invalid period_type '{period_type}' for request end defaulting")
 
 
 def _validate_download_scope(
@@ -889,8 +889,8 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
 def _resolution_for_artifact(dataset: dict[str, Any]) -> str:
     """Return the ISO 8601 resolution for a dataset dict, falling back to 'unknown'."""
     try:
-        resolution: object = dataset["extents"]["temporal"]["resolution"]
-        return str(resolution) if isinstance(resolution, str) else "unknown"
+        period_type: object = dataset["extents"]["temporal"]["resolution"]
+        return str(period_type) if isinstance(period_type, str) else "unknown"
     except (KeyError, TypeError):
         return "unknown"
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -887,7 +887,6 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
     return links
 
 
-
 def _period_type_for_artifact(dataset: dict[str, Any]) -> str:
     try:
         return get_period_type(dataset)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -22,6 +22,7 @@ from climate_api import config as api_config
 from climate_api.data_accessor.services.accessor import get_data_coverage_for_paths
 from climate_api.data_manager.services import downloader
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import (
     ArtifactCoverage,
@@ -160,7 +161,7 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
-    period_type = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    period_type = get_period_type(dataset)
     start = _normalize_request_period(start, period_type=period_type, field_name="start")
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     download_start = _normalize_optional_request_period(
@@ -345,7 +346,7 @@ def store_materialized_zarr_artifact(
     publish: bool,
 ) -> ArtifactRecord:
     """Store metadata for a locally materialized Zarr artifact."""
-    period_type = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    period_type = get_period_type(dataset)
     normalized_start = _normalize_request_period(start, period_type=period_type, field_name="start")
     normalized_end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     request_scope = ArtifactRequestScope(
@@ -889,8 +890,7 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
 def _resolution_for_artifact(dataset: dict[str, Any]) -> str:
     """Return the ISO 8601 resolution for a dataset dict, falling back to 'unknown'."""
     try:
-        period_type: object = dataset["extents"]["temporal"]["resolution"]
-        return str(period_type) if isinstance(period_type, str) else "unknown"
+        return get_period_type(dataset)
     except (KeyError, TypeError):
         return "unknown"
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -705,7 +705,7 @@ def _normalize_optional_request_period(value: str | None, *, period_type: str, f
 
 def _default_request_end(period_type: str) -> str:
     """Return the current dataset-native period string for omitted ingestion end values."""
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "P1D":
         return utc_today().isoformat()

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -822,17 +822,13 @@ def _temporal_coverage_matches_request_scope(
 def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> DatasetRecord:
     latest = max(artifacts, key=lambda artifact: artifact.created_at)
     source_dataset = registry_datasets.get_dataset(latest.dataset_id) or {}
-    try:
-        period_type = get_period_type(source_dataset)
-    except (KeyError, TypeError):
-        period_type = "unknown"
     return DatasetRecord(
         dataset_id=dataset_id,
         source_dataset_id=latest.dataset_id,
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
         variable=latest.variable,
-        period_type=period_type,
+        period_type=_period_type_for_artifact(source_dataset),
         units=_as_optional_str(source_dataset.get("units")),
         resolution=_as_optional_str(source_dataset.get("resolution")),
         source=_as_optional_str(source_dataset.get("source")),
@@ -890,6 +886,13 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
         )
     return links
 
+
+
+def _period_type_for_artifact(dataset: dict[str, Any]) -> str:
+    try:
+        return get_period_type(dataset)
+    except (KeyError, TypeError):
+        return "unknown"
 
 
 def _as_optional_str(value: object) -> str | None:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -10,6 +10,7 @@ import os
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import pyproj
@@ -21,6 +22,7 @@ from climate_api import config as api_config
 from climate_api.data_accessor.services.accessor import get_data_coverage_for_paths
 from climate_api.data_manager.services import downloader
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.extents.services import get_extent
 from climate_api.ingestions.schemas import (
     ArtifactCoverage,
@@ -159,7 +161,7 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
-    period_type = str(dataset["period_type"])
+    period_type = get_period_type(dataset)
     start = _normalize_request_period(start, period_type=period_type, field_name="start")
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     download_start = _normalize_optional_request_period(
@@ -344,7 +346,7 @@ def store_materialized_zarr_artifact(
     publish: bool,
 ) -> ArtifactRecord:
     """Store metadata for a locally materialized Zarr artifact."""
-    period_type = str(dataset["period_type"])
+    period_type = get_period_type(dataset)
     normalized_start = _normalize_request_period(start, period_type=period_type, field_name="start")
     normalized_end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     request_scope = ArtifactRequestScope(
@@ -826,7 +828,7 @@ def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> D
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
         variable=latest.variable,
-        period_type=_as_optional_str(source_dataset.get("period_type")) or "unknown",
+        period_type=_period_type_for_artifact(source_dataset),
         units=_as_optional_str(source_dataset.get("units")),
         resolution=_as_optional_str(source_dataset.get("resolution")),
         source=_as_optional_str(source_dataset.get("source")),
@@ -883,6 +885,14 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
             DatasetAccessLink(href=latest.publication.pygeoapi_path, rel="ogc-collection", title="OGC collection")
         )
     return links
+
+
+def _period_type_for_artifact(dataset: dict[str, Any]) -> str:
+    """Return the period-class string for a dataset dict, falling back to 'unknown'."""
+    try:
+        return get_period_type(dataset)
+    except (KeyError, ValueError):
+        return "unknown"
 
 
 def _as_optional_str(value: object) -> str | None:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -705,16 +705,16 @@ def _normalize_optional_request_period(value: str | None, *, period_type: str, f
 
 def _default_request_end(period_type: str) -> str:
     """Return the current dataset-native period string for omitted ingestion end values."""
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         return utc_today().isoformat()
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         today = utc_today()
         return f"{today.year:04d}-{today.month:02d}"
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         return str(utc_today().year)
     raise HTTPException(status_code=400, detail=f"Invalid period_type '{period_type}' for request end defaulting")
 

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from typing import Any
 
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions.schemas import ArtifactRecord, SyncAction, SyncDetail, SyncKind, SyncResponse
 from climate_api.providers import availability as provider_availability
 from climate_api.publications.services import managed_dataset_id_for
@@ -75,7 +76,7 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
-    period_type: str = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    period_type: str = get_period_type(source_dataset)
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
     requested_target_end_source = "request" if normalized_requested_end is not None else "default_today"
@@ -402,8 +403,7 @@ def _provider_latest_available_end(
     if not isinstance(result, str):
         raise SyncConfigurationError(f"Latest availability function '{function_path}' must return a period string")
     try:
-        period_type: object = source_dataset["extents"]["temporal"]["resolution"]  # type: ignore[index]
-        return normalize_period_string(result, str(period_type))
+        return normalize_period_string(result, get_period_type(source_dataset))
     except (KeyError, TypeError, ValueError) as exc:
         raise SyncConfigurationError(
             f"Latest availability function '{function_path}' returned invalid period "

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -75,14 +75,14 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
-    resolution: str = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    period_type: str = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
     requested_target_end_source = "request" if normalized_requested_end is not None else "default_today"
     if normalized_requested_end is not None:
-        resolved_end = normalize_period_string(normalized_requested_end, resolution)
+        resolved_end = normalize_period_string(normalized_requested_end, period_type)
     else:
-        resolved_end = _default_target_end(resolution=resolution)
+        resolved_end = _default_target_end(period_type=period_type)
     latest_available_end = _latest_available_end(source_dataset=source_dataset, requested_end=resolved_end)
     target_end_source = (
         requested_target_end_source
@@ -91,7 +91,7 @@ def plan_sync(
     )
 
     if sync_kind == SyncKind.TEMPORAL:
-        next_period_start = _next_period_start(current_end, resolution=resolution)
+        next_period_start = _next_period_start(current_end, period_type=period_type)
         if next_period_start > latest_available_end:
             return SyncDetail(
                 source_dataset_id=latest_artifact.dataset_id,
@@ -286,47 +286,47 @@ def _sync_plan_message(
     return f"Data exists through {current_end}. Sync will rematerialize the dataset through {target_end}."
 
 
-def _next_period_start(latest_period_end: str, *, resolution: str) -> str:
+def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
     """Return the next dataset-native period after a covered temporal end value.
 
     This helper is part of sync planning because temporal datasets need to know
     whether another period could exist beyond the current materialized coverage.
     """
-    if "T" in resolution.upper():
+    if "T" in period_type.upper():
         timestamp = parse_hourly_period_string(latest_period_end)
-        return datetime_to_period_string(timestamp + timedelta(hours=1), resolution)
-    if resolution == "P1D":
+        return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
+    if period_type == "P1D":
         current = date.fromisoformat(latest_period_end)
         return (current + timedelta(days=1)).isoformat()
-    if resolution == "P1W":
+    if period_type == "P1W":
         current = parse_period_string_to_datetime(latest_period_end).date()
         next_week = datetime.combine(current + timedelta(days=7), time(0))
-        return datetime_to_period_string(next_week, resolution)
-    if resolution == "P1M":
+        return datetime_to_period_string(next_week, period_type)
+    if period_type == "P1M":
         current = date.fromisoformat(f"{latest_period_end}-01")
         month = current.month + 1
         year = current.year + (1 if month == 13 else 0)
         month = 1 if month == 13 else month
         return f"{year:04d}-{month:02d}"
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         return str(int(latest_period_end) + 1)
-    raise ValueError(f"Unsupported resolution '{resolution}' for sync")
+    raise ValueError(f"Unsupported period_type '{period_type}' for sync")
 
 
-def _default_target_end(*, resolution: str) -> str:
+def _default_target_end(*, period_type: str) -> str:
     """Return the default sync target in the dataset-native period format."""
     today = utc_today()
-    if "T" in resolution.upper():
-        return datetime_to_period_string(utc_now(), resolution)
-    if resolution == "P1D":
+    if "T" in period_type.upper():
+        return datetime_to_period_string(utc_now(), period_type)
+    if period_type == "P1D":
         return today.isoformat()
-    if resolution == "P1W":
-        return datetime_to_period_string(utc_now(), resolution)
-    if resolution == "P1M":
+    if period_type == "P1W":
+        return datetime_to_period_string(utc_now(), period_type)
+    if period_type == "P1M":
         return f"{today.year:04d}-{today.month:02d}"
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         return str(today.year)
-    raise ValueError(f"Unsupported resolution '{resolution}' for sync")
+    raise ValueError(f"Unsupported period_type '{period_type}' for sync")
 
 
 def _latest_available_end(*, source_dataset: dict[str, Any], requested_end: str) -> str:
@@ -402,8 +402,8 @@ def _provider_latest_available_end(
     if not isinstance(result, str):
         raise SyncConfigurationError(f"Latest availability function '{function_path}' must return a period string")
     try:
-        resolution: object = source_dataset["extents"]["temporal"]["resolution"]  # type: ignore[index]
-        return normalize_period_string(result, str(resolution))
+        period_type: object = source_dataset["extents"]["temporal"]["resolution"]  # type: ignore[index]
+        return normalize_period_string(result, str(period_type))
     except (KeyError, TypeError, ValueError) as exc:
         raise SyncConfigurationError(
             f"Latest availability function '{function_path}' returned invalid period "

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -293,7 +293,7 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
     This helper is part of sync planning because temporal datasets need to know
     whether another period could exist beyond the current materialized coverage.
     """
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         timestamp = parse_hourly_period_string(latest_period_end)
         return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
     if period_type == "P1D":
@@ -317,7 +317,7 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
 def _default_target_end(*, period_type: str) -> str:
     """Return the default sync target in the dataset-native period format."""
     today = utc_today()
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "P1D":
         return today.isoformat()

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -18,7 +18,6 @@ from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from typing import Any
 
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions.schemas import ArtifactRecord, SyncAction, SyncDetail, SyncKind, SyncResponse
 from climate_api.providers import availability as provider_availability
 from climate_api.publications.services import managed_dataset_id_for
@@ -76,14 +75,14 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
-    period_type = get_period_type(source_dataset)
+    resolution: str = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
     requested_target_end_source = "request" if normalized_requested_end is not None else "default_today"
     if normalized_requested_end is not None:
-        resolved_end = normalize_period_string(normalized_requested_end, period_type)
+        resolved_end = normalize_period_string(normalized_requested_end, resolution)
     else:
-        resolved_end = _default_target_end(period_type=period_type)
+        resolved_end = _default_target_end(resolution=resolution)
     latest_available_end = _latest_available_end(source_dataset=source_dataset, requested_end=resolved_end)
     target_end_source = (
         requested_target_end_source
@@ -92,7 +91,7 @@ def plan_sync(
     )
 
     if sync_kind == SyncKind.TEMPORAL:
-        next_period_start = _next_period_start(current_end, period_type=period_type)
+        next_period_start = _next_period_start(current_end, resolution=resolution)
         if next_period_start > latest_available_end:
             return SyncDetail(
                 source_dataset_id=latest_artifact.dataset_id,
@@ -287,47 +286,47 @@ def _sync_plan_message(
     return f"Data exists through {current_end}. Sync will rematerialize the dataset through {target_end}."
 
 
-def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
+def _next_period_start(latest_period_end: str, *, resolution: str) -> str:
     """Return the next dataset-native period after a covered temporal end value.
 
     This helper is part of sync planning because temporal datasets need to know
     whether another period could exist beyond the current materialized coverage.
     """
-    if period_type == "hourly":
+    if "T" in resolution.upper():
         timestamp = parse_hourly_period_string(latest_period_end)
-        return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
-    if period_type == "daily":
+        return datetime_to_period_string(timestamp + timedelta(hours=1), resolution)
+    if resolution == "P1D":
         current = date.fromisoformat(latest_period_end)
         return (current + timedelta(days=1)).isoformat()
-    if period_type == "weekly":
+    if resolution == "P1W":
         current = parse_period_string_to_datetime(latest_period_end).date()
         next_week = datetime.combine(current + timedelta(days=7), time(0))
-        return datetime_to_period_string(next_week, period_type)
-    if period_type == "monthly":
+        return datetime_to_period_string(next_week, resolution)
+    if resolution == "P1M":
         current = date.fromisoformat(f"{latest_period_end}-01")
         month = current.month + 1
         year = current.year + (1 if month == 13 else 0)
         month = 1 if month == 13 else month
         return f"{year:04d}-{month:02d}"
-    if period_type == "yearly":
+    if resolution == "P1Y":
         return str(int(latest_period_end) + 1)
-    raise ValueError(f"Unsupported period_type '{period_type}' for sync")
+    raise ValueError(f"Unsupported resolution '{resolution}' for sync")
 
 
-def _default_target_end(*, period_type: str) -> str:
+def _default_target_end(*, resolution: str) -> str:
     """Return the default sync target in the dataset-native period format."""
     today = utc_today()
-    if period_type == "hourly":
-        return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "daily":
+    if "T" in resolution.upper():
+        return datetime_to_period_string(utc_now(), resolution)
+    if resolution == "P1D":
         return today.isoformat()
-    if period_type == "weekly":
-        return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "monthly":
+    if resolution == "P1W":
+        return datetime_to_period_string(utc_now(), resolution)
+    if resolution == "P1M":
         return f"{today.year:04d}-{today.month:02d}"
-    if period_type == "yearly":
+    if resolution == "P1Y":
         return str(today.year)
-    raise ValueError(f"Unsupported period_type '{period_type}' for sync")
+    raise ValueError(f"Unsupported resolution '{resolution}' for sync")
 
 
 def _latest_available_end(*, source_dataset: dict[str, Any], requested_end: str) -> str:
@@ -403,7 +402,8 @@ def _provider_latest_available_end(
     if not isinstance(result, str):
         raise SyncConfigurationError(f"Latest availability function '{function_path}' must return a period string")
     try:
-        return normalize_period_string(result, period_type=get_period_type(source_dataset))
+        resolution: object = source_dataset["extents"]["temporal"]["resolution"]  # type: ignore[index]
+        return normalize_period_string(result, str(resolution))
     except (KeyError, TypeError, ValueError) as exc:
         raise SyncConfigurationError(
             f"Latest availability function '{function_path}' returned invalid period "

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -293,23 +293,23 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
     This helper is part of sync planning because temporal datasets need to know
     whether another period could exist beyond the current materialized coverage.
     """
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         timestamp = parse_hourly_period_string(latest_period_end)
         return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         current = date.fromisoformat(latest_period_end)
         return (current + timedelta(days=1)).isoformat()
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         current = parse_period_string_to_datetime(latest_period_end).date()
         next_week = datetime.combine(current + timedelta(days=7), time(0))
         return datetime_to_period_string(next_week, period_type)
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         current = date.fromisoformat(f"{latest_period_end}-01")
         month = current.month + 1
         year = current.year + (1 if month == 13 else 0)
         month = 1 if month == 13 else month
         return f"{year:04d}-{month:02d}"
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         return str(int(latest_period_end) + 1)
     raise ValueError(f"Unsupported period_type '{period_type}' for sync")
 
@@ -317,15 +317,15 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
 def _default_target_end(*, period_type: str) -> str:
     """Return the default sync target in the dataset-native period format."""
     today = utc_today()
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         return today.isoformat()
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         return datetime_to_period_string(utc_now(), period_type)
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         return f"{today.year:04d}-{today.month:02d}"
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         return str(today.year)
     raise ValueError(f"Unsupported period_type '{period_type}' for sync")
 

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from typing import Any
 
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions.schemas import ArtifactRecord, SyncAction, SyncDetail, SyncKind, SyncResponse
 from climate_api.providers import availability as provider_availability
 from climate_api.publications.services import managed_dataset_id_for
@@ -75,7 +76,7 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
-    period_type = str(source_dataset["period_type"])
+    period_type = get_period_type(source_dataset)
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
     requested_target_end_source = "request" if normalized_requested_end is not None else "default_today"
@@ -402,11 +403,11 @@ def _provider_latest_available_end(
     if not isinstance(result, str):
         raise SyncConfigurationError(f"Latest availability function '{function_path}' must return a period string")
     try:
-        return normalize_period_string(result, period_type=str(source_dataset["period_type"]))
+        return normalize_period_string(result, period_type=get_period_type(source_dataset))
     except (KeyError, TypeError, ValueError) as exc:
         raise SyncConfigurationError(
             f"Latest availability function '{function_path}' returned invalid period "
-            f"'{result}' for dataset period_type '{source_dataset.get('period_type')}'"
+            f"'{result}' for dataset '{source_dataset.get('id')}'"
         ) from exc
 
 

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -41,17 +41,25 @@ DERIVED_DATA_DIR: Path = _derived_data_dir()
 
 
 def _frequency_to_iso_resolution(frequency: str) -> str:
-    """Map a pandas frequency alias to a canonical ISO 8601 duration string."""
-    name = type(pd.tseries.frequencies.to_offset(frequency)).__name__
-    if any(x in name for x in ("Hour", "Minute", "Second")):
-        return "PT1H"
+    """Map a pandas frequency alias to an ISO 8601 duration string preserving the multiplier."""
+    offset = pd.tseries.frequencies.to_offset(frequency)
+    n = abs(offset.n)
+    name = type(offset).__name__
+    if "Hour" in name:
+        return f"PT{n}H"
+    if "Minute" in name:
+        return f"PT{n}M"
+    if "Second" in name:
+        return f"PT{n}S"
     if "Week" in name:
-        return "P1W"
-    if any(x in name for x in ("Month", "Quarter")):
-        return "P1M"
-    if any(x in name for x in ("Year", "Annual")):
-        return "P1Y"
-    return "P1D"
+        return f"P{n}W"
+    if "Quarter" in name:
+        return f"P{n * 3}M"
+    if "Month" in name:
+        return f"P{n}M"
+    if "Year" in name or "Annual" in name:
+        return f"P{n}Y"
+    return f"P{n}D"
 
 
 def derived_dataset_id(*, source_dataset_id: str, frequency: str, method: str) -> str:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -237,7 +237,10 @@ def _previous_source_period_start(boundary: datetime, *, source_period_type: str
         return previous_month_last_day.replace(day=1)
     if source_period_type == "P1Y":  # yearly
         return boundary.replace(year=boundary.year - 1, month=1, day=1)
-    raise HTTPException(status_code=400, detail=f"Unsupported source temporal resolution '{source_period_type}' for resampling")
+    raise HTTPException(
+        status_code=400,
+        detail=f"Unsupported source temporal resolution '{source_period_type}' for resampling",
+    )
 
 
 def _write_resampled_zarr(ds: xr.Dataset, zarr_path: Path) -> None:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -18,7 +18,6 @@ from fastapi import HTTPException
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim
 from climate_api.data_registry.services import datasets as registry_datasets
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, ArtifactRequestScope, PublicationStatus
 from climate_api.publications.services import managed_dataset_id_for_scope
@@ -99,7 +98,7 @@ def materialize_resampled_artifact(
     try:
         resampled = _resample_dataset(
             source_ds=source_ds,
-            source_period_type=get_period_type(source_dataset),
+            source_resolution=str(source_dataset["extents"]["temporal"]["resolution"]),  # type: ignore[index]
             frequency=frequency,
             method=method,
             start=start,
@@ -149,7 +148,7 @@ def _resolve_source_artifact(*, source_dataset_id: str) -> ArtifactRecord:
 def _resample_dataset(
     *,
     source_ds: xr.Dataset,
-    source_period_type: str,
+    source_resolution: str,
     frequency: str,
     method: str,
     start: str,
@@ -177,7 +176,7 @@ def _resample_dataset(
         result=result,
         source_start=source_start,
         source_end=source_end,
-        source_period_type=source_period_type,
+        source_resolution=source_resolution,
         frequency=frequency,
     )
     return result
@@ -188,7 +187,7 @@ def _drop_incomplete_edge_periods(
     result: xr.Dataset,
     source_start: datetime,
     source_end: datetime,
-    source_period_type: str,
+    source_resolution: str,
     frequency: str,
 ) -> xr.Dataset:
     time_dim = get_time_dim(result)
@@ -204,7 +203,7 @@ def _drop_incomplete_edge_periods(
     last_output_start = _coerce_numpy_datetime(result[time_dim].values[-1])
     offset = pd.tseries.frequencies.to_offset(frequency)
     next_target_start = (pd.Timestamp(last_output_start) + offset).to_pydatetime().replace(tzinfo=None)
-    required_source_end = _previous_source_period_start(next_target_start, source_period_type=source_period_type)
+    required_source_end = _previous_source_period_start(next_target_start, source_resolution=source_resolution)
     if source_end < required_source_end:
         return result.isel({time_dim: slice(0, -1)})
     return result
@@ -225,19 +224,19 @@ def _find_existing_resampled_artifact(
     )
 
 
-def _previous_source_period_start(boundary: datetime, *, source_period_type: str) -> datetime:
-    if source_period_type == "hourly":
+def _previous_source_period_start(boundary: datetime, *, source_resolution: str) -> datetime:
+    if "T" in source_resolution.upper():
         return boundary - timedelta(hours=1)
-    if source_period_type == "daily":
+    if source_resolution == "P1D":
         return boundary - timedelta(days=1)
-    if source_period_type == "weekly":
+    if source_resolution == "P1W":
         return boundary - timedelta(days=7)
-    if source_period_type == "monthly":
+    if source_resolution == "P1M":
         previous_month_last_day = boundary.replace(day=1) - timedelta(days=1)
         return previous_month_last_day.replace(day=1)
-    if source_period_type == "yearly":
+    if source_resolution == "P1Y":
         return boundary.replace(year=boundary.year - 1, month=1, day=1)
-    raise HTTPException(status_code=400, detail=f"Unsupported source period_type '{source_period_type}' for resampling")
+    raise HTTPException(status_code=400, detail=f"Unsupported source resolution '{source_resolution}' for resampling")
 
 
 def _write_resampled_zarr(ds: xr.Dataset, zarr_path: Path) -> None:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -98,7 +98,7 @@ def materialize_resampled_artifact(
     try:
         resampled = _resample_dataset(
             source_ds=source_ds,
-            source_resolution=str(source_dataset["extents"]["temporal"]["resolution"]),  # type: ignore[index]
+            source_period_type=str(source_dataset["extents"]["temporal"]["resolution"]),  # type: ignore[index]
             frequency=frequency,
             method=method,
             start=start,
@@ -148,7 +148,7 @@ def _resolve_source_artifact(*, source_dataset_id: str) -> ArtifactRecord:
 def _resample_dataset(
     *,
     source_ds: xr.Dataset,
-    source_resolution: str,
+    source_period_type: str,
     frequency: str,
     method: str,
     start: str,
@@ -176,7 +176,7 @@ def _resample_dataset(
         result=result,
         source_start=source_start,
         source_end=source_end,
-        source_resolution=source_resolution,
+        source_period_type=source_period_type,
         frequency=frequency,
     )
     return result
@@ -187,7 +187,7 @@ def _drop_incomplete_edge_periods(
     result: xr.Dataset,
     source_start: datetime,
     source_end: datetime,
-    source_resolution: str,
+    source_period_type: str,
     frequency: str,
 ) -> xr.Dataset:
     time_dim = get_time_dim(result)
@@ -203,7 +203,7 @@ def _drop_incomplete_edge_periods(
     last_output_start = _coerce_numpy_datetime(result[time_dim].values[-1])
     offset = pd.tseries.frequencies.to_offset(frequency)
     next_target_start = (pd.Timestamp(last_output_start) + offset).to_pydatetime().replace(tzinfo=None)
-    required_source_end = _previous_source_period_start(next_target_start, source_resolution=source_resolution)
+    required_source_end = _previous_source_period_start(next_target_start, source_period_type=source_period_type)
     if source_end < required_source_end:
         return result.isel({time_dim: slice(0, -1)})
     return result
@@ -224,19 +224,19 @@ def _find_existing_resampled_artifact(
     )
 
 
-def _previous_source_period_start(boundary: datetime, *, source_resolution: str) -> datetime:
-    if "T" in source_resolution.upper():
+def _previous_source_period_start(boundary: datetime, *, source_period_type: str) -> datetime:
+    if "T" in source_period_type.upper():
         return boundary - timedelta(hours=1)
-    if source_resolution == "P1D":
+    if source_period_type == "P1D":
         return boundary - timedelta(days=1)
-    if source_resolution == "P1W":
+    if source_period_type == "P1W":
         return boundary - timedelta(days=7)
-    if source_resolution == "P1M":
+    if source_period_type == "P1M":
         previous_month_last_day = boundary.replace(day=1) - timedelta(days=1)
         return previous_month_last_day.replace(day=1)
-    if source_resolution == "P1Y":
+    if source_period_type == "P1Y":
         return boundary.replace(year=boundary.year - 1, month=1, day=1)
-    raise HTTPException(status_code=400, detail=f"Unsupported source resolution '{source_resolution}' for resampling")
+    raise HTTPException(status_code=400, detail=f"Unsupported source resolution '{source_period_type}' for resampling")
 
 
 def _write_resampled_zarr(ds: xr.Dataset, zarr_path: Path) -> None:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, ArtifactRequestScope, PublicationStatus
 from climate_api.publications.services import managed_dataset_id_for_scope
@@ -98,7 +99,7 @@ def materialize_resampled_artifact(
     try:
         resampled = _resample_dataset(
             source_ds=source_ds,
-            source_period_type=str(source_dataset["extents"]["temporal"]["resolution"]),  # type: ignore[index]
+            source_period_type=get_period_type(source_dataset),
             frequency=frequency,
             method=method,
             start=start,

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -53,6 +53,20 @@ def _frequency_to_period_type(frequency: str) -> str:
     return "daily"
 
 
+_PERIOD_TYPE_TO_ISO_RESOLUTION: dict[str, str] = {
+    "hourly": "PT1H",
+    "daily": "P1D",
+    "weekly": "P1W",
+    "monthly": "P1M",
+    "yearly": "P1Y",
+}
+
+
+def _frequency_to_iso_resolution(frequency: str) -> str:
+    """Return the ISO 8601 duration string for the given pandas frequency alias."""
+    return _PERIOD_TYPE_TO_ISO_RESOLUTION[_frequency_to_period_type(frequency)]
+
+
 def derived_dataset_id(*, source_dataset_id: str, frequency: str, method: str) -> str:
     """Return the stable derived dataset id auto-generated from source + parameters."""
     freq_slug = re.sub(r"[^a-z0-9]", "_", frequency.lower()).strip("_")
@@ -124,6 +138,7 @@ def materialize_resampled_artifact(
         "name": target_dataset_id,
         "variable": source_dataset.get("variable", "value"),
         "period_type": _frequency_to_period_type(frequency),
+        "extents": {"temporal": {"resolution": _frequency_to_iso_resolution(frequency)}},
     }
     return ingestion_services.store_materialized_zarr_artifact(
         dataset=target_dataset,

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 
@@ -22,7 +22,7 @@ from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, ArtifactRequestScope, PublicationStatus
 from climate_api.publications.services import managed_dataset_id_for_scope
-from climate_api.shared.time import _coerce_numpy_datetime, utc_today
+from climate_api.shared.time import _coerce_numpy_datetime, _iso_duration_to_offset, utc_today
 
 logger = logging.getLogger(__name__)
 
@@ -234,21 +234,7 @@ def _find_existing_resampled_artifact(
 
 
 def _previous_source_period_start(boundary: datetime, *, source_period_type: str) -> datetime:
-    if source_period_type == "PT1H":  # hourly
-        return boundary - timedelta(hours=1)
-    if source_period_type == "P1D":  # daily
-        return boundary - timedelta(days=1)
-    if source_period_type == "P1W":  # weekly
-        return boundary - timedelta(days=7)
-    if source_period_type == "P1M":  # monthly
-        previous_month_last_day = boundary.replace(day=1) - timedelta(days=1)
-        return previous_month_last_day.replace(day=1)
-    if source_period_type == "P1Y":  # yearly
-        return boundary.replace(year=boundary.year - 1, month=1, day=1)
-    raise HTTPException(
-        status_code=400,
-        detail=f"Unsupported source temporal resolution '{source_period_type}' for resampling",
-    )
+    return (pd.Timestamp(boundary) - _iso_duration_to_offset(source_period_type)).to_pydatetime()
 
 
 def _write_resampled_zarr(ds: xr.Dataset, zarr_path: Path) -> None:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -22,7 +22,12 @@ from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, ArtifactRequestScope, PublicationStatus
 from climate_api.publications.services import managed_dataset_id_for_scope
-from climate_api.shared.time import _coerce_numpy_datetime, _iso_duration_to_offset, utc_today
+from climate_api.shared.time import (
+    _coerce_numpy_datetime,
+    _iso_duration_to_offset,
+    _iso_resolution_to_frequency,
+    utc_today,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,38 +45,16 @@ def _derived_data_dir() -> Path:
 DERIVED_DATA_DIR: Path = _derived_data_dir()
 
 
-def _frequency_to_iso_resolution(frequency: str) -> str:
-    """Map a pandas frequency alias to an ISO 8601 duration string preserving the multiplier."""
-    offset = pd.tseries.frequencies.to_offset(frequency)
-    n = abs(offset.n)
-    name = type(offset).__name__
-    if "Hour" in name:
-        return f"PT{n}H"
-    if "Minute" in name:
-        return f"PT{n}M"
-    if "Second" in name:
-        return f"PT{n}S"
-    if "Week" in name:
-        return f"P{n}W"
-    if "Quarter" in name:
-        return f"P{n * 3}M"
-    if "Month" in name:
-        return f"P{n}M"
-    if "Year" in name or "Annual" in name:
-        return f"P{n}Y"
-    return f"P{n}D"
-
-
-def derived_dataset_id(*, source_dataset_id: str, frequency: str, method: str) -> str:
+def derived_dataset_id(*, source_dataset_id: str, resolution: str, method: str) -> str:
     """Return the stable derived dataset id auto-generated from source + parameters."""
-    freq_slug = re.sub(r"[^a-z0-9]", "_", frequency.lower()).strip("_")
-    return f"{source_dataset_id}_{freq_slug}_{method}"
+    resolution_slug = re.sub(r"[^a-z0-9]", "", resolution.lower())
+    return f"{source_dataset_id}_{resolution_slug}_{method}"
 
 
 def materialize_resampled_artifact(
     *,
     source_dataset_id: str,
-    frequency: str,
+    resolution: str,
     method: str,
     start: str,
     end: str | None,
@@ -79,7 +62,7 @@ def materialize_resampled_artifact(
     publish: bool,
 ) -> ArtifactRecord:
     """Materialize a derived dataset by resampling an existing managed source dataset."""
-    target_dataset_id = derived_dataset_id(source_dataset_id=source_dataset_id, frequency=frequency, method=method)
+    target_dataset_id = derived_dataset_id(source_dataset_id=source_dataset_id, resolution=resolution, method=method)
     resolved_end = end or utc_today().isoformat()
 
     existing = ingestion_services._find_existing_artifact(
@@ -103,12 +86,13 @@ def materialize_resampled_artifact(
     target_managed_dataset_id = managed_dataset_id_for_scope(target_dataset_id)
     zarr_path = DERIVED_DATA_DIR / f"{target_managed_dataset_id}.zarr"
 
+    pandas_frequency = _iso_resolution_to_frequency(resolution)
     source_ds = open_zarr_dataset(source_artifact.path or source_artifact.asset_paths[0])
     try:
         resampled = _resample_dataset(
             source_ds=source_ds,
             source_period_type=get_period_type(source_dataset),
-            frequency=frequency,
+            pandas_frequency=pandas_frequency,
             method=method,
             start=start,
             end=resolved_end,
@@ -134,7 +118,7 @@ def materialize_resampled_artifact(
         "variable": source_dataset.get("variable", "value"),
         "extents": {
             "temporal": {
-                "resolution": _frequency_to_iso_resolution(frequency),
+                "resolution": resolution,
             }
         },
     }
@@ -158,13 +142,13 @@ def _resample_dataset(
     *,
     source_ds: xr.Dataset,
     source_period_type: str,
-    frequency: str,
+    pandas_frequency: str,
     method: str,
     start: str,
     end: str,
 ) -> xr.Dataset:
     time_dim = get_time_dim(source_ds)
-    offset = pd.tseries.frequencies.to_offset(frequency)
+    offset = pd.tseries.frequencies.to_offset(pandas_frequency)
     target_start = pd.Timestamp(start).to_pydatetime().replace(tzinfo=None)
     target_end_exclusive = (pd.Timestamp(end) + offset).to_pydatetime().replace(tzinfo=None)
     subset = source_ds.where(source_ds[time_dim] >= np.datetime64(target_start), drop=True)
@@ -176,7 +160,7 @@ def _resample_dataset(
 
     with xr.set_options(keep_attrs=True):
         resampler = subset.resample(
-            {time_dim: frequency},
+            {time_dim: pandas_frequency},
             label="left",
             closed="left",
         )
@@ -186,7 +170,7 @@ def _resample_dataset(
         source_start=source_start,
         source_end=source_end,
         source_period_type=source_period_type,
-        frequency=frequency,
+        pandas_frequency=pandas_frequency,
     )
     return result
 
@@ -197,7 +181,7 @@ def _drop_incomplete_edge_periods(
     source_start: datetime,
     source_end: datetime,
     source_period_type: str,
-    frequency: str,
+    pandas_frequency: str,
 ) -> xr.Dataset:
     time_dim = get_time_dim(result)
     if result.sizes.get(time_dim, 0) == 0:
@@ -210,7 +194,7 @@ def _drop_incomplete_edge_periods(
             return result
 
     last_output_start = _coerce_numpy_datetime(result[time_dim].values[-1])
-    offset = pd.tseries.frequencies.to_offset(frequency)
+    offset = pd.tseries.frequencies.to_offset(pandas_frequency)
     next_target_start = (pd.Timestamp(last_output_start) + offset).to_pydatetime().replace(tzinfo=None)
     required_source_end = _previous_source_period_start(next_target_start, source_period_type=source_period_type)
     if source_end < required_source_end:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -228,14 +228,14 @@ def _find_existing_resampled_artifact(
 def _previous_source_period_start(boundary: datetime, *, source_period_type: str) -> datetime:
     if "T" in source_period_type.upper():
         return boundary - timedelta(hours=1)
-    if source_period_type == "P1D":
+    if source_period_type == "P1D":  # daily
         return boundary - timedelta(days=1)
-    if source_period_type == "P1W":
+    if source_period_type == "P1W":  # weekly
         return boundary - timedelta(days=7)
-    if source_period_type == "P1M":
+    if source_period_type == "P1M":  # monthly
         previous_month_last_day = boundary.replace(day=1) - timedelta(days=1)
         return previous_month_last_day.replace(day=1)
-    if source_period_type == "P1Y":
+    if source_period_type == "P1Y":  # yearly
         return boundary.replace(year=boundary.year - 1, month=1, day=1)
     raise HTTPException(status_code=400, detail=f"Unsupported source resolution '{source_period_type}' for resampling")
 

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, ArtifactRequestScope, PublicationStatus
 from climate_api.publications.services import managed_dataset_id_for_scope
@@ -39,18 +40,18 @@ def _derived_data_dir() -> Path:
 DERIVED_DATA_DIR: Path = _derived_data_dir()
 
 
-def _frequency_to_period_type(frequency: str) -> str:
-    """Map a pandas frequency alias to a Climate API period_type string."""
+def _frequency_to_iso_resolution(frequency: str) -> str:
+    """Map a pandas frequency alias to a canonical ISO 8601 duration string."""
     name = type(pd.tseries.frequencies.to_offset(frequency)).__name__
     if any(x in name for x in ("Hour", "Minute", "Second")):
-        return "hourly"
+        return "PT1H"
     if "Week" in name:
-        return "weekly"
+        return "P1W"
     if any(x in name for x in ("Month", "Quarter")):
-        return "monthly"
+        return "P1M"
     if any(x in name for x in ("Year", "Annual")):
-        return "yearly"
-    return "daily"
+        return "P1Y"
+    return "P1D"
 
 
 def derived_dataset_id(*, source_dataset_id: str, frequency: str, method: str) -> str:
@@ -98,7 +99,7 @@ def materialize_resampled_artifact(
     try:
         resampled = _resample_dataset(
             source_ds=source_ds,
-            source_period_type=str(source_dataset["period_type"]),
+            source_period_type=get_period_type(source_dataset),
             frequency=frequency,
             method=method,
             start=start,
@@ -123,7 +124,11 @@ def materialize_resampled_artifact(
         "id": target_dataset_id,
         "name": target_dataset_id,
         "variable": source_dataset.get("variable", "value"),
-        "period_type": _frequency_to_period_type(frequency),
+        "extents": {
+            "temporal": {
+                "resolution": _frequency_to_iso_resolution(frequency),
+            }
+        },
     }
     return ingestion_services.store_materialized_zarr_artifact(
         dataset=target_dataset,

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -53,20 +53,6 @@ def _frequency_to_period_type(frequency: str) -> str:
     return "daily"
 
 
-_PERIOD_TYPE_TO_ISO_RESOLUTION: dict[str, str] = {
-    "hourly": "PT1H",
-    "daily": "P1D",
-    "weekly": "P1W",
-    "monthly": "P1M",
-    "yearly": "P1Y",
-}
-
-
-def _frequency_to_iso_resolution(frequency: str) -> str:
-    """Return the ISO 8601 duration string for the given pandas frequency alias."""
-    return _PERIOD_TYPE_TO_ISO_RESOLUTION[_frequency_to_period_type(frequency)]
-
-
 def derived_dataset_id(*, source_dataset_id: str, frequency: str, method: str) -> str:
     """Return the stable derived dataset id auto-generated from source + parameters."""
     freq_slug = re.sub(r"[^a-z0-9]", "_", frequency.lower()).strip("_")
@@ -138,7 +124,6 @@ def materialize_resampled_artifact(
         "name": target_dataset_id,
         "variable": source_dataset.get("variable", "value"),
         "period_type": _frequency_to_period_type(frequency),
-        "extents": {"temporal": {"resolution": _frequency_to_iso_resolution(frequency)}},
     }
     return ingestion_services.store_materialized_zarr_artifact(
         dataset=target_dataset,

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -237,7 +237,7 @@ def _previous_source_period_start(boundary: datetime, *, source_period_type: str
         return previous_month_last_day.replace(day=1)
     if source_period_type == "P1Y":  # yearly
         return boundary.replace(year=boundary.year - 1, month=1, day=1)
-    raise HTTPException(status_code=400, detail=f"Unsupported source resolution '{source_period_type}' for resampling")
+    raise HTTPException(status_code=400, detail=f"Unsupported source temporal resolution '{source_period_type}' for resampling")
 
 
 def _write_resampled_zarr(ds: xr.Dataset, zarr_path: Path) -> None:

--- a/climate_api/processing/resample.py
+++ b/climate_api/processing/resample.py
@@ -226,7 +226,7 @@ def _find_existing_resampled_artifact(
 
 
 def _previous_source_period_start(boundary: datetime, *, source_period_type: str) -> datetime:
-    if "T" in source_period_type.upper():
+    if source_period_type == "PT1H":  # hourly
         return boundary - timedelta(hours=1)
     if source_period_type == "P1D":  # daily
         return boundary - timedelta(days=1)

--- a/climate_api/processing/services.py
+++ b/climate_api/processing/services.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-import pandas as pd
 from fastapi import HTTPException
 
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import DatasetRecord
 from climate_api.processing.resample import materialize_resampled_artifact
+from climate_api.shared.time import _ISO_8601_DURATION_RE
 
 _SUPPORTED_RESAMPLE_METHODS: frozenset[str] = frozenset({"mean", "sum", "min", "max"})
 
@@ -17,7 +17,7 @@ _SUPPORTED_RESAMPLE_METHODS: frozenset[str] = frozenset({"mean", "sum", "min", "
 def execute_resample(
     *,
     source_dataset_id: str,
-    frequency: str,
+    resolution: str,
     method: str,
     start: str,
     end: str | None = None,
@@ -33,16 +33,15 @@ def execute_resample(
     if method not in _SUPPORTED_RESAMPLE_METHODS:
         supported = ", ".join(sorted(_SUPPORTED_RESAMPLE_METHODS))
         raise HTTPException(status_code=400, detail=f"Unsupported method '{method}'. Supported: {supported}")
-    try:
-        _offset = pd.tseries.frequencies.to_offset(frequency)
-    except ValueError:
-        _offset = None
-    if _offset is None:
-        raise HTTPException(status_code=400, detail=f"Invalid frequency '{frequency}'")
+    if not _ISO_8601_DURATION_RE.fullmatch(resolution):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid resolution '{resolution}'; expected an ISO 8601 duration (e.g. P1M, P1W, P1D, PT1H)",
+        )
 
     artifact_id, dataset_summary = run_resample_process(
         source_dataset_id=source_dataset_id,
-        frequency=frequency,
+        resolution=resolution,
         method=method,
         start=start,
         end=end,
@@ -59,7 +58,7 @@ def execute_resample(
 def run_resample_process(
     *,
     source_dataset_id: str,
-    frequency: str,
+    resolution: str,
     method: str,
     start: str,
     end: str | None,
@@ -69,7 +68,7 @@ def run_resample_process(
     """Materialize one derived resampled dataset and return its artifact id plus dataset summary."""
     artifact = materialize_resampled_artifact(
         source_dataset_id=source_dataset_id,
-        frequency=frequency,
+        resolution=resolution,
         method=method,
         start=start,
         end=end,

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -43,7 +43,7 @@ def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> s
     except (KeyError, TypeError):
         return requested_end
 
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         lag_hours = availability.get("lag_hours")
         if isinstance(lag_hours, int) and lag_hours > 0:
             latest = utc_now() - timedelta(hours=lag_hours)
@@ -53,11 +53,11 @@ def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> s
     lag_days = availability.get("lag_days")
     if period_type in {"P1D", "P1M"} and isinstance(lag_days, int) and lag_days > 0:
         latest_date = utc_today() - timedelta(days=lag_days)
-        if period_type == "P1M":
+        if period_type == "P1M":  # monthly
             return f"{latest_date.year:04d}-{latest_date.month:02d}"
         return latest_date.isoformat()
 
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         latest_year_offset = availability.get("latest_year_offset")
         if isinstance(latest_year_offset, int) and latest_year_offset >= 0:
             return str(utc_today().year - latest_year_offset)

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -43,7 +43,7 @@ def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> s
     except (KeyError, TypeError):
         return requested_end
 
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         lag_hours = availability.get("lag_hours")
         if isinstance(lag_hours, int) and lag_hours > 0:
             latest = utc_now() - timedelta(hours=lag_hours)

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -11,6 +11,7 @@ from calendar import monthrange
 from datetime import date, timedelta
 from typing import Any
 
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.shared.time import datetime_to_period_string, utc_now, utc_today
 
 
@@ -37,7 +38,7 @@ def chirps3_daily_latest_available(*, dataset: dict[str, Any], requested_end: st
 def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> str:
     """Return latest available period by applying YAML-declared lag metadata."""
     availability = _availability_metadata(dataset)
-    period_type = str(dataset.get("period_type", "daily"))
+    period_type = get_period_type(dataset)
 
     if period_type == "hourly":
         lag_hours = availability.get("lag_hours")

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -11,7 +11,6 @@ from calendar import monthrange
 from datetime import date, timedelta
 from typing import Any
 
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.shared.time import datetime_to_period_string, utc_now, utc_today
 
 
@@ -38,23 +37,26 @@ def chirps3_daily_latest_available(*, dataset: dict[str, Any], requested_end: st
 def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> str:
     """Return latest available period by applying YAML-declared lag metadata."""
     availability = _availability_metadata(dataset)
-    period_type = get_period_type(dataset)
+    try:
+        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    except (KeyError, TypeError):
+        return requested_end
 
-    if period_type == "hourly":
+    if "T" in resolution.upper():
         lag_hours = availability.get("lag_hours")
         if isinstance(lag_hours, int) and lag_hours > 0:
             latest = utc_now() - timedelta(hours=lag_hours)
-            return datetime_to_period_string(latest, period_type)
+            return datetime_to_period_string(latest, resolution)
         return requested_end
 
     lag_days = availability.get("lag_days")
-    if period_type in {"daily", "monthly"} and isinstance(lag_days, int) and lag_days > 0:
+    if resolution in {"P1D", "P1M"} and isinstance(lag_days, int) and lag_days > 0:
         latest_date = utc_today() - timedelta(days=lag_days)
-        if period_type == "monthly":
+        if resolution == "P1M":
             return f"{latest_date.year:04d}-{latest_date.month:02d}"
         return latest_date.isoformat()
 
-    if period_type == "yearly":
+    if resolution == "P1Y":
         latest_year_offset = availability.get("latest_year_offset")
         if isinstance(latest_year_offset, int) and latest_year_offset >= 0:
             return str(utc_today().year - latest_year_offset)

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -11,8 +11,8 @@ from calendar import monthrange
 from datetime import date, timedelta
 from typing import Any
 
-from climate_api.shared.time import datetime_to_period_string, utc_now, utc_today
 from climate_api.data_registry.services.datasets import get_period_type
+from climate_api.shared.time import datetime_to_period_string, utc_now, utc_today
 
 
 def chirps3_daily_latest_available(*, dataset: dict[str, Any], requested_end: str) -> str:

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -38,25 +38,25 @@ def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> s
     """Return latest available period by applying YAML-declared lag metadata."""
     availability = _availability_metadata(dataset)
     try:
-        resolution: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
     except (KeyError, TypeError):
         return requested_end
 
-    if "T" in resolution.upper():
+    if "T" in period_type.upper():
         lag_hours = availability.get("lag_hours")
         if isinstance(lag_hours, int) and lag_hours > 0:
             latest = utc_now() - timedelta(hours=lag_hours)
-            return datetime_to_period_string(latest, resolution)
+            return datetime_to_period_string(latest, period_type)
         return requested_end
 
     lag_days = availability.get("lag_days")
-    if resolution in {"P1D", "P1M"} and isinstance(lag_days, int) and lag_days > 0:
+    if period_type in {"P1D", "P1M"} and isinstance(lag_days, int) and lag_days > 0:
         latest_date = utc_today() - timedelta(days=lag_days)
-        if resolution == "P1M":
+        if period_type == "P1M":
             return f"{latest_date.year:04d}-{latest_date.month:02d}"
         return latest_date.isoformat()
 
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         latest_year_offset = availability.get("latest_year_offset")
         if isinstance(latest_year_offset, int) and latest_year_offset >= 0:
             return str(utc_today().year - latest_year_offset)

--- a/climate_api/providers/availability.py
+++ b/climate_api/providers/availability.py
@@ -12,6 +12,7 @@ from datetime import date, timedelta
 from typing import Any
 
 from climate_api.shared.time import datetime_to_period_string, utc_now, utc_today
+from climate_api.data_registry.services.datasets import get_period_type
 
 
 def chirps3_daily_latest_available(*, dataset: dict[str, Any], requested_end: str) -> str:
@@ -38,7 +39,7 @@ def lagged_latest_available(*, dataset: dict[str, Any], requested_end: str) -> s
     """Return latest available period by applying YAML-declared lag metadata."""
     availability = _availability_metadata(dataset)
     try:
-        period_type: str = str(dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str = get_period_type(dataset)
     except (KeyError, TypeError):
         return requested_end
 

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -28,7 +28,7 @@ def _coerce_numpy_datetime(value: object) -> datetime:
 def datetime_to_period_string(value: datetime, period_type: str) -> str:
     """Convert a datetime to the dataset-native period string format."""
     value = _normalize_datetime_for_period(value)
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
     if period_type == "P1D":
         return value.date().isoformat()
@@ -71,7 +71,7 @@ def parse_weekly_period_string(value: str) -> datetime:
 
 def normalize_period_string(value: str, period_type: str) -> str:
     """Normalize an input period string to the dataset-native period format."""
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         try:
             return datetime_to_period_string(parse_hourly_period_string(value), period_type)
         except ValueError as exc:
@@ -128,7 +128,7 @@ def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type
     """Convert an array of numpy datetimes to truncated period strings."""
     if period_type != "P1W":
         lengths = {"PT1H": 13, "P1D": 10, "P1M": 7, "P1Y": 4}
-        length = lengths.get(period_type, 13 if "T" in period_type.upper() else 10)
+        length = lengths.get(period_type, 13 if period_type == "PT1H" else 10)
         return np.datetime_as_string(datetimes, unit="s").astype(f"U{length}")
 
     dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -25,21 +25,21 @@ def _coerce_numpy_datetime(value: object) -> datetime:
     return datetime.fromisoformat(np.datetime_as_string(np_value, unit="s"))
 
 
-def datetime_to_period_string(value: datetime, period_type: str) -> str:
+def datetime_to_period_string(value: datetime, resolution: str) -> str:
     """Convert a datetime to the dataset-native period string format."""
     value = _normalize_datetime_for_period(value)
-    if period_type == "hourly":
+    if "T" in resolution.upper():
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
-    if period_type == "daily":
+    if resolution == "P1D":
         return value.date().isoformat()
-    if period_type == "weekly":
+    if resolution == "P1W":
         iso_year, iso_week, _ = value.isocalendar()
         return f"{iso_year:04d}-W{iso_week:02d}"
-    if period_type == "monthly":
+    if resolution == "P1M":
         return f"{value.year:04d}-{value.month:02d}"
-    if period_type == "yearly":
+    if resolution == "P1Y":
         return str(value.year)
-    raise ValueError(f"Unsupported period_type '{period_type}'")
+    raise ValueError(f"Unsupported resolution '{resolution}'")
 
 
 def utc_now() -> datetime:
@@ -69,40 +69,40 @@ def parse_weekly_period_string(value: str) -> datetime:
     return datetime.fromisoformat(value)
 
 
-def normalize_period_string(value: str, period_type: str) -> str:
+def normalize_period_string(value: str, resolution: str) -> str:
     """Normalize an input period string to the dataset-native period format."""
-    if period_type == "hourly":
+    if "T" in resolution.upper():
         try:
-            return datetime_to_period_string(parse_hourly_period_string(value), period_type)
+            return datetime_to_period_string(parse_hourly_period_string(value), resolution)
         except ValueError as exc:
             raise ValueError(f"Invalid hourly period '{value}'; expected YYYY-MM-DDTHH or ISO datetime") from exc
-    if period_type == "daily":
+    if resolution == "P1D":
         try:
-            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
+            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
         except ValueError as exc:
             raise ValueError(f"Invalid daily period '{value}'; expected YYYY-MM-DD or ISO datetime") from exc
-    if period_type == "weekly":
+    if resolution == "P1W":
         try:
-            return datetime_to_period_string(parse_weekly_period_string(value), period_type)
+            return datetime_to_period_string(parse_weekly_period_string(value), resolution)
         except ValueError as exc:
             raise ValueError(f"Invalid weekly period '{value}'; expected YYYY-Www or ISO datetime") from exc
-    if period_type == "monthly":
+    if resolution == "P1M":
         try:
             if len(value) == 7:
                 datetime.fromisoformat(f"{value}-01")
                 return value
-            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
+            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
         except ValueError as exc:
             raise ValueError(f"Invalid monthly period '{value}'; expected YYYY-MM or ISO datetime") from exc
-    if period_type == "yearly":
+    if resolution == "P1Y":
         try:
             if len(value) == 4:
                 int(value)
                 return value
-            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
+            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
         except ValueError as exc:
             raise ValueError(f"Invalid yearly period '{value}'; expected YYYY or ISO datetime") from exc
-    raise ValueError(f"Unsupported period_type '{period_type}'")
+    raise ValueError(f"Unsupported resolution '{resolution}'")
 
 
 def parse_period_string_to_datetime(value: str) -> datetime:
@@ -124,11 +124,12 @@ def parse_period_string_to_datetime(value: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
-def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type: str) -> np.ndarray[Any, Any]:
+def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], resolution: str) -> np.ndarray[Any, Any]:
     """Convert an array of numpy datetimes to truncated period strings."""
-    if period_type != "weekly":
-        lengths = {"hourly": 13, "daily": 10, "monthly": 7, "yearly": 4}
-        return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[period_type]}")
+    if resolution != "P1W":
+        lengths = {"PT1H": 13, "P1D": 10, "P1M": 7, "P1Y": 4}
+        length = lengths.get(resolution, 13 if "T" in resolution.upper() else 10)
+        return np.datetime_as_string(datetimes, unit="s").astype(f"U{length}")
 
     dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
     iso = dt_index.isocalendar()

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -28,16 +28,16 @@ def _coerce_numpy_datetime(value: object) -> datetime:
 def datetime_to_period_string(value: datetime, period_type: str) -> str:
     """Convert a datetime to the dataset-native period string format."""
     value = _normalize_datetime_for_period(value)
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         return value.date().isoformat()
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         iso_year, iso_week, _ = value.isocalendar()
         return f"{iso_year:04d}-W{iso_week:02d}"
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         return f"{value.year:04d}-{value.month:02d}"
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         return str(value.year)
     raise ValueError(f"Unsupported period_type '{period_type}'")
 
@@ -71,22 +71,22 @@ def parse_weekly_period_string(value: str) -> datetime:
 
 def normalize_period_string(value: str, period_type: str) -> str:
     """Normalize an input period string to the dataset-native period format."""
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         try:
             return datetime_to_period_string(parse_hourly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid hourly period '{value}'; expected YYYY-MM-DDTHH or ISO datetime") from exc
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         try:
             return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid daily period '{value}'; expected YYYY-MM-DD or ISO datetime") from exc
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         try:
             return datetime_to_period_string(parse_weekly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid weekly period '{value}'; expected YYYY-Www or ISO datetime") from exc
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         try:
             if len(value) == 7:
                 datetime.fromisoformat(f"{value}-01")
@@ -94,7 +94,7 @@ def normalize_period_string(value: str, period_type: str) -> str:
             return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid monthly period '{value}'; expected YYYY-MM or ISO datetime") from exc
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         try:
             if len(value) == 4:
                 int(value)

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -128,8 +128,9 @@ def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type
     """Convert an array of numpy datetimes to truncated period strings."""
     if period_type != "P1W":
         lengths = {"PT1H": 13, "P1D": 10, "P1M": 7, "P1Y": 4}
-        length = lengths.get(period_type, 13 if period_type == "PT1H" else 10)
-        return np.datetime_as_string(datetimes, unit="s").astype(f"U{length}")
+        if period_type not in lengths:
+            raise ValueError(f"Unsupported period_type '{period_type}'")
+        return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[period_type]}")
 
     dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
     iso = dt_index.isocalendar()

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -31,6 +31,36 @@ def _iso_duration_to_offset(period_type: str) -> pd.DateOffset:
     )
 
 
+def _iso_resolution_to_frequency(period_type: str) -> str:
+    """Convert an ISO 8601 duration to a pandas frequency alias for xarray resampling.
+
+    Weekly durations are anchored on Monday for ISO week compatibility.
+    Month and year durations use period-start labels (MS, YS).
+    """
+    m = _ISO_8601_DURATION_RE.fullmatch(period_type)
+    if not m:
+        raise ValueError(f"Invalid ISO 8601 duration '{period_type}'")
+    g = m.groupdict(default="0")
+    years, months, weeks, days, hours, minutes, seconds = (
+        int(g[k]) for k in ("years", "months", "weeks", "days", "hours", "minutes", "seconds")
+    )
+    if years:
+        return f"{years}YS"
+    if months:
+        return f"{months}MS"
+    if weeks:
+        return "W-MON" if weeks == 1 else f"{weeks}W-MON"
+    if days:
+        return f"{days}D"
+    if hours:
+        return f"{hours}h"
+    if minutes:
+        return f"{minutes}min"
+    if seconds:
+        return f"{seconds}s"
+    raise ValueError(f"ISO 8601 duration '{period_type}' specifies no time components")
+
+
 def _period_family(period_type: str) -> str:
     """Map an ISO 8601 duration to the canonical period type used for string formatting.
 

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -8,6 +8,27 @@ import numpy as np
 import pandas as pd
 
 _WEEKLY_PERIOD_PATTERN = re.compile(r"^(?P<year>\d{4})-W(?P<week>\d{2})$")
+_ISO_8601_DURATION_RE = re.compile(
+    r"P(?:(?P<years>\d+)Y)?(?:(?P<months>\d+)M)?(?:(?P<weeks>\d+)W)?(?:(?P<days>\d+)D)?"
+    r"(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?)?"
+)
+
+
+def _iso_duration_to_offset(period_type: str) -> pd.DateOffset:
+    """Convert an ISO 8601 duration string to a pandas DateOffset."""
+    m = _ISO_8601_DURATION_RE.fullmatch(period_type)
+    if not m:
+        raise ValueError(f"Invalid ISO 8601 duration '{period_type}'")
+    g = m.groupdict(default="0")
+    return pd.DateOffset(
+        years=int(g["years"]),
+        months=int(g["months"]),
+        weeks=int(g["weeks"]),
+        days=int(g["days"]),
+        hours=int(g["hours"]),
+        minutes=int(g["minutes"]),
+        seconds=int(g["seconds"]),
+    )
 
 
 def _period_family(period_type: str) -> str:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -25,21 +25,21 @@ def _coerce_numpy_datetime(value: object) -> datetime:
     return datetime.fromisoformat(np.datetime_as_string(np_value, unit="s"))
 
 
-def datetime_to_period_string(value: datetime, resolution: str) -> str:
+def datetime_to_period_string(value: datetime, period_type: str) -> str:
     """Convert a datetime to the dataset-native period string format."""
     value = _normalize_datetime_for_period(value)
-    if "T" in resolution.upper():
+    if "T" in period_type.upper():
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
-    if resolution == "P1D":
+    if period_type == "P1D":
         return value.date().isoformat()
-    if resolution == "P1W":
+    if period_type == "P1W":
         iso_year, iso_week, _ = value.isocalendar()
         return f"{iso_year:04d}-W{iso_week:02d}"
-    if resolution == "P1M":
+    if period_type == "P1M":
         return f"{value.year:04d}-{value.month:02d}"
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         return str(value.year)
-    raise ValueError(f"Unsupported resolution '{resolution}'")
+    raise ValueError(f"Unsupported period_type '{period_type}'")
 
 
 def utc_now() -> datetime:
@@ -69,40 +69,40 @@ def parse_weekly_period_string(value: str) -> datetime:
     return datetime.fromisoformat(value)
 
 
-def normalize_period_string(value: str, resolution: str) -> str:
+def normalize_period_string(value: str, period_type: str) -> str:
     """Normalize an input period string to the dataset-native period format."""
-    if "T" in resolution.upper():
+    if "T" in period_type.upper():
         try:
-            return datetime_to_period_string(parse_hourly_period_string(value), resolution)
+            return datetime_to_period_string(parse_hourly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid hourly period '{value}'; expected YYYY-MM-DDTHH or ISO datetime") from exc
-    if resolution == "P1D":
+    if period_type == "P1D":
         try:
-            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
+            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid daily period '{value}'; expected YYYY-MM-DD or ISO datetime") from exc
-    if resolution == "P1W":
+    if period_type == "P1W":
         try:
-            return datetime_to_period_string(parse_weekly_period_string(value), resolution)
+            return datetime_to_period_string(parse_weekly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid weekly period '{value}'; expected YYYY-Www or ISO datetime") from exc
-    if resolution == "P1M":
+    if period_type == "P1M":
         try:
             if len(value) == 7:
                 datetime.fromisoformat(f"{value}-01")
                 return value
-            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
+            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid monthly period '{value}'; expected YYYY-MM or ISO datetime") from exc
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         try:
             if len(value) == 4:
                 int(value)
                 return value
-            return datetime_to_period_string(datetime.fromisoformat(value), resolution)
+            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid yearly period '{value}'; expected YYYY or ISO datetime") from exc
-    raise ValueError(f"Unsupported resolution '{resolution}'")
+    raise ValueError(f"Unsupported period_type '{period_type}'")
 
 
 def parse_period_string_to_datetime(value: str) -> datetime:
@@ -124,11 +124,11 @@ def parse_period_string_to_datetime(value: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
-def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], resolution: str) -> np.ndarray[Any, Any]:
+def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type: str) -> np.ndarray[Any, Any]:
     """Convert an array of numpy datetimes to truncated period strings."""
-    if resolution != "P1W":
+    if period_type != "P1W":
         lengths = {"PT1H": 13, "P1D": 10, "P1M": 7, "P1Y": 4}
-        length = lengths.get(resolution, 13 if "T" in resolution.upper() else 10)
+        length = lengths.get(period_type, 13 if "T" in period_type.upper() else 10)
         return np.datetime_as_string(datetimes, unit="s").astype(f"U{length}")
 
     dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -10,6 +10,25 @@ import pandas as pd
 _WEEKLY_PERIOD_PATTERN = re.compile(r"^(?P<year>\d{4})-W(?P<week>\d{2})$")
 
 
+def _period_family(period_type: str) -> str:
+    """Map an ISO 8601 duration to the canonical period type used for string formatting.
+
+    Compound durations are resolved by their largest component (years beat months, etc.).
+    Sub-daily durations (any with a T designator) map to the hourly family.
+    """
+    if "T" in period_type:  # sub-daily: PTnH, PTnM, PnDTnH, …
+        return "PT1H"
+    if "Y" in period_type:
+        return "P1Y"
+    if "M" in period_type:  # months (date portion — no T present)
+        return "P1M"
+    if "W" in period_type:
+        return "P1W"
+    if "D" in period_type:
+        return "P1D"
+    raise ValueError(f"Unsupported period_type '{period_type}'")
+
+
 def _normalize_datetime_for_period(value: datetime) -> datetime:
     """Convert aware datetimes to UTC before deriving dataset-native periods."""
     if value.tzinfo is not None:
@@ -28,18 +47,17 @@ def _coerce_numpy_datetime(value: object) -> datetime:
 def datetime_to_period_string(value: datetime, period_type: str) -> str:
     """Convert a datetime to the dataset-native period string format."""
     value = _normalize_datetime_for_period(value)
-    if period_type == "PT1H":  # hourly
+    family = _period_family(period_type)
+    if family == "PT1H":  # hourly
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
-    if period_type == "P1D":  # daily
+    if family == "P1D":  # daily
         return value.date().isoformat()
-    if period_type == "P1W":  # weekly
+    if family == "P1W":  # weekly
         iso_year, iso_week, _ = value.isocalendar()
         return f"{iso_year:04d}-W{iso_week:02d}"
-    if period_type == "P1M":  # monthly
+    if family == "P1M":  # monthly
         return f"{value.year:04d}-{value.month:02d}"
-    if period_type == "P1Y":  # yearly
-        return str(value.year)
-    raise ValueError(f"Unsupported period_type '{period_type}'")
+    return str(value.year)  # yearly
 
 
 def utc_now() -> datetime:
@@ -71,22 +89,23 @@ def parse_weekly_period_string(value: str) -> datetime:
 
 def normalize_period_string(value: str, period_type: str) -> str:
     """Normalize an input period string to the dataset-native period format."""
-    if period_type == "PT1H":  # hourly
+    family = _period_family(period_type)
+    if family == "PT1H":  # hourly
         try:
             return datetime_to_period_string(parse_hourly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid hourly period '{value}'; expected YYYY-MM-DDTHH or ISO datetime") from exc
-    if period_type == "P1D":  # daily
+    if family == "P1D":  # daily
         try:
             return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid daily period '{value}'; expected YYYY-MM-DD or ISO datetime") from exc
-    if period_type == "P1W":  # weekly
+    if family == "P1W":  # weekly
         try:
             return datetime_to_period_string(parse_weekly_period_string(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid weekly period '{value}'; expected YYYY-Www or ISO datetime") from exc
-    if period_type == "P1M":  # monthly
+    if family == "P1M":  # monthly
         try:
             if len(value) == 7:
                 datetime.fromisoformat(f"{value}-01")
@@ -94,15 +113,14 @@ def normalize_period_string(value: str, period_type: str) -> str:
             return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid monthly period '{value}'; expected YYYY-MM or ISO datetime") from exc
-    if period_type == "P1Y":  # yearly
-        try:
-            if len(value) == 4:
-                int(value)
-                return value
-            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
-        except ValueError as exc:
-            raise ValueError(f"Invalid yearly period '{value}'; expected YYYY or ISO datetime") from exc
-    raise ValueError(f"Unsupported period_type '{period_type}'")
+    # yearly
+    try:
+        if len(value) == 4:
+            int(value)
+            return value
+        return datetime_to_period_string(datetime.fromisoformat(value), period_type)
+    except ValueError as exc:
+        raise ValueError(f"Invalid yearly period '{value}'; expected YYYY or ISO datetime") from exc
 
 
 def parse_period_string_to_datetime(value: str) -> datetime:
@@ -126,11 +144,10 @@ def parse_period_string_to_datetime(value: str) -> datetime:
 
 def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type: str) -> np.ndarray[Any, Any]:
     """Convert an array of numpy datetimes to truncated period strings."""
-    if period_type != "P1W":
+    family = _period_family(period_type)
+    if family != "P1W":
         lengths = {"PT1H": 13, "P1D": 10, "P1M": 7, "P1Y": 4}
-        if period_type not in lengths:
-            raise ValueError(f"Unsupported period_type '{period_type}'")
-        return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[period_type]}")
+        return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[family]}")
 
     dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
     iso = dt_index.isocalendar()

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -16,6 +16,7 @@ from xstac import xarray_to_stac
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 from climate_api.shared.time import parse_period_string_to_datetime
@@ -119,7 +120,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
     try:
-        period_type: str | None = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str | None = get_period_type(source_dataset)
     except (KeyError, TypeError):
         period_type = None
     _override_time_step(collection_payload, _period_step(period_type))

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -16,7 +16,6 @@ from xstac import xarray_to_stac
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
-from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 from climate_api.shared.time import parse_period_string_to_datetime
@@ -120,10 +119,10 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
     try:
-        pt: str | None = get_period_type(source_dataset)
-    except (KeyError, ValueError):
-        pt = None
-    _override_time_step(collection_payload, _period_step(pt))
+        resolution: str | None = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+    except (KeyError, TypeError):
+        resolution = None
+    _override_time_step(collection_payload, _period_step(resolution))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
@@ -323,15 +322,19 @@ def _abs_url(request: Request, path: str) -> str:
     return f"{str(request.base_url).rstrip('/')}{path}"
 
 
-def _period_step(period_type: object) -> str | None:
-    if period_type == "hourly":
+def _period_step(resolution: object) -> str | None:
+    if not isinstance(resolution, str):
+        return None
+    if "T" in resolution.upper():
         return "PT1H"
-    if period_type == "daily":
+    if resolution == "P1D":
         return "P1D"
-    if period_type == "monthly":
+    if resolution == "P1M":
         return "P1M"
-    if period_type == "yearly":
+    if resolution == "P1Y":
         return "P1Y"
+    if resolution == "P1W":
+        return "P1W"
     return None
 
 

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -326,7 +326,7 @@ def _abs_url(request: Request, path: str) -> str:
 def _period_step(period_type: object) -> str | None:
     if not isinstance(period_type, str):
         return None
-    if "T" in period_type.upper():
+    if period_type == "PT1H":
         return "PT1H"
     if period_type == "P1D":
         return "P1D"

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -326,15 +326,15 @@ def _abs_url(request: Request, path: str) -> str:
 def _period_step(period_type: object) -> str | None:
     if not isinstance(period_type, str):
         return None
-    if period_type == "PT1H":
+    if period_type == "PT1H":  # hourly
         return "PT1H"
-    if period_type == "P1D":
+    if period_type == "P1D":  # daily
         return "P1D"
-    if period_type == "P1M":
+    if period_type == "P1M":  # monthly
         return "P1M"
-    if period_type == "P1Y":
+    if period_type == "P1Y":  # yearly
         return "P1Y"
-    if period_type == "P1W":
+    if period_type == "P1W":  # weekly
         return "P1W"
     return None
 

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -16,6 +16,7 @@ from xstac import xarray_to_stac
 from climate_api.data_accessor.services.accessor import open_zarr_dataset
 from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
+from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
 from climate_api.shared.time import parse_period_string_to_datetime
@@ -118,7 +119,11 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, _period_step(source_dataset.get("period_type")))
+    try:
+        pt: str | None = get_period_type(source_dataset)
+    except (KeyError, ValueError):
+        pt = None
+    _override_time_step(collection_payload, _period_step(pt))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -19,7 +19,7 @@ from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.data_registry.services.datasets import get_period_type
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime
+from climate_api.shared.time import _period_family, parse_period_string_to_datetime
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -326,17 +326,11 @@ def _abs_url(request: Request, path: str) -> str:
 def _period_step(period_type: object) -> str | None:
     if not isinstance(period_type, str):
         return None
-    if period_type == "PT1H":  # hourly
-        return "PT1H"
-    if period_type == "P1D":  # daily
-        return "P1D"
-    if period_type == "P1M":  # monthly
-        return "P1M"
-    if period_type == "P1Y":  # yearly
-        return "P1Y"
-    if period_type == "P1W":  # weekly
-        return "P1W"
-    return None
+    try:
+        _period_family(period_type)
+    except ValueError:
+        return None
+    return period_type
 
 
 def _override_time_step(collection: dict[str, Any], step: str | None) -> None:

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -119,10 +119,10 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
     try:
-        resolution: str | None = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
+        period_type: str | None = str(source_dataset["extents"]["temporal"]["resolution"])  # type: ignore[index]
     except (KeyError, TypeError):
-        resolution = None
-    _override_time_step(collection_payload, _period_step(resolution))
+        period_type = None
+    _override_time_step(collection_payload, _period_step(period_type))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
@@ -322,18 +322,18 @@ def _abs_url(request: Request, path: str) -> str:
     return f"{str(request.base_url).rstrip('/')}{path}"
 
 
-def _period_step(resolution: object) -> str | None:
-    if not isinstance(resolution, str):
+def _period_step(period_type: object) -> str | None:
+    if not isinstance(period_type, str):
         return None
-    if "T" in resolution.upper():
+    if "T" in period_type.upper():
         return "PT1H"
-    if resolution == "P1D":
+    if period_type == "P1D":
         return "P1D"
-    if resolution == "P1M":
+    if period_type == "P1M":
         return "P1M"
-    if resolution == "P1Y":
+    if period_type == "P1Y":
         return "P1Y"
-    if resolution == "P1W":
+    if period_type == "P1W":
         return "P1W"
     return None
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -158,7 +158,7 @@ extents:
     resolution: P1D              # required — ISO 8601 duration, see https://en.wikipedia.org/wiki/ISO_8601#Durations
 ```
 
-`extents.temporal.resolution` is required and must be one of: `PT1H` (hourly), `P1D` (daily), `P1W` (weekly), `P1M` (monthly), `P1Y` (yearly). It drives the `period_type` used internally — you do not set `period_type` directly.
+`extents.temporal.resolution` is required and must be a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Common values: `PT1H` (hourly), `P1D` (daily), `P1W` (weekly), `P1M` (monthly), `P1Y` (yearly). The `period_type` used internally is derived from the largest time component — you do not set it directly.
 
 If an ingest request's bounding box has no overlap with `extents.spatial.bbox`, the API returns HTTP 400 immediately. Partial overlap is allowed — the provider will return data for the intersecting area.
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -157,7 +157,7 @@ extents:
     resolution: P1D              # required — ISO 8601 duration, see https://en.wikipedia.org/wiki/ISO_8601#Durations
 ```
 
-`extents.temporal.resolution` is required and must be a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Common values: `PT1H` (hourly), `P1D` (daily), `P1W` (weekly), `P1M` (monthly), `P1Y` (yearly). The `period_type` used internally is derived from the largest time component — you do not set it directly.
+`extents.temporal.resolution` is required and must be a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Common values: `PT1H` (hourly), `P1D` (daily), `P1W` (weekly), `P1M` (monthly), `P1Y` (yearly).
 
 If an ingest request's bounding box has no overlap with `extents.spatial.bbox`, the API returns HTTP 400 immediately. Partial overlap is allowed — the provider will return data for the intersecting area.
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -102,7 +102,6 @@ Create a directory for your custom templates and add a YAML file. Each file cont
 
 **Period and sync**
 
-The temporal resolution (`period_type`) is derived automatically from `extents.temporal.resolution` — you do not set it directly.
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -70,10 +70,15 @@ Create a directory for your custom templates and add a YAML file. Each file cont
   name: ENACTS Rainfall (daily)
   short_name: Rainfall
   variable: rainfall
-  period_type: daily
   sync:
     kind: temporal
     execution: append
+  extents:
+    spatial:
+      bbox: [-20, 5, 55, 25]
+    temporal:
+      begin: "1981-01-01"
+      resolution: P1D
   ingestion:
     function: mypackage.sources.enacts.download
   units: mm
@@ -97,9 +102,10 @@ Create a directory for your custom templates and add a YAML file. Each file cont
 
 **Period and sync**
 
+The temporal resolution (`period_type`) is derived automatically from `extents.temporal.resolution` — you do not set it directly.
+
 | Field | Required | Description |
 | ----- | -------- | ----------- |
-| `period_type` | Yes | Temporal resolution: `hourly`, `daily`, `monthly`, `yearly` |
 | `sync.kind` | Yes | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced |
 | `sync.execution` | No | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync |
 | `sync.availability` | No | Provider availability policy — see below |
@@ -146,13 +152,13 @@ See [Extensibility — Transform functions](extensibility.md#transform-functions
 extents:
   spatial:
     bbox: [-180, -50, 180, 50]   # [xmin, ymin, xmax, ymax] in WGS84
-    crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
   temporal:
     begin: "1981-01-01"
     end: "2030-12-31"            # omit if ongoing
-    trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
-    resolution: P1D              # ISO 8601 duration: PT1H, P1D, P1M, P1Y
+    resolution: P1D              # required — ISO 8601 duration, see https://en.wikipedia.org/wiki/ISO_8601#Durations
 ```
+
+`extents.temporal.resolution` is required and must be one of: `PT1H` (hourly), `P1D` (daily), `P1W` (weekly), `P1M` (monthly), `P1Y` (yearly). It drives the `period_type` used internally — you do not set `period_type` directly.
 
 If an ingest request's bounding box has no overlap with `extents.spatial.bbox`, the API returns HTTP 400 immediately. Partial overlap is allowed — the provider will return data for the intersecting area.
 
@@ -219,9 +225,11 @@ The smallest valid template for a static dataset with no sync:
 - id: my_static_dataset
   name: My static dataset
   variable: value
-  period_type: daily
   sync:
     kind: static
+  extents:
+    temporal:
+      resolution: P1D
   ingestion:
     function: mypackage.sources.my_source.download
 ```

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -235,7 +235,7 @@ Example response:
       "dataset_name": "Total precipitation (CHIRPS3)",
       "short_name": "Total precipitation",
       "variable": "precip",
-      "period_type": "daily",
+      "period_type": "P1D",
       "units": "mm",
       "resolution": "5 km x 5 km",
       "source": "CHIRPS v3",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,11 +167,11 @@ def test_plugins_dir_adds_root_to_sys_path_and_makes_modules_importable(
 - id: plugin_dataset
   name: Plugin dataset
   variable: val
+  sync:
+    kind: static
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: static
   ingestion:
     function: myplugin.source.download
 """,
@@ -203,11 +203,11 @@ def test_plugins_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, 
 - id: custom_dataset
   name: Custom dataset
   variable: val
+  sync:
+    kind: static
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: static
   ingestion:
     function: mypackage.sources.download
 """,
@@ -238,11 +238,11 @@ def test_plugins_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monkey
         """
 - id: deployed_dataset
   variable: val
+  sync:
+    kind: static
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: static
   ingestion:
     function: mypackage.sources.download
 """,
@@ -266,11 +266,11 @@ def test_plugins_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.Monke
 - id: chirps3_precipitation_daily
   name: Custom CHIRPS override
   variable: precip
+  sync:
+    kind: static
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: static
   ingestion:
     function: mypackage.sources.download
 """,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,7 +167,9 @@ def test_plugins_dir_adds_root_to_sys_path_and_makes_modules_importable(
 - id: plugin_dataset
   name: Plugin dataset
   variable: val
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: static
   ingestion:
@@ -201,7 +203,9 @@ def test_plugins_dir_in_config_adds_to_bundled(monkeypatch: pytest.MonkeyPatch, 
 - id: custom_dataset
   name: Custom dataset
   variable: val
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: static
   ingestion:
@@ -234,7 +238,9 @@ def test_plugins_dir_resolved_relative_to_config_file(monkeypatch: pytest.Monkey
         """
 - id: deployed_dataset
   variable: val
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: static
   ingestion:
@@ -260,7 +266,9 @@ def test_plugins_dir_in_config_overrides_bundled_by_id(monkeypatch: pytest.Monke
 - id: chirps3_precipitation_daily
   name: Custom CHIRPS override
   variable: precip
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: static
   ingestion:

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pytest
 
 from climate_api.data_registry.services import datasets
-from climate_api.data_registry.services.datasets import get_period_type
 
 
 def test_dataset_registry_requires_sync_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -208,7 +207,7 @@ def test_dataset_registry_accepts_sync_availability_function(
     )
 
 
-def test_dataset_registry_derives_period_type_from_resolution(
+def test_dataset_registry_stores_iso_resolutions(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -271,11 +270,11 @@ def test_dataset_registry_derives_period_type_from_resolution(
     monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
 
     loaded = {d["id"]: d for d in datasets.list_datasets()}
-    assert get_period_type(loaded["hourly_ds"]) == "hourly"
-    assert get_period_type(loaded["daily_ds"]) == "daily"
-    assert get_period_type(loaded["weekly_ds"]) == "weekly"
-    assert get_period_type(loaded["monthly_ds"]) == "monthly"
-    assert get_period_type(loaded["yearly_ds"]) == "yearly"
+    assert loaded["hourly_ds"]["extents"]["temporal"]["resolution"] == "PT1H"
+    assert loaded["daily_ds"]["extents"]["temporal"]["resolution"] == "P1D"
+    assert loaded["weekly_ds"]["extents"]["temporal"]["resolution"] == "P1W"
+    assert loaded["monthly_ds"]["extents"]["temporal"]["resolution"] == "P1M"
+    assert loaded["yearly_ds"]["extents"]["temporal"]["resolution"] == "P1Y"
 
 
 def test_dataset_registry_rejects_missing_resolution(
@@ -326,15 +325,15 @@ def test_dataset_registry_rejects_missing_extents(
         datasets.list_datasets()
 
 
-def test_dataset_registry_rejects_unrecognised_resolution(
+def test_dataset_registry_accepts_non_standard_resolution(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    registry_file = tmp_path / "bad_resolution.yaml"
+    registry_file = tmp_path / "non_standard_resolution.yaml"
     registry_file.write_text(
         """
-- id: bad_resolution
-  name: Bad resolution
+- id: non_standard_resolution
+  name: Non-standard resolution
   variable: value
   sync:
     kind: temporal
@@ -348,5 +347,5 @@ def test_dataset_registry_rejects_unrecognised_resolution(
     )
     monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
 
-    with pytest.raises(ValueError, match="unrecognised.*extents.temporal.resolution.*P6H"):
-        datasets.list_datasets()
+    loaded = datasets.list_datasets()
+    assert loaded[0]["extents"]["temporal"]["resolution"] == "P6H"

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -339,7 +339,7 @@ def test_dataset_registry_accepts_non_standard_resolution(
     kind: temporal
   extents:
     temporal:
-      resolution: P6H
+      resolution: PT6H
   ingestion:
     function: some.download.function
 """,
@@ -348,4 +348,4 @@ def test_dataset_registry_accepts_non_standard_resolution(
     monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
 
     loaded = datasets.list_datasets()
-    assert loaded[0]["extents"]["temporal"]["resolution"] == "P6H"
+    assert loaded[0]["extents"]["temporal"]["resolution"] == "PT6H"

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -349,3 +349,29 @@ def test_dataset_registry_accepts_non_standard_resolution(
 
     loaded = datasets.list_datasets()
     assert loaded[0]["extents"]["temporal"]["resolution"] == "PT6H"
+
+
+def test_dataset_registry_rejects_invalid_iso_8601_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_file = tmp_path / "invalid_resolution.yaml"
+    registry_file.write_text(
+        """
+- id: invalid_resolution
+  name: Invalid resolution
+  variable: value
+  sync:
+    kind: temporal
+  extents:
+    temporal:
+      resolution: P6H
+  ingestion:
+    function: some.download.function
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="invalid extents.temporal.resolution"):
+        datasets.list_datasets()

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from climate_api.data_registry.services import datasets
+from climate_api.data_registry.services.datasets import get_period_type
 
 
 def test_dataset_registry_requires_sync_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -58,11 +59,11 @@ def test_dataset_registry_accepts_supported_sync_kind(
 - id: valid_temporal
   name: Valid temporal
   variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: temporal
   ingestion:
     function: some.download.function
 """,
@@ -134,12 +135,12 @@ def test_dataset_registry_accepts_supported_sync_execution(
 - id: valid_append
   name: Valid append
   variable: value
-  extents:
-    temporal:
-      resolution: P1D
   sync:
     kind: temporal
     execution: append
+  extents:
+    temporal:
+      resolution: P1D
   ingestion:
     function: some.download.function
 """,
@@ -160,13 +161,13 @@ def test_dataset_registry_rejects_invalid_sync_availability_function(
 - id: invalid_sync_availability
   name: Invalid sync availability
   variable: value
-  extents:
-    temporal:
-      resolution: P1D
   sync:
     kind: temporal
     availability:
       latest_available_function: 42
+  extents:
+    temporal:
+      resolution: P1D
   ingestion:
     function: some.download.function
 """,
@@ -188,13 +189,13 @@ def test_dataset_registry_accepts_sync_availability_function(
 - id: valid_sync_availability
   name: Valid sync availability
   variable: value
-  extents:
-    temporal:
-      resolution: P1D
   sync:
     kind: temporal
     availability:
       latest_available_function: climate_api.providers.availability.lagged_latest_available
+  extents:
+    temporal:
+      resolution: P1D
   ingestion:
     function: some.download.function
 """,
@@ -211,93 +212,88 @@ def test_dataset_registry_derives_period_type_from_resolution(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    registry_file = tmp_path / "datasets.yaml"
+    registry_file = tmp_path / "resolutions.yaml"
     registry_file.write_text(
         """
 - id: hourly_ds
   name: Hourly
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: PT1H
-  sync:
-    kind: temporal
   ingestion:
-    function: some.func
-
+    function: some.download.function
 - id: daily_ds
   name: Daily
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P1D
-  sync:
-    kind: temporal
   ingestion:
-    function: some.func
-
+    function: some.download.function
 - id: weekly_ds
   name: Weekly
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P1W
-  sync:
-    kind: temporal
   ingestion:
-    function: some.func
-
+    function: some.download.function
 - id: monthly_ds
   name: Monthly
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P1M
-  sync:
-    kind: temporal
   ingestion:
-    function: some.func
-
+    function: some.download.function
 - id: yearly_ds
   name: Yearly
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P1Y
-  sync:
-    kind: release
   ingestion:
-    function: some.func
+    function: some.download.function
 """,
         encoding="utf-8",
     )
     monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
 
     loaded = {d["id"]: d for d in datasets.list_datasets()}
-    assert loaded["hourly_ds"]["period_type"] == "hourly"
-    assert loaded["daily_ds"]["period_type"] == "daily"
-    assert loaded["weekly_ds"]["period_type"] == "weekly"
-    assert loaded["monthly_ds"]["period_type"] == "monthly"
-    assert loaded["yearly_ds"]["period_type"] == "yearly"
+    assert get_period_type(loaded["hourly_ds"]) == "hourly"
+    assert get_period_type(loaded["daily_ds"]) == "daily"
+    assert get_period_type(loaded["weekly_ds"]) == "weekly"
+    assert get_period_type(loaded["monthly_ds"]) == "monthly"
+    assert get_period_type(loaded["yearly_ds"]) == "yearly"
 
 
 def test_dataset_registry_rejects_missing_resolution(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    registry_file = tmp_path / "no_resolution.yaml"
+    registry_file = tmp_path / "missing_resolution.yaml"
     registry_file.write_text(
         """
-- id: no_resolution
-  name: No resolution
-  variable: v
-  extents:
-    temporal:
-      begin: "2020-01-01"
+- id: missing_resolution
+  name: Missing resolution
+  variable: value
   sync:
     kind: temporal
+  extents:
+    temporal: {}
   ingestion:
-    function: some.func
+    function: some.download.function
 """,
         encoding="utf-8",
     )
@@ -311,16 +307,16 @@ def test_dataset_registry_rejects_missing_extents(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    registry_file = tmp_path / "no_extents.yaml"
+    registry_file = tmp_path / "missing_extents.yaml"
     registry_file.write_text(
         """
-- id: no_extents
-  name: No extents
-  variable: v
+- id: missing_extents
+  name: Missing extents
+  variable: value
   sync:
     kind: temporal
   ingestion:
-    function: some.func
+    function: some.download.function
 """,
         encoding="utf-8",
     )
@@ -339,14 +335,14 @@ def test_dataset_registry_rejects_unrecognised_resolution(
         """
 - id: bad_resolution
   name: Bad resolution
-  variable: v
+  variable: value
+  sync:
+    kind: temporal
   extents:
     temporal:
       resolution: P6H
-  sync:
-    kind: temporal
   ingestion:
-    function: some.func
+    function: some.download.function
 """,
         encoding="utf-8",
     )

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -12,7 +12,9 @@ def test_dataset_registry_requires_sync_kind(monkeypatch: pytest.MonkeyPatch, tm
 - id: missing_sync_kind
   name: Missing sync kind
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
 """,
         encoding="utf-8",
     )
@@ -32,7 +34,9 @@ def test_dataset_registry_rejects_unsupported_sync_kind(
 - id: invalid_sync_kind
   name: Invalid sync kind
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: sometimes
 """,
@@ -54,7 +58,9 @@ def test_dataset_registry_accepts_supported_sync_kind(
 - id: valid_temporal
   name: Valid temporal
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
   ingestion:
@@ -77,7 +83,9 @@ def test_dataset_registry_rejects_unsupported_sync_execution(
 - id: invalid_sync_execution
   name: Invalid sync execution
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
     execution: sometimes
@@ -100,7 +108,9 @@ def test_dataset_registry_rejects_non_string_sync_execution(
 - id: invalid_sync_execution_type
   name: Invalid sync execution type
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
     execution:
@@ -124,7 +134,9 @@ def test_dataset_registry_accepts_supported_sync_execution(
 - id: valid_append
   name: Valid append
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
     execution: append
@@ -148,7 +160,9 @@ def test_dataset_registry_rejects_invalid_sync_availability_function(
 - id: invalid_sync_availability
   name: Invalid sync availability
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
     availability:
@@ -174,7 +188,9 @@ def test_dataset_registry_accepts_sync_availability_function(
 - id: valid_sync_availability
   name: Valid sync availability
   variable: value
-  period_type: daily
+  extents:
+    temporal:
+      resolution: P1D
   sync:
     kind: temporal
     availability:
@@ -189,3 +205,152 @@ def test_dataset_registry_accepts_sync_availability_function(
     assert datasets.list_datasets()[0]["sync"]["availability"]["latest_available_function"].endswith(
         "lagged_latest_available"
     )
+
+
+def test_dataset_registry_derives_period_type_from_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_file = tmp_path / "datasets.yaml"
+    registry_file.write_text(
+        """
+- id: hourly_ds
+  name: Hourly
+  variable: v
+  extents:
+    temporal:
+      resolution: PT1H
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+
+- id: daily_ds
+  name: Daily
+  variable: v
+  extents:
+    temporal:
+      resolution: P1D
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+
+- id: weekly_ds
+  name: Weekly
+  variable: v
+  extents:
+    temporal:
+      resolution: P1W
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+
+- id: monthly_ds
+  name: Monthly
+  variable: v
+  extents:
+    temporal:
+      resolution: P1M
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+
+- id: yearly_ds
+  name: Yearly
+  variable: v
+  extents:
+    temporal:
+      resolution: P1Y
+  sync:
+    kind: release
+  ingestion:
+    function: some.func
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
+
+    loaded = {d["id"]: d for d in datasets.list_datasets()}
+    assert loaded["hourly_ds"]["period_type"] == "hourly"
+    assert loaded["daily_ds"]["period_type"] == "daily"
+    assert loaded["weekly_ds"]["period_type"] == "weekly"
+    assert loaded["monthly_ds"]["period_type"] == "monthly"
+    assert loaded["yearly_ds"]["period_type"] == "yearly"
+
+
+def test_dataset_registry_rejects_missing_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_file = tmp_path / "no_resolution.yaml"
+    registry_file.write_text(
+        """
+- id: no_resolution
+  name: No resolution
+  variable: v
+  extents:
+    temporal:
+      begin: "2020-01-01"
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="must define extents.temporal.resolution"):
+        datasets.list_datasets()
+
+
+def test_dataset_registry_rejects_missing_extents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_file = tmp_path / "no_extents.yaml"
+    registry_file.write_text(
+        """
+- id: no_extents
+  name: No extents
+  variable: v
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="must define extents.temporal.resolution"):
+        datasets.list_datasets()
+
+
+def test_dataset_registry_rejects_unrecognised_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_file = tmp_path / "bad_resolution.yaml"
+    registry_file.write_text(
+        """
+- id: bad_resolution
+  name: Bad resolution
+  variable: v
+  extents:
+    temporal:
+      resolution: P6H
+  sync:
+    kind: temporal
+  ingestion:
+    function: some.func
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="unrecognised.*extents.temporal.resolution.*P6H"):
+        datasets.list_datasets()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -111,7 +111,7 @@ def test_list_datasets_groups_artifacts_by_managed_dataset_id(monkeypatch: pytes
     dataset = result.items[0]
     assert dataset.dataset_id == "chirps3_precipitation_daily"
     assert dataset.source_dataset_id == "chirps3_precipitation_daily"
-    assert dataset.period_type == "daily"
+    assert dataset.period_type == "P1D"
     assert dataset.units == "mm"
     assert dataset.extent.temporal.end == "2026-01-11"
     assert dataset.publication.status == PublicationStatus.PUBLISHED

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -97,7 +97,7 @@ def test_list_datasets_groups_artifacts_by_managed_dataset_id(monkeypatch: pytes
         lambda _: {
             "id": "chirps3_precipitation_daily",
             "short_name": "CHIRPS3 precip",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "units": "mm",
             "resolution": "5 km x 5 km",
             "source": "CHIRPS v3",
@@ -150,7 +150,7 @@ def test_list_ingestions_returns_most_recent_first(monkeypatch: pytest.MonkeyPat
         lambda _: {
             "id": "chirps3_precipitation_daily",
             "short_name": "CHIRPS3 precip",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "units": "mm",
             "resolution": "5 km x 5 km",
             "source": "CHIRPS v3",
@@ -233,7 +233,7 @@ def test_list_datasets_ignores_stale_records(monkeypatch: pytest.MonkeyPatch) ->
         lambda _: {
             "id": "chirps3_precipitation_daily",
             "short_name": "CHIRPS3 precip",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "units": "mm",
             "resolution": "5 km x 5 km",
             "source": "CHIRPS v3",
@@ -267,7 +267,7 @@ def test_create_artifact_computes_coverage_from_created_artifact_paths(
         "id": "worldpop_population_yearly",
         "name": "Total population (WorldPop Global12)",
         "variable": "pop_total",
-        "period_type": "yearly",
+        "extents": {"temporal": {"resolution": "P1Y"}},
     }
     created_file = tmp_path / "worldpop_population_yearly_2020.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -323,7 +323,7 @@ def test_create_artifact_normalizes_request_scope_to_dataset_period(
         "id": "era5land_temperature_hourly",
         "name": "2m temperature (ERA5-Land)",
         "variable": "t2m",
-        "period_type": "hourly",
+        "extents": {"temporal": {"resolution": "PT1H"}},
     }
     created_file = tmp_path / "era5land_temperature_hourly_2026-04-21.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -385,7 +385,7 @@ def test_create_artifact_defaults_omitted_end_to_dataset_native_period_for_downl
         "id": "era5land_temperature_hourly",
         "name": "2m temperature (ERA5-Land)",
         "variable": "t2m",
-        "period_type": "hourly",
+        "extents": {"temporal": {"resolution": "PT1H"}},
     }
     created_file = tmp_path / "era5land_temperature_hourly_2026-04-21.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -451,7 +451,7 @@ def test_create_artifact_returns_409_when_downloaded_artifact_has_no_data(
         "id": "worldpop_population_yearly",
         "name": "Total population (WorldPop Global12)",
         "variable": "pop_total",
-        "period_type": "yearly",
+        "extents": {"temporal": {"resolution": "P1Y"}},
     }
     created_file = tmp_path / "worldpop_population_yearly_2020.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -495,7 +495,7 @@ def test_create_artifact_can_download_delta_while_recording_full_request_scope(
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
     created_file = tmp_path / "chirps3_precipitation_daily_2026-02-01_2026-02-10.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -560,7 +560,7 @@ def test_create_artifact_rejects_partial_download_scope(monkeypatch: pytest.Monk
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
 
     with pytest.raises(services.HTTPException) as exc_info:
@@ -588,7 +588,7 @@ def test_create_artifact_rejects_download_scope_outside_request_scope(monkeypatc
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
 
     with pytest.raises(services.HTTPException) as exc_info:
@@ -616,7 +616,7 @@ def test_create_artifact_delta_does_not_reuse_netcdf_artifact_when_canonical_zar
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
     created_file = tmp_path / "chirps3_precipitation_daily_2026-02-01_2026-02-10.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -680,7 +680,7 @@ def test_create_artifact_delta_requires_canonical_zarr_when_prefer_zarr_is_false
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
     created_file = tmp_path / "chirps3_precipitation_daily_2026-02-01_2026-02-10.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -739,7 +739,7 @@ def test_create_artifact_delta_fails_when_canonical_zarr_build_fails(
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
     created_file = tmp_path / "chirps3_precipitation_daily_2026-02-01_2026-02-10.nc"
     created_file.write_text("dummy", encoding="utf-8")
@@ -778,7 +778,7 @@ def test_create_artifact_delta_rejects_short_rebuilt_coverage(
         "id": "chirps3_precipitation_daily",
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
     }
     created_file = tmp_path / "chirps3_precipitation_daily_2026-02-01_2026-02-10.nc"
     created_file.write_text("dummy", encoding="utf-8")

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -357,18 +357,18 @@ def test_default_hourly_target_end_is_utc_aware(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(sync_engine, "utc_now", lambda: FixedDateTime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
 
-    result = sync_engine._default_target_end(period_type="hourly")
+    result = sync_engine._default_target_end(resolution="PT1H")
 
     assert result == "2026-04-21T13"
 
 
-def test_default_target_end_rejects_unsupported_period_type() -> None:
-    with pytest.raises(ValueError, match="Unsupported period_type 'fortnightly' for sync"):
-        sync_engine._default_target_end(period_type="fortnightly")
+def test_default_target_end_rejects_unsupported_resolution() -> None:
+    with pytest.raises(ValueError, match="Unsupported resolution 'P14D' for sync"):
+        sync_engine._default_target_end(resolution="P14D")
 
 
 def test_next_period_start_preserves_hourly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-04-21T13", period_type="hourly")
+    result = sync_engine._next_period_start("2026-04-21T13", resolution="PT1H")
 
     assert result == "2026-04-21T14"
 
@@ -376,19 +376,19 @@ def test_next_period_start_preserves_hourly_period_format() -> None:
 def test_default_weekly_target_end_uses_iso_week_format(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sync_engine, "utc_now", lambda: datetime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
 
-    result = sync_engine._default_target_end(period_type="weekly")
+    result = sync_engine._default_target_end(resolution="P1W")
 
     assert result == "2026-W17"
 
 
 def test_next_period_start_preserves_weekly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-W17", period_type="weekly")
+    result = sync_engine._next_period_start("2026-W17", resolution="P1W")
 
     assert result == "2026-W18"
 
 
 def test_next_period_start_rolls_weekly_period_across_iso_year_boundary() -> None:
-    result = sync_engine._next_period_start("2020-W53", period_type="weekly")
+    result = sync_engine._next_period_start("2020-W53", resolution="P1W")
 
     assert result == "2021-W01"
 

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -66,7 +66,7 @@ def _dataset_detail(dataset_id: str) -> DatasetDetailRecord:
         dataset_name="CHIRPS3 precipitation",
         short_name="CHIRPS3 precip",
         variable="precip",
-        period_type="daily",
+        period_type="P1D",
         units="mm",
         resolution="5 km x 5 km",
         source="CHIRPS v3",
@@ -357,18 +357,18 @@ def test_default_hourly_target_end_is_utc_aware(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(sync_engine, "utc_now", lambda: FixedDateTime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
 
-    result = sync_engine._default_target_end(resolution="PT1H")
+    result = sync_engine._default_target_end(period_type="PT1H")
 
     assert result == "2026-04-21T13"
 
 
 def test_default_target_end_rejects_unsupported_resolution() -> None:
-    with pytest.raises(ValueError, match="Unsupported resolution 'P14D' for sync"):
-        sync_engine._default_target_end(resolution="P14D")
+    with pytest.raises(ValueError, match="Unsupported period_type 'P14D' for sync"):
+        sync_engine._default_target_end(period_type="P14D")
 
 
 def test_next_period_start_preserves_hourly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-04-21T13", resolution="PT1H")
+    result = sync_engine._next_period_start("2026-04-21T13", period_type="PT1H")
 
     assert result == "2026-04-21T14"
 
@@ -376,19 +376,19 @@ def test_next_period_start_preserves_hourly_period_format() -> None:
 def test_default_weekly_target_end_uses_iso_week_format(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sync_engine, "utc_now", lambda: datetime(2026, 4, 21, 13, 47, 31, tzinfo=UTC))
 
-    result = sync_engine._default_target_end(resolution="P1W")
+    result = sync_engine._default_target_end(period_type="P1W")
 
     assert result == "2026-W17"
 
 
 def test_next_period_start_preserves_weekly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-W17", resolution="P1W")
+    result = sync_engine._next_period_start("2026-W17", period_type="P1W")
 
     assert result == "2026-W18"
 
 
 def test_next_period_start_rolls_weekly_period_across_iso_year_boundary() -> None:
-    result = sync_engine._next_period_start("2020-W53", resolution="P1W")
+    result = sync_engine._next_period_start("2020-W53", period_type="P1W")
 
     assert result == "2021-W01"
 

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -97,7 +97,7 @@ def test_sync_dataset_returns_up_to_date_when_no_new_period_is_due(monkeypatch: 
         "get_dataset",
         lambda _: {
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"kind": "temporal"},
             "ingestion": {},
         },
@@ -126,7 +126,11 @@ def test_sync_dataset_creates_new_version_from_next_period(monkeypatch: pytest.M
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
+            "sync": {"kind": "temporal"},
+        },
     )
 
     captured: dict[str, object] = {}
@@ -172,7 +176,7 @@ def test_sync_dataset_append_policy_downloads_only_delta_but_preserves_full_scop
         "get_dataset",
         lambda _: {
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"kind": "temporal", "execution": "append"},
             "ingestion": {},
         },
@@ -229,7 +233,7 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_pyramid_zarr
         "get_dataset",
         lambda _: {
             "id": "worldpop_population_yearly",
-            "period_type": "yearly",
+            "extents": {"temporal": {"resolution": "P1Y"}},
             "sync": {"kind": "temporal", "execution": "append"},
             "ingestion": {},
         },
@@ -275,7 +279,11 @@ def test_sync_dataset_release_policy_returns_up_to_date_when_release_matches(mon
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "worldpop_population_yearly", "period_type": "yearly", "sync": {"kind": "release"}},
+        lambda _: {
+            "id": "worldpop_population_yearly",
+            "extents": {"temporal": {"resolution": "P1Y"}},
+            "sync": {"kind": "release"},
+        },
     )
     monkeypatch.setattr(services, "get_dataset_or_404", lambda _: _dataset_detail(dataset_id))
 
@@ -309,7 +317,7 @@ def test_sync_dataset_release_policy_clamps_future_year_by_template_availability
         "get_dataset",
         lambda _: {
             "id": "release_dataset_yearly",
-            "period_type": "yearly",
+            "extents": {"temporal": {"resolution": "P1Y"}},
             "sync": {"kind": "release", "availability": {"latest_year_offset": 1}},
         },
     )
@@ -399,7 +407,7 @@ def test_sync_dataset_static_policy_returns_not_syncable_without_period_arithmet
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "static_dataset", "period_type": "unsupported-static-period", "sync": {"kind": "static"}},
+        lambda _: {"id": "static_dataset", "sync": {"kind": "static"}},
     )
     monkeypatch.setattr(services, "create_artifact", lambda **_: pytest.fail("static sync should not create artifacts"))
     monkeypatch.setattr(services, "get_dataset_or_404", lambda _: _dataset_detail(dataset_id))
@@ -418,7 +426,7 @@ def test_plan_sync_requires_sync_kind() -> None:
 
     with pytest.raises(ValueError, match="must define sync.kind"):
         sync_engine.plan_sync(
-            source_dataset={"id": "chirps3_precipitation_daily", "period_type": "daily"},
+            source_dataset={"id": "chirps3_precipitation_daily", "extents": {"temporal": {"resolution": "P1D"}}},
             latest_artifact=latest,
             requested_end="2026-02-10",
         )
@@ -433,7 +441,7 @@ def test_plan_sync_static_policy_ignores_period_normalization() -> None:
     )
 
     result = sync_engine.plan_sync(
-        source_dataset={"id": "static_dataset", "period_type": "unsupported-static-period", "sync": {"kind": "static"}},
+        source_dataset={"id": "static_dataset", "sync": {"kind": "static"}},
         latest_artifact=latest,
         requested_end=None,
     )
@@ -450,7 +458,11 @@ def test_plan_sync_dataset_returns_plan_without_creating_artifact(monkeypatch: p
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
+            "sync": {"kind": "temporal"},
+        },
     )
     monkeypatch.setattr(services, "create_artifact", lambda **_: pytest.fail("sync plan should not create artifacts"))
 
@@ -477,7 +489,11 @@ def test_sync_plan_route_returns_plan_without_creating_artifact(
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
+            "sync": {"kind": "temporal"},
+        },
     )
     monkeypatch.setattr(services, "create_artifact", lambda **_: pytest.fail("sync plan should not create artifacts"))
 
@@ -509,7 +525,11 @@ def test_sync_plan_route_returns_400_for_invalid_end_period(
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
+            "sync": {"kind": "temporal"},
+        },
     )
 
     response = client.get(f"/sync/{dataset_id}/plan", params={"end": "not-a-period"})
@@ -528,7 +548,7 @@ def test_plan_sync_treats_blank_end_as_default_target(monkeypatch: pytest.Monkey
     result = sync_engine.plan_sync(
         source_dataset={
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"kind": "temporal", "execution": "append"},
             "ingestion": {},
         },
@@ -550,7 +570,11 @@ def test_sync_route_executes_rematerialize_and_returns_structured_detail(
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
+            "sync": {"kind": "temporal"},
+        },
     )
     monkeypatch.setattr(
         services,
@@ -585,7 +609,7 @@ def test_latest_available_end_preserves_requested_month_without_lag(monkeypatch:
     result = sync_engine._latest_available_end(
         source_dataset={
             "id": "monthly_dataset",
-            "period_type": "monthly",
+            "extents": {"temporal": {"resolution": "P1M"}},
             "sync": {"availability": {"lag_days": 0}},
         },
         requested_end="2026-05",
@@ -605,7 +629,7 @@ def test_plan_sync_marks_default_target_end_source(monkeypatch: pytest.MonkeyPat
     result = sync_engine.plan_sync(
         source_dataset={
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"kind": "temporal", "execution": "append"},
             "ingestion": {},
         },
@@ -625,7 +649,7 @@ def test_plan_sync_marks_request_target_clamped_by_availability(monkeypatch: pyt
     result = sync_engine.plan_sync(
         source_dataset={
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {
                 "kind": "temporal",
                 "execution": "append",
@@ -656,7 +680,7 @@ def test_latest_available_end_clamps_monthly_lag_to_month_period(monkeypatch: py
     result = sync_engine._latest_available_end(
         source_dataset={
             "id": "monthly_dataset",
-            "period_type": "monthly",
+            "extents": {"temporal": {"resolution": "P1M"}},
             "sync": {"availability": {"lag_days": 1}},
         },
         requested_end="2026-05",
@@ -676,7 +700,7 @@ def test_latest_available_end_uses_provider_availability_hook(monkeypatch: pytes
 
     source_dataset = {
         "id": "provider_dataset",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
         "sync": {"availability": {"latest_available_function": "provider.latest_available"}},
     }
     result = sync_engine._latest_available_end(source_dataset=source_dataset, requested_end="2026-02-10")
@@ -691,7 +715,7 @@ def test_latest_available_end_clamps_provider_availability_to_requested_end(monk
     result = sync_engine._latest_available_end(
         source_dataset={
             "id": "provider_dataset",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"availability": {"latest_available_function": "provider.latest_available"}},
         },
         requested_end="2026-02-10",
@@ -713,7 +737,7 @@ def test_latest_available_end_wraps_provider_import_errors(monkeypatch: pytest.M
         sync_engine._latest_available_end(
             source_dataset={
                 "id": "provider_dataset",
-                "period_type": "daily",
+                "extents": {"temporal": {"resolution": "P1D"}},
                 "sync": {"availability": {"latest_available_function": "provider.latest_available"}},
             },
             requested_end="2026-02-10",
@@ -730,7 +754,7 @@ def test_latest_available_end_rejects_invalid_provider_period_string(monkeypatch
         sync_engine._latest_available_end(
             source_dataset={
                 "id": "provider_dataset",
-                "period_type": "daily",
+                "extents": {"temporal": {"resolution": "P1D"}},
                 "sync": {"availability": {"latest_available_function": "provider.latest_available"}},
             },
             requested_end="2026-02-10",
@@ -742,7 +766,7 @@ def test_latest_available_end_wraps_invalid_provider_function_path(monkeypatch: 
         sync_engine._latest_available_end(
             source_dataset={
                 "id": "provider_dataset",
-                "period_type": "daily",
+                "extents": {"temporal": {"resolution": "P1D"}},
                 "sync": {"availability": {"latest_available_function": "invalid_path"}},
             },
             requested_end="2026-02-10",
@@ -761,7 +785,7 @@ def test_sync_plan_route_returns_500_for_provider_hook_misconfiguration(
         "get_dataset",
         lambda _: {
             "id": "chirps3_precipitation_daily",
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"kind": "temporal", "availability": {"latest_available_function": "provider.latest_available"}},
         },
     )
@@ -803,7 +827,11 @@ def test_run_sync_raises_clear_error_when_append_invariants_are_missing(monkeypa
     with pytest.raises(ValueError, match="Sync execution requires current_start"):
         sync_engine.run_sync(
             latest_artifact=latest_artifact,
-            source_dataset={"id": "chirps3_precipitation_daily", "period_type": "daily", "sync": {"kind": "temporal"}},
+            source_dataset={
+                "id": "chirps3_precipitation_daily",
+                "extents": {"temporal": {"resolution": "P1D"}},
+                "sync": {"kind": "temporal"},
+            },
             requested_end="2026-02-11",
             country_code=None,
             prefer_zarr=True,
@@ -825,7 +853,11 @@ def test_sync_dataset_forwards_country_code_from_extent(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         services.registry_datasets,
         "get_dataset",
-        lambda _: {"id": "worldpop_population_yearly", "period_type": "yearly", "sync": {"kind": "release"}},
+        lambda _: {
+            "id": "worldpop_population_yearly",
+            "extents": {"temporal": {"resolution": "P1Y"}},
+            "sync": {"kind": "release"},
+        },
     )
     monkeypatch.setattr(
         services,

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -613,7 +613,7 @@ def test_coverage_from_dataset_populates_spatial_wgs84_for_projected_crs() -> No
         coords={"time": times, "y": y, "x": x},
     )
 
-    result = _coverage_from_dataset(ds=ds, period_type="daily", native_crs="EPSG:25833")
+    result = _coverage_from_dataset(ds=ds, resolution="P1D", native_crs="EPSG:25833")
 
     wgs84 = result["coverage"]["spatial_wgs84"]
     assert wgs84 is not None
@@ -639,6 +639,6 @@ def test_coverage_from_dataset_leaves_spatial_wgs84_none_for_wgs84() -> None:
         coords={"time": times, "y": y, "x": x},
     )
 
-    result = _coverage_from_dataset(ds=ds, period_type="daily", native_crs="EPSG:4326")
+    result = _coverage_from_dataset(ds=ds, resolution="P1D", native_crs="EPSG:4326")
 
     assert result["coverage"]["spatial_wgs84"] is None

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -613,7 +613,7 @@ def test_coverage_from_dataset_populates_spatial_wgs84_for_projected_crs() -> No
         coords={"time": times, "y": y, "x": x},
     )
 
-    result = _coverage_from_dataset(ds=ds, resolution="P1D", native_crs="EPSG:25833")
+    result = _coverage_from_dataset(ds=ds, period_type="P1D", native_crs="EPSG:25833")
 
     wgs84 = result["coverage"]["spatial_wgs84"]
     assert wgs84 is not None
@@ -639,6 +639,6 @@ def test_coverage_from_dataset_leaves_spatial_wgs84_none_for_wgs84() -> None:
         coords={"time": times, "y": y, "x": x},
     )
 
-    result = _coverage_from_dataset(ds=ds, resolution="P1D", native_crs="EPSG:4326")
+    result = _coverage_from_dataset(ds=ds, period_type="P1D", native_crs="EPSG:4326")
 
     assert result["coverage"]["spatial_wgs84"] is None

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -164,12 +164,8 @@ def test_get_cache_prefix_uses_dataset_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-_CHIRPS3_EXTENTS: dict[str, Any] = {
-    "spatial": {"bbox": [-180, -50, 180, 50], "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"}
-}
-_LIMITED_LON_EXTENTS: dict[str, Any] = {
-    "spatial": {"bbox": [-180, -90, 60, 90], "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"}
-}
+_CHIRPS3_EXTENTS: dict[str, Any] = {"spatial": {"bbox": [-180, -50, 180, 50]}}
+_LIMITED_LON_EXTENTS: dict[str, Any] = {"spatial": {"bbox": [-180, -90, 60, 90]}}
 
 
 def test_validate_spatial_coverage_passes_when_no_extents_declared() -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -316,14 +316,14 @@ def _write_daily_nc_file(tmp_path: Path) -> list[Path]:
 _FLAT_DATASET: dict[str, Any] = {
     "id": "my_dataset",
     "variable": "pop_total",
-    "period_type": "yearly",
+    "extents": {"temporal": {"resolution": "P1Y"}},
     "ingestion": {},
 }
 
 _PYRAMID_DATASET: dict[str, Any] = {
     "id": "my_dataset",
     "variable": "pop_total",
-    "period_type": "yearly",
+    "extents": {"temporal": {"resolution": "P1Y"}},
     "ingestion": {},
 }
 
@@ -425,7 +425,7 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
     dataset: dict[str, Any] = {
         "id": "era5land_temperature_hourly",
         "variable": "t2m",
-        "period_type": "hourly",
+        "extents": {"temporal": {"resolution": "PT1H"}},
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
@@ -461,7 +461,7 @@ def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monke
     dataset: dict[str, Any] = {
         "id": "chirps3_precipitation_daily",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
@@ -487,7 +487,7 @@ def test_build_dataset_zarr_clips_to_requested_daily_range(
     dataset: dict[str, Any] = {
         "id": "chirps3_precipitation_daily",
         "variable": "precip",
-        "period_type": "daily",
+        "extents": {"temporal": {"resolution": "P1D"}},
         "ingestion": {},
     }
     monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)

--- a/tests/test_processing_resample.py
+++ b/tests/test_processing_resample.py
@@ -88,7 +88,9 @@ def test_materialize_resampled_artifact_builds_daily_dataset_from_hourly_source(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}}
+            if dataset_id == "era5land_temperature_hourly"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -143,7 +145,9 @@ def test_materialize_resampled_artifact_supports_custom_frequency_dekadal(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -209,7 +213,9 @@ def test_materialize_resampled_artifact_drops_incomplete_trailing_week(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -263,7 +269,9 @@ def test_materialize_resampled_artifact_drops_incomplete_leading_week(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -317,7 +325,9 @@ def test_materialize_resampled_artifact_returns_409_when_source_has_no_data_in_r
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -366,7 +376,9 @@ def test_materialize_resampled_artifact_builds_monthly_dataset_from_daily_source
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -420,7 +432,9 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}}
+            if dataset_id == "era5land_temperature_hourly"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -482,7 +496,9 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}}
+            if dataset_id == "chirps3_precipitation_daily"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -538,7 +554,9 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}}
+            if dataset_id == "era5land_temperature_hourly"
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -609,7 +627,9 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}}
+            if dataset_id == "era5land_temperature_hourly"
+            else None
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_processing_resample.py
+++ b/tests/test_processing_resample.py
@@ -19,6 +19,22 @@ from climate_api.ingestions.schemas import (
 from climate_api.processing import resample
 
 
+def test_frequency_to_iso_resolution_preserves_multiplier() -> None:
+    assert resample._frequency_to_iso_resolution("6h") == "PT6H"
+    assert resample._frequency_to_iso_resolution("10D") == "P10D"
+    assert resample._frequency_to_iso_resolution("2W") == "P2W"
+    assert resample._frequency_to_iso_resolution("3ME") == "P3M"
+    assert resample._frequency_to_iso_resolution("2YE") == "P2Y"
+
+
+def test_frequency_to_iso_resolution_canonical_values() -> None:
+    assert resample._frequency_to_iso_resolution("1h") == "PT1H"
+    assert resample._frequency_to_iso_resolution("1D") == "P1D"
+    assert resample._frequency_to_iso_resolution("W-MON") == "P1W"
+    assert resample._frequency_to_iso_resolution("ME") == "P1M"
+    assert resample._frequency_to_iso_resolution("YE") == "P1Y"
+
+
 @pytest.fixture(autouse=True)
 def isolated_artifact_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     artifacts_dir = tmp_path / "artifacts"

--- a/tests/test_processing_resample.py
+++ b/tests/test_processing_resample.py
@@ -88,7 +88,7 @@ def test_materialize_resampled_artifact_builds_daily_dataset_from_hourly_source(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "hourly"} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
         ),
     )
     monkeypatch.setattr(
@@ -143,7 +143,7 @@ def test_materialize_resampled_artifact_supports_custom_frequency_dekadal(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -209,7 +209,7 @@ def test_materialize_resampled_artifact_drops_incomplete_trailing_week(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -263,7 +263,7 @@ def test_materialize_resampled_artifact_drops_incomplete_leading_week(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -317,7 +317,7 @@ def test_materialize_resampled_artifact_returns_409_when_source_has_no_data_in_r
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -366,7 +366,7 @@ def test_materialize_resampled_artifact_builds_monthly_dataset_from_daily_source
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -420,7 +420,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "hourly"} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
         ),
     )
     monkeypatch.setattr(
@@ -482,7 +482,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "daily"} if dataset_id == "chirps3_precipitation_daily" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "P1D"}}} if dataset_id == "chirps3_precipitation_daily" else None
         ),
     )
     monkeypatch.setattr(
@@ -538,7 +538,7 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "hourly"} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
         ),
     )
     monkeypatch.setattr(
@@ -609,7 +609,7 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
         resample.registry_datasets,
         "get_dataset",
         lambda dataset_id: (
-            {"id": dataset_id, "period_type": "hourly"} if dataset_id == "era5land_temperature_hourly" else None
+            {"id": dataset_id, "extents": {"temporal": {"resolution": "PT1H"}}} if dataset_id == "era5land_temperature_hourly" else None
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_processing_resample.py
+++ b/tests/test_processing_resample.py
@@ -19,22 +19,6 @@ from climate_api.ingestions.schemas import (
 from climate_api.processing import resample
 
 
-def test_frequency_to_iso_resolution_preserves_multiplier() -> None:
-    assert resample._frequency_to_iso_resolution("6h") == "PT6H"
-    assert resample._frequency_to_iso_resolution("10D") == "P10D"
-    assert resample._frequency_to_iso_resolution("2W") == "P2W"
-    assert resample._frequency_to_iso_resolution("3ME") == "P3M"
-    assert resample._frequency_to_iso_resolution("2YE") == "P2Y"
-
-
-def test_frequency_to_iso_resolution_canonical_values() -> None:
-    assert resample._frequency_to_iso_resolution("1h") == "PT1H"
-    assert resample._frequency_to_iso_resolution("1D") == "P1D"
-    assert resample._frequency_to_iso_resolution("W-MON") == "P1W"
-    assert resample._frequency_to_iso_resolution("ME") == "P1M"
-    assert resample._frequency_to_iso_resolution("YE") == "P1Y"
-
-
 @pytest.fixture(autouse=True)
 def isolated_artifact_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     artifacts_dir = tmp_path / "artifacts"
@@ -117,7 +101,7 @@ def test_materialize_resampled_artifact_builds_daily_dataset_from_hourly_source(
 
     artifact = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-02",
@@ -125,7 +109,7 @@ def test_materialize_resampled_artifact_builds_daily_dataset_from_hourly_source(
         publish=False,
     )
 
-    assert artifact.dataset_id == "era5land_temperature_hourly_1d_mean"
+    assert artifact.dataset_id == "era5land_temperature_hourly_p1d_mean"
     assert artifact.coverage.temporal.start == "2026-01-01"
     assert artifact.coverage.temporal.end == "2026-01-02"
     result = xr.open_zarr(artifact.path, consolidated=True)
@@ -174,7 +158,7 @@ def test_materialize_resampled_artifact_supports_custom_frequency_dekadal(
 
     artifact = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="10D",
+        resolution="P10D",
         method="sum",
         start="2026-01-01",
         end="2026-01-01",
@@ -182,7 +166,7 @@ def test_materialize_resampled_artifact_supports_custom_frequency_dekadal(
         publish=False,
     )
 
-    assert artifact.dataset_id == "chirps3_precipitation_daily_10d_sum"
+    assert artifact.dataset_id == "chirps3_precipitation_daily_p10d_sum"
     assert artifact.coverage.temporal.start == "2026-01-01"
     result = xr.open_zarr(artifact.path, consolidated=True)
     try:
@@ -195,7 +179,7 @@ def test_materialize_resampled_artifact_returns_404_when_source_dataset_template
     with pytest.raises(resample.HTTPException, match="Source dataset template 'missing_daily' not found"):
         resample.materialize_resampled_artifact(
             source_dataset_id="missing_daily",
-            frequency="W-MON",
+            resolution="P1W",
             method="sum",
             start="2026-01-05",
             end="2026-01-12",
@@ -242,7 +226,7 @@ def test_materialize_resampled_artifact_drops_incomplete_trailing_week(
 
     artifact = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="W-MON",
+        resolution="P1W",
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
@@ -298,7 +282,7 @@ def test_materialize_resampled_artifact_drops_incomplete_leading_week(
 
     artifact = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="W-MON",
+        resolution="P1W",
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
@@ -358,7 +342,7 @@ def test_materialize_resampled_artifact_returns_409_when_source_has_no_data_in_r
     ):
         resample.materialize_resampled_artifact(
             source_dataset_id="chirps3_precipitation_daily",
-            frequency="W-MON",
+            resolution="P1W",
             method="sum",
             start="2026-03-02",  # 2026-W10 — well beyond source data
             end="2026-03-02",
@@ -405,7 +389,7 @@ def test_materialize_resampled_artifact_builds_monthly_dataset_from_daily_source
 
     artifact = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="MS",
+        resolution="P1M",
         method="sum",
         start="2026-01-01",
         end="2026-01-01",
@@ -461,7 +445,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
 
     first = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
@@ -476,7 +460,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_when_overwrite_
     )
     second = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
@@ -525,7 +509,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
 
     first = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="W-MON",
+        resolution="P1W",
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
@@ -534,7 +518,7 @@ def test_materialize_resampled_artifact_reuses_existing_artifact_by_realized_end
     )
     second = resample.materialize_resampled_artifact(
         source_dataset_id="chirps3_precipitation_daily",
-        frequency="W-MON",
+        resolution="P1W",
         method="sum",
         start="2026-01-05",
         end="2026-01-12",
@@ -583,7 +567,7 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
 
     existing = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
@@ -606,7 +590,7 @@ def test_materialize_resampled_artifact_publishes_reused_existing_artifact_when_
 
     reused = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
@@ -656,7 +640,7 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
 
     first = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",
@@ -672,7 +656,7 @@ def test_materialize_resampled_artifact_rematerializes_when_overwrite_is_true(
 
     second = resample.materialize_resampled_artifact(
         source_dataset_id="era5land_temperature_hourly",
-        frequency="1D",
+        resolution="P1D",
         method="mean",
         start="2026-01-01",
         end="2026-01-01",

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -54,7 +54,7 @@ def test_post_resample_execution_returns_completed_response(
         "/processes/resample/execution",
         json={
             "source_dataset_id": "chirps3_precipitation_daily",
-            "frequency": "W-MON",
+            "resolution": "P1W",
             "method": "sum",
             "start": "2026-01-05",
             "end": "2026-01-12",
@@ -85,7 +85,7 @@ def test_post_resample_execution_passes_params_to_service(
         "/processes/resample/execution",
         json={
             "source_dataset_id": "chirps3_precipitation_daily",
-            "frequency": "W-MON",
+            "resolution": "P1W",
             "method": "sum",
             "start": "2026-01-05",
             "end": "2026-01-12",
@@ -96,7 +96,7 @@ def test_post_resample_execution_passes_params_to_service(
 
     assert response.status_code == 200
     assert captured["source_dataset_id"] == "chirps3_precipitation_daily"
-    assert captured["frequency"] == "W-MON"
+    assert captured["resolution"] == "P1W"
     assert captured["method"] == "sum"
     assert captured["start"] == "2026-01-05"
     assert captured["end"] == "2026-01-12"
@@ -104,7 +104,7 @@ def test_post_resample_execution_passes_params_to_service(
     assert captured["publish"] is False
 
 
-def test_post_resample_execution_returns_400_for_invalid_frequency(
+def test_post_resample_execution_returns_400_for_invalid_resolution(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -112,7 +112,7 @@ def test_post_resample_execution_returns_400_for_invalid_frequency(
         "/processes/resample/execution",
         json={
             "source_dataset_id": "chirps3_precipitation_daily",
-            "frequency": "invalid",
+            "resolution": "invalid",
             "method": "sum",
             "start": "2026-01-01",
         },
@@ -128,7 +128,7 @@ def test_post_resample_execution_returns_400_for_unsupported_method(
         "/processes/resample/execution",
         json={
             "source_dataset_id": "chirps3_precipitation_daily",
-            "frequency": "W-MON",
+            "resolution": "P1W",
             "method": "median",
             "start": "2026-01-05",
         },
@@ -144,7 +144,7 @@ def test_post_unknown_process_id_returns_404(
         "/processes/unknown_process/execution",
         json={
             "source_dataset_id": "chirps3_precipitation_daily",
-            "frequency": "W-MON",
+            "resolution": "P1W",
             "method": "sum",
             "start": "2026-01-05",
         },

--- a/tests/test_provider_availability.py
+++ b/tests/test_provider_availability.py
@@ -51,7 +51,7 @@ def test_lagged_latest_available_formats_hourly_lag(monkeypatch: pytest.MonkeyPa
 
     result = availability.lagged_latest_available(
         dataset={
-            "period_type": "hourly",
+            "extents": {"temporal": {"resolution": "PT1H"}},
             "sync": {"availability": {"lag_hours": 5}},
         },
         requested_end="2026-04-21T12:00:00",
@@ -70,7 +70,7 @@ def test_lagged_latest_available_formats_daily_lag(monkeypatch: pytest.MonkeyPat
 
     result = availability.lagged_latest_available(
         dataset={
-            "period_type": "daily",
+            "extents": {"temporal": {"resolution": "P1D"}},
             "sync": {"availability": {"lag_days": 2}},
         },
         requested_end="2026-04-21",
@@ -81,7 +81,7 @@ def test_lagged_latest_available_formats_daily_lag(monkeypatch: pytest.MonkeyPat
 
 def test_worldpop_release_latest_available_allows_configured_future_projection() -> None:
     result = availability.worldpop_release_latest_available(
-        dataset={"period_type": "yearly", "sync": {"availability": {"allow_future": True}}},
+        dataset={"extents": {"temporal": {"resolution": "P1Y"}}, "sync": {"availability": {"allow_future": True}}},
         requested_end="2030",
     )
 
@@ -98,7 +98,7 @@ def test_lagged_latest_available_formats_yearly_offset(monkeypatch: pytest.Monke
 
     result = availability.lagged_latest_available(
         dataset={
-            "period_type": "yearly",
+            "extents": {"temporal": {"resolution": "P1Y"}},
             "sync": {"availability": {"latest_year_offset": 1}},
         },
         requested_end="2028",

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -1,11 +1,25 @@
 import pytest
 
 from climate_api.shared.time import (
+    _iso_duration_to_offset,
     _period_family,
     datetime_to_period_string,
     normalize_period_string,
     parse_period_string_to_datetime,
 )
+
+
+def test_iso_duration_to_offset() -> None:
+    import pandas as pd
+
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("PT1H")).isoformat() == "2024-02-29T23:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("P1D")).isoformat() == "2024-02-29T00:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("P1W")).isoformat() == "2024-02-23T00:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("P1M")).isoformat() == "2024-02-01T00:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("P1Y")).isoformat() == "2023-03-01T00:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("P2W")).isoformat() == "2024-02-16T00:00:00"
+    assert (pd.Timestamp("2024-03-11") - _iso_duration_to_offset("P10D")).isoformat() == "2024-03-01T00:00:00"
+    assert (pd.Timestamp("2024-03-01") - _iso_duration_to_offset("PT6H")).isoformat() == "2024-02-29T18:00:00"
 
 
 def test_period_family_maps_canonical_values() -> None:

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -2,11 +2,28 @@ import pytest
 
 from climate_api.shared.time import (
     _iso_duration_to_offset,
+    _iso_resolution_to_frequency,
     _period_family,
     datetime_to_period_string,
     normalize_period_string,
     parse_period_string_to_datetime,
 )
+
+
+def test_iso_resolution_to_frequency_canonical_values() -> None:
+    assert _iso_resolution_to_frequency("P1Y") == "1YS"
+    assert _iso_resolution_to_frequency("P1M") == "1MS"
+    assert _iso_resolution_to_frequency("P1W") == "W-MON"
+    assert _iso_resolution_to_frequency("P1D") == "1D"
+    assert _iso_resolution_to_frequency("PT1H") == "1h"
+
+
+def test_iso_resolution_to_frequency_preserves_multiplier() -> None:
+    assert _iso_resolution_to_frequency("P2Y") == "2YS"
+    assert _iso_resolution_to_frequency("P3M") == "3MS"
+    assert _iso_resolution_to_frequency("P2W") == "2W-MON"
+    assert _iso_resolution_to_frequency("P10D") == "10D"
+    assert _iso_resolution_to_frequency("PT6H") == "6h"
 
 
 def test_iso_duration_to_offset() -> None:

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -5,27 +5,27 @@ from climate_api.shared.time import datetime_to_period_string, normalize_period_
 
 def test_normalize_period_string_raises_targeted_monthly_error() -> None:
     with pytest.raises(ValueError, match="Invalid monthly period '2024-13'; expected YYYY-MM or ISO datetime"):
-        normalize_period_string("2024-13", "monthly")
+        normalize_period_string("2024-13", "P1M")
 
 
 def test_normalize_period_string_accepts_dataset_native_hourly_period() -> None:
-    assert normalize_period_string("2026-04-21T13", "hourly") == "2026-04-21T13"
+    assert normalize_period_string("2026-04-21T13", "PT1H") == "2026-04-21T13"
 
 
 def test_normalize_period_string_converts_aware_hourly_datetime_to_utc_period() -> None:
-    assert normalize_period_string("2026-04-21T13:30:00+02:00", "hourly") == "2026-04-21T11"
+    assert normalize_period_string("2026-04-21T13:30:00+02:00", "PT1H") == "2026-04-21T11"
 
 
 def test_normalize_period_string_converts_aware_daily_datetime_to_utc_period() -> None:
-    assert normalize_period_string("2026-04-21T00:30:00+02:00", "daily") == "2026-04-20"
+    assert normalize_period_string("2026-04-21T00:30:00+02:00", "P1D") == "2026-04-20"
 
 
 def test_normalize_period_string_accepts_dataset_native_weekly_period() -> None:
-    assert normalize_period_string("2026-W17", "weekly") == "2026-W17"
+    assert normalize_period_string("2026-W17", "P1W") == "2026-W17"
 
 
 def test_normalize_period_string_converts_datetime_to_weekly_period() -> None:
-    assert normalize_period_string("2026-04-21T13:30:00+00:00", "weekly") == "2026-W17"
+    assert normalize_period_string("2026-04-21T13:30:00+00:00", "P1W") == "2026-W17"
 
 
 def test_datetime_to_period_string_converts_aware_monthly_datetime_to_utc_period() -> None:
@@ -33,12 +33,12 @@ def test_datetime_to_period_string_converts_aware_monthly_datetime_to_utc_period
 
     value = datetime.fromisoformat("2026-05-01T00:30:00+02:00")
 
-    assert datetime_to_period_string(value, "monthly") == "2026-04"
+    assert datetime_to_period_string(value, "P1M") == "2026-04"
 
 
 def test_normalize_period_string_rejects_invalid_weekly_period() -> None:
     with pytest.raises(ValueError, match="Invalid weekly period '2026-W54'; expected YYYY-Www or ISO datetime"):
-        normalize_period_string("2026-W54", "weekly")
+        normalize_period_string("2026-W54", "P1W")
 
 
 def test_parse_period_string_to_datetime_accepts_dataset_native_hourly_period() -> None:

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -1,6 +1,46 @@
 import pytest
 
-from climate_api.shared.time import datetime_to_period_string, normalize_period_string, parse_period_string_to_datetime
+from climate_api.shared.time import (
+    _period_family,
+    datetime_to_period_string,
+    normalize_period_string,
+    parse_period_string_to_datetime,
+)
+
+
+def test_period_family_maps_canonical_values() -> None:
+    assert _period_family("PT1H") == "PT1H"
+    assert _period_family("P1D") == "P1D"
+    assert _period_family("P1W") == "P1W"
+    assert _period_family("P1M") == "P1M"
+    assert _period_family("P1Y") == "P1Y"
+
+
+def test_period_family_maps_non_canonical_multipliers() -> None:
+    assert _period_family("PT6H") == "PT1H"
+    assert _period_family("P10D") == "P1D"
+    assert _period_family("P2W") == "P1W"
+    assert _period_family("P3M") == "P1M"
+    assert _period_family("P2Y") == "P1Y"
+
+
+def test_period_family_maps_compound_to_largest_component() -> None:
+    assert _period_family("P1Y6M") == "P1Y"
+    assert _period_family("P1DT12H") == "PT1H"
+
+
+def test_datetime_to_period_string_uses_family_for_non_canonical_period_type() -> None:
+    from datetime import datetime
+
+    value = datetime(2026, 1, 11)
+    assert datetime_to_period_string(value, "P10D") == "2026-01-11"
+    assert datetime_to_period_string(value, "PT6H") == "2026-01-11T00"
+    assert datetime_to_period_string(value, "P3M") == "2026-01"
+
+
+def test_normalize_period_string_accepts_non_canonical_period_type() -> None:
+    assert normalize_period_string("2026-01-11", "P10D") == "2026-01-11"
+    assert normalize_period_string("2026-04-21T13", "PT6H") == "2026-04-21T13"
 
 
 def test_normalize_period_string_raises_targeted_monthly_error() -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -250,7 +250,11 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"extents": {"temporal": {"resolution": "PT1H"}}, "source": "ERA5-Land", "short_name": "2m temperature"},
+        lambda _: {
+            "extents": {"temporal": {"resolution": "PT1H"}},
+            "source": "ERA5-Land",
+            "short_name": "2m temperature",
+        },
     )
     monkeypatch.setattr(
         stac_services,
@@ -470,7 +474,11 @@ def test_collection_reuses_cached_xstac_payload(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
+    monkeypatch.setattr(
+        stac_services.registry_datasets,
+        "get_dataset",
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}},
+    )
     monkeypatch.setattr(stac_services, "open_zarr_dataset", fake_open)
     monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
@@ -519,7 +527,11 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
+    monkeypatch.setattr(
+        stac_services.registry_datasets,
+        "get_dataset",
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}},
+    )
     monkeypatch.setattr(stac_services, "open_zarr_dataset", lambda _: DummyDataset())
     monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
@@ -553,7 +565,11 @@ def test_collection_returns_500_for_missing_artifact_store_metadata(
 ) -> None:
     artifact = _artifact(artifact_id="a1", path=None, asset_paths=[])
     monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
+    monkeypatch.setattr(
+        stac_services.registry_datasets,
+        "get_dataset",
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}},
+    )
 
     response = client.get("/stac/collections/chirps3_precipitation_daily")
 
@@ -572,7 +588,11 @@ def test_collection_returns_503_when_zarr_store_cannot_be_opened(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
+    monkeypatch.setattr(
+        stac_services.registry_datasets,
+        "get_dataset",
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}},
+    )
     monkeypatch.setattr(
         stac_services,
         "open_zarr_dataset",

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -128,7 +128,7 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3"},
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}, "units": "mm", "source": "CHIRPS v3"},
     )
     monkeypatch.setattr(
         stac_services,
@@ -207,7 +207,7 @@ def test_collection_uses_configured_base_url(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "units": "mm"},
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}, "units": "mm"},
     )
     monkeypatch.setattr(
         stac_services,
@@ -250,7 +250,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature"},
+        lambda _: {"extents": {"temporal": {"resolution": "PT1H"}}, "source": "ERA5-Land", "short_name": "2m temperature"},
     )
     monkeypatch.setattr(
         stac_services,
@@ -290,7 +290,7 @@ def test_collection_uses_level0_href_for_pyramid_zarr_store(
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {}},
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}, "source": "CHIRPS v3", "ingestion": {}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -326,7 +326,7 @@ def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "source": "CHIRPS v3", "ingestion": {}},
+        lambda _: {"extents": {"temporal": {"resolution": "P1D"}}, "source": "CHIRPS v3", "ingestion": {}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -470,7 +470,7 @@ def test_collection_reuses_cached_xstac_payload(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
     monkeypatch.setattr(stac_services, "open_zarr_dataset", fake_open)
     monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
@@ -519,7 +519,7 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
     monkeypatch.setattr(stac_services, "open_zarr_dataset", lambda _: DummyDataset())
     monkeypatch.setattr(stac_services, "get_x_y_dims", lambda _: ("x", "y"))
     monkeypatch.setattr(stac_services, "get_time_dim", lambda _: "time")
@@ -553,7 +553,7 @@ def test_collection_returns_500_for_missing_artifact_store_metadata(
 ) -> None:
     artifact = _artifact(artifact_id="a1", path=None, asset_paths=[])
     monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
 
     response = client.get("/stac/collections/chirps3_precipitation_daily")
 
@@ -572,7 +572,7 @@ def test_collection_returns_503_when_zarr_store_cannot_be_opened(
         "list_artifacts",
         lambda: SimpleNamespace(items=[_artifact(artifact_id="a1")]),
     )
-    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"extents": {"temporal": {"resolution": "P1D"}}})
     monkeypatch.setattr(
         stac_services,
         "open_zarr_dataset",


### PR DESCRIPTION
Closes #94

## Summary

- `period_type` removed from all three built-in dataset YAMLs (`chirps3.yaml`, `worldpop.yaml`, `era5_land.yaml`) — no longer stored in the dataset dict at all
- `extents.spatial.crs` and `extents.temporal.trs` removed from all dataset YAMLs — neither field is read by any runtime code
- `get_period_type(dataset)` helper in `data_registry` reads `extents.temporal.resolution` directly and returns the ISO 8601 duration string; all internal call sites use this instead of `dataset["period_type"]`
- All `"T" in period_type.upper()` checks replaced with explicit `period_type == "PT1H"` comparisons
- API responses now return the ISO 8601 string in `period_type` (e.g. `"P1D"`, `"PT1H"`) instead of the old period-class label (e.g. `"daily"`, `"hourly"`)
- Validation raises a clear error when `extents.temporal.resolution` is missing

## Breaking changes

- `period_type` in dataset and artifact API responses changes from period-class strings (`"daily"`, `"hourly"`) to ISO 8601 duration strings (`"P1D"`, `"PT1H"`)
- Plugin YAMLs that carried an explicit `period_type` field: the field is now ignored entirely — only `extents.temporal.resolution` is used
- `extents.spatial.crs` and `extents.temporal.trs` are no longer valid YAML fields (ignored if present)

## Test plan

- [x] All 217 existing tests pass
- [x] New tests verify derivation for all five period types
- [x] New tests verify errors on missing/unrecognised resolution
- [x] `make lint` clean