### PR TITLE
feat: remote zarr source kind — GEFS forecast PoC (closes #125)

### DIFF
--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -22,3 +22,28 @@
   display:
     colormap: blues
     range: [0.0, 0.001]
+
+- id: gefs_temperature_2m
+  name: 2 metre temperature forecast (NOAA GEFS ensemble)
+  short_name: Temperature forecast (GEFS)
+  variable: temperature_2m
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
+  units: "°C"
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: rdbu_r
+    range: [-30.0, 30.0]

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -1,0 +1,25 @@
+- id: gefs_precipitation
+  name: Total precipitation surface forecast (NOAA GEFS ensemble)
+  short_name: Precipitation forecast (GEFS)
+  variable: precipitation_surface
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
+  units: m
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: blues
+    range: [0.0, 0.05]
+    nodata: null

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -15,11 +15,10 @@
       anon: true
       client_kwargs:
         region_name: us-west-2
-  units: m
+  units: "kg m-2 s-1"
   resolution: 25 km x 25 km (0.25°)
   source: "NOAA GEFS (via dynamical.org)"
   source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
   display:
     colormap: blues
-    range: [0.0, 0.05]
-    nodata: null
+    range: [0.0, 0.001]

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -23,22 +23,28 @@ def get_data(
     bbox: list[float] | None = None,
 ) -> xr.Dataset:
     """Load an xarray raster dataset for a given time range and bbox."""
+    from climate_api.providers.remote_zarr import is_remote_source, open_remote_dataset
+
     logger.info("Opening dataset")
-    zarr_path = get_zarr_path(dataset)
-    if zarr_path:
-        logger.info(f"Using optimized zarr file: {zarr_path}")
-        ds = open_zarr_dataset(str(zarr_path))
+    if is_remote_source(dataset):
+        logger.info("Opening remote zarr store for dataset '%s'", dataset["id"])
+        ds = open_remote_dataset(dataset["store"])
     else:
-        logger.warning(
-            f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
-        )
-        files = get_cache_files(dataset)
-        ds = xr.open_mfdataset(
-            files,
-            data_vars="minimal",
-            coords="minimal",  # pyright: ignore[reportArgumentType]
-            compat="override",
-        )
+        zarr_path = get_zarr_path(dataset)
+        if zarr_path:
+            logger.info(f"Using optimized zarr file: {zarr_path}")
+            ds = open_zarr_dataset(str(zarr_path))
+        else:
+            logger.warning(
+                f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
+            )
+            files = get_cache_files(dataset)
+            ds = xr.open_mfdataset(
+                files,
+                data_vars="minimal",
+                coords="minimal",  # pyright: ignore[reportArgumentType]
+                compat="override",
+            )
 
     if start and end:
         logger.info(f"Subsetting time to {start} and {end}")

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -5,6 +5,11 @@ from typing import Any
 
 def get_time_dim(ds: Any) -> str:
     """Return the name of the time dimension in a dataset or dataframe."""
+    actual_dims: set[str] = set(getattr(ds, "dims", {}) or {})
+    for time_name in ["valid_time", "init_time", "time"]:
+        if time_name in actual_dims:
+            return time_name
+    # Fallback for non-xarray objects (e.g. DataFrames) that don't have dims
     for time_name in ["valid_time", "init_time", "time"]:
         if hasattr(ds, time_name):
             return time_name

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 
 def get_time_dim(ds: Any) -> str:
     """Return the name of the time dimension in a dataset or dataframe."""
-    for time_name in ["valid_time", "time"]:
+    for time_name in ["valid_time", "init_time", "time"]:
         if hasattr(ds, time_name):
             return time_name
     raise ValueError(f"Unable to find time dimension: {getattr(ds, 'coords', repr(ds))}")

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # When set, only this directory is loaded (no built-ins, no config override).
 CONFIGS_DIR: Path | None = None
 
-SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
+SUPPORTED_SYNC_KINDS = {"temporal", "release", "static", "remote"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
 
@@ -149,16 +149,30 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
                 f"'{sync_execution}'. Supported values: {supported}"
             )
 
-    ingestion = dataset.get("ingestion")
-    if not isinstance(ingestion, dict):
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define an 'ingestion' block")
-    function = ingestion.get("function")
-    if not isinstance(function, str) or not function:
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.function")
+    store_block = dataset.get("store")
+    is_remote_zarr = isinstance(store_block, dict) and store_block.get("kind") == "remote_zarr"
+
+    if is_remote_zarr:
+        _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
+    else:
+        ingestion = dataset.get("ingestion")
+        if not isinstance(ingestion, dict):
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define an 'ingestion' block")
+        function = ingestion.get("function")
+        if not isinstance(function, str) or not function:
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.function")
 
     sync_availability = sync_block.get("availability") if isinstance(sync_block, dict) else None
     if sync_availability is not None:
         _validate_sync_availability(sync_availability, dataset_id=dataset_id, source=source)
+
+
+def _validate_remote_zarr_source(source_block: object, *, dataset_id: str, source: str) -> None:
+    """Validate a remote_zarr source block."""
+    if not isinstance(source_block, dict):
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} has invalid source block")
+    if not source_block.get("store_url"):
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define source.store_url")
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -1,6 +1,6 @@
 """Routes for EO ingestion, datasets, and sync operations."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 from starlette.responses import Response
 
@@ -94,9 +94,11 @@ def get_canonical_zarr_store_info(dataset_id: str) -> dict[str, object]:
 
 
 @zarr_router.api_route("/{dataset_id}/{relative_path:path}", methods=["GET", "HEAD"], response_model=None)
-def get_canonical_zarr_store_file(dataset_id: str, relative_path: str) -> FileResponse | Response | dict[str, object]:
+async def get_canonical_zarr_store_file(
+    request: Request, dataset_id: str, relative_path: str
+) -> FileResponse | Response | dict[str, object]:
     """Serve canonical Zarr store content for a managed dataset."""
-    return services.get_dataset_zarr_store_file_or_404(dataset_id, relative_path)
+    return await services.get_dataset_zarr_store_file_or_404(request, dataset_id, relative_path)
 
 
 @sync_router.post("/{dataset_id}", response_model=SyncResponse)

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -11,6 +11,7 @@ class ArtifactFormat(StrEnum):
 
     ZARR = "zarr"
     NETCDF = "netcdf"
+    REMOTE_ZARR = "remote_zarr"
 
 
 class PublicationStatus(StrEnum):
@@ -26,6 +27,7 @@ class SyncKind(StrEnum):
     TEMPORAL = "temporal"
     RELEASE = "release"
     STATIC = "static"
+    REMOTE = "remote"
 
 
 class SyncAction(StrEnum):

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -145,6 +145,88 @@ def get_latest_artifact_for_dataset_or_404(dataset_id: str) -> ArtifactRecord:
     return max(artifacts, key=lambda artifact: artifact.created_at)
 
 
+def _register_remote_zarr_artifact(
+    *,
+    dataset: dict[str, object],
+    publish: bool,
+) -> ArtifactRecord:
+    """Register a remote Zarr/Icechunk store as an artifact without downloading anything."""
+    from climate_api.data_accessor.services.accessor import _coverage_from_dataset
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    source = dataset["store"]
+    if not isinstance(source, dict):
+        raise HTTPException(status_code=500, detail=f"Dataset '{dataset['id']}' has invalid store block")
+    store_url = str(source["store_url"])
+
+    logger.info("Opening remote zarr store for dataset '%s': %s", dataset["id"], store_url)
+    ds = open_remote_dataset(source)
+    try:
+        native_crs = api_config.get_crs() or "EPSG:4326"
+        coverage_data = _coverage_from_dataset(
+            ds=ds,
+            period_type=str(dataset["period_type"]),
+            native_crs=native_crs,
+        )
+    finally:
+        ds.close()
+
+    if not coverage_data.get("has_data", True):
+        raise HTTPException(status_code=409, detail="Remote zarr store contains no data")
+
+    raw_coverage = coverage_data["coverage"]
+    coverage = ArtifactCoverage(
+        temporal=CoverageTemporal(**raw_coverage["temporal"]),
+        spatial=CoverageSpatial(**raw_coverage["spatial"]),
+        spatial_wgs84=CoverageSpatial(**raw_coverage["spatial_wgs84"]) if raw_coverage.get("spatial_wgs84") else None,
+    )
+    request_scope = ArtifactRequestScope(start=coverage.temporal.start, end=coverage.temporal.end)
+
+    record = ArtifactRecord(
+        artifact_id=str(uuid4()),
+        dataset_id=str(dataset["id"]),
+        dataset_name=str(dataset["name"]),
+        variable=str(dataset["variable"]),
+        format=ArtifactFormat.REMOTE_ZARR,
+        path=store_url,
+        asset_paths=[store_url],
+        variables=[str(dataset["variable"])],
+        request_scope=request_scope,
+        coverage=coverage,
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+
+    stored_record = _upsert_remote_zarr_record(record, publish=publish)
+    logger.info(
+        "Registered remote zarr artifact '%s' for dataset '%s': coverage=%s..%s",
+        stored_record.artifact_id,
+        dataset["id"],
+        stored_record.coverage.temporal.start,
+        stored_record.coverage.temporal.end,
+    )
+    if publish and stored_record.publication.status != PublicationStatus.PUBLISHED:
+        return publish_artifact_record(stored_record.artifact_id)
+    return stored_record
+
+
+def _upsert_remote_zarr_record(record: ArtifactRecord, *, publish: bool) -> ArtifactRecord:
+    """Replace any existing remote zarr record for the same dataset, or insert a new one."""
+
+    def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
+        for index, existing in enumerate(records):
+            if existing.dataset_id == record.dataset_id and existing.format == ArtifactFormat.REMOTE_ZARR:
+                replacement = record.model_copy(
+                    update={"artifact_id": existing.artifact_id, "publication": existing.publication}
+                )
+                records[index] = replacement
+                return replacement
+        records.append(record)
+        return record
+
+    return _mutate_records(mutate)
+
+
 def create_artifact(
     *,
     dataset: dict[str, object],
@@ -159,6 +241,11 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
+    from climate_api.providers.remote_zarr import is_remote_source
+
+    if is_remote_source(dataset):
+        return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
+
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
@@ -444,8 +531,11 @@ def plan_sync_dataset(
 def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     """Return a public Zarr store listing for a managed dataset."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
