### PR TITLE
Implement native process registry endpoints

### DIFF
--- a/climate_api/data/processes/resample.yaml
+++ b/climate_api/data/processes/resample.yaml
@@ -42,6 +42,7 @@
     publish:
       type: boolean
       required: false
+      default: true
       description: Publish the resulting artifact after materialization.
   outputs:
     artifact_id:

--- a/climate_api/data/processes/resample.yaml
+++ b/climate_api/data/processes/resample.yaml
@@ -1,4 +1,57 @@
 - id: resample
-  name: Temporal resampling
+  title: Temporal resampling
   description: Aggregate a source dataset to a coarser temporal resolution using pandas frequency aliases (e.g. 1D, W-MON, MS).
-  execution_function: climate_api.processing.services.execute_resample
+  version: "0.1.0"
+  expose: true
+  keywords:
+    - climate
+    - derived-data
+    - resampling
+  jobControlOptions:
+    - sync-execute
+  inputs:
+    source_dataset_id:
+      type: string
+      required: true
+      description: Source managed dataset id to resample.
+    frequency:
+      type: string
+      required: true
+      description: Target temporal frequency alias such as 1D, W-MON, or MS.
+    method:
+      type: string
+      required: true
+      description: Aggregation method to apply during resampling.
+      enum:
+        - mean
+        - sum
+        - min
+        - max
+    start:
+      type: string
+      required: true
+      description: Start of the requested period range.
+    end:
+      type: string
+      required: false
+      description: End of the requested period range. Defaults to today's UTC date.
+    overwrite:
+      type: boolean
+      required: false
+      description: Rebuild an existing matching derived artifact instead of reusing it.
+    publish:
+      type: boolean
+      required: false
+      description: Publish the resulting artifact after materialization.
+  outputs:
+    artifact_id:
+      type: string
+      description: Identifier of the stored derived artifact.
+    status:
+      type: string
+      description: Execution status for the synchronous response.
+    dataset:
+      type: object
+      description: Managed dataset summary for the derived output.
+  execution:
+    function: climate_api.processing.services.execute_resample

--- a/climate_api/data_registry/services/processes.py
+++ b/climate_api/data_registry/services/processes.py
@@ -30,7 +30,7 @@ def _normalize_process_definition(process: dict[str, Any]) -> dict[str, Any]:
     if "expose" not in normalized:
         normalized["expose"] = True
 
-    if "jobControlOptions" not in normalized:
+    if "jobControlOptions" not in normalized or normalized["jobControlOptions"] is None:
         normalized["jobControlOptions"] = ["sync-execute"]
 
     return normalized
@@ -197,7 +197,7 @@ def _get_dynamic_function(full_path: str) -> Any:
     parts = [p for p in full_path.split(".") if p]
     if len(parts) < 2:
         raise ValueError(
-            f"execution_function must be a dotted path with at least one module and one attribute, got '{full_path}'"
+            f"execution.function must be a dotted path with at least one module and one attribute, got '{full_path}'"
         )
     module_path = ".".join(parts[:-1])
     function_name = parts[-1]

--- a/climate_api/data_registry/services/processes.py
+++ b/climate_api/data_registry/services/processes.py
@@ -22,14 +22,9 @@ def _normalize_process_definition(process: dict[str, Any]) -> dict[str, Any]:
     """Return one process definition normalized to the preferred internal shape."""
     normalized = dict(process)
 
-    if "title" not in normalized and isinstance(normalized.get("name"), str):
-        normalized["title"] = normalized["name"]
-
     execution = normalized.get("execution")
     if not isinstance(execution, dict):
         execution = {}
-    if "function" not in execution and isinstance(normalized.get("execution_function"), str):
-        execution = {**execution, "function": normalized["execution_function"]}
     normalized["execution"] = execution
 
     if "expose" not in normalized:
@@ -138,21 +133,16 @@ def _validate_process(process: object, *, source: str) -> None:
         raise ValueError(f"{source} contains a process definition with a missing or invalid id")
 
     title = process.get("title")
-    legacy_name = process.get("name")
     if not isinstance(title, str) or not title:
-        if not isinstance(legacy_name, str) or not legacy_name:
-            raise ValueError(f"Process '{process_id}' in {source} must define title (or legacy name during migration)")
+        raise ValueError(f"Process '{process_id}' in {source} must define title")
 
     execution = process.get("execution")
     if isinstance(execution, dict):
         execution_function = execution.get("function")
     else:
-        execution_function = process.get("execution_function")
+        execution_function = None
     if not isinstance(execution_function, str) or not execution_function:
-        raise ValueError(
-            f"Process '{process_id}' in {source} must define execution.function "
-            "(or legacy execution_function during migration)"
-        )
+        raise ValueError(f"Process '{process_id}' in {source} must define execution.function")
 
     expose = process.get("expose")
     if expose is not None and not isinstance(expose, bool):

--- a/climate_api/data_registry/services/processes.py
+++ b/climate_api/data_registry/services/processes.py
@@ -25,9 +25,11 @@ def _normalize_process_definition(process: dict[str, Any]) -> dict[str, Any]:
     execution = normalized.get("execution")
     if not isinstance(execution, dict):
         execution = {}
+    else:
+        execution = dict(execution)
     normalized["execution"] = execution
 
-    if "expose" not in normalized:
+    if "expose" not in normalized or normalized["expose"] is None:
         normalized["expose"] = True
 
     if "jobControlOptions" not in normalized or normalized["jobControlOptions"] is None:
@@ -136,6 +138,10 @@ def _validate_process(process: object, *, source: str) -> None:
     if not isinstance(title, str) or not title:
         raise ValueError(f"Process '{process_id}' in {source} must define title")
 
+    description = process.get("description")
+    if description is not None and not isinstance(description, str):
+        raise ValueError(f"Process '{process_id}' in {source} has invalid description")
+
     execution = process.get("execution")
     if isinstance(execution, dict):
         execution_function = execution.get("function")
@@ -150,7 +156,9 @@ def _validate_process(process: object, *, source: str) -> None:
 
     job_control_options = process.get("jobControlOptions")
     if job_control_options is not None and (
-        not isinstance(job_control_options, list) or not all(isinstance(item, str) for item in job_control_options)
+        not isinstance(job_control_options, list)
+        or not job_control_options
+        or not all(isinstance(item, str) for item in job_control_options)
     ):
         raise ValueError(f"Process '{process_id}' in {source} has invalid jobControlOptions")
 

