### PR TITLE
chore: remove redundant crs and trs defaults from dataset YAMLs

### DIFF
--- a/climate_api/data/datasets/chirps3.yaml
+++ b/climate_api/data/datasets/chirps3.yaml
@@ -11,10 +11,8 @@
   extents:
     spatial:
       bbox: [-180, -50, 180, 50]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1981-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1D
   ingestion:
     function: dhis2eo.data.chc.chirps3.daily.download

--- a/climate_api/data/datasets/era5_land.yaml
+++ b/climate_api/data/datasets/era5_land.yaml
@@ -12,10 +12,8 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download
@@ -45,10 +43,8 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "1950-01-01"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: PT1H
   ingestion:
     function: dhis2eo.data.destine.era5_land.hourly.download

--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -12,11 +12,9 @@
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
-      crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     temporal:
       begin: "2015"
       end: "2030"
-      trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
       resolution: P1Y
   ingestion:
     function: dhis2eo.data.worldpop.pop_total.yearly.download


### PR DESCRIPTION
## Summary

- Removes `crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84` and `trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian` from all three built-in dataset YAMLs
- Neither field is read anywhere in runtime code — they are purely decorative metadata that duplicates the implicit defaults
- Non-default values (e.g. `source_crs: EPSG:32633` in seNorge plugin) are unaffected

## Test plan

- [ ] All tests pass unchanged (no code changes)