-    store_root = _get_zarr_root_or_409(artifact)
 
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        return _remote_zarr_store_info(dataset_id, artifact)
+
+    store_root = _get_zarr_root_or_409(artifact)
     entries = _zarr_entries(dataset_id=dataset_id, store_root=store_root, directory=store_root)
     store_attrs = _read_zarr_attrs(store_root)
     store_crs = store_attrs.get("proj:code") if store_attrs else None
@@ -459,6 +549,33 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
         "proj4": _crs_to_proj4(crs),
         "bounds": _read_zarr_bounds(store_attrs),
         "entries": entries,
+    }
+
+
+def _remote_zarr_store_info(dataset_id: str, artifact: ArtifactRecord) -> dict[str, object]:
+    """Return store metadata for a remote zarr artifact."""
+    source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
+    raw_store = source_dataset.get("store", {})
+    store: dict[str, object] = raw_store if isinstance(raw_store, dict) else {}
+    crs = "EPSG:4326"
+    coverage = artifact.coverage
+    return {
+        "kind": "ZarrListing",
+        "dataset_id": dataset_id,
+        "format": artifact.format,
+        "path": ".",
+        "crs": crs,
+        "proj4": _crs_to_proj4(crs),
+        "bounds": [
+            coverage.spatial.xmin,
+            coverage.spatial.ymin,
+            coverage.spatial.xmax,
+            coverage.spatial.ymax,
+        ],
+        "remote_url": artifact.path,
+        "provider": store.get("provider"),
+        "catalog_id": store.get("catalog_id"),
+        "entries": [],
     }
 
 
@@ -513,6 +630,14 @@ def get_dataset_zarr_store_file_or_404(
 ) -> FileResponse | Response | dict[str, object]:
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"Direct file access for remote zarr dataset '{dataset_id}' is not supported. "
+                f"Access the store directly at: {artifact.path}"
+            ),
+        )
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -792,7 +917,9 @@ def _materialized_records(records: list[ArtifactRecord]) -> list[ArtifactRecord]
 
 
 def _artifact_storage_exists(record: ArtifactRecord) -> bool:
