### PR TITLE
fix: remove time step cap and debounce zarr selector in map viewer

### DIFF
--- a/climate_api/data/datasets/era5_land.yaml
+++ b/climate_api/data/datasets/era5_land.yaml
@@ -27,7 +27,7 @@
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
   display:
     colormap: rdbu_r
-    range: [15.0, 40.0]
+    range: [-30.0, 30.0]
 
 - id: era5land_precipitation_hourly
   name: Total precipitation (ERA5-Land)

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -286,15 +286,19 @@
       function generateDateRange(start, end, step) {
         const inc = parseDuration(step);
         if (!inc) return [start];
-        const steps = [];
-        let cur = new Date(start);
-        const endDate = new Date(end);
-        // Guard against accidentally generating tens of thousands of steps.
-        while (cur <= endDate && steps.length < 5000) {
-          steps.push(cur.toISOString().slice(0, 10));
-          cur = new Date(cur.getTime() + inc);
-        }
-        return steps;
+        const count = Math.floor((new Date(end) - new Date(start)) / inc) + 1;
+        return { lazy: true, start, inc, count };
+      }
+
+      function timeStepCount() {
+        return Array.isArray(timeSteps) ? timeSteps.length : timeSteps.count;
+      }
+
+      function timeStepAt(i) {
+        if (Array.isArray(timeSteps)) return timeSteps[i];
+        return new Date(new Date(timeSteps.start).getTime() + i * timeSteps.inc)
+          .toISOString()
+          .slice(0, 10);
       }
 
       // Minimal ISO 8601 duration parser for common climate period types.
@@ -458,7 +462,7 @@
           cm = buildColormap(colormapName);
           const zarrVersion = zarr["zarr:zarr_format"] ?? null;
           const selector =
-            timeSteps.length > 0 ? { [timeDimKey]: 0 } : {};
+            timeStepCount() > 0 ? { [timeDimKey]: 0 } : {};
           activeLayer = new ZarrLayer({
             id: "zarr-layer",
             source: zarr.href,
@@ -485,11 +489,11 @@
 
 
         // Time slider.
-        if (timeSteps.length > 1) {
-          timeSlider.max = timeSteps.length - 1;
+        if (timeStepCount() > 1) {
+          timeSlider.max = timeStepCount() - 1;
           timeSlider.value = 0;
-          timeValueEl.textContent = timeSteps[0];
-          timeCountEl.textContent = `1 / ${timeSteps.length}`;
+          timeValueEl.textContent = timeStepAt(0);
+          timeCountEl.textContent = `1 / ${timeStepCount()}`;
           timeSection.classList.remove("hidden");
         }
 
@@ -518,11 +522,15 @@
         if (e.target.value) loadDataset(e.target.value);
       });
 
+      let _selectorDebounce = null;
       timeSlider.addEventListener("input", (e) => {
         const i = parseInt(e.target.value, 10);
-        timeValueEl.textContent = timeSteps[i] ?? "—";
-        timeCountEl.textContent = `${i + 1} / ${timeSteps.length}`;
-        activeLayer?.setSelector({ [timeDimKey]: i });
+        timeValueEl.textContent = timeStepAt(i) ?? "—";
+        timeCountEl.textContent = `${i + 1} / ${timeStepCount()}`;
+        clearTimeout(_selectorDebounce);
+        _selectorDebounce = setTimeout(() => {
+          activeLayer?.setSelector({ [timeDimKey]: i });
+        }, 150);
       });
 
       map.on("load", () => {

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -286,7 +286,10 @@
       function generateDateRange(start, end, step) {
         const inc = parseDuration(step);
         if (!inc) return [start];
-        const count = Math.floor((new Date(end) - new Date(start)) / inc) + 1;
+        const startMs = new Date(start).getTime();
+        const endMs = new Date(end).getTime();
+        if (isNaN(startMs) || isNaN(endMs)) return [start];
+        const count = Math.max(1, Math.floor((endMs - startMs) / inc) + 1);
         return { lazy: true, start, inc, count };
       }
 
@@ -396,6 +399,7 @@
 
       async function loadDataset(href) {
         setStatus("Loading...");
+        clearTimeout(_selectorDebounce);
         if (activeLayer) {
           try {
             map.removeLayer("zarr-layer");
@@ -527,9 +531,11 @@
         const i = parseInt(e.target.value, 10);
         timeValueEl.textContent = timeStepAt(i) ?? "—";
         timeCountEl.textContent = `${i + 1} / ${timeStepCount()}`;
+        const layer = activeLayer;
+        const dimKey = timeDimKey;
         clearTimeout(_selectorDebounce);
         _selectorDebounce = setTimeout(() => {
-          activeLayer?.setSelector({ [timeDimKey]: i });
+          layer?.setSelector({ [dimKey]: i });
         }, 150);
       });
 


### PR DESCRIPTION
## Summary

- **Remove 5000-step cap**: The time slider previously capped at 5000 steps to avoid allocating a large date array upfront. Replaced with a lazy descriptor `{start, inc, count}` — the ISO date string at any position is computed on demand, so all available time steps are shown regardless of dataset length.
- **Debounce zarr selector**: Added 150 ms debounce on `setSelector` calls so zarr tile fetches only fire when the user pauses during a drag, rather than queueing a fetch for every intermediate slider position. The date label still updates on every tick, so the UI feels instant.

## Test plan

- [ ] Load a daily dataset with >5000 steps (e.g. seNorge 1990–present) and verify the slider shows all steps (should read `1 / 13277`)
- [ ] Drag the slider quickly — verify the map only reloads after releasing/pausing, not on every intermediate tick
- [ ] Click to a specific slider position — verify the map updates within ~150 ms
- [ ] Load a dataset with explicit `values` in `cube:dimensions` — verify the array path is unchanged