### PR TITLE
perf: open NetCDF cache files in parallel when building zarr

### DIFF
--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -116,7 +116,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     files = get_cache_files(dataset)
     logger.info(f"Opening {len(files)} files from cache")
-    ds = xr.open_mfdataset(files)
+    ds = xr.open_mfdataset(files, parallel=True)
 
     x_dim, y_dim = get_x_y_dims(ds)
     dims = [x_dim, y_dim]


### PR DESCRIPTION
## Summary

- Pass `parallel=True` to `xr.open_mfdataset` in `build_dataset_zarr`

`parallel=True` uses dask to open all cache files concurrently rather than sequentially, reducing task graph construction time for large historical datasets (e.g. 437 monthly files for seNorge 1990–2026).

## Test plan

- [x] All 213 existing tests pass
- [x] No lint errors introduced