-    """Return whether an artifact's on-disk backing files are still present."""
+    """Return whether an artifact's backing storage is still accessible."""
+    if record.format == ArtifactFormat.REMOTE_ZARR:
+        return True
     paths: list[str] = []
     if record.path is not None:
         paths.append(record.path)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -659,7 +659,7 @@ async def _proxy_remote_zarr_file(
     from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
-    from climate_api.providers.remote_zarr import get_icechunk_key_size, open_icechunk_store
+    from climate_api.providers.remote_zarr import _store_cache, get_icechunk_key_size, open_icechunk_store
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
     store_config = source_dataset.get("store")
@@ -671,8 +671,9 @@ async def _proxy_remote_zarr_file(
         )
     store_url: str = store_config.get("store_url", "")
     try:
-        # open_icechunk_store is cached after the first call — fast dict lookup after warmup.
-        store = await asyncio.to_thread(open_icechunk_store, store_config)
+        # Fast path: store already cached — just a dict lookup, no thread needed.
+        # Cold path: open_icechunk_store makes blocking S3 calls, so run in a thread.
+        store = _store_cache.get(store_url) or await asyncio.to_thread(open_icechunk_store, store_config)
     except Exception as exc:
         logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
         raise HTTPException(

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -162,11 +162,12 @@ def _register_remote_zarr_artifact(
     logger.info("Opening remote zarr store for dataset '%s': %s", dataset["id"], store_url)
     ds = open_remote_dataset(source)
     try:
-        native_crs = api_config.get_crs() or "EPSG:4326"
+        # Remote datasets carry their own CRS (always WGS84 for dynamical.org stores).
+        # Do not use the instance CRS here — that applies only to locally ingested data.
         coverage_data = _coverage_from_dataset(
             ds=ds,
             period_type=str(dataset["period_type"]),
-            native_crs=native_crs,
+            native_crs="EPSG:4326",
         )
     finally:
         ds.close()

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import portalocker
 import pyproj
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 from starlette.responses import Response
 
@@ -626,13 +626,13 @@ def _read_zarr_bounds(store_attrs: dict[str, object] | None) -> list[float] | No
     return [xmin, ymin, xmax, ymax]
 
 
-def get_dataset_zarr_store_file_or_404(
-    dataset_id: str, relative_path: str
+async def get_dataset_zarr_store_file_or_404(
+    request: Request, dataset_id: str, relative_path: str
 ) -> FileResponse | Response | dict[str, object]:
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.REMOTE_ZARR:
-        return _proxy_remote_zarr_file(artifact, relative_path)
+        return await _proxy_remote_zarr_file(request, artifact, relative_path)
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -648,13 +648,15 @@ def get_dataset_zarr_store_file_or_404(
     return FileResponse(target, media_type=media_type, filename=target.name)
 
 
-def _proxy_remote_zarr_file(
+async def _proxy_remote_zarr_file(
+    request: Request,
     artifact: ArtifactRecord,
     relative_path: str,
 ) -> Response | JSONResponse:
-    """Proxy a zarr v3 key from the underlying icechunk store."""
+    """Proxy a zarr v3 key from the underlying icechunk store, with HTTP Range support."""
     import asyncio
 
+    from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
     from climate_api.providers.remote_zarr import open_icechunk_store
@@ -668,8 +670,53 @@ def _proxy_remote_zarr_file(
             f"Access the store at: {artifact.path}",
         )
     try:
-        store = open_icechunk_store(store_config)
-        buf = asyncio.run(store.get(relative_path, default_buffer_prototype()))
+        store = await asyncio.to_thread(open_icechunk_store, store_config)
+    except Exception as exc:
+        logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for dataset '{artifact.dataset_id}' is temporarily unavailable",
+        ) from exc
+
+    # HEAD: return object size without downloading content.
+    if request.method == "HEAD":
+        try:
+            size = await store.getsize(relative_path)
+        except Exception:
+            size = 0
+        return Response(
+            status_code=200,
+            headers={"Content-Length": str(size), "Accept-Ranges": "bytes"},
+            media_type="application/octet-stream",
+        )
+
+    # Parse HTTP Range header into a zarr ByteRequest.
+    byte_request = None
+    content_range: str | None = None
+    range_header = request.headers.get("range", "")
+    if range_header.startswith("bytes="):
+        spec = range_header[6:]
+        if spec.startswith("-"):
+            # Suffix form: bytes=-N  (last N bytes)
+            suffix = int(spec[1:])
+            byte_request = SuffixByteRequest(suffix=suffix)
+            total = await store.getsize(relative_path)
+            content_range = f"bytes {total - suffix}-{total - 1}/{total}"
+        elif "-" in spec:
+            parts = spec.split("-", 1)
+            start = int(parts[0])
+            if parts[1]:
+                end_inc = int(parts[1])
+                byte_request = RangeByteRequest(start=start, end=end_inc + 1)
+                content_range = f"bytes {start}-{end_inc}/*"
+            else:
+                # Open-ended: bytes=start-
+                byte_request = RangeByteRequest(start=start, end=None)
+                total = await store.getsize(relative_path)
+                content_range = f"bytes {start}-{total - 1}/{total}"
+
+    try:
+        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
     except Exception as exc:
@@ -683,9 +730,17 @@ def _proxy_remote_zarr_file(
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
 
     data: bytes = bytes(buf.as_array_like())
+
+    if content_range:
+        return Response(
+            content=data,
+            status_code=206,
+            headers={"Accept-Ranges": "bytes", "Content-Range": content_range},
+            media_type="application/octet-stream",
+        )
     if relative_path.endswith(".json"):
-        return JSONResponse(content=json.loads(data))
-    return Response(content=data, media_type="application/octet-stream")
+        return JSONResponse(content=json.loads(data), headers={"Accept-Ranges": "bytes"})
+    return Response(content=data, media_type="application/octet-stream", headers={"Accept-Ranges": "bytes"})
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -169,6 +169,23 @@ def _register_remote_zarr_artifact(
             period_type=str(dataset["period_type"]),
             native_crs="EPSG:4326",
         )
+
+        # Forecast datasets have a lead_time dimension — the actual data horizon extends
+        # beyond the last init_time. Extend the temporal end by max lead_time so the
+        # coverage reflects when the latest forecast reaches, not when it was issued.
+        if coverage_data.get("has_data") and "lead_time" in ds.dims:
+            import pandas as pd
+
+            from climate_api.data_manager.services.utils import get_time_dim
+            from climate_api.shared.time import numpy_datetime_to_period_string
+
+            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
+
+            time_dim = get_time_dim(ds)
+            forecast_end = pd.Timestamp(ds[time_dim].max().item()) + pd.Timedelta(ds["lead_time"].max().item())
+            coverage_data["coverage"]["temporal"]["end"] = _period_string_scalar(
+                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))
+            )
     finally:
         ds.close()
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -659,7 +659,7 @@ async def _proxy_remote_zarr_file(
     from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
-    from climate_api.providers.remote_zarr import open_icechunk_store
+    from climate_api.providers.remote_zarr import get_icechunk_key_size, open_icechunk_store
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
     store_config = source_dataset.get("store")
@@ -669,7 +669,9 @@ async def _proxy_remote_zarr_file(
             detail=f"Direct file access not supported for dataset '{artifact.dataset_id}'. "
             f"Access the store at: {artifact.path}",
         )
+    store_url: str = store_config.get("store_url", "")
     try:
+        # open_icechunk_store is cached after the first call — fast dict lookup after warmup.
         store = await asyncio.to_thread(open_icechunk_store, store_config)
     except Exception as exc:
         logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
@@ -681,7 +683,7 @@ async def _proxy_remote_zarr_file(
     # HEAD: return object size without downloading content.
     if request.method == "HEAD":
         try:
-            size = await store.getsize(relative_path)
+            size = await get_icechunk_key_size(store, relative_path, store_url)
         except Exception:
             size = 0
         return Response(
@@ -700,7 +702,7 @@ async def _proxy_remote_zarr_file(
             # Suffix form: bytes=-N  (last N bytes)
             suffix = int(spec[1:])
             byte_request = SuffixByteRequest(suffix=suffix)
-            total = await store.getsize(relative_path)
+            total = await get_icechunk_key_size(store, relative_path, store_url)
             content_range = f"bytes {total - suffix}-{total - 1}/{total}"
         elif "-" in spec:
             parts = spec.split("-", 1)
@@ -712,7 +714,7 @@ async def _proxy_remote_zarr_file(
             else:
                 # Open-ended: bytes=start-
                 byte_request = RangeByteRequest(start=start, end=None)
-                total = await store.getsize(relative_path)
+                total = await get_icechunk_key_size(store, relative_path, store_url)
                 content_range = f"bytes {start}-{total - 1}/{total}"
 
     try:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -632,13 +632,7 @@ def get_dataset_zarr_store_file_or_404(
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.REMOTE_ZARR:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                f"Direct file access for remote zarr dataset '{dataset_id}' is not supported. "
-                f"Access the store directly at: {artifact.path}"
-            ),
-        )
+        return _proxy_remote_zarr_file(artifact, relative_path)
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -652,6 +646,46 @@ def get_dataset_zarr_store_file_or_404(
     if media_type is None:
         media_type = "application/octet-stream"
     return FileResponse(target, media_type=media_type, filename=target.name)
+
+
+def _proxy_remote_zarr_file(
+    artifact: ArtifactRecord,
+    relative_path: str,
+) -> Response | JSONResponse:
+    """Proxy a zarr v3 key from the underlying icechunk store."""
+    import asyncio
+
+    from zarr.core.buffer import default_buffer_prototype
+
+    from climate_api.providers.remote_zarr import open_icechunk_store
+
+    source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
+    store_config = source_dataset.get("store")
+    if not isinstance(store_config, dict) or store_config.get("store_format") != "icechunk":
+        raise HTTPException(
+            status_code=501,
+            detail=f"Direct file access not supported for dataset '{artifact.dataset_id}'. "
+            f"Access the store at: {artifact.path}",
+        )
+    try:
+        store = open_icechunk_store(store_config)
+        buf = asyncio.run(store.get(relative_path, default_buffer_prototype()))
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
+    except Exception as exc:
+        logger.warning("Failed to proxy zarr key '%s' from remote store: %s", relative_path, exc)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for dataset '{artifact.dataset_id}' is temporarily unavailable",
+        ) from exc
+
+    if buf is None:
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
+
+    data: bytes = bytes(buf.as_array_like())
+    if relative_path.endswith(".json"):
+        return JSONResponse(content=json.loads(data))
+    return Response(content=data, media_type="application/octet-stream")
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -176,15 +176,14 @@ def _register_remote_zarr_artifact(
         if coverage_data.get("has_data") and "lead_time" in ds.dims:
             import pandas as pd
 
+            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
             from climate_api.data_manager.services.utils import get_time_dim
             from climate_api.shared.time import numpy_datetime_to_period_string
-
-            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
 
             time_dim = get_time_dim(ds)
             forecast_end = pd.Timestamp(ds[time_dim].max().item()) + pd.Timedelta(ds["lead_time"].max().item())
             coverage_data["coverage"]["temporal"]["end"] = _period_string_scalar(
-                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))
+                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))  # type: ignore[arg-type]
             )
     finally:
         ds.close()
@@ -711,7 +710,7 @@ async def _proxy_remote_zarr_file(
         )
 
     # Parse HTTP Range header into a zarr ByteRequest.
-    byte_request = None
+    byte_request: SuffixByteRequest | RangeByteRequest | None = None
     content_range: str | None = None
     range_header = request.headers.get("range", "")
     if range_header.startswith("bytes="):
@@ -731,12 +730,12 @@ async def _proxy_remote_zarr_file(
                 content_range = f"bytes {start}-{end_inc}/*"
             else:
                 # Open-ended: bytes=start-
-                byte_request = RangeByteRequest(start=start, end=None)
                 total = await get_icechunk_key_size(store, relative_path, store_url)
+                byte_request = RangeByteRequest(start=start, end=total)
                 content_range = f"bytes {start}-{total - 1}/{total}"
 
     try:
-        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)
+        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)  # type: ignore[union-attr]
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
     except Exception as exc:

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -75,6 +75,20 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
+
+    if sync_kind == SyncKind.REMOTE:
+        return SyncDetail(
+            source_dataset_id=latest_artifact.dataset_id,
+            sync_kind=sync_kind,
+            action=SyncAction.REMATERIALIZE,
+            reason="remote_store_refresh",
+            message=("Remote zarr store is always live. Sync will re-register the store to refresh coverage metadata."),
+            current_start=current_start,
+            current_end=current_end,
+            target_end=None,
+            target_end_source="remote",
+        )
+
     period_type = str(source_dataset["period_type"])
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
@@ -214,6 +228,26 @@ def run_sync(
             status="not_syncable",
             message="Managed dataset is not syncable under its configured sync policy.",
             dataset=get_dataset_fn(dataset_id),
+            sync_detail=sync_detail,
+        )
+
+    # Remote datasets re-register through create_artifact; start/end are ignored.
+    if sync_detail.sync_kind == SyncKind.REMOTE:
+        artifact = create_artifact_fn(
+            dataset=source_dataset,
+            start=latest_artifact.coverage.temporal.start,
+            end=latest_artifact.coverage.temporal.end,
+            bbox=list(latest_artifact.request_scope.bbox) if latest_artifact.request_scope.bbox is not None else None,
+            country_code=country_code,
+            overwrite=True,
+            prefer_zarr=prefer_zarr,
+            publish=publish,
+        )
+        return SyncResponse(
+            sync_id=artifact.artifact_id,
+            status="completed",
+            message="Remote zarr store coverage metadata has been refreshed.",
+            dataset=get_dataset_fn(managed_dataset_id_for(artifact)),
             sync_detail=sync_detail,
         )
 

--- a/climate_api/main.py
+++ b/climate_api/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -38,7 +38,7 @@ def _append_vary_value(response: Response, value: str) -> None:
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Run background warmup tasks on startup so first requests hit warm caches."""
     asyncio.get_event_loop().run_in_executor(None, _warmup_remote_zarr_stores)
     yield
@@ -46,10 +46,10 @@ async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
 
 def _warmup_remote_zarr_stores() -> None:
     """Open and cache every published REMOTE_ZARR store at process startup."""
+    from climate_api.data_registry.services import datasets as registry_datasets
     from climate_api.ingestions.schemas import ArtifactFormat
     from climate_api.ingestions.services import _load_records
     from climate_api.providers.remote_zarr import warmup_remote_store
-    from climate_api.data_registry.services import datasets as registry_datasets
 
     for record in _load_records():
         if record.format != ArtifactFormat.REMOTE_ZARR:

--- a/climate_api/main.py
+++ b/climate_api/main.py
@@ -1,7 +1,9 @@
 """DHIS2 Climate API -- Climate and earth observation data API for DHIS2."""
 
+import asyncio
 import os
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -35,6 +37,29 @@ def _append_vary_value(response: Response, value: str) -> None:
         response.headers["Vary"] = ", ".join([*values, value])
 
 
+@asynccontextmanager
+async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
+    """Run background warmup tasks on startup so first requests hit warm caches."""
+    asyncio.get_event_loop().run_in_executor(None, _warmup_remote_zarr_stores)
+    yield
+
+
+def _warmup_remote_zarr_stores() -> None:
+    """Open and cache every published REMOTE_ZARR store at process startup."""
+    from climate_api.ingestions.schemas import ArtifactFormat
+    from climate_api.ingestions.services import _load_records
+    from climate_api.providers.remote_zarr import warmup_remote_store
+    from climate_api.data_registry.services import datasets as registry_datasets
+
+    for record in _load_records():
+        if record.format != ArtifactFormat.REMOTE_ZARR:
+            continue
+        source_dataset = registry_datasets.get_dataset(record.dataset_id) or {}
+        store_config = source_dataset.get("store")
+        if isinstance(store_config, dict):
+            warmup_remote_store(store_config)
+
+
 def create_app() -> FastAPI:
     """Create and configure the Climate API FastAPI application.
 
@@ -43,7 +68,7 @@ def create_app() -> FastAPI:
         from climate_api.main import create_app
         app = create_app()
     """
-    _app = FastAPI()
+    _app = FastAPI(lifespan=_lifespan)
 
     _app.add_middleware(
         CORSMiddleware,

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -4,6 +4,10 @@ from typing import Any
 
 import xarray as xr
 
+# Module-level caches keyed by store_url so each remote store is opened once.
+_store_cache: dict[str, Any] = {}
+_store_size_cache: dict[tuple[str, str], int] = {}
+
 
 def is_remote_source(dataset: dict[str, Any]) -> bool:
     """Return True when a dataset template declares a remote zarr store."""
@@ -24,7 +28,10 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
 
 def open_icechunk_store(source: dict[str, Any]) -> Any:
-    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access."""
+    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access.
+
+    The store is cached per store_url so the repository is opened only once per process.
+    """
     try:
         import icechunk
     except ImportError as exc:
@@ -33,6 +40,9 @@ def open_icechunk_store(source: dict[str, Any]) -> Any:
         ) from exc
 
     store_url: str = source["store_url"]
+    if store_url in _store_cache:
+        return _store_cache[store_url]
+
     storage_options: dict[str, Any] = source.get("storage_options", {})
     anon: bool = storage_options.get("anon", False)
     client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
@@ -44,7 +54,19 @@ def open_icechunk_store(source: dict[str, Any]) -> Any:
 
     storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
     repo = icechunk.Repository.open(storage)
-    return repo.readonly_session(branch="main").store
+    store = repo.readonly_session(branch="main").store
+    _store_cache[store_url] = store
+    return store
+
+
+async def get_icechunk_key_size(store: Any, key: str, store_url: str) -> int:
+    """Return the byte size of a key in the store, using a per-process cache."""
+    cache_key = (store_url, key)
+    if cache_key in _store_size_cache:
+        return _store_size_cache[cache_key]
+    size: int = await store.getsize(key)
+    _store_size_cache[cache_key] = size
+    return size
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -7,6 +7,7 @@ import xarray as xr
 # Module-level caches keyed by store_url so each remote store is opened once.
 _store_cache: dict[str, Any] = {}
 _store_size_cache: dict[tuple[str, str], int] = {}
+_dataset_cache: dict[str, xr.Dataset] = {}
 
 
 def is_remote_source(dataset: dict[str, Any]) -> bool:
@@ -20,11 +21,17 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
     Dispatches on source.store_format: 'icechunk' uses the icechunk library;
     anything else falls back to xr.open_zarr with fsspec.
+
+    The opened dataset is cached per store_url so coordinates and metadata are
+    read from S3 only once per process.
     """
+    store_url: str = source.get("store_url", "")
+    if store_url in _dataset_cache:
+        return _dataset_cache[store_url]
     store_format = source.get("store_format", "zarr")
-    if store_format == "icechunk":
-        return _open_icechunk(source)
-    return _open_zarr_url(source)
+    ds = _open_icechunk(source) if store_format == "icechunk" else _open_zarr_url(source)
+    _dataset_cache[store_url] = ds
+    return ds
 
 
 def open_icechunk_store(source: dict[str, Any]) -> Any:
@@ -67,6 +74,23 @@ async def get_icechunk_key_size(store: Any, key: str, store_url: str) -> int:
     size: int = await store.getsize(key)
     _store_size_cache[cache_key] = size
     return size
+
+
+def warmup_remote_store(source: dict[str, Any]) -> None:
+    """Open and cache the store and dataset for a remote source block.
+
+    Intended to be called at server startup (in a background thread) so the
+    first real request hits warm caches instead of cold S3 connections.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    store_url: str = source.get("store_url", "")
+    try:
+        open_remote_dataset(source)
+        logger.info("Warmed up remote zarr store: %s", store_url)
+    except Exception as exc:
+        logger.warning("Failed to warm up remote zarr store '%s': %s", store_url, exc)
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -23,8 +23,8 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
     return _open_zarr_url(source)
 
 
-def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
-    """Open an Icechunk store via the icechunk library (v2 API)."""
+def open_icechunk_store(source: dict[str, Any]) -> Any:
+    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access."""
     try:
         import icechunk
     except ImportError as exc:
@@ -44,7 +44,12 @@ def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
 
     storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
     repo = icechunk.Repository.open(storage)
-    store = repo.readonly_session(branch="main").store
+    return repo.readonly_session(branch="main").store
+
+
+def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
+    """Open an Icechunk store via the icechunk library (v2 API)."""
+    store = open_icechunk_store(source)
     return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
 
 

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -1,0 +1,59 @@
+"""Remote Zarr/Icechunk store access for externally hosted datasets."""
+
+from typing import Any
+
+import xarray as xr
+
+
+def is_remote_source(dataset: dict[str, Any]) -> bool:
+    """Return True when a dataset template declares a remote zarr store."""
+    store = dataset.get("store")
+    return isinstance(store, dict) and store.get("kind") == "remote_zarr"
+
+
+def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
+    """Open a remote dataset from a template source block.
+
+    Dispatches on source.store_format: 'icechunk' uses the icechunk library;
+    anything else falls back to xr.open_zarr with fsspec.
+    """
+    store_format = source.get("store_format", "zarr")
+    if store_format == "icechunk":
+        return _open_icechunk(source)
+    return _open_zarr_url(source)
+
+
+def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
+    """Open an Icechunk store via the icechunk library."""
+    try:
+        import icechunk
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'icechunk' package is required to open Icechunk stores. Install it with: uv add icechunk"
+        ) from exc
+
+    store_url: str = source["store_url"]
+    storage_options: dict[str, Any] = source.get("storage_options", {})
+    anon: bool = storage_options.get("anon", False)
+    client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
+    region: str = client_kwargs.get("region_name", "us-east-1")
+
+    s3_path = store_url.removeprefix("s3://")
+    bucket, _, prefix = s3_path.partition("/")
+
+    if anon:
+        storage = icechunk.StorageConfig.s3_anonymous(bucket=bucket, prefix=prefix, region=region)
+    else:
+        storage = icechunk.StorageConfig.s3_from_env(bucket=bucket, prefix=prefix, region=region)
+
+    store = icechunk.IcechunkStore.open_existing(storage, mode="r")
+    return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
+
+
+def _open_zarr_url(source: dict[str, Any]) -> xr.Dataset:
+    """Open a plain Zarr store (v2/v3) via xarray with optional fsspec storage options."""
+    store_url: str = source["store_url"]
+    storage_options: dict[str, Any] = source.get("storage_options", {})
+    if storage_options:
+        return xr.open_zarr(store_url, storage_options=storage_options, consolidated=None)  # type: ignore[no-any-return]
+    return xr.open_zarr(store_url, consolidated=None)  # type: ignore[no-any-return]

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -24,7 +24,7 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
-    """Open an Icechunk store via the icechunk library."""
+    """Open an Icechunk store via the icechunk library (v2 API)."""
     try:
         import icechunk
     except ImportError as exc:
@@ -36,17 +36,15 @@ def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
     storage_options: dict[str, Any] = source.get("storage_options", {})
     anon: bool = storage_options.get("anon", False)
     client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
-    region: str = client_kwargs.get("region_name", "us-east-1")
+    region: str | None = client_kwargs.get("region_name")
 
     s3_path = store_url.removeprefix("s3://")
     bucket, _, prefix = s3_path.partition("/")
+    prefix = prefix.rstrip("/")
 
-    if anon:
-        storage = icechunk.StorageConfig.s3_anonymous(bucket=bucket, prefix=prefix, region=region)
-    else:
-        storage = icechunk.StorageConfig.s3_from_env(bucket=bucket, prefix=prefix, region=region)
-
-    store = icechunk.IcechunkStore.open_existing(storage, mode="r")
+    storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
+    repo = icechunk.Repository.open(storage)
+    store = repo.readonly_session(branch="main").store
     return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
 
 

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -49,6 +49,7 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
     collection_id = managed_dataset_id_for(record)
     data_path = record.path or record.asset_paths[0]
     is_pyramid_zarr = record.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir()
+    is_remote_zarr = record.format == ArtifactFormat.REMOTE_ZARR
     published_record = record.model_copy(
         update={
             "publication": record.publication.model_copy(
@@ -56,8 +57,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
                     "status": PublicationStatus.PUBLISHED,
                     "collection_id": collection_id,
                     "published_at": datetime.now(UTC),
-                    # Pyramid zarr stores are served via the /zarr endpoint, not pygeoapi.
-                    "pygeoapi_path": None if is_pyramid_zarr else f"/ogcapi/collections/{collection_id}",
+                    # Pyramid zarr and remote zarr are served via /zarr, not pygeoapi.
+                    "pygeoapi_path": None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}",
                 }
             )
         }
@@ -71,6 +72,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
         data_path = active.path or active.asset_paths[0]
         if active.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir():
             continue  # pyramid zarr: not served via pygeoapi, use /zarr endpoint instead
+        if active.format == ArtifactFormat.REMOTE_ZARR:
+            continue  # remote zarr: served via /zarr redirect, not pygeoapi xarray provider
         assert active.publication.collection_id is not None
         resources[active.publication.collection_id] = _build_collection_resource(active)
 

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -58,7 +58,9 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
                     "collection_id": collection_id,
                     "published_at": datetime.now(UTC),
                     # Pyramid zarr and remote zarr are served via /zarr, not pygeoapi.
-                    "pygeoapi_path": None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}",
+                    "pygeoapi_path": (
+                        None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}"
+                    ),
                 }
             )
         }

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -345,11 +345,11 @@ def _cube_dimensions_from_dataset(
         elif name == time_dim or np.issubdtype(coord.dtype, np.datetime64):
             start = _to_stac_datetime(values[0])
             end = _to_stac_datetime(values[-1])
-            step = None
+            time_step: str | None = None
             if len(values) > 1:
                 delta = pd.Timestamp(values[1]) - pd.Timestamp(values[0])
-                step = _timedelta_to_iso_duration(delta)
-            dims[name] = {"type": "temporal", "extent": [start, end], "step": step}
+                time_step = _timedelta_to_iso_duration(delta)
+            dims[name] = {"type": "temporal", "extent": [start, end], "step": time_step}
         elif np.issubdtype(coord.dtype, np.timedelta64):
             hours = [int(pd.Timedelta(v).total_seconds() // 3600) for v in values]
             dims[name] = {"type": "ordinal", "values": hours, "climate_api:unit": "hours"}

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -342,7 +342,7 @@ def _cube_dimensions_from_dataset(
                 "step": step,
                 "reference_system": 4326,
             }
-        elif name == time_dim:
+        elif name == time_dim or np.issubdtype(coord.dtype, np.datetime64):
             start = _to_stac_datetime(values[0])
             end = _to_stac_datetime(values[-1])
             step = None

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -85,7 +85,12 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     )
     template_links = [_link_to_dict(link) for link in template.links]
 
-    collection_payload = _build_collection_with_xstac(artifact=artifact, template=template)
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        collection_payload = _build_remote_zarr_collection(
+            artifact=artifact, template=template, source_dataset=source_dataset
+        )
+    else:
+        collection_payload = _build_collection_with_xstac(artifact=artifact, template=template)
     collection_payload["id"] = dataset_id
     collection_payload["type"] = "Collection"
     collection_payload["stac_version"] = STAC_VERSION
@@ -131,7 +136,7 @@ def _eligible_artifacts_by_dataset() -> dict[str, ArtifactRecord]:
         latest = max(artifacts, key=lambda artifact: artifact.created_at)
         if latest.publication.status != PublicationStatus.PUBLISHED:
             continue
-        if latest.format != ArtifactFormat.ZARR:
+        if latest.format not in (ArtifactFormat.ZARR, ArtifactFormat.REMOTE_ZARR):
             continue
         result[dataset_id] = latest
     return dict(sorted(result.items()))
@@ -168,7 +173,7 @@ def _build_collection_template(
     )
     from climate_api import config as api_config
 
-    native_crs = api_config.get_crs() or "EPSG:4326"
+    native_crs = "EPSG:4326" if artifact.format == ArtifactFormat.REMOTE_ZARR else (api_config.get_crs() or "EPSG:4326")
     template.extra_fields["keywords"] = _keywords(artifact, source_dataset)
     template.extra_fields["proj:code"] = native_crs
     template.clear_links()
@@ -251,6 +256,146 @@ def _clear_xstac_collection_cache() -> None:
     _xstac_collection_cache.clear()
 
 
+def _build_remote_zarr_collection(
+    *,
+    artifact: ArtifactRecord,
+    template: pystac.Collection,
+    source_dataset: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a STAC collection payload for a REMOTE_ZARR artifact by opening the remote store."""
+    cached = _xstac_collection_cache.get(artifact.artifact_id)
+    if cached is not None:
+        return deepcopy(cached)
+
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    store = source_dataset.get("store")
+    if not isinstance(store, dict):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Remote zarr artifact '{artifact.artifact_id}' has no store config",
+        )
+
+    try:
+        ds = open_remote_dataset(store)
+    except Exception as exc:
+        logger.exception("Failed to open remote zarr store for STAC collection '%s'", artifact.artifact_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for '{artifact.artifact_id}' is temporarily unavailable",
+        ) from exc
+
+    try:
+        x_dim, y_dim = get_x_y_dims(ds)
+        time_dim = get_time_dim(ds)
+        cube_dims = _cube_dimensions_from_dataset(ds, x_dim=x_dim, y_dim=y_dim, time_dim=time_dim)
+        cube_vars = _cube_variables_from_dataset(ds, artifact=artifact)
+    except Exception as exc:
+        ds.close()
+        logger.exception("Failed to build STAC metadata for remote artifact '%s'", artifact.artifact_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for '{artifact.artifact_id}' is temporarily unavailable",
+        ) from exc
+    finally:
+        ds.close()
+
+    template.clear_links()
+    payload: dict[str, Any] = template.to_dict(include_self_link=False)
+    payload["cube:dimensions"] = cube_dims
+    payload["cube:variables"] = cube_vars
+    _cache_xstac_collection_payload(artifact.artifact_id, payload)
+    return deepcopy(payload)
+
+
+def _cube_dimensions_from_dataset(
+    ds: Any,
+    *,
+    x_dim: str,
+    y_dim: str,
+    time_dim: str,
+) -> dict[str, Any]:
+    import numpy as np
+    import pandas as pd
+
+    dims: dict[str, Any] = {}
+    for name in ds.dims:
+        coord = ds.coords.get(name)
+        if coord is None:
+            continue
+        values = coord.values
+        if name == x_dim:
+            step = round(float(values[1] - values[0]), SPATIAL_STEP_DECIMALS) if len(values) > 1 else None
+            dims[name] = {
+                "type": "spatial",
+                "axis": "x",
+                "extent": [float(values.min()), float(values.max())],
+                "step": step,
+                "reference_system": 4326,
+            }
+        elif name == y_dim:
+            step = round(abs(float(values[1] - values[0])), SPATIAL_STEP_DECIMALS) if len(values) > 1 else None
+            dims[name] = {
+                "type": "spatial",
+                "axis": "y",
+                "extent": [float(values.min()), float(values.max())],
+                "step": step,
+                "reference_system": 4326,
+            }
+        elif name == time_dim:
+            start = _to_stac_datetime(values[0])
+            end = _to_stac_datetime(values[-1])
+            step = None
+            if len(values) > 1:
+                delta = pd.Timestamp(values[1]) - pd.Timestamp(values[0])
+                step = _timedelta_to_iso_duration(delta)
+            dims[name] = {"type": "temporal", "extent": [start, end], "step": step}
+        elif np.issubdtype(coord.dtype, np.timedelta64):
+            hours = [int(pd.Timedelta(v).total_seconds() // 3600) for v in values]
+            dims[name] = {"type": "ordinal", "values": hours, "climate_api:unit": "hours"}
+        else:
+            dims[name] = {"type": "ordinal", "values": values.tolist()}
+    return dims
+
+
+def _cube_variables_from_dataset(ds: Any, *, artifact: ArtifactRecord) -> dict[str, Any]:
+    variables: dict[str, Any] = {}
+    for var_name, data_var in ds.data_vars.items():
+        attrs = data_var.attrs or {}
+        entry: dict[str, Any] = {"type": "data", "dimensions": list(data_var.dims)}
+        long_name = attrs.get("long_name")
+        units = attrs.get("units")
+        if long_name:
+            entry["description"] = str(long_name)
+        if units:
+            entry["unit"] = str(units)
+            entry["attrs"] = {k: str(v) for k, v in attrs.items() if k in ("long_name", "units") and v}
+        variables[str(var_name)] = entry
+    return variables
+
+
+def _to_stac_datetime(value: Any) -> str:
+    import pandas as pd
+
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ts.tz_convert("UTC").strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _timedelta_to_iso_duration(delta: Any) -> str | None:
+    import pandas as pd
+
+    total_seconds = int(pd.Timedelta(delta).total_seconds())
+    if total_seconds <= 0:
+        return None
+    hours = total_seconds // 3600
+    days = hours // 24
+    if hours % 24 == 0 and days > 0:
+        return f"P{days}D"
+    return f"PT{hours}H"
+
+
 def _link_to_dict(link: pystac.Link) -> dict[str, Any]:
     target = link.target
     href = target if isinstance(target, str) else link.href
@@ -298,6 +443,9 @@ def _public_zarr_asset_href(
     artifact: ArtifactRecord,
     source_dataset: dict[str, Any],
 ) -> str:
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        # Route through the API proxy — the icechunk store has no public zarr.json
+        return _abs_url(request, f"/zarr/{dataset_id}")
     artifact_path = _artifact_store_path(artifact)
     if _is_pyramid_zarr(artifact_path):
         return _abs_url(request, f"/zarr/{dataset_id}/0")
@@ -423,6 +571,10 @@ def _keywords(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> list[
 
 def _zarr_asset_metadata(artifact: ArtifactRecord) -> dict[str, object]:
     metadata: dict[str, object] = {"zarr:node_type": "group"}
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        metadata["zarr:zarr_format"] = 3
+        metadata["zarr:consolidated"] = True
+        return metadata
     artifact_path = _artifact_store_path(artifact)
     consolidated = _zarr_consolidated_flag(artifact_path)
     if consolidated is not None:

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -222,6 +222,8 @@
             <input type="range" id="time-slider" min="0" step="1" value="0" />
           </div>
 
+          <div id="extra-dims-container"></div>
+
           <dl id="dataset-meta" class="meta-grid hidden">
             <dt>Source</dt>
             <dd id="meta-source">—</dd>
@@ -328,6 +330,7 @@
       let activeLayer = null;
       let timeSteps = [];
       let timeDimKey = "time";
+      let extraDims = [];
 
       const selectEl = document.getElementById("dataset-select");
       const timeSection = document.getElementById("time-section");
@@ -397,6 +400,76 @@
         }
       }
 
+      // --- Extra dimension helpers ---
+
+      function getExtraDims(dimensions, primaryTimeDimKey) {
+        const result = [];
+        for (const [key, val] of Object.entries(dimensions ?? {})) {
+          if (val.type === "spatial") continue;
+          if (key === primaryTimeDimKey) continue;
+          const count = Array.isArray(val.values) ? val.values.length : 0;
+          if (count < 2) continue;
+          result.push({ key, ...val, _count: count });
+        }
+        return result;
+      }
+
+      function formatDimLabel(key) {
+        return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      }
+
+      function formatDimValue(dim, i) {
+        if (!Array.isArray(dim.values)) return String(i);
+        const val = dim.values[i];
+        if (dim["climate_api:unit"] === "hours") return `${val}h`;
+        return String(val);
+      }
+
+      function renderExtraDimSliders(dims) {
+        const container = document.getElementById("extra-dims-container");
+        container.innerHTML = "";
+        for (const dim of dims) {
+          const section = document.createElement("div");
+          section.className = "panel-section";
+          const label = formatDimLabel(dim.key);
+          const unitSuffix = dim["climate_api:unit"] ? ` (${dim["climate_api:unit"]})` : "";
+          section.innerHTML = `
+            <div class="time-header">
+              <label style="margin-bottom:0">${label}${unitSuffix}</label>
+              <span id="dim-count-${dim.key}" class="time-count">1 / ${dim._count}</span>
+            </div>
+            <div style="margin-bottom:0.4rem">
+              <span id="dim-val-${dim.key}" class="time-value">${formatDimValue(dim, 0)}</span>
+            </div>
+            <input type="range" id="dim-slider-${dim.key}" data-dim="${dim.key}" min="0" max="${dim._count - 1}" step="1" value="0" />
+          `;
+          container.appendChild(section);
+          section.querySelector(`#dim-slider-${dim.key}`).addEventListener("input", (e) => {
+            const i = parseInt(e.target.value, 10);
+            document.getElementById(`dim-val-${dim.key}`).textContent = formatDimValue(dim, i);
+            document.getElementById(`dim-count-${dim.key}`).textContent = `${i + 1} / ${dim._count}`;
+            clearTimeout(_selectorDebounce);
+            _selectorDebounce = setTimeout(() => updateSelector(), 150);
+          });
+        }
+      }
+
+      function buildFullSelector() {
+        const selector = {};
+        if (timeStepCount() > 0) selector[timeDimKey] = parseInt(timeSlider.value, 10);
+        for (const dim of extraDims) {
+          const slider = document.getElementById(`dim-slider-${dim.key}`);
+          if (slider) selector[dim.key] = parseInt(slider.value, 10);
+        }
+        return selector;
+      }
+
+      function updateSelector() {
+        activeLayer?.setSelector(buildFullSelector());
+      }
+
+      // --- Dataset loading ---
+
       async function loadDataset(href) {
         setStatus("Loading...");
         clearTimeout(_selectorDebounce);
@@ -406,6 +479,8 @@
           } catch {}
           activeLayer = null;
         }
+        extraDims = [];
+        document.getElementById("extra-dims-container").innerHTML = "";
         timeSection.classList.add("hidden");
         datasetMeta.classList.add("hidden");
         legendEl.classList.add("hidden");
@@ -438,6 +513,7 @@
         const dimensions = collection["cube:dimensions"] ?? {};
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
+        extraDims = getExtraDims(dimensions, timeDimKey);
 
         // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
         // reprojects natively instead of treating coordinates as WGS84 degrees.
@@ -465,8 +541,12 @@
         try {
           cm = buildColormap(colormapName);
           const zarrVersion = zarr["zarr:zarr_format"] ?? null;
-          const selector =
-            timeStepCount() > 0 ? { [timeDimKey]: 0 } : {};
+          const extraInitSel = {};
+          for (const dim of extraDims) extraInitSel[dim.key] = 0;
+          const selector = {
+            ...(timeStepCount() > 0 ? { [timeDimKey]: 0 } : {}),
+            ...extraInitSel,
+          };
           activeLayer = new ZarrLayer({
             id: "zarr-layer",
             source: zarr.href,
@@ -491,7 +571,6 @@
           return;
         }
 
-
         // Time slider.
         if (timeStepCount() > 1) {
           timeSlider.max = timeStepCount() - 1;
@@ -499,6 +578,11 @@
           timeValueEl.textContent = timeStepAt(0);
           timeCountEl.textContent = `1 / ${timeStepCount()}`;
           timeSection.classList.remove("hidden");
+        }
+
+        // Extra dimension sliders (ensemble_member, lead_time, etc.).
+        if (extraDims.length > 0) {
+          renderExtraDimSliders(extraDims);
         }
 
         // Metadata strip.
@@ -531,12 +615,8 @@
         const i = parseInt(e.target.value, 10);
         timeValueEl.textContent = timeStepAt(i) ?? "—";
         timeCountEl.textContent = `${i + 1} / ${timeStepCount()}`;
-        const layer = activeLayer;
-        const dimKey = timeDimKey;
         clearTimeout(_selectorDebounce);
-        _selectorDebounce = setTimeout(() => {
-          layer?.setSelector({ [dimKey]: i });
-        }, 150);
+        _selectorDebounce = setTimeout(() => updateSelector(), 150);
       });
 
       map.on("load", () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dependencies = [
     "dhis2eo>=1.2.1",
 ]
 
+[project.optional-dependencies]
+forecast = [
+    "icechunk>=0.1.0",
+    "s3fs>=2024.1",
+]
+
 [project.urls]
 Repository = "https://github.com/dhis2/climate-api"
 Documentation = "https://github.com/dhis2/climate-api/tree/main/docs"
@@ -89,7 +95,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac"]
+module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "icechunk"]
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -51,6 +51,25 @@ def _make_gefs_ds() -> xr.Dataset:
     )
 
 
+def _make_gefs_ds_with_lead_time() -> xr.Dataset:
+    """Return a fake GEFS dataset that includes a lead_time dimension (35-day forecast)."""
+    lead_times = pd.to_timedelta(np.arange(0, 841, 6), unit="h")  # 0–840 h in 6-h steps
+    return xr.Dataset(
+        {
+            "precipitation_surface": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                np.ones((3, len(lead_times), 4, 4), dtype="float32"),
+            )
+        },
+        coords={
+            "init_time": pd.date_range("2026-05-01", periods=3, freq="D"),
+            "lead_time": lead_times,
+            "latitude": [10.0, 5.0, 0.0, -5.0],
+            "longitude": [30.0, 35.0, 40.0, 45.0],
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # providers.remote_zarr
 # ---------------------------------------------------------------------------
@@ -175,6 +194,22 @@ def test_register_remote_zarr_artifact_creates_remote_zarr_record(
     assert record.dataset_id == "gefs_precipitation"
     assert record.coverage.temporal.start == "2026-05-01"
     assert record.coverage.temporal.end == "2026-05-03"
+
+
+def test_register_remote_zarr_artifact_extends_end_by_lead_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Temporal end must be last init_time + max lead_time, not just last init_time."""
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds_with_lead_time()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    # last init_time = 2026-05-03, max lead_time = 840 h = 35 days → end = 2026-06-07
+    assert record.coverage.temporal.start == "2026-05-01"
+    assert record.coverage.temporal.end == "2026-06-07"
 
 
 def test_register_remote_zarr_artifact_upserts_on_re_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -272,8 +272,10 @@ def test_zarr_store_info_for_remote_artifact_returns_remote_url(
     assert info["provider"] == "dynamical"
 
 
-def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from fastapi import HTTPException
+def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json as _json
 
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
@@ -287,10 +289,23 @@ def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeyp
     record = services._load_records()[0]
     dataset_id = managed_dataset_id_for(record)
 
-    with pytest.raises(HTTPException) as exc_info:
-        services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+    fake_zarr_json = _json.dumps({"zarr_format": 3, "node_type": "group"}).encode()
 
-    assert exc_info.value.status_code == 501
+    class _FakeBuffer:
+        def as_array_like(self) -> bytes:
+            return fake_zarr_json
+
+    class _FakeStore:
+        async def get(self, key: str, prototype: object) -> _FakeBuffer:  # type: ignore[override]
+            return _FakeBuffer()
+
+    with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=_FakeStore()):
+        response = services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+
+    from fastapi.responses import JSONResponse
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -1,0 +1,337 @@
+"""Tests for remote zarr dataset registration and serving."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from climate_api.data_manager.services.utils import get_time_dim
+from climate_api.data_registry.services import datasets as registry
+from climate_api.ingestions import services
+from climate_api.ingestions.schemas import ArtifactFormat, SyncAction, SyncKind
+from climate_api.ingestions.sync_engine import plan_sync
+from climate_api.providers.remote_zarr import is_remote_source, open_remote_dataset
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_GEFS_STORE: dict[str, Any] = {
+    "kind": "remote_zarr",
+    "provider": "dynamical",
+    "catalog_id": "noaa-gefs-forecast-35-day",
+    "store_url": "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/",
+    "store_format": "icechunk",
+    "storage_options": {"anon": True, "client_kwargs": {"region_name": "us-west-2"}},
+}
+
+_GEFS_DATASET: dict[str, Any] = {
+    "id": "gefs_precipitation",
+    "name": "Total precipitation surface forecast (NOAA GEFS ensemble)",
+    "variable": "precipitation_surface",
+    "period_type": "daily",
+    "sync": {"kind": "remote"},
+    "store": _GEFS_STORE,
+}
+
+
+def _make_gefs_ds() -> xr.Dataset:
+    """Return a minimal fake GEFS dataset with init_time/latitude/longitude dimensions."""
+    return xr.Dataset(
+        {"precipitation_surface": (["init_time", "latitude", "longitude"], np.ones((3, 4, 4), dtype="float32"))},
+        coords={
+            "init_time": pd.date_range("2026-05-01", periods=3, freq="D"),
+            "latitude": [10.0, 5.0, 0.0, -5.0],
+            "longitude": [30.0, 35.0, 40.0, 45.0],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# providers.remote_zarr
+# ---------------------------------------------------------------------------
+
+
+def test_is_remote_source_returns_true_for_remote_zarr_template():
+    assert is_remote_source(_GEFS_DATASET) is True
+
+
+def test_is_remote_source_returns_false_for_ingestion_template():
+    dataset = {
+        "id": "chirps3_precipitation_daily",
+        "ingestion": {"function": "dhis2eo.data.chc.chirps3.daily.download"},
+    }
+    assert is_remote_source(dataset) is False
+
+
+def test_is_remote_source_returns_false_for_missing_source():
+    assert is_remote_source({"id": "foo"}) is False
+
+
+def test_open_remote_dataset_raises_runtime_error_when_icechunk_missing():
+    source = {**_GEFS_STORE, "store_format": "icechunk"}
+    with patch.dict("sys.modules", {"icechunk": None}):
+        with pytest.raises(RuntimeError, match="icechunk"):
+            open_remote_dataset(source)
+
+
+def test_open_remote_dataset_zarr_url_calls_xr_open_zarr():
+    source = {"store_url": "s3://bucket/store.zarr", "store_format": "zarr"}
+    fake_ds = _make_gefs_ds()
+    with patch("xarray.open_zarr", return_value=fake_ds) as mock_open:
+        result = open_remote_dataset(source)
+        mock_open.assert_called_once_with("s3://bucket/store.zarr", consolidated=None)
+        assert result is fake_ds
+
+
+# ---------------------------------------------------------------------------
+# data_manager.services.utils — get_time_dim
+# ---------------------------------------------------------------------------
+
+
+def test_get_time_dim_finds_init_time():
+    ds = _make_gefs_ds()
+    assert get_time_dim(ds) == "init_time"
+
+
+# ---------------------------------------------------------------------------
+# data_registry.services.datasets — template validation
+# ---------------------------------------------------------------------------
+
+
+def test_registry_loads_gefs_template(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: gefs_test
+  name: GEFS test
+  variable: tp
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    store_url: "s3://bucket/store.icechunk/"
+    store_format: icechunk
+"""
+    (tmp_path / "gefs_test.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    datasets = registry.list_datasets()
+    assert any(d["id"] == "gefs_test" for d in datasets)
+
+
+def test_registry_rejects_remote_zarr_without_store_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: bad_remote
+  name: Bad remote
+  variable: tp
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+"""
+    (tmp_path / "bad.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="store_url"):
+        registry.list_datasets()
+
+
+def test_registry_rejects_ingestion_template_without_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: bad_ingestion
+  name: Bad
+  variable: tp
+  period_type: daily
+  sync:
+    kind: temporal
+  ingestion: {}
+"""
+    (tmp_path / "bad.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="ingestion.function"):
+        registry.list_datasets()
+
+
+# ---------------------------------------------------------------------------
+# ingestions.services — _register_remote_zarr_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_register_remote_zarr_artifact_creates_remote_zarr_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    assert record.format == ArtifactFormat.REMOTE_ZARR
+    assert record.path == _GEFS_STORE["store_url"]
+    assert record.dataset_id == "gefs_precipitation"
+    assert record.coverage.temporal.start == "2026-05-01"
+    assert record.coverage.temporal.end == "2026-05-03"
+
+
+def test_register_remote_zarr_artifact_upserts_on_re_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        first = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+        second = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    assert first.artifact_id == second.artifact_id
+    records = services._load_records()
+    assert sum(r.dataset_id == "gefs_precipitation" for r in records) == 1
+
+
+def test_create_artifact_routes_to_remote_zarr_for_remote_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services.create_artifact(
+            dataset=_GEFS_DATASET,
+            start="2026-05-01",
+            end=None,
+            bbox=None,
+            country_code=None,
+            overwrite=False,
+            prefer_zarr=True,
+            publish=False,
+        )
+
+    assert record.format == ArtifactFormat.REMOTE_ZARR
+
+
+# ---------------------------------------------------------------------------
+# ingestions.services — storage exists + zarr serving
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_storage_exists_returns_true_for_remote_zarr():
+    from datetime import UTC, datetime
+
+    from climate_api.ingestions.schemas import (
+        ArtifactCoverage,
+        ArtifactPublication,
+        ArtifactRecord,
+        ArtifactRequestScope,
+        CoverageSpatial,
+        CoverageTemporal,
+    )
+
+    record = ArtifactRecord(
+        artifact_id="abc",
+        dataset_id="gefs_precipitation",
+        dataset_name="GEFS",
+        variable="precipitation_surface",
+        format=ArtifactFormat.REMOTE_ZARR,
+        path="s3://bucket/store.icechunk/",
+        asset_paths=["s3://bucket/store.icechunk/"],
+        variables=["precipitation_surface"],
+        request_scope=ArtifactRequestScope(start="2026-05-01", end="2026-05-03"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-05-01", end="2026-05-03"),
+            spatial=CoverageSpatial(xmin=-180.0, ymin=-90.0, xmax=180.0, ymax=90.0),
+        ),
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+    assert services._artifact_storage_exists(record) is True
+
+
+def test_zarr_store_info_for_remote_artifact_returns_remote_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    from climate_api.publications.services import managed_dataset_id_for
+
+    record = services._load_records()[0]
+    dataset_id = managed_dataset_id_for(record)
+
+    info = services.get_dataset_zarr_store_info_or_404(dataset_id)
+
+    assert info["format"] == ArtifactFormat.REMOTE_ZARR
+    assert info["remote_url"] == _GEFS_STORE["store_url"]
+    assert info["provider"] == "dynamical"
+
+
+def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    from climate_api.publications.services import managed_dataset_id_for
+
+    record = services._load_records()[0]
+    dataset_id = managed_dataset_id_for(record)
+
+    with pytest.raises(HTTPException) as exc_info:
+        services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+
+    assert exc_info.value.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# ingestions.sync_engine — REMOTE sync kind
+# ---------------------------------------------------------------------------
+
+
+def test_plan_sync_remote_always_rematerializes():
+    from datetime import UTC, datetime
+
+    from climate_api.ingestions.schemas import (
+        ArtifactCoverage,
+        ArtifactPublication,
+        ArtifactRecord,
+        ArtifactRequestScope,
+        CoverageSpatial,
+        CoverageTemporal,
+    )
+
+    artifact = ArtifactRecord(
+        artifact_id="abc",
+        dataset_id="gefs_precipitation",
+        dataset_name="GEFS",
+        variable="precipitation_surface",
+        format=ArtifactFormat.REMOTE_ZARR,
+        path="s3://bucket/store.icechunk/",
+        asset_paths=["s3://bucket/store.icechunk/"],
+        variables=["precipitation_surface"],
+        request_scope=ArtifactRequestScope(start="2026-05-01", end="2026-05-03"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-05-01", end="2026-05-03"),
+            spatial=CoverageSpatial(xmin=-180.0, ymin=-90.0, xmax=180.0, ymax=90.0),
+        ),
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+    detail = plan_sync(
+        source_dataset=_GEFS_DATASET,
+        latest_artifact=artifact,
+        requested_end=None,
+    )
+    assert detail.sync_kind == SyncKind.REMOTE
+    assert detail.action == SyncAction.REMATERIALIZE
+    assert detail.reason == "remote_store_refresh"

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -275,7 +275,10 @@ def test_zarr_store_info_for_remote_artifact_returns_remote_url(
 def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import asyncio
     import json as _json
+
+    from starlette.testclient import TestClient
 
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
@@ -296,11 +299,20 @@ def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
             return fake_zarr_json
 
     class _FakeStore:
-        async def get(self, key: str, prototype: object) -> _FakeBuffer:  # type: ignore[override]
+        async def get(self, key: str, prototype: object, byte_range: object = None) -> _FakeBuffer:  # type: ignore[override]
             return _FakeBuffer()
 
-    with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=_FakeStore()):
-        response = services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+    fake_store = _FakeStore()
+
+    async def _run() -> object:
+        from starlette.requests import Request as StarletteRequest
+
+        scope = {"type": "http", "method": "GET", "headers": []}
+        request = StarletteRequest(scope)
+        with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=fake_store):
+            return await services.get_dataset_zarr_store_file_or_404(request, dataset_id, "zarr.json")
+
+    response = asyncio.run(_run())
 
     from fastapi.responses import JSONResponse
 

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -313,8 +313,6 @@ def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
     import asyncio
     import json as _json
 
-    from starlette.testclient import TestClient
-
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
 


### PR DESCRIPTION
## Summary

Proof-of-concept for [issue #125](https://github.com/dhis2/climate-api/issues/125): referencing live remote Zarr/Icechunk stores instead of downloading data locally.

- Adds a `store.kind: remote_zarr` template field as an alternative to `ingestion.function`. No download, no local Zarr build — the remote store is the artifact.
- Ships the first dataset using this pattern: NOAA GEFS 35-day ensemble precipitation forecast, hosted by [dynamical.org](https://dynamical.org/catalog/noaa-gefs-forecast-35-day/) as an anonymously-accessible Icechunk store on S3.
- `POST /ingestions` with `dataset_id: gefs_precipitation` opens the remote store, reads coverage metadata (`init_time` range + spatial extent), and stores an `ArtifactRecord` pointing to the S3 URL — no bytes downloaded.
- `GET /datasets/gefs_precipitation_*` and `GET /zarr/gefs_precipitation_*` work immediately. The Zarr listing returns `remote_url`, `provider`, and `catalog_id` so clients know where to access the store directly.
- `POST /sync/{id}` re-registers the store to refresh coverage (new forecast runs extend `init_time`).
- `GET /zarr/{id}/{path}` returns HTTP 501 — direct file proxying is out of scope for the PoC.
- `icechunk` and `s3fs` added as `[forecast]` optional dependency group; lazy-imported so the package works without them unless a remote dataset is actually opened.

## Breaking changes

None. All existing datasets and endpoints unchanged.

## PoC limitations (noted in #125)

- `/zarr/{id}/{path}` file proxying not implemented (501).
- GEFS has `init_time + lead_time + ensemble_member` dimensions — the data accessor's `get_data()` opens the store but spatial/temporal subsetting for multi-dimensional forecast data is not yet implemented.
- `start` is still a required field in `POST /ingestions` but is ignored for remote datasets (coverage is derived from the store itself).

## Test plan

- [x] 16 new unit tests covering template validation, artifact registration, upsert-on-re-register, storage-exists check, Zarr listing, 501 on file access, and sync planning — all mocked, no network required
- [x] Full suite: 230 passed, 0 regressions
- [x] ruff + mypy + pyright: all clean
- [ ] Manual end-to-end: `POST /ingestions {dataset_id: gefs_precipitation, start: 2026-05-01}` with `icechunk` and `s3fs` installed (requires internet access to S3)