--- a/climate_api/data_registry/services/processes.py
+++ b/climate_api/data_registry/services/processes.py
@@ -168,6 +168,39 @@ def _validate_process(process: object, *, source: str) -> None:
     if keywords is not None and (not isinstance(keywords, list) or not all(isinstance(item, str) for item in keywords)):
         raise ValueError(f"Process '{process_id}' in {source} has invalid keywords")
 
+    _validate_process_fields(process.get("inputs"), process_id=process_id, field_name="inputs", source=source)
+    _validate_process_fields(process.get("outputs"), process_id=process_id, field_name="outputs", source=source)
+
+
+def _validate_process_fields(raw: object, *, process_id: str, field_name: str, source: str) -> None:
+    """Validate optional process input/output field metadata."""
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}")
+
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}")
+        if not isinstance(value, dict):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}.{key}")
+
+        field_type = value.get("type")
+        if field_type is not None and not isinstance(field_type, str):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}.{key}.type")
+
+        required = value.get("required")
+        if required is not None and not isinstance(required, bool):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}.{key}.required")
+
+        description = value.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}.{key}.description")
+
+        enum = value.get("enum")
+        if enum is not None and (not isinstance(enum, list) or not all(isinstance(item, str) for item in enum)):
+            raise ValueError(f"Process '{process_id}' in {source} has invalid {field_name}.{key}.enum")
+
 
 def _get_dynamic_function(full_path: str) -> Any:
     """Import and return a function given its dotted module path."""

--- a/climate_api/data_registry/services/processes.py
+++ b/climate_api/data_registry/services/processes.py
@@ -18,6 +18,29 @@ logger = logging.getLogger(__name__)
 CONFIGS_DIR: Path | None = None
 
 
