### PR TITLE
docs: add built-in datasets, transforms, and processes pages

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -138,7 +138,7 @@ transforms:
   - mypackage.transforms.my_custom_transform
 ```
 
-See [Extensibility — Transform functions](extensibility.md#transform-functions) for the full transform contract and built-in options.
+See [Transforms](transforms.md) for the full pipeline description, built-in options, and how to write a custom transform.
 
 **Spatial and temporal extents** — declares what the source dataset covers. Used to validate ingest requests before hitting the provider:
 

--- a/docs/built_in_datasets.md
+++ b/docs/built_in_datasets.md
@@ -1,0 +1,96 @@
+# Built-in datasets
+
+The Climate API ships with four built-in dataset templates covering precipitation, temperature, and population. Each template describes a data source and the rules for downloading, transforming, and syncing it. They are available in every instance without any additional configuration.
+
+To ingest a built-in dataset for your configured extent, see the [API reference](managed_data_api_guide.md). To add datasets beyond these four, see [Adding custom datasets](adding_custom_datasets.md).
+
+---
+
+## CHIRPS v3 — daily precipitation
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `chirps3_precipitation_daily` |
+| **Variable** | `precip` |
+| **Units** | mm |
+| **Period** | Daily |
+| **Spatial coverage** | Global land, 50°S–50°N |
+| **Spatial resolution** | ~5 km |
+| **Record start** | 1981-01-01 |
+| **Source** | [CHIRPS v3](https://www.chc.ucsb.edu/data/chirps3) |
+
+CHIRPS (Climate Hazards Group InfraRed Precipitation with Station data) v3 is a quasi-global daily precipitation dataset merging satellite thermal infrared imagery with station observations. It is widely used for drought monitoring, food security analysis, and WASH planning in low- and middle-income countries.
+
+**Sync behaviour** — new data is ingested incrementally as it becomes available. CHIRPS has a nominal publication lag of around 3–7 days, so data through yesterday is not always present. The API uses a custom availability function that checks the actual latest available date from the CHIRPS server before each sync.
+
+**Transforms** — none applied; data is stored as received in mm.
+
+---
+
+## ERA5-Land — 2 m temperature (hourly)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_temperature_hourly` |
+| **Variable** | `t2m` |
+| **Units** | °C |
+| **Period** | Hourly |
+| **Spatial coverage** | Global |
+| **Spatial resolution** | ~9 km |
+| **Record start** | 1950-01-01 |
+| **Source** | [ERA5-Land Reanalysis via DestinE Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+
+ERA5-Land is a global atmospheric reanalysis produced by ECMWF. The 2 m temperature variable (`t2m`) represents the air temperature 2 metres above the land surface, including corrections for topography relative to the ERA5 pressure levels.
+
+**Sync behaviour** — new hours are appended incrementally. ERA5-Land is published with a nominal 5-day lag; the API will not request data closer than 120 hours to the current time.
+
+**Transforms** — raw values are in Kelvin. The `kelvin_to_celsius` transform is applied at ingest time, so stored values are in °C.
+
+---
+
+## ERA5-Land — total precipitation (hourly)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_precipitation_hourly` |
+| **Variable** | `tp` |
+| **Units** | mm |
+| **Period** | Hourly |
+| **Spatial coverage** | Global |
+| **Spatial resolution** | ~9 km |
+| **Record start** | 1950-01-01 |
+| **Source** | [ERA5-Land Reanalysis via DestinE Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+
+Total precipitation (`tp`) from ERA5-Land is an accumulated hourly value representing the sum of large-scale and convective precipitation falling onto the land surface. It is useful as a high-resolution complement to CHIRPS for countries outside CHIRPS's 50°N–50°S band, or for sub-daily analysis.
+
+**Sync behaviour** — same 5-day lag as ERA5-Land temperature; hours are appended incrementally.
+
+**Transforms** — raw values are in metres per hour. The `metres_to_mm` transform converts to mm at ingest time.
+
+---
+
+## WorldPop Global2 — total population (yearly)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `worldpop_population_yearly` |
+| **Variable** | `pop_total` |
+| **Units** | people |
+| **Period** | Yearly |
+| **Spatial coverage** | Global |
+| **Spatial resolution** | ~100 m |
+| **Record start** | 2015 |
+| **Record end** | 2030 |
+| **Source** | [WorldPop Global2](https://hub.worldpop.org/project/categories?id=3) |
+
+WorldPop Global2 provides gridded population estimates and projections at 100 m resolution. Each raster year represents estimated residential population counts. Years up to and including the present are backward-modelled estimates; years beyond the present are forward projections.
+
+**Sync behaviour** — population data is released year by year, not as a continuous stream. The API uses a `release`-kind sync that checks each calendar year separately. Future years (projections) are also requestable, since the underlying data covers through 2030.
+
+**Transforms** — none applied; values are stored as received (population counts per pixel).
+
+---
+
+## Derived datasets
+
+In addition to the four built-in sources, the API can produce **derived datasets** by resampling any ingested dataset to a coarser temporal resolution. Derived datasets are created on demand via the `resample` process. See [Processes](processes.md) for details.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -64,20 +64,9 @@ import xarray as xr
 from typing import Any
 
 def clip_to_bbox(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
-    """Clip values outside a valid range."""
     varname = dataset["variable"]
     return ds.assign({varname: ds[varname].clip(min=0)})
 ```
-
-Transforms are applied in order. The built-in transforms are:
-
-| Function | Description |
-| -------- | ----------- |
-| `climate_api.transforms.kelvin_to_celsius` | Convert temperature from K to °C |
-| `climate_api.transforms.metres_to_mm` | Convert precipitation from m to mm |
-| `climate_api.transforms.reproject_to_instance_crs` | Reproject to the instance CRS (applied automatically — no need to declare this one) |
-
-Custom transforms can live in any importable package or in a module under `plugins_dir`.
 
 Dict entries with params are also supported:
 
@@ -88,7 +77,9 @@ transforms:
       factor: 0.01
 ```
 
-The `params` dict is forwarded as keyword arguments to the transform function.
+The `params` dict is forwarded as keyword arguments to the transform function. Custom transforms can live in any importable package or in a module under `plugins_dir`.
+
+For the built-in transforms and a full description of the pipeline, see [Transforms](transforms.md).
 
 ---
 
@@ -135,6 +126,8 @@ def execute(*, source_dataset_id: str, factor: float, **_ignored: Any) -> dict[s
 ```
 
 Invalid or missing arguments raise `TypeError`, which the route dispatcher catches and returns as HTTP 400.
+
+For the built-in `resample` process and usage examples, see [Processes](processes.md).
 
 ---
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -54,7 +54,7 @@ Transforms are functions applied to a dataset after download and before the Zarr
 ```yaml
 transforms:
   - climate_api.transforms.kelvin_to_celsius
-  - mypackage.transforms.clip_to_bbox
+  - mypackage.transforms.clamp_negatives
 ```
 
 Each transform receives the `xr.Dataset` and the dataset template dict, and returns a (possibly modified) `xr.Dataset`:
@@ -63,7 +63,7 @@ Each transform receives the `xr.Dataset` and the dataset template dict, and retu
 import xarray as xr
 from typing import Any
 
-def clip_to_bbox(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
+def clamp_negatives(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
     varname = dataset["variable"]
     return ds.assign({varname: ds[varname].clip(min=0)})
 ```

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -241,6 +241,46 @@
   </div>
 </section>
 
+<section class="home-docs">
+  <div class="home-section__inner">
+    <h2 class="home-section__title">Documentation</h2>
+    <div class="docs-links">
+      <a href="setup_guide/" class="docs-link">
+        <span class="docs-link__title">Get started</span>
+        <span class="docs-link__desc">Install, configure your extent, and ingest your first dataset</span>
+      </a>
+      <a href="user_guide/" class="docs-link">
+        <span class="docs-link__title">Accessing data</span>
+        <span class="docs-link__desc">Discover and open datasets with xarray and the client library</span>
+      </a>
+      <a href="built_in_datasets/" class="docs-link">
+        <span class="docs-link__title">Built-in datasets</span>
+        <span class="docs-link__desc">CHIRPS3, ERA5-Land temperature and precipitation, WorldPop</span>
+      </a>
+      <a href="transforms/" class="docs-link">
+        <span class="docs-link__title">Transforms</span>
+        <span class="docs-link__desc">Unit conversion, reprojection, and custom transform functions</span>
+      </a>
+      <a href="processes/" class="docs-link">
+        <span class="docs-link__title">Processes</span>
+        <span class="docs-link__desc">Temporal resampling and derived dataset creation</span>
+      </a>
+      <a href="adding_custom_datasets/" class="docs-link">
+        <span class="docs-link__title">Adding custom datasets</span>
+        <span class="docs-link__desc">Connect a new data source with a download function and YAML template</span>
+      </a>
+      <a href="extensibility/" class="docs-link">
+        <span class="docs-link__title">Extensibility</span>
+        <span class="docs-link__desc">All extension points: datasets, ingestion, transforms, processes</span>
+      </a>
+      <a href="managed_data_api_guide/" class="docs-link">
+        <span class="docs-link__title">API reference</span>
+        <span class="docs-link__desc">Full endpoint reference for ingestion, sync, datasets, and OGC API</span>
+      </a>
+    </div>
+  </div>
+</section>
+
 <section class="home-ecosystem">
   <div class="home-section__inner">
     <p class="home-ecosystem__label">Part of the DHIS2 Climate ecosystem</p>

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -15,7 +15,7 @@ Content-Type: application/json
 { ...parameters... }
 ```
 
-Available processes are listed at `GET /processes`.
+Available processes are listed at `GET /ogcapi/processes`.
 
 ---
 
@@ -53,11 +53,11 @@ The derived dataset is stored under an auto-generated ID:
 {source_dataset_id}_{frequency_slug}_{method}
 ```
 
-Where `frequency_slug` is the frequency alias lowercased with non-alphanumeric characters removed. For example:
+Where `frequency_slug` is the frequency alias lowercased with non-alphanumeric characters replaced by `_` and leading/trailing underscores stripped. For example:
 
 | Source | Frequency | Method | Derived ID |
 | --- | --- | --- | --- |
-| `chirps3_precipitation_daily` | `W-MON` | `sum` | `chirps3_precipitation_daily_wmon_sum` |
+| `chirps3_precipitation_daily` | `W-MON` | `sum` | `chirps3_precipitation_daily_w_mon_sum` |
 | `era5land_temperature_hourly` | `1D` | `mean` | `era5land_temperature_hourly_1d_mean` |
 | `chirps3_precipitation_daily` | `MS` | `sum` | `chirps3_precipitation_daily_ms_sum` |
 
@@ -84,7 +84,7 @@ Response:
 
 ```json
 {
-  "artifact_id": "era5land_temperature_hourly_1d_mean_abc123",
+  "artifact_id": "3f2a1b4c-8e7d-4f9a-b2c1-0d5e6f7a8b9c",
   "status": "completed",
   "dataset": {
     "dataset_id": "era5land_temperature_hourly_1d_mean",

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -1,0 +1,144 @@
+# Processes
+
+Processes are named operations that produce derived datasets from existing ingested data. They are dispatched via `POST /processes/{id}/execution` and follow the [OGC API Processes](https://ogcapi.ogc.org/processes/) standard.
+
+---
+
+## How processes work
+
+A process takes parameters from the JSON request body, executes a computation, and returns a JSON response. The result is typically a new derived dataset artifact that can be opened via the Zarr endpoint or published to the OGC API catalog.
+
+```
+POST /processes/{id}/execution
+Content-Type: application/json
+
+{ ...parameters... }
+```
+
+Available processes are listed at `GET /processes`.
+
+---
+
+## Built-in process: `resample`
+
+The `resample` process aggregates a source dataset to a coarser temporal resolution. It is the primary way to produce daily totals from hourly data, weekly averages from daily data, and so on.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `source_dataset_id` | string | Yes | ID of the source managed dataset to resample |
+| `frequency` | string | Yes | Target temporal resolution as a pandas frequency alias (e.g. `1D`, `W-MON`, `MS`) |
+| `method` | string | Yes | Aggregation method: `mean`, `sum`, `min`, or `max` |
+| `start` | string | Yes | Start of the period range to resample (ISO 8601 date or datetime) |
+| `end` | string | No | End of the period range. Defaults to today's UTC date |
+| `overwrite` | boolean | No | Re-materialize the derived dataset even if it already exists. Default: `false` |
+| `publish` | boolean | No | Publish the result to the OGC API catalog after materializing. Default: `true` |
+
+**Supported frequency aliases:**
+
+| Alias | Meaning |
+| --- | --- |
+| `1D`, `7D`, `10D`, … | Every N calendar days |
+| `W-MON` | ISO weeks starting Monday |
+| `MS` | Calendar months (month-start) |
+| `QS` | Calendar quarters (quarter-start) |
+| `YS` | Calendar years (year-start) |
+
+### Derived dataset ID
+
+The derived dataset is stored under an auto-generated ID:
+
+```
+{source_dataset_id}_{frequency_slug}_{method}
+```
+
+Where `frequency_slug` is the frequency alias lowercased with non-alphanumeric characters removed. For example:
+
+| Source | Frequency | Method | Derived ID |
+| --- | --- | --- | --- |
+| `chirps3_precipitation_daily` | `W-MON` | `sum` | `chirps3_precipitation_daily_wmon_sum` |
+| `era5land_temperature_hourly` | `1D` | `mean` | `era5land_temperature_hourly_1d_mean` |
+| `chirps3_precipitation_daily` | `MS` | `sum` | `chirps3_precipitation_daily_ms_sum` |
+
+### Idempotency
+
+If a derived dataset artifact already exists for the requested `source_dataset_id`, `frequency`, `method`, and time range, the process returns the existing artifact without re-materializing it. Pass `overwrite: true` to force a rebuild.
+
+### Example: daily mean temperature from hourly ERA5-Land
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/processes/resample/execution \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_dataset_id": "era5land_temperature_hourly",
+    "frequency": "1D",
+    "method": "mean",
+    "start": "2024-01-01",
+    "end": "2024-01-31",
+    "publish": true
+  }' | jq
+```
+
+Response:
+
+```json
+{
+  "artifact_id": "era5land_temperature_hourly_1d_mean_abc123",
+  "status": "completed",
+  "dataset": {
+    "dataset_id": "era5land_temperature_hourly_1d_mean",
+    "dataset_name": "era5land_temperature_hourly_1d_mean",
+    "variable": "t2m",
+    "period_type": "daily",
+    ...
+  }
+}
+```
+
+### Example: weekly precipitation totals from CHIRPS daily
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/processes/resample/execution \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_dataset_id": "chirps3_precipitation_daily",
+    "frequency": "W-MON",
+    "method": "sum",
+    "start": "2024-01-01",
+    "end": "2024-03-31",
+    "publish": true
+  }' | jq
+```
+
+### Incomplete edge periods
+
+The resampler automatically drops leading and trailing periods that are not fully covered by the source data. For example, if the source daily dataset starts on a Wednesday and you resample to weekly (Monday–Sunday), the first Monday-anchored week is dropped because it only has data from Wednesday onward.
+
+This means the realized time range of the derived artifact may be shorter than the requested range if the source data does not fully cover the first or last target period.
+
+### Opening the derived dataset
+
+Once materialized, the derived dataset can be opened like any other managed dataset:
+
+```python
+from climate_api.client import Client
+
+api = Client("http://127.0.0.1:8000")
+ds = api.open("era5land_temperature_hourly_1d_mean")
+print(ds)
+```
+
+Or directly via the Zarr endpoint:
+
+```bash
+# open in Python
+import xarray as xr
+ds = xr.open_zarr("http://127.0.0.1:8000/zarr/era5land_temperature_hourly_1d_mean", consolidated=True)
+```
+
+---
+
+## Custom processes
+
+You can register additional processes from a `plugins_dir/processes/` directory. See [Extensibility — Processes](extensibility.md#processes) for the YAML format and execution function contract.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -373,6 +373,51 @@
   color: var(--dhis2-blue);
 }
 
+/* ── Documentation index ─────────────────────────────────────────────── */
+
+.home-docs {
+  padding: 4rem 1rem;
+  background: var(--md-code-bg-color);
+}
+
+.docs-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.docs-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1rem 1.2rem;
+  border: 1.5px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.docs-link:hover {
+  border-color: var(--dhis2-blue);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+}
+
+.docs-link__title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--dhis2-blue);
+}
+
+.docs-link__desc {
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
+}
+
 /* ── Ecosystem links ─────────────────────────────────────────────────── */
 
 .home-ecosystem {

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -48,9 +48,15 @@ Used by: ERA5-Land total precipitation (`era5land_precipitation_hourly`).
 
 ### `climate_api.transforms.reproject_to_instance_crs`
 
-Reprojects the dataset to the CRS configured for the API instance. If the instance CRS already matches the source CRS (both WGS84, which is the default), this transform is a no-op.
+Reprojects the dataset to the CRS configured for the API instance. It is a no-op when the instance CRS matches the transform's `source_crs` parameter (default `EPSG:4326`).
 
-This transform is applied **automatically** by the ingestion pipeline whenever the instance CRS differs from WGS84. You do not need to declare it in your dataset YAML — it runs implicitly after any user-declared transforms.
+This transform is applied **automatically** by the ingestion pipeline — always, as the final step after any user-declared transforms. You do not need to declare it in your dataset YAML. **Do not declare it explicitly**: doing so would run reprojection twice, with the second pass using the wrong source CRS.
+
+If your source data is not in `EPSG:4326`, set `source_crs` in the dataset template rather than declaring the transform manually:
+
+```yaml
+source_crs: EPSG:32633
+```
 
 ---
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -1,0 +1,100 @@
+# Transforms
+
+Transforms are functions applied to a dataset **after download and before the Zarr store is written**. They handle things like unit conversion and reprojection that would be awkward or costly to do at read time.
+
+---
+
+## How transforms work
+
+When an ingestion runs, the pipeline is:
+
+```
+download → (transforms) → write Zarr
+```
+
+Transforms are applied in declaration order. Each function receives the full `xr.Dataset` and the dataset template dict, and returns a (possibly modified) `xr.Dataset`. The modified dataset is then passed to the next transform, or written to Zarr if there are no more.
+
+Transforms are declared in the dataset YAML as a list of dotted Python paths:
+
+```yaml
+transforms:
+  - climate_api.transforms.kelvin_to_celsius
+  - mypackage.transforms.clip_to_valid_range
+```
+
+---
+
+## Built-in transforms
+
+### `climate_api.transforms.kelvin_to_celsius`
+
+Converts the dataset's primary variable from Kelvin to degrees Celsius.
+
+```
+°C = K − 273.15
+```
+
+Used by: ERA5-Land 2 m temperature (`era5land_temperature_hourly`).
+
+### `climate_api.transforms.metres_to_mm`
+
+Converts the dataset's primary variable from metres to millimetres.
+
+```
+mm = m × 1000
+```
+
+Used by: ERA5-Land total precipitation (`era5land_precipitation_hourly`).
+
+### `climate_api.transforms.reproject_to_instance_crs`
+
+Reprojects the dataset to the CRS configured for the API instance. If the instance CRS already matches the source CRS (both WGS84, which is the default), this transform is a no-op.
+
+This transform is applied **automatically** by the ingestion pipeline whenever the instance CRS differs from WGS84. You do not need to declare it in your dataset YAML — it runs implicitly after any user-declared transforms.
+
+---
+
+## Passing parameters to a transform
+
+If a transform needs configuration, use the dict form instead of a bare dotted path:
+
+```yaml
+transforms:
+  - function: mypackage.transforms.scale_variable
+    params:
+      factor: 0.01
+      units: m
+```
+
+The `params` dict is forwarded to the function as extra keyword arguments:
+
+```python
+def scale_variable(ds: xr.Dataset, dataset: dict[str, Any], *, factor: float, units: str) -> xr.Dataset:
+    ...
+```
+
+---
+
+## Writing a custom transform
+
+A transform is any callable with this signature:
+
+```python
+import xarray as xr
+from typing import Any
+
+def my_transform(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
+    varname = dataset["variable"]
+    return ds.assign({varname: ds[varname].clip(min=0)})
+```
+
+`dataset` is the full template dict, so you can read `dataset["variable"]`, `dataset["units"]`, or any other field declared in the YAML.
+
+The function can live in any importable package, or in a Python module placed directly under `plugins_dir` (which is added to `sys.path` automatically). Reference it by its dotted path:
+
+```yaml
+transforms:
+  - myplugin.transforms.my_transform
+```
+
+For built-in and custom transform examples, see [Extensibility — Transform functions](extensibility.md#transform-functions).

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -1,6 +1,6 @@
 # Transforms
 
-Transforms are functions applied to a dataset **after download and before the Zarr store is written**. They handle things like unit conversion and reprojection that would be awkward or costly to do at read time.
+Transforms are functions applied to a dataset **after download and before the Zarr store is written**. They handle things like unit conversion that would be awkward or costly to do at read time.
 
 ---
 
@@ -46,13 +46,13 @@ mm = m × 1000
 
 Used by: ERA5-Land total precipitation (`era5land_precipitation_hourly`).
 
-### `climate_api.transforms.reproject_to_instance_crs`
+---
 
-Reprojects the dataset to the CRS configured for the API instance. It is a no-op when the instance CRS matches the transform's `source_crs` parameter (default `EPSG:4326`).
+## Reprojection
 
-This transform is applied **automatically** by the ingestion pipeline — always, as the final step after any user-declared transforms. You do not need to declare it in your dataset YAML. **Do not declare it explicitly**: doing so would run reprojection twice, with the second pass using the wrong source CRS.
+Reprojection to the instance CRS is handled automatically by the ingestion pipeline as a separate step after all user-declared transforms have run. It is not a transform and should not be declared in the `transforms` list.
 
-If your source data is not in `EPSG:4326`, set `source_crs` in the dataset template rather than declaring the transform manually:
+If your source data is not in `EPSG:4326`, declare `source_crs` in the dataset template so the pipeline knows what to reproject from:
 
 ```yaml
 source_crs: EPSG:32633

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -84,19 +84,9 @@ spatial_mean = ds[variable].isel(time=slice(10)).mean(dim=["y", "x"])
 print(spatial_mean.to_dataframe())
 ```
 
-## Dataset IDs
-
-Dataset IDs match the template `id` field from the dataset YAML. Available datasets in the built-in catalogue:
-
-| Dataset ID                      | Variable    | Period | Source    |
-| ------------------------------- | ----------- | ------ | --------- |
-| `chirps3_precipitation_daily`   | `precip`    | Daily  | CHIRPS v3 |
-| `era5land_temperature_hourly`   | `t2m`       | Hourly | ERA5-Land |
-| `era5land_precipitation_hourly` | `tp`        | Hourly | ERA5-Land |
-| `worldpop_population_yearly`    | `pop_total` | Yearly | WorldPop  |
-
 ## What's next
 
+- See [built_in_datasets.md](built_in_datasets.md) for coverage, units, and sync behaviour of each built-in dataset.
 - See [`examples/stac_discover_and_open.py`](../examples/stac_discover_and_open.py) for a complete discovery and access script.
 - See [`examples/zarr_direct_access.py`](../examples/zarr_direct_access.py) for direct Zarr access and spatial/temporal subsetting.
 - See [managed_data_api_guide.md](managed_data_api_guide.md) for the full ingestion and sync API reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,9 @@ nav:
       - OGC API: ogcapi.md
   - Guides:
       - Accessing data: user_guide.md
+      - Built-in datasets: built_in_datasets.md
+      - Transforms: transforms.md
+      - Processes: processes.md
       - Adding custom datasets: adding_custom_datasets.md
       - Extensibility: extensibility.md
       - API reference: managed_data_api_guide.md


### PR DESCRIPTION
## Summary

- Adds [built_in_datasets.md](docs/built_in_datasets.md) — one section per built-in source (CHIRPS3, ERA5-Land temperature, ERA5-Land precipitation, WorldPop) with variable, units, spatial coverage, temporal range, sync behaviour, and applied transforms
- Adds [transforms.md](docs/transforms.md) — explains when transforms run in the pipeline, documents all three built-in transforms (`kelvin_to_celsius`, `metres_to_mm`, `reproject_to_instance_crs`), and shows the params-dict variant for parameterised transforms
- Adds [processes.md](docs/processes.md) — explains the `resample` process end-to-end: all parameters, frequency alias reference, derived dataset ID naming, idempotency behaviour, incomplete edge period handling, and two curl examples
- Updates `mkdocs.yml` nav to include all three new pages under Guides

## Test plan

- [ ] `mkdocs serve` renders all three new pages without broken links
- [ ] Examples in processes.md match the actual `execute_resample` function signature