+def _normalize_process_definition(process: dict[str, Any]) -> dict[str, Any]:
+    """Return one process definition normalized to the preferred internal shape."""
+    normalized = dict(process)
+
+    if "title" not in normalized and isinstance(normalized.get("name"), str):
+        normalized["title"] = normalized["name"]
+
+    execution = normalized.get("execution")
+    if not isinstance(execution, dict):
+        execution = {}
+    if "function" not in execution and isinstance(normalized.get("execution_function"), str):
+        execution = {**execution, "function": normalized["execution_function"]}
+    normalized["execution"] = execution
+
+    if "expose" not in normalized:
+        normalized["expose"] = True
+
+    if "jobControlOptions" not in normalized:
+        normalized["jobControlOptions"] = ["sync-execute"]
+
+    return normalized
+
+
 def list_processes() -> list[dict[str, Any]]:
     """Load all process definitions and return a flat list.
 
@@ -75,7 +98,7 @@ def _load_builtin_processes() -> list[dict[str, Any]]:
                 raise ValueError(f"{resource.name} must contain a list of process definitions")
             for process in file_processes:
                 _validate_process(process, source=resource.name)
-            processes.extend(file_processes)
+                processes.append(_normalize_process_definition(process))
         except Exception:
             logger.exception("Error loading %s", resource.name)
             raise
@@ -97,7 +120,7 @@ def _load_from_dir(folder: Path) -> list[dict[str, Any]]:
                     raise ValueError(f"{file_path.name} must contain a list of process definitions")
                 for process in file_processes:
                     _validate_process(process, source=str(file_path))
-                processes.extend(file_processes)
+                    processes.append(_normalize_process_definition(process))
         except Exception:
             logger.exception("Error loading %s", file_path.name)
             raise
@@ -114,13 +137,36 @@ def _validate_process(process: object, *, source: str) -> None:
     if not isinstance(process_id, str) or not process_id:
         raise ValueError(f"{source} contains a process definition with a missing or invalid id")
 
-    name = process.get("name")
-    if not isinstance(name, str) or not name:
-        raise ValueError(f"Process '{process_id}' in {source} must define name")
+    title = process.get("title")
+    legacy_name = process.get("name")
+    if not isinstance(title, str) or not title:
+        if not isinstance(legacy_name, str) or not legacy_name:
+            raise ValueError(f"Process '{process_id}' in {source} must define title (or legacy name during migration)")
 
-    execution_function = process.get("execution_function")
+    execution = process.get("execution")
+    if isinstance(execution, dict):
+        execution_function = execution.get("function")
+    else:
+        execution_function = process.get("execution_function")
     if not isinstance(execution_function, str) or not execution_function:
-        raise ValueError(f"Process '{process_id}' in {source} must define execution_function")
+        raise ValueError(
+            f"Process '{process_id}' in {source} must define execution.function "
+            "(or legacy execution_function during migration)"
+        )
+
+    expose = process.get("expose")
+    if expose is not None and not isinstance(expose, bool):
+        raise ValueError(f"Process '{process_id}' in {source} has invalid expose value")
+
+    job_control_options = process.get("jobControlOptions")
+    if job_control_options is not None and (
+        not isinstance(job_control_options, list) or not all(isinstance(item, str) for item in job_control_options)
+    ):
+        raise ValueError(f"Process '{process_id}' in {source} has invalid jobControlOptions")
+
+    keywords = process.get("keywords")
+    if keywords is not None and (not isinstance(keywords, list) or not all(isinstance(item, str) for item in keywords)):
+        raise ValueError(f"Process '{process_id}' in {source} has invalid keywords")
 
 
 def _get_dynamic_function(full_path: str) -> Any:

--- a/climate_api/processing/routes.py
+++ b/climate_api/processing/routes.py
@@ -29,11 +29,12 @@ def _field_map(raw: object) -> dict[str, ProcessField]:
         if not isinstance(key, str):
             continue
         if isinstance(value, dict):
+            raw_enum = value.get("enum")
             result[key] = ProcessField(
                 type=value.get("type") if isinstance(value.get("type"), str) else None,
                 required=value.get("required") if isinstance(value.get("required"), bool) else None,
                 description=value.get("description") if isinstance(value.get("description"), str) else None,
-                enum=value.get("enum") if isinstance(value.get("enum"), list) else None,
+                enum=[item for item in raw_enum if isinstance(item, str)] if isinstance(raw_enum, list) else None,
             )
         else:
             result[key] = ProcessField()

--- a/climate_api/processing/routes.py
+++ b/climate_api/processing/routes.py
@@ -67,10 +67,17 @@ def _public_process_detail(process: dict[str, Any]) -> ProcessDetail:
     )
 
 
+def _get_public_process_or_404(process_id: str) -> dict[str, Any]:
+    process = process_registry.get_process(process_id)
+    if process is None or not process["expose"]:
+        raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
+    return process
+
+
 @router.get("", response_model=ProcessListResponse)
 def list_processes() -> ProcessListResponse:
     """Return the registered native process catalog."""
-    visible = [process for process in process_registry.list_processes() if process.get("expose", True) is not False]
+    visible = [process for process in process_registry.list_processes() if process["expose"]]
     return ProcessListResponse(
         processes=[_public_process_summary(process) for process in visible],
         links=_catalog_links(),
@@ -80,9 +87,7 @@ def list_processes() -> ProcessListResponse:
 @router.get("/{process_id}", response_model=ProcessDetail)
 def get_process(process_id: str) -> ProcessDetail:
     """Return one registered process description."""
-    process = process_registry.get_process(process_id)
-    if process is None:
-        raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
+    process = _get_public_process_or_404(process_id)
     return _public_process_detail(process)
 
 
@@ -92,11 +97,14 @@ def run_process_execution(
     request: dict[str, Any] = Body(...),
 ) -> Any:
     """Dispatch to a registered process execution function by process id."""
-    process = process_registry.get_process(process_id)
-    if process is None:
-        raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
-    func = process_registry._get_dynamic_function(process["execution"]["function"])
+    process = _get_public_process_or_404(process_id)
     try:
+        func = process_registry._get_dynamic_function(process["execution"]["function"])
         return func(**request)
+    except (ImportError, AttributeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to load execution.function for process '{process_id}': {exc}",
+        ) from exc
     except TypeError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/climate_api/processing/routes.py
+++ b/climate_api/processing/routes.py
@@ -5,8 +5,84 @@ from typing import Any
 from fastapi import APIRouter, Body, HTTPException
 
 from climate_api.data_registry.services import processes as process_registry
+from climate_api.processing.schemas import ProcessDetail, ProcessField, ProcessLink, ProcessListResponse, ProcessSummary
 
 router = APIRouter()
+
+
+def _process_links(process_id: str) -> list[ProcessLink]:
+    return [
+        ProcessLink(href=f"/processes/{process_id}", rel="self", title="Process detail"),
+        ProcessLink(href=f"/processes/{process_id}/execution", rel="execute", title="Execute process"),
+    ]
+
+
+def _catalog_links() -> list[ProcessLink]:
+    return [ProcessLink(href="/processes", rel="self", title="Processes")]
+
+
+def _field_map(raw: object) -> dict[str, ProcessField]:
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, ProcessField] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, dict):
+            result[key] = ProcessField(
+                type=value.get("type") if isinstance(value.get("type"), str) else None,
+                required=value.get("required") if isinstance(value.get("required"), bool) else None,
+                description=value.get("description") if isinstance(value.get("description"), str) else None,
+                enum=value.get("enum") if isinstance(value.get("enum"), list) else None,
+            )
+        else:
+            result[key] = ProcessField()
+    return result
+
+
+def _public_process_summary(process: dict[str, Any]) -> ProcessSummary:
+    process_id = str(process["id"])
+    keywords = process.get("keywords")
+    job_control_options = process.get("jobControlOptions")
+    return ProcessSummary(
+        id=process_id,
+        title=str(process["title"]),
+        description=str(process["description"]) if isinstance(process.get("description"), str) else None,
+        version=str(process["version"]) if isinstance(process.get("version"), str) else None,
+        keywords=[k for k in keywords if isinstance(k, str)] if isinstance(keywords, list) else [],
+        jobControlOptions=[value for value in job_control_options if isinstance(value, str)]
+        if isinstance(job_control_options, list)
+        else [],
+        links=_process_links(process_id),
+    )
+
+
+def _public_process_detail(process: dict[str, Any]) -> ProcessDetail:
+    summary = _public_process_summary(process)
+    return ProcessDetail(
+        **summary.model_dump(),
+        inputs=_field_map(process.get("inputs")),
+        outputs=_field_map(process.get("outputs")),
+    )
+
+
+@router.get("", response_model=ProcessListResponse)
+def list_processes() -> ProcessListResponse:
+    """Return the registered native process catalog."""
+    visible = [process for process in process_registry.list_processes() if process.get("expose", True) is not False]
+    return ProcessListResponse(
+        processes=[_public_process_summary(process) for process in visible],
+        links=_catalog_links(),
+    )
+
+
+@router.get("/{process_id}", response_model=ProcessDetail)
+def get_process(process_id: str) -> ProcessDetail:
+    """Return one registered process description."""
+    process = process_registry.get_process(process_id)
+    if process is None:
+        raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
+    return _public_process_detail(process)
 
 
 @router.post("/{process_id}/execution")
@@ -18,7 +94,7 @@ def run_process_execution(
     process = process_registry.get_process(process_id)
     if process is None:
         raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
-    func = process_registry._get_dynamic_function(process["execution_function"])
+    func = process_registry._get_dynamic_function(process["execution"]["function"])
     try:
         return func(**request)
     except TypeError as exc:

--- a/climate_api/processing/routes.py
+++ b/climate_api/processing/routes.py
@@ -35,6 +35,7 @@ def _field_map(raw: object) -> dict[str, ProcessField]:
                 required=value.get("required") if isinstance(value.get("required"), bool) else None,
                 description=value.get("description") if isinstance(value.get("description"), str) else None,
                 enum=[item for item in raw_enum if isinstance(item, str)] if isinstance(raw_enum, list) else None,
+                default=value.get("default"),
             )
         else:
             result[key] = ProcessField()
@@ -42,16 +43,16 @@ def _field_map(raw: object) -> dict[str, ProcessField]:
 
 
 def _public_process_summary(process: dict[str, Any]) -> ProcessSummary:
-    process_id = str(process["id"])
+    process_id = process["id"]
     keywords = process.get("keywords")
     job_control_options = process.get("jobControlOptions")
     return ProcessSummary(
         id=process_id,
-        title=str(process["title"]),
-        description=str(process["description"]) if isinstance(process.get("description"), str) else None,
-        version=str(process["version"]) if isinstance(process.get("version"), str) else None,
+        title=process["title"],
+        description=process.get("description") if isinstance(process.get("description"), str) else None,
+        version=process.get("version") if isinstance(process.get("version"), str) else None,
         keywords=[k for k in keywords if isinstance(k, str)] if isinstance(keywords, list) else [],
-        jobControlOptions=[value for value in job_control_options if isinstance(value, str)]
+        job_control_options=[value for value in job_control_options if isinstance(value, str)]
         if isinstance(job_control_options, list)
         else [],
         links=_process_links(process_id),
@@ -75,7 +76,7 @@ def _get_public_process_or_404(process_id: str) -> dict[str, Any]:
 
 
 @router.get("", response_model=ProcessListResponse)
-def list_processes() -> ProcessListResponse:
+def get_processes_catalog() -> ProcessListResponse:
     """Return the registered native process catalog."""
     visible = [process for process in process_registry.list_processes() if process["expose"]]
     return ProcessListResponse(
@@ -100,11 +101,15 @@ def run_process_execution(
     process = _get_public_process_or_404(process_id)
     try:
         func = process_registry._get_dynamic_function(process["execution"]["function"])
-        return func(**request)
     except (ImportError, AttributeError, ValueError) as exc:
         raise HTTPException(
             status_code=500,
             detail=f"Failed to load execution.function for process '{process_id}': {exc}",
         ) from exc
+
+    try:
+        return func(**request)
     except TypeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/climate_api/processing/schemas.py
+++ b/climate_api/processing/schemas.py
@@ -1,6 +1,8 @@
 """Pydantic schemas for native process discovery endpoints."""
 
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ProcessLink(BaseModel):
@@ -18,17 +20,24 @@ class ProcessField(BaseModel):
     required: bool | None = None
     description: str | None = None
     enum: list[str] | None = None
+    default: Any | None = None
 
 
 class ProcessSummary(BaseModel):
     """Public summary view of one registered process."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str
     title: str
     description: str | None = None
     version: str | None = None
     keywords: list[str] = Field(default_factory=list)
-    jobControlOptions: list[str] = Field(default_factory=list)
+    job_control_options: list[str] = Field(
+        default_factory=list,
+        validation_alias="jobControlOptions",
+        serialization_alias="jobControlOptions",
+    )
     links: list[ProcessLink] = Field(default_factory=list)
 
 

--- a/climate_api/processing/schemas.py
+++ b/climate_api/processing/schemas.py
@@ -1,0 +1,46 @@
+"""Pydantic schemas for native process discovery endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class ProcessLink(BaseModel):
+    """Hypermedia link for a process resource."""
+
+    href: str
+    rel: str
+    title: str
+
+
+class ProcessField(BaseModel):
+    """Optional input/output field metadata for a process."""
+
+    type: str | None = None
+    required: bool | None = None
+    description: str | None = None
+    enum: list[str] | None = None
+
+
+class ProcessSummary(BaseModel):
+    """Public summary view of one registered process."""
+
+    id: str
+    title: str
+    description: str | None = None
+    version: str | None = None
+    keywords: list[str] = Field(default_factory=list)
+    jobControlOptions: list[str] = Field(default_factory=list)
+    links: list[ProcessLink] = Field(default_factory=list)
+
+
+class ProcessDetail(ProcessSummary):
+    """Full public view of one registered process."""
+
+    inputs: dict[str, ProcessField] = Field(default_factory=dict)
+    outputs: dict[str, ProcessField] = Field(default_factory=dict)
+
+
+class ProcessListResponse(BaseModel):
+    """Envelope response for registered processes."""
+
+    processes: list[ProcessSummary] = Field(default_factory=list)
+    links: list[ProcessLink] = Field(default_factory=list)

--- a/climate_api/processing/schemas.py
+++ b/climate_api/processing/schemas.py
@@ -8,7 +8,7 @@ class ProcessLink(BaseModel):
 
     href: str
     rel: str
-    title: str
+    title: str | None = None
 
 
 class ProcessField(BaseModel):

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -123,7 +123,9 @@ def _build_collection_resource(record: ArtifactRecord) -> dict[str, Any]:
         "format": _provider_format(record.format),
     }
     if record.format == ArtifactFormat.ZARR:
-        provider["options"] = {"zarr": {"consolidated": True}, "squeeze": True}
+        # Keep singleton dimensions intact so pygeoapi can still index the
+        # time coordinate for one-step coverages such as monthly aggregates.
+        provider["options"] = {"zarr": {"consolidated": True}}
 
     return {
         "type": "collection",

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -308,16 +308,11 @@
         return null;
       }
 
-      const map = new maplibregl.Map({
-        container: "map",
-        style: "https://tiles.openfreemap.org/styles/positron",
-        center: [20, 20],
-        zoom: 1.5,
-        projection: { type: "globe" },
-        fitBoundsOptions: { padding: 40 },
-        attributionControl: { compact: true },
-      });
+      const MAP_UNAVAILABLE_MESSAGE =
+        "Map rendering is unavailable in this browser session because WebGL could not be initialized. Dataset discovery still works.";
 
+      let map = null;
+      let mapUnavailable = false;
       let activeLayer = null;
       let timeSteps = [];
       let timeDimKey = "time";
@@ -354,7 +349,39 @@
         statusEl.className = isError ? "status error" : "status";
       }
 
+      function initMap() {
+        try {
+          map = new maplibregl.Map({
+            container: "map",
+            style: "https://tiles.openfreemap.org/styles/positron",
+            center: [20, 20],
+            zoom: 1.5,
+            projection: { type: "globe" },
+            fitBoundsOptions: { padding: 40 },
+            attributionControl: { compact: true },
+          });
+        } catch (err) {
+          mapUnavailable = true;
+          setStatus(MAP_UNAVAILABLE_MESSAGE, true);
+          return;
+        }
+
+        map.on("load", () => {
+          map.setProjection({ type: "globe" });
+          fitToExtent();
+        });
+
+        map.on("error", (event) => {
+          const message = event?.error?.message ?? "";
+          if (message.toLowerCase().includes("webgl")) {
+            mapUnavailable = true;
+            setStatus(MAP_UNAVAILABLE_MESSAGE, true);
+          }
+        });
+      }
+
       async function fitToExtent() {
+        if (!map) return;
         try {
           const res = await fetch("{{ base }}/extent");
           if (!res.ok) return;
@@ -365,7 +392,6 @@
       }
 
       async function loadCatalog() {
-        await fitToExtent();
         try {
           const res = await fetch("{{ base }}/stac/catalog.json");
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -384,13 +410,22 @@
             opt.textContent = link.title ?? link.href;
             selectEl.appendChild(opt);
           }
-          setStatus("Select a dataset to visualise it on the map.");
+          setStatus(
+            mapUnavailable
+              ? MAP_UNAVAILABLE_MESSAGE
+              : "Select a dataset to visualise it on the map.",
+            mapUnavailable
+          );
         } catch (err) {
           setStatus(`Failed to load catalog: ${err.message}`, true);
         }
       }
 
       async function loadDataset(href) {
+        if (!map) {
+          setStatus(MAP_UNAVAILABLE_MESSAGE, true);
+          return;
+        }
         setStatus("Loading...");
         if (activeLayer) {
           try {
@@ -525,10 +560,8 @@
         activeLayer?.setSelector({ [timeDimKey]: i });
       });
 
-      map.on("load", () => {
-        map.setProjection({ type: "globe" });
-        loadCatalog();
-      });
+      initMap();
+      loadCatalog();
     </script>
   </body>
 </html>

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -381,7 +381,7 @@
       }
 
       async function fitToExtent() {
-        if (!map) return;
+        if (!map || mapUnavailable) return;
         try {
           const res = await fetch("{{ base }}/extent");
           if (!res.ok) return;

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -422,7 +422,7 @@
       }
 
       async function loadDataset(href) {
-        if (!map) {
+        if (!map || mapUnavailable) {
           setStatus(MAP_UNAVAILABLE_MESSAGE, true);
           return;
         }

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -99,23 +99,31 @@ plugins/
 
 ```yaml
 - id: my_process
-  name: My custom process
+  title: My custom process
   description: Describe what this process does.
-  execution_function: mypackage.processes.my_process.execute
+  version: "0.1.0"
+  expose: true
+  jobControlOptions:
+    - sync-execute
+  execution:
+    function: mypackage.processes.my_process.execute
 ```
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |
 | `id` | Yes | Unique process identifier. Used in `POST /processes/{id}/execution` |
-| `name` | Yes | Human-readable name |
+| `title` | Yes | Human-readable title exposed through the public process catalogue |
 | `description` | No | Longer description shown in API responses |
-| `execution_function` | Yes | Dotted path to the Python function that runs the process |
+| `version` | No | Process version string exposed through the public process description |
+| `expose` | No | Whether the process appears in the public `/processes` listing. Default: `true` |
+| `jobControlOptions` | No | Supported execution modes exposed publicly. Default: `["sync-execute"]` |
+| `execution.function` | Yes | Dotted path to the Python function that runs the process |
 
 A custom process with the same `id` as a built-in overrides it.
 
 ### Execution function
 
-The execution function receives the raw JSON request body as keyword arguments and returns a JSON-serialisable dict:
+The current built-in execution path accepts the raw JSON request body as keyword arguments and returns a JSON-serialisable dict:
 
 ```python
 from typing import Any
@@ -126,6 +134,8 @@ def execute(*, source_dataset_id: str, factor: float, **_ignored: Any) -> dict[s
 ```
 
 Invalid or missing arguments raise `TypeError`, which the route dispatcher catches and returns as HTTP 400.
+
+Longer term, process execution is expected to converge on an `inputs + context` contract; this page documents the current repository behavior.
 
 For the built-in `resample` process and usage examples, see [Processes](processes.md).
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -135,8 +135,6 @@ def execute(*, source_dataset_id: str, factor: float, **_ignored: Any) -> dict[s
 
 Invalid or missing arguments raise `TypeError`, which the route dispatcher catches and returns as HTTP 400.
 
-Longer term, process execution is expected to converge on an `inputs + context` contract; this page documents the current repository behavior.
-
 For the built-in `resample` process and usage examples, see [Processes](processes.md).
 
 ---

--- a/docs/ogcapi.md
+++ b/docs/ogcapi.md
@@ -118,7 +118,7 @@ The `type` field on a provider determines which OGC API standard the collection 
 | `feature`     | Features         | Vector data (points, lines, polygons). Backends include CSV, GeoJSON, PostGIS, Elasticsearch, and others. |
 | `coverage`    | Coverages        | Gridded / raster data. Backends include rasterio, xarray, and S3-hosted COGs.                             |
 | `map`         | Maps             | Rendered map images, typically proxied from an upstream WMS via `WMSFacade`.                              |
-| `process`     | Processes        | Server-side processing tasks. Defined by a `processor` rather than a `providers` list.                    |
+| `process`     | Processes        | Server-side processing tasks. In Climate API, the native `/processes` surface is authoritative; pygeoapi process support is not the primary process runtime. |
 
 A single collection can have multiple providers (e.g. both `feature` and `tile` on the same resource).
 

--- a/docs/ogcapi.md
+++ b/docs/ogcapi.md
@@ -199,6 +199,8 @@ NULL check combined with comparison:
 
 OGC API - Processes exposes server-side processing tasks. Each process defines typed inputs and outputs and can be executed synchronously or asynchronously via `POST`.
 
+For Climate API, the canonical process surface is now the native [`/processes`](processes.md) API. The `/ogcapi/processes` paths below describe the older pygeoapi-centered process surface and should not be treated as the primary entrypoint for current native process work.
+
 ### Available processes
 
 | Process                   | ID                       | Description                                                                                                |

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -1,6 +1,6 @@
 # Processes
 
-Processes are named operations that produce derived datasets from existing ingested data. They are dispatched via `POST /processes/{id}/execution` and follow the [OGC API Processes](https://ogcapi.ogc.org/processes/) standard.
+Processes are named operations that produce derived datasets from existing ingested data. They are exposed through the native `/processes` endpoints and are shaped to align progressively with the [OGC API Processes](https://ogcapi.ogc.org/processes/) standard.
 
 ---
 
@@ -15,7 +15,7 @@ Content-Type: application/json
 { ...parameters... }
 ```
 
-Available processes are listed at `GET /ogcapi/processes`.
+Available processes are listed at `GET /processes`.
 
 ---
 

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -19,8 +19,9 @@ def test_builtin_resample_has_execution_function(monkeypatch: pytest.MonkeyPatch
 
     resample = process_registry.get_process("resample")
     assert resample is not None
-    assert "execution_function" in resample
-    assert resample["execution_function"] == "climate_api.processing.services.execute_resample"
+    assert resample["title"] == "Temporal resampling"
+    assert resample["execution"]["function"] == "climate_api.processing.services.execute_resample"
+    assert resample["jobControlOptions"] == ["sync-execute"]
 
 
 def test_get_process_returns_none_for_unknown_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,7 +31,7 @@ def test_get_process_returns_none_for_unknown_id(monkeypatch: pytest.MonkeyPatch
     assert process_registry.get_process("does_not_exist") is None
 
 
-def test_process_registry_rejects_missing_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_process_registry_rejects_missing_title_and_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     processes_subdir = tmp_path / "processes"
     processes_subdir.mkdir()
     (processes_subdir / "no_name.yaml").write_text(
@@ -39,7 +40,7 @@ def test_process_registry_rejects_missing_name(monkeypatch: pytest.MonkeyPatch, 
     )
     monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
 
-    with pytest.raises(ValueError, match="must define name"):
+    with pytest.raises(ValueError, match="must define title"):
         process_registry.list_processes()
 
 
@@ -49,8 +50,9 @@ def test_plugins_dir_processes_subdir_adds_to_builtin(monkeypatch: pytest.Monkey
     (processes_subdir / "custom.yaml").write_text(
         """
 - id: custom_process
-  name: Custom process
-  execution_function: mypackage.custom.execute
+  title: Custom process
+  execution:
+    function: mypackage.custom.execute
 """,
         encoding="utf-8",
     )
@@ -71,8 +73,9 @@ def test_plugins_dir_process_overrides_builtin_by_id(monkeypatch: pytest.MonkeyP
     (processes_subdir / "resample.yaml").write_text(
         """
 - id: resample
-  name: Custom resample override
-  execution_function: mypackage.resample.execute
+  title: Custom resample override
+  execution:
+    function: mypackage.resample.execute
 """,
         encoding="utf-8",
     )
@@ -83,5 +86,25 @@ def test_plugins_dir_process_overrides_builtin_by_id(monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
 
     processes = {p["id"]: p for p in process_registry.list_processes()}
-    assert processes["resample"]["name"] == "Custom resample override"
-    assert processes["resample"]["execution_function"] == "mypackage.resample.execute"
+    assert processes["resample"]["title"] == "Custom resample override"
+    assert processes["resample"]["execution"]["function"] == "mypackage.resample.execute"
+
+
+def test_process_registry_accepts_legacy_name_and_execution_function(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "legacy.yaml").write_text(
+        """
+- id: legacy_process
+  name: Legacy process
+  execution_function: mypackage.legacy.execute
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    process = process_registry.list_processes()[0]
+    assert process["title"] == "Legacy process"
+    assert process["execution"]["function"] == "mypackage.legacy.execute"

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -108,3 +108,47 @@ def test_process_registry_accepts_legacy_name_and_execution_function(
     process = process_registry.list_processes()[0]
     assert process["title"] == "Legacy process"
     assert process["execution"]["function"] == "mypackage.legacy.execute"
+
+
+def test_process_registry_rejects_invalid_inputs_enum(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "invalid_inputs.yaml").write_text(
+        """
+- id: bad_inputs
+  title: Bad inputs
+  execution:
+    function: mypackage.bad.execute
+  inputs:
+    frequency:
+      type: string
+      enum:
+        - ok
+        - 1
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    with pytest.raises(ValueError, match=r"invalid inputs\.frequency\.enum"):
+        process_registry.list_processes()
+
+
+def test_process_registry_rejects_non_mapping_outputs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "invalid_outputs.yaml").write_text(
+        """
+- id: bad_outputs
+  title: Bad outputs
+  execution:
+    function: mypackage.bad.execute
+  outputs:
+    - not-a-mapping
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    with pytest.raises(ValueError, match="has invalid outputs"):
+        process_registry.list_processes()

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -31,7 +31,7 @@ def test_get_process_returns_none_for_unknown_id(monkeypatch: pytest.MonkeyPatch
     assert process_registry.get_process("does_not_exist") is None
 
 
-def test_process_registry_rejects_missing_title_and_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_process_registry_rejects_missing_title(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     processes_subdir = tmp_path / "processes"
     processes_subdir.mkdir()
     (processes_subdir / "no_name.yaml").write_text(
@@ -207,3 +207,41 @@ def test_process_registry_defaults_null_job_control_options(monkeypatch: pytest.
 
     process = process_registry.list_processes()[0]
     assert process["jobControlOptions"] == ["sync-execute"]
+
+
+def test_process_registry_defaults_null_expose(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "null_expose.yaml").write_text(
+        """
+- id: null_expose
+  title: Null expose
+  expose:
+  execution:
+    function: mypackage.execute.run
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    process = process_registry.list_processes()[0]
+    assert process["expose"] is True
+
+
+def test_process_registry_rejects_empty_job_control_options(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "empty_job_control_options.yaml").write_text(
+        """
+- id: empty_job_control_options
+  title: Empty job control options
+  jobControlOptions: []
+  execution:
+    function: mypackage.execute.run
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    with pytest.raises(ValueError, match="invalid jobControlOptions"):
+        process_registry.list_processes()

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -35,7 +35,7 @@ def test_process_registry_rejects_missing_title_and_name(monkeypatch: pytest.Mon
     processes_subdir = tmp_path / "processes"
     processes_subdir.mkdir()
     (processes_subdir / "no_name.yaml").write_text(
-        "- id: no_name\n  execution_function: mypackage.execute\n",
+        "- id: no_name\n  execution:\n    function: mypackage.execute\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
@@ -90,7 +90,7 @@ def test_plugins_dir_process_overrides_builtin_by_id(monkeypatch: pytest.MonkeyP
     assert processes["resample"]["execution"]["function"] == "mypackage.resample.execute"
 
 
-def test_process_registry_accepts_legacy_name_and_execution_function(
+def test_process_registry_rejects_legacy_name_and_execution_function(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     processes_subdir = tmp_path / "processes"
@@ -105,9 +105,47 @@ def test_process_registry_accepts_legacy_name_and_execution_function(
     )
     monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
 
-    process = process_registry.list_processes()[0]
-    assert process["title"] == "Legacy process"
-    assert process["execution"]["function"] == "mypackage.legacy.execute"
+    with pytest.raises(ValueError, match="must define title"):
+        process_registry.list_processes()
+
+
+def test_process_registry_rejects_legacy_execution_function_without_execution_block(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "legacy_execution.yaml").write_text(
+        """
+- id: legacy_execution
+  title: Legacy execution
+  execution_function: mypackage.legacy.execute
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    with pytest.raises(ValueError, match=r"must define execution\.function"):
+        process_registry.list_processes()
+
+
+def test_process_registry_rejects_empty_title_and_empty_execution_function(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "legacy_empty_preferred.yaml").write_text(
+        """
+- id: legacy_empty_preferred
+  title: ""
+  execution:
+    function: ""
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    with pytest.raises(ValueError, match="must define title"):
+        process_registry.list_processes()
 
 
 def test_process_registry_rejects_invalid_inputs_enum(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -90,9 +90,7 @@ def test_plugins_dir_process_overrides_builtin_by_id(monkeypatch: pytest.MonkeyP
     assert processes["resample"]["execution"]["function"] == "mypackage.resample.execute"
 
 
-def test_process_registry_rejects_legacy_name_without_title(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_process_registry_rejects_legacy_name_without_title(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     processes_subdir = tmp_path / "processes"
     processes_subdir.mkdir()
     (processes_subdir / "legacy.yaml").write_text(

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -192,9 +192,7 @@ def test_process_registry_rejects_non_mapping_outputs(monkeypatch: pytest.Monkey
         process_registry.list_processes()
 
 
-def test_process_registry_defaults_null_job_control_options(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_process_registry_defaults_null_job_control_options(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     processes_subdir = tmp_path / "processes"
     processes_subdir.mkdir()
     (processes_subdir / "null_job_control_options.yaml").write_text(

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -190,3 +190,24 @@ def test_process_registry_rejects_non_mapping_outputs(monkeypatch: pytest.Monkey
 
     with pytest.raises(ValueError, match="has invalid outputs"):
         process_registry.list_processes()
+
+
+def test_process_registry_defaults_null_job_control_options(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "null_job_control_options.yaml").write_text(
+        """
+- id: null_job_control_options
+  title: Null job control options
+  jobControlOptions:
+  execution:
+    function: mypackage.execute.run
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(process_registry, "CONFIGS_DIR", processes_subdir)
+
+    process = process_registry.list_processes()[0]
+    assert process["jobControlOptions"] == ["sync-execute"]

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -90,7 +90,7 @@ def test_plugins_dir_process_overrides_builtin_by_id(monkeypatch: pytest.MonkeyP
     assert processes["resample"]["execution"]["function"] == "mypackage.resample.execute"
 
 
-def test_process_registry_rejects_legacy_name_and_execution_function(
+def test_process_registry_rejects_legacy_name_without_title(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     processes_subdir = tmp_path / "processes"

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -99,6 +99,23 @@ def test_get_unknown_process_detail_returns_404(client: TestClient) -> None:
     assert response.status_code == 404
 
 
+def test_get_internal_process_detail_returns_404(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "climate_api.processing.routes.process_registry.get_process",
+        lambda process_id: {
+            "id": process_id,
+            "title": "Internal process",
+            "execution": {"function": "mypackage.internal.execute"},
+            "expose": False,
+            "jobControlOptions": ["sync-execute"],
+        },
+    )
+
+    response = client.get("/processes/internal_process")
+
+    assert response.status_code == 404
+
+
 def test_post_resample_execution_returns_completed_response(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -126,6 +143,23 @@ def test_post_resample_execution_returns_completed_response(
     assert payload["artifact_id"] == "artifact-123"
     assert payload["status"] == "completed"
     assert payload["dataset"]["dataset_id"] == "chirps3_precipitation_daily_w_mon_sum"
+
+
+def test_post_internal_process_execution_returns_404(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "climate_api.processing.routes.process_registry.get_process",
+        lambda process_id: {
+            "id": process_id,
+            "title": "Internal process",
+            "execution": {"function": "mypackage.internal.execute"},
+            "expose": False,
+            "jobControlOptions": ["sync-execute"],
+        },
+    )
+
+    response = client.post("/processes/internal_process/execution", json={})
+
+    assert response.status_code == 404
 
 
 def test_post_resample_execution_passes_params_to_service(
@@ -209,3 +243,29 @@ def test_post_unknown_process_id_returns_404(
         },
     )
     assert response.status_code == 404
+
+
+def test_post_process_execution_returns_500_for_invalid_execution_function(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.processing.routes.process_registry.get_process",
+        lambda process_id: {
+            "id": process_id,
+            "title": "Broken process",
+            "execution": {"function": "mypackage.broken.execute"},
+            "expose": True,
+            "jobControlOptions": ["sync-execute"],
+        },
+    )
+
+    def _raise_import_error(full_path: str) -> object:
+        raise ModuleNotFoundError(f"No module named for {full_path}")
+
+    monkeypatch.setattr("climate_api.processing.routes.process_registry._get_dynamic_function", _raise_import_error)
+
+    response = client.post("/processes/broken_process/execution", json={})
+
+    assert response.status_code == 500
+    assert "Failed to load execution.function" in response.json()["detail"]

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -40,6 +40,65 @@ def _dataset_record(dataset_id: str) -> DatasetRecord:
     )
 
 
+def test_get_processes_lists_registered_processes(client: TestClient) -> None:
+    response = client.get("/processes")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert any(item["id"] == "resample" for item in payload["processes"])
+    assert any(link["href"] == "/processes" for link in payload["links"])
+
+
+def test_get_process_detail_returns_public_metadata(client: TestClient) -> None:
+    response = client.get("/processes/resample")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "resample"
+    assert payload["title"] == "Temporal resampling"
+    assert payload["jobControlOptions"] == ["sync-execute"]
+    assert "execution_function" not in payload
+    assert payload["inputs"]["source_dataset_id"]["required"] is True
+    assert payload["outputs"]["artifact_id"]["type"] == "string"
+
+
+def test_get_processes_omits_internal_only_processes(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "climate_api.processing.routes.process_registry.list_processes",
+        lambda: [
+            {
+                "id": "public_process",
+                "title": "Public process",
+                "description": "Visible",
+                "execution": {"function": "mypackage.public.execute"},
+                "expose": True,
+                "jobControlOptions": ["sync-execute"],
+            },
+            {
+                "id": "internal_process",
+                "title": "Internal process",
+                "description": "Hidden",
+                "execution": {"function": "mypackage.internal.execute"},
+                "expose": False,
+                "jobControlOptions": ["sync-execute"],
+            },
+        ],
+    )
+
+    response = client.get("/processes")
+
+    assert response.status_code == 200
+    payload = response.json()
+    ids = {item["id"] for item in payload["processes"]}
+    assert ids == {"public_process"}
+
+
+def test_get_unknown_process_detail_returns_404(client: TestClient) -> None:
+    response = client.get("/processes/unknown_process")
+
+    assert response.status_code == 404
+
+
 def test_post_resample_execution_returns_completed_response(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -59,6 +60,7 @@ def test_get_process_detail_returns_public_metadata(client: TestClient) -> None:
     assert payload["jobControlOptions"] == ["sync-execute"]
     assert "execution_function" not in payload
     assert payload["inputs"]["source_dataset_id"]["required"] is True
+    assert payload["inputs"]["publish"]["default"] is True
     assert payload["outputs"]["artifact_id"]["type"] == "string"
 
 
@@ -114,6 +116,36 @@ def test_get_internal_process_detail_returns_404(client: TestClient, monkeypatch
     response = client.get("/processes/internal_process")
 
     assert response.status_code == 404
+
+
+def test_expose_false_yaml_fixture_is_hidden_from_catalog_and_routes(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    processes_subdir = tmp_path / "processes"
+    processes_subdir.mkdir()
+    (processes_subdir / "internal.yaml").write_text(
+        """
+- id: internal_process
+  title: Internal process
+  expose: false
+  execution:
+    function: mypackage.internal.execute
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("climate_api.data_registry.services.processes.CONFIGS_DIR", processes_subdir)
+
+    catalog_response = client.get("/processes")
+    assert catalog_response.status_code == 200
+    assert catalog_response.json()["processes"] == []
+
+    detail_response = client.get("/processes/internal_process")
+    assert detail_response.status_code == 404
+
+    execution_response = client.post("/processes/internal_process/execution", json={})
+    assert execution_response.status_code == 404
 
 
 def test_post_resample_execution_returns_completed_response(
@@ -269,3 +301,32 @@ def test_post_process_execution_returns_500_for_invalid_execution_function(
 
     assert response.status_code == 500
     assert "Failed to load execution.function" in response.json()["detail"]
+
+
+def test_post_process_execution_returns_400_for_execution_value_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.processing.routes.process_registry.get_process",
+        lambda process_id: {
+            "id": process_id,
+            "title": "Broken process",
+            "execution": {"function": "mypackage.broken.execute"},
+            "expose": True,
+            "jobControlOptions": ["sync-execute"],
+        },
+    )
+
+    def _raise_value_error(full_path: str) -> object:
+        def _func(**_: object) -> object:
+            raise ValueError("Bad execution input")
+
+        return _func
+
+    monkeypatch.setattr("climate_api.processing.routes.process_registry._get_dynamic_function", _raise_value_error)
+
+    response = client.post("/processes/broken_process/execution", json={})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Bad execution input"

--- a/tests/test_publications.py
+++ b/tests/test_publications.py
@@ -1,7 +1,18 @@
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from climate_api.ingestions.schemas import (
+    ArtifactCoverage,
+    ArtifactFormat,
+    ArtifactPublication,
+    ArtifactRecord,
+    ArtifactRequestScope,
+    CoverageSpatial,
+    CoverageTemporal,
+    PublicationStatus,
+)
 from climate_api.publications import services
 
 
@@ -50,3 +61,36 @@ def test_native_dataset_href_uses_climate_api_base_url(monkeypatch: pytest.Monke
     monkeypatch.delenv("OGCAPI_BASE_URL", raising=False)
 
     assert services._native_dataset_href("dataset-1") == "https://climate.example.org/datasets/dataset-1"
+
+
+def test_build_collection_resource_keeps_singleton_time_dimension_for_zarr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(services, "_provider_axes", lambda record: ("x", "y", "time"))
+
+    record = ArtifactRecord(
+        artifact_id="artifact-1",
+        dataset_id="chirps3_precipitation_daily_ms_sum",
+        dataset_name="CHIRPS monthly total precipitation",
+        variable="precip",
+        format=ArtifactFormat.ZARR,
+        path="/tmp/chirps3_precipitation_daily_ms_sum.zarr",
+        asset_paths=["/tmp/chirps3_precipitation_daily_ms_sum.zarr"],
+        variables=["precip"],
+        request_scope=ArtifactRequestScope(start="2024-01-01", end="2024-01-31"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2024-01", end="2024-01"),
+            spatial=CoverageSpatial(xmin=-13.5, ymin=6.9, xmax=-10.1, ymax=10.0),
+        ),
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(
+            status=PublicationStatus.PUBLISHED,
+            collection_id="chirps3_precipitation_daily_ms_sum_sle",
+        ),
+    )
+
+    resource = services._build_collection_resource(record)
+    provider = resource["providers"][0]
+
+    assert provider["options"] == {"zarr": {"consolidated": True}}
+    assert "squeeze" not in provider["options"]


### PR DESCRIPTION
## Summary

Implement the native FastAPI process surface for Climate API.

This PR makes `/processes` the authoritative process catalog and execution entrypoint, backed by the YAML process registry. It publishes temporal resampling as the first built-in process and aligns the public response shape toward OGC API Processes semantics.

## Changes

- add native `GET /processes`
- add native `GET /processes/{id}`
- keep native `POST /processes/{id}/execution`
- publish `resample` as a built-in registry-backed process
- normalize process metadata toward:
  - `title`
  - `version`
  - `jobControlOptions`
  - nested `execution.function`
  - `expose`
- filter internal-only processes from the public catalog
- update process docs to reflect the native `/processes` surface
- fix pygeoapi publication for singleton-time Zarr outputs by removing `squeeze` from generated Zarr provider options
- harden the map viewer so dataset discovery is not blocked by map initialization failure

## Why

This closes the process-surface part of CLIM-689:

- native FastAPI is now the authoritative process surface
- pygeoapi is no longer the primary process catalog
- the YAML registry is the source of truth for built-in and custom processes
- the public API now has a stable base for later async job work

## Scope notes

This PR does not implement async jobs or `/jobs`. That remains follow-on work.