### PR TITLE
feat: derived GEFS forecast artifact (ensemble mean, valid_time)

### DIFF
--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -5,6 +5,8 @@
   period_type: daily
   sync:
     kind: derived
+  ingestion:
+    function: climate_api.processing.gefs.derive_dataset
   store:
     kind: remote_zarr
     provider: dynamical
@@ -30,6 +32,8 @@
   period_type: daily
   sync:
     kind: derived
+  ingestion:
+    function: climate_api.processing.gefs.derive_dataset
   store:
     kind: remote_zarr
     provider: dynamical

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -22,3 +22,28 @@
   display:
     colormap: blues
     range: [0.0, 0.001]
+
+- id: gefs_temperature_2m
+  name: 2 metre temperature forecast (NOAA GEFS ensemble)
+  short_name: Temperature forecast (GEFS)
+  variable: temperature_2m
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
+  units: "°C"
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: rdbu_r
+    range: [-30.0, 30.0]

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -7,6 +7,8 @@
     kind: derived
   ingestion:
     function: climate_api.processing.gefs.derive_dataset
+  transforms:
+    - function: climate_api.transforms.unit_conversion.flux_to_mm_per_day
   store:
     kind: remote_zarr
     provider: dynamical
@@ -17,13 +19,13 @@
       anon: true
       client_kwargs:
         region_name: us-west-2
-  units: "kg m-2 s-1"
+  units: "mm/day"
   resolution: 25 km x 25 km (0.25°)
   source: "NOAA GEFS (via dynamical.org)"
   source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
   display:
     colormap: blues
-    range: [0.0, 0.001]
+    range: [0, 25]
 
 - id: gefs_temperature_2m_forecast
   name: 2 metre temperature forecast — ensemble mean (NOAA GEFS)

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -47,3 +47,35 @@
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
+
+- id: gefs_precipitation_forecast
+  name: Precipitation forecast — ensemble mean (NOAA GEFS)
+  short_name: Precipitation forecast
+  variable: precipitation_surface
+  period_type: daily
+  sync:
+    kind: derived
+    source_dataset_id: gefs_precipitation
+  units: "kg m-2 s-1"
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: blues
+    range: [0.0, 0.001]
+
+- id: gefs_temperature_2m_forecast
+  name: 2 metre temperature forecast — ensemble mean (NOAA GEFS)
+  short_name: Temperature forecast
+  variable: temperature_2m
+  period_type: daily
+  sync:
+    kind: derived
+    source_dataset_id: gefs_temperature_2m
+  units: "°C"
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: rdbu_r
+    range: [-30.0, 30.0]

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -1,53 +1,3 @@
-- id: gefs_precipitation
-  name: Total precipitation surface forecast (NOAA GEFS ensemble)
-  short_name: Precipitation forecast (GEFS)
-  variable: precipitation_surface
-  period_type: daily
-  sync:
-    kind: remote
-  store:
-    kind: remote_zarr
-    provider: dynamical
-    catalog_id: noaa-gefs-forecast-35-day
-    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
-    store_format: icechunk
-    storage_options:
-      anon: true
-      client_kwargs:
-        region_name: us-west-2
-  units: "kg m-2 s-1"
-  resolution: 25 km x 25 km (0.25°)
-  source: "NOAA GEFS (via dynamical.org)"
-  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
-  display:
-    colormap: blues
-    range: [0.0, 0.001]
-
-- id: gefs_temperature_2m
-  name: 2 metre temperature forecast (NOAA GEFS ensemble)
-  short_name: Temperature forecast (GEFS)
-  variable: temperature_2m
-  period_type: daily
-  sync:
-    kind: remote
-  store:
-    kind: remote_zarr
-    provider: dynamical
-    catalog_id: noaa-gefs-forecast-35-day
-    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
-    store_format: icechunk
-    storage_options:
-      anon: true
-      client_kwargs:
-        region_name: us-west-2
-  units: "°C"
-  resolution: 25 km x 25 km (0.25°)
-  source: "NOAA GEFS (via dynamical.org)"
-  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
-  display:
-    colormap: rdbu_r
-    range: [-30.0, 30.0]
-
 - id: gefs_precipitation_forecast
   name: Precipitation forecast — ensemble mean (NOAA GEFS)
   short_name: Precipitation forecast
@@ -55,7 +5,16 @@
   period_type: daily
   sync:
     kind: derived
-    source_dataset_id: gefs_precipitation
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
   units: "kg m-2 s-1"
   resolution: 25 km x 25 km (0.25°)
   source: "NOAA GEFS (via dynamical.org)"
@@ -71,7 +30,16 @@
   period_type: daily
   sync:
     kind: derived
-    source_dataset_id: gefs_temperature_2m
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
   units: "°C"
   resolution: 25 km x 25 km (0.25°)
   source: "NOAA GEFS (via dynamical.org)"

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -1,0 +1,25 @@
+- id: gefs_precipitation
+  name: Total precipitation surface forecast (NOAA GEFS ensemble)
+  short_name: Precipitation forecast (GEFS)
+  variable: precipitation_surface
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    provider: dynamical
+    catalog_id: noaa-gefs-forecast-35-day
+    store_url: "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/"
+    store_format: icechunk
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-west-2
+  units: m
+  resolution: 25 km x 25 km (0.25°)
+  source: "NOAA GEFS (via dynamical.org)"
+  source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
+  display:
+    colormap: blues
+    range: [0.0, 0.05]
+    nodata: null

--- a/climate_api/data/datasets/gefs.yaml
+++ b/climate_api/data/datasets/gefs.yaml
@@ -15,11 +15,10 @@
       anon: true
       client_kwargs:
         region_name: us-west-2
-  units: m
+  units: "kg m-2 s-1"
   resolution: 25 km x 25 km (0.25°)
   source: "NOAA GEFS (via dynamical.org)"
   source_url: "https://dynamical.org/catalog/noaa-gefs-forecast-35-day/"
   display:
     colormap: blues
-    range: [0.0, 0.05]
-    nodata: null
+    range: [0.0, 0.001]

--- a/climate_api/data_accessor/services/accessor.py
+++ b/climate_api/data_accessor/services/accessor.py
@@ -23,22 +23,28 @@ def get_data(
     bbox: list[float] | None = None,
 ) -> xr.Dataset:
     """Load an xarray raster dataset for a given time range and bbox."""
+    from climate_api.providers.remote_zarr import is_remote_source, open_remote_dataset
+
     logger.info("Opening dataset")
-    zarr_path = get_zarr_path(dataset)
-    if zarr_path:
-        logger.info(f"Using optimized zarr file: {zarr_path}")
-        ds = open_zarr_dataset(str(zarr_path))
+    if is_remote_source(dataset):
+        logger.info("Opening remote zarr store for dataset '%s'", dataset["id"])
+        ds = open_remote_dataset(dataset["store"])
     else:
-        logger.warning(
-            f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
-        )
-        files = get_cache_files(dataset)
-        ds = xr.open_mfdataset(
-            files,
-            data_vars="minimal",
-            coords="minimal",  # pyright: ignore[reportArgumentType]
-            compat="override",
-        )
+        zarr_path = get_zarr_path(dataset)
+        if zarr_path:
+            logger.info(f"Using optimized zarr file: {zarr_path}")
+            ds = open_zarr_dataset(str(zarr_path))
+        else:
+            logger.warning(
+                f"Could not find optimized zarr file for dataset {dataset['id']}, using slower netcdf files instead."
+            )
+            files = get_cache_files(dataset)
+            ds = xr.open_mfdataset(
+                files,
+                data_vars="minimal",
+                coords="minimal",  # pyright: ignore[reportArgumentType]
+                compat="override",
+            )
 
     if start and end:
         logger.info(f"Subsetting time to {start} and {end}")

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -5,6 +5,11 @@ from typing import Any
 
 def get_time_dim(ds: Any) -> str:
     """Return the name of the time dimension in a dataset or dataframe."""
+    actual_dims: set[str] = set(getattr(ds, "dims", {}) or {})
+    for time_name in ["valid_time", "init_time", "time"]:
+        if time_name in actual_dims:
+            return time_name
+    # Fallback for non-xarray objects (e.g. DataFrames) that don't have dims
     for time_name in ["valid_time", "init_time", "time"]:
         if hasattr(ds, time_name):
             return time_name

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 
 def get_time_dim(ds: Any) -> str:
     """Return the name of the time dimension in a dataset or dataframe."""
-    for time_name in ["valid_time", "time"]:
+    for time_name in ["valid_time", "init_time", "time"]:
         if hasattr(ds, time_name):
             return time_name
     raise ValueError(f"Unable to find time dimension: {getattr(ds, 'coords', repr(ds))}")

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -153,12 +153,8 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     is_remote_zarr = isinstance(store_block, dict) and store_block.get("kind") == "remote_zarr"
     is_derived = sync_kind == "derived"
 
-    if is_remote_zarr:
+    if is_remote_zarr or is_derived:
         _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
-    elif is_derived:
-        sync_source = sync_block.get("source_dataset_id") if isinstance(sync_block, dict) else None
-        if not isinstance(sync_source, str) or not sync_source:
-            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define sync.source_dataset_id")
     else:
         ingestion = dataset.get("ingestion")
         if not isinstance(ingestion, dict):

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -169,11 +169,11 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
 
 
 def _validate_remote_zarr_source(source_block: object, *, dataset_id: str, source: str) -> None:
-    """Validate a remote_zarr source block."""
+    """Validate a remote_zarr store block."""
     if not isinstance(source_block, dict):
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} has invalid source block")
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} has invalid store block")
     if not source_block.get("store_url"):
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define source.store_url")
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define store.store_url")
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # When set, only this directory is loaded (no built-ins, no config override).
 CONFIGS_DIR: Path | None = None
 
-SUPPORTED_SYNC_KINDS = {"temporal", "release", "static", "remote"}
+SUPPORTED_SYNC_KINDS = {"temporal", "release", "static", "remote", "derived"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
 
@@ -151,9 +151,14 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
 
     store_block = dataset.get("store")
     is_remote_zarr = isinstance(store_block, dict) and store_block.get("kind") == "remote_zarr"
+    is_derived = sync_kind == "derived"
 
     if is_remote_zarr:
         _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
+    elif is_derived:
+        sync_source = sync_block.get("source_dataset_id") if isinstance(sync_block, dict) else None
+        if not isinstance(sync_source, str) or not sync_source:
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define sync.source_dataset_id")
     else:
         ingestion = dataset.get("ingestion")
         if not isinstance(ingestion, dict):

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # When set, only this directory is loaded (no built-ins, no config override).
 CONFIGS_DIR: Path | None = None
 
-SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
+SUPPORTED_SYNC_KINDS = {"temporal", "release", "static", "remote"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
 
@@ -149,16 +149,30 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
                 f"'{sync_execution}'. Supported values: {supported}"
             )
 
-    ingestion = dataset.get("ingestion")
-    if not isinstance(ingestion, dict):
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define an 'ingestion' block")
-    function = ingestion.get("function")
-    if not isinstance(function, str) or not function:
-        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.function")
+    store_block = dataset.get("store")
+    is_remote_zarr = isinstance(store_block, dict) and store_block.get("kind") == "remote_zarr"
+
+    if is_remote_zarr:
+        _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
+    else:
+        ingestion = dataset.get("ingestion")
+        if not isinstance(ingestion, dict):
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define an 'ingestion' block")
+        function = ingestion.get("function")
+        if not isinstance(function, str) or not function:
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.function")
 
     sync_availability = sync_block.get("availability") if isinstance(sync_block, dict) else None
     if sync_availability is not None:
         _validate_sync_availability(sync_availability, dataset_id=dataset_id, source=source)
+
+
+def _validate_remote_zarr_source(source_block: object, *, dataset_id: str, source: str) -> None:
+    """Validate a remote_zarr source block."""
+    if not isinstance(source_block, dict):
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} has invalid source block")
+    if not source_block.get("store_url"):
+        raise ValueError(f"Dataset template '{dataset_id}' in {source} must define source.store_url")
 
 
 def _validate_sync_availability(sync_availability: object, *, dataset_id: str, source: str) -> None:

--- a/climate_api/data_registry/services/datasets.py
+++ b/climate_api/data_registry/services/datasets.py
@@ -153,8 +153,16 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     is_remote_zarr = isinstance(store_block, dict) and store_block.get("kind") == "remote_zarr"
     is_derived = sync_kind == "derived"
 
-    if is_remote_zarr or is_derived:
+    if is_remote_zarr:
         _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
+    elif is_derived:
+        _validate_remote_zarr_source(store_block, dataset_id=dataset_id, source=source)
+        ingestion = dataset.get("ingestion")
+        if not isinstance(ingestion, dict):
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define an 'ingestion' block")
+        function = ingestion.get("function")
+        if not isinstance(function, str) or not function:
+            raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.function")
     else:
         ingestion = dataset.get("ingestion")
         if not isinstance(ingestion, dict):

--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -1,6 +1,6 @@
 """Routes for EO ingestion, datasets, and sync operations."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 from starlette.responses import Response
 
@@ -94,9 +94,11 @@ def get_canonical_zarr_store_info(dataset_id: str) -> dict[str, object]:
 
 
 @zarr_router.api_route("/{dataset_id}/{relative_path:path}", methods=["GET", "HEAD"], response_model=None)
-def get_canonical_zarr_store_file(dataset_id: str, relative_path: str) -> FileResponse | Response | dict[str, object]:
+async def get_canonical_zarr_store_file(
+    request: Request, dataset_id: str, relative_path: str
+) -> FileResponse | Response | dict[str, object]:
     """Serve canonical Zarr store content for a managed dataset."""
-    return services.get_dataset_zarr_store_file_or_404(dataset_id, relative_path)
+    return await services.get_dataset_zarr_store_file_or_404(request, dataset_id, relative_path)
 
 
 @sync_router.post("/{dataset_id}", response_model=SyncResponse)

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -112,7 +112,11 @@ class CreateIngestionRequest(BaseModel):
     """Request payload for creating or updating a managed dataset."""
 
     dataset_id: str = Field(description="Source dataset template id from the Climate API registry.")
-    start: str | None = Field(default=None, description="Start period to ingest. Required for temporal/release datasets; omit for derived and remote datasets.")
+    start: str | None = Field(
+        default=None,
+        description="Start period to ingest. Required for temporal/release datasets; "
+        "omit for derived and remote datasets.",
+    )
     end: str | None = Field(default=None, description="Optional end period to ingest.")
     overwrite: bool = Field(
         default=False,

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -11,6 +11,7 @@ class ArtifactFormat(StrEnum):
 
     ZARR = "zarr"
     NETCDF = "netcdf"
+    REMOTE_ZARR = "remote_zarr"
 
 
 class PublicationStatus(StrEnum):
@@ -26,6 +27,7 @@ class SyncKind(StrEnum):
     TEMPORAL = "temporal"
     RELEASE = "release"
     STATIC = "static"
+    REMOTE = "remote"
 
 
 class SyncAction(StrEnum):

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -28,6 +28,7 @@ class SyncKind(StrEnum):
     RELEASE = "release"
     STATIC = "static"
     REMOTE = "remote"
+    DERIVED = "derived"
 
 
 class SyncAction(StrEnum):

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -112,7 +112,7 @@ class CreateIngestionRequest(BaseModel):
     """Request payload for creating or updating a managed dataset."""
 
     dataset_id: str = Field(description="Source dataset template id from the Climate API registry.")
-    start: str = Field(description="Start period to ingest.")
+    start: str | None = Field(default=None, description="Start period to ingest. Required for temporal/release datasets; omit for derived and remote datasets.")
     end: str | None = Field(default=None, description="Optional end period to ingest.")
     overwrite: bool = Field(
         default=False,

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -320,10 +320,20 @@ def _derive_gefs_artifact(
     finally:
         ds_raw.close()
 
-    coverage_data = get_data_coverage_for_paths(
-        dataset,
-        zarr_path=output_path_str,
-    )
+    # Derived GEFS data is always in WGS84 — use EPSG:4326 explicitly so the
+    # instance CRS (e.g. UTM) is not applied, which would corrupt spatial_wgs84.
+    from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
+
+    ds_written = open_zarr_dataset(output_path_str)
+    try:
+        coverage_data = _coverage_from_dataset(
+            ds=ds_written,
+            period_type=str(dataset["period_type"]),
+            native_crs="EPSG:4326",
+        )
+    finally:
+        ds_written.close()
+
     if not coverage_data.get("has_data", True):
         raise HTTPException(status_code=409, detail="Derived forecast artifact contains no data")
 
@@ -331,7 +341,7 @@ def _derive_gefs_artifact(
     coverage = ArtifactCoverage(
         temporal=CoverageTemporal(**raw_cov["temporal"]),
         spatial=CoverageSpatial(**raw_cov["spatial"]),
-        spatial_wgs84=CoverageSpatial(**raw_cov["spatial_wgs84"]) if raw_cov.get("spatial_wgs84") else None,
+        spatial_wgs84=None,
     )
     request_scope = ArtifactRequestScope(start=coverage.temporal.start, end=coverage.temporal.end)
 
@@ -395,11 +405,11 @@ def create_artifact(
     """Download a dataset, persist it locally, and store artifact metadata."""
     from climate_api.providers.remote_zarr import is_remote_source
 
-    if is_remote_source(dataset):
-        return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
-
     if _is_derived_source(dataset):
         return _derive_gefs_artifact(dataset=dataset, publish=publish)
+
+    if is_remote_source(dataset):
+        return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
 
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -145,6 +145,88 @@ def get_latest_artifact_for_dataset_or_404(dataset_id: str) -> ArtifactRecord:
     return max(artifacts, key=lambda artifact: artifact.created_at)
 
 
+def _register_remote_zarr_artifact(
+    *,
+    dataset: dict[str, object],
+    publish: bool,
+) -> ArtifactRecord:
+    """Register a remote Zarr/Icechunk store as an artifact without downloading anything."""
+    from climate_api.data_accessor.services.accessor import _coverage_from_dataset
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    source = dataset["store"]
+    if not isinstance(source, dict):
+        raise HTTPException(status_code=500, detail=f"Dataset '{dataset['id']}' has invalid store block")
+    store_url = str(source["store_url"])
+
+    logger.info("Opening remote zarr store for dataset '%s': %s", dataset["id"], store_url)
+    ds = open_remote_dataset(source)
+    try:
+        native_crs = api_config.get_crs() or "EPSG:4326"
+        coverage_data = _coverage_from_dataset(
+            ds=ds,
+            period_type=str(dataset["period_type"]),
+            native_crs=native_crs,
+        )
+    finally:
+        ds.close()
+
+    if not coverage_data.get("has_data", True):
+        raise HTTPException(status_code=409, detail="Remote zarr store contains no data")
+
+    raw_coverage = coverage_data["coverage"]
+    coverage = ArtifactCoverage(
+        temporal=CoverageTemporal(**raw_coverage["temporal"]),
+        spatial=CoverageSpatial(**raw_coverage["spatial"]),
+        spatial_wgs84=CoverageSpatial(**raw_coverage["spatial_wgs84"]) if raw_coverage.get("spatial_wgs84") else None,
+    )
+    request_scope = ArtifactRequestScope(start=coverage.temporal.start, end=coverage.temporal.end)
+
+    record = ArtifactRecord(
+        artifact_id=str(uuid4()),
+        dataset_id=str(dataset["id"]),
+        dataset_name=str(dataset["name"]),
+        variable=str(dataset["variable"]),
+        format=ArtifactFormat.REMOTE_ZARR,
+        path=store_url,
+        asset_paths=[store_url],
+        variables=[str(dataset["variable"])],
+        request_scope=request_scope,
+        coverage=coverage,
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+
+    stored_record = _upsert_remote_zarr_record(record, publish=publish)
+    logger.info(
+        "Registered remote zarr artifact '%s' for dataset '%s': coverage=%s..%s",
+        stored_record.artifact_id,
+        dataset["id"],
+        stored_record.coverage.temporal.start,
+        stored_record.coverage.temporal.end,
+    )
+    if publish and stored_record.publication.status != PublicationStatus.PUBLISHED:
+        return publish_artifact_record(stored_record.artifact_id)
+    return stored_record
+
+
+def _upsert_remote_zarr_record(record: ArtifactRecord, *, publish: bool) -> ArtifactRecord:
+    """Replace any existing remote zarr record for the same dataset, or insert a new one."""
+
+    def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
+        for index, existing in enumerate(records):
+            if existing.dataset_id == record.dataset_id and existing.format == ArtifactFormat.REMOTE_ZARR:
+                replacement = record.model_copy(
+                    update={"artifact_id": existing.artifact_id, "publication": existing.publication}
+                )
+                records[index] = replacement
+                return replacement
+        records.append(record)
+        return record
+
+    return _mutate_records(mutate)
+
+
 def create_artifact(
     *,
     dataset: dict[str, object],
@@ -159,6 +241,11 @@ def create_artifact(
     download_end: str | None = None,
 ) -> ArtifactRecord:
     """Download a dataset, persist it locally, and store artifact metadata."""
+    from climate_api.providers.remote_zarr import is_remote_source
+
+    if is_remote_source(dataset):
+        return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
+
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
@@ -444,8 +531,11 @@ def plan_sync_dataset(
 def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     """Return a public Zarr store listing for a managed dataset."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
-    store_root = _get_zarr_root_or_409(artifact)
 
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        return _remote_zarr_store_info(dataset_id, artifact)
+
+    store_root = _get_zarr_root_or_409(artifact)
     entries = _zarr_entries(dataset_id=dataset_id, store_root=store_root, directory=store_root)
     store_attrs = _read_zarr_attrs(store_root)
     store_crs = store_attrs.get("proj:code") if store_attrs else None
@@ -459,6 +549,33 @@ def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
         "proj4": _crs_to_proj4(crs),
         "bounds": _read_zarr_bounds(store_attrs),
         "entries": entries,
+    }
+
+
+def _remote_zarr_store_info(dataset_id: str, artifact: ArtifactRecord) -> dict[str, object]:
+    """Return store metadata for a remote zarr artifact."""
+    source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
+    raw_store = source_dataset.get("store", {})
+    store: dict[str, object] = raw_store if isinstance(raw_store, dict) else {}
+    crs = "EPSG:4326"
+    coverage = artifact.coverage
+    return {
+        "kind": "ZarrListing",
+        "dataset_id": dataset_id,
+        "format": artifact.format,
+        "path": ".",
+        "crs": crs,
+        "proj4": _crs_to_proj4(crs),
+        "bounds": [
+            coverage.spatial.xmin,
+            coverage.spatial.ymin,
+            coverage.spatial.xmax,
+            coverage.spatial.ymax,
+        ],
+        "remote_url": artifact.path,
+        "provider": store.get("provider"),
+        "catalog_id": store.get("catalog_id"),
+        "entries": [],
     }
 
 
@@ -513,6 +630,14 @@ def get_dataset_zarr_store_file_or_404(
 ) -> FileResponse | Response | dict[str, object]:
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"Direct file access for remote zarr dataset '{dataset_id}' is not supported. "
+                f"Access the store directly at: {artifact.path}"
+            ),
+        )
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -792,7 +917,9 @@ def _materialized_records(records: list[ArtifactRecord]) -> list[ArtifactRecord]
 
 
 def _artifact_storage_exists(record: ArtifactRecord) -> bool:
-    """Return whether an artifact's on-disk backing files are still present."""
+    """Return whether an artifact's backing storage is still accessible."""
+    if record.format == ArtifactFormat.REMOTE_ZARR:
+        return True
     paths: list[str] = []
     if record.path is not None:
         paths.append(record.path)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -659,7 +659,7 @@ async def _proxy_remote_zarr_file(
     from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
-    from climate_api.providers.remote_zarr import get_icechunk_key_size, open_icechunk_store
+    from climate_api.providers.remote_zarr import _store_cache, get_icechunk_key_size, open_icechunk_store
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
     store_config = source_dataset.get("store")
@@ -671,8 +671,9 @@ async def _proxy_remote_zarr_file(
         )
     store_url: str = store_config.get("store_url", "")
     try:
-        # open_icechunk_store is cached after the first call — fast dict lookup after warmup.
-        store = await asyncio.to_thread(open_icechunk_store, store_config)
+        # Fast path: store already cached — just a dict lookup, no thread needed.
+        # Cold path: open_icechunk_store makes blocking S3 calls, so run in a thread.
+        store = _store_cache.get(store_url) or await asyncio.to_thread(open_icechunk_store, store_config)
     except Exception as exc:
         logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
         raise HTTPException(

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -314,6 +314,8 @@ def _derive_gefs_artifact(
         output_path_str = str(output_path.resolve())
         output_path.parent.mkdir(parents=True, exist_ok=True)
         logger.info("Writing derived forecast zarr to '%s'", output_path_str)
+        # Ensure ascending lat/lon order (GEFS raw store is lat-descending).
+        ds_daily = ds_daily.sortby(["latitude", "longitude"])
         # Resampling produces irregular dask chunks; rechunk to uniform before writing.
         ds_daily = ds_daily.chunk({"time": 10, "latitude": -1, "longitude": -1})
         ds_daily.to_zarr(output_path, mode="w", consolidated=True)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -315,9 +315,13 @@ def _derive_artifact(
         ds_pre = open_zarr_dataset(output_path_str)
         try:
             ds_transformed = _run_transforms(ds_pre, dataset)
-            ds_transformed.to_zarr(output_path, mode="w", consolidated=True)
+            # Load into memory before closing — writing to the same path we are
+            # reading from while the store is still open would truncate the source
+            # and produce all-zero reads.
+            ds_transformed.load()
         finally:
             ds_pre.close()
+        ds_transformed.to_zarr(output_path, mode="w", consolidated=True)
 
     # Use store.crs when declared; fall back to EPSG:4326 for the common case of
     # WGS84 remote stores (dynamical.org, ARCO-ERA5, etc.).

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -310,9 +310,8 @@ def _derive_artifact(
 
     output_path_str = str(output_path.resolve())
 
-    from geozarr_toolkit import create_geozarr_attrs
-
     import zarr as _zarr
+    from geozarr_toolkit import create_geozarr_attrs
 
     from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
     from climate_api.data_manager.services.downloader import _run_transforms
@@ -445,9 +444,11 @@ def create_artifact(
         return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
 
     if start is None:
+        sync = dataset.get("sync")
+        sync_kind = sync.get("kind") if isinstance(sync, dict) else None
         raise HTTPException(
             status_code=422,
-            detail=f"'start' is required for dataset '{dataset['id']}' (sync kind: {dataset.get('sync', {}).get('kind')})",
+            detail=f"'start' is required for dataset '{dataset['id']}' (sync kind: {sync_kind})",
         )
 
     period_type = str(dataset["period_type"])

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -266,35 +266,18 @@ def _derive_gefs_artifact(
     """
     import pandas as pd
 
-    sync_block = dataset.get("sync")
-    source_dataset_id = str(sync_block.get("source_dataset_id", "") if isinstance(sync_block, dict) else "")
-    if not source_dataset_id:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Dataset '{dataset['id']}' is missing sync.source_dataset_id",
-        )
-    source_template = registry_datasets.get_dataset(source_dataset_id)
-    if source_template is None:
-        raise HTTPException(
-            status_code=409,
-            detail=(f"Source dataset '{source_dataset_id}' not found. Register it before deriving '{dataset['id']}'."),
-        )
-    source_store = source_template.get("store")
+    source_store = dataset.get("store")
     if not isinstance(source_store, dict):
         raise HTTPException(
             status_code=500,
-            detail=f"Source dataset '{source_dataset_id}' has no store block",
+            detail=f"Dataset '{dataset['id']}' is missing a store block",
         )
 
     from climate_api.providers.remote_zarr import open_remote_dataset
 
     variable = str(dataset["variable"])
 
-    logger.info(
-        "Deriving forecast artifact for '%s' from remote source '%s'",
-        dataset["id"],
-        source_dataset_id,
-    )
+    logger.info("Deriving forecast artifact for '%s'", dataset["id"])
 
     ds_raw = open_remote_dataset(source_store)
     try:
@@ -331,6 +314,8 @@ def _derive_gefs_artifact(
         output_path_str = str(output_path.resolve())
         output_path.parent.mkdir(parents=True, exist_ok=True)
         logger.info("Writing derived forecast zarr to '%s'", output_path_str)
+        # Resampling produces irregular dask chunks; rechunk to uniform before writing.
+        ds_daily = ds_daily.chunk({"time": 10, "latitude": -1, "longitude": -1})
         ds_daily.to_zarr(output_path, mode="w", consolidated=True)
     finally:
         ds_raw.close()

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -162,11 +162,12 @@ def _register_remote_zarr_artifact(
     logger.info("Opening remote zarr store for dataset '%s': %s", dataset["id"], store_url)
     ds = open_remote_dataset(source)
     try:
-        native_crs = api_config.get_crs() or "EPSG:4326"
+        # Remote datasets carry their own CRS (always WGS84 for dynamical.org stores).
+        # Do not use the instance CRS here — that applies only to locally ingested data.
         coverage_data = _coverage_from_dataset(
             ds=ds,
             period_type=str(dataset["period_type"]),
-            native_crs=native_crs,
+            native_crs="EPSG:4326",
         )
     finally:
         ds.close()

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -9,7 +9,12 @@ import os
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import xarray as xr
 
 import portalocker
 import pyproj
@@ -250,7 +255,7 @@ def _is_derived_source(dataset: dict[str, object]) -> bool:
     return isinstance(sync, dict) and sync.get("kind") == "derived"
 
 
-def _most_recent_complete_init(ds_raw: object, *, variable: str) -> object:
+def _most_recent_complete_init(ds_raw: xr.Dataset, *, variable: str) -> pd.Timestamp:
     """Return the most recent init_time that has a complete forecast.
 
     The latest run is often still being distributed and has NaN placeholders
@@ -336,8 +341,8 @@ def _derive_gefs_artifact(
         # Drop trailing time steps that are entirely NaN — these are unpublished
         # lead_times that exist as placeholders in the icechunk store but have no
         # actual forecast data yet (the run is still being distributed).
-        valid_mask = ds_daily[variable].isnull().all(dim=["latitude", "longitude"]).compute()
-        first_all_nan = int(valid_mask.argmax().item()) if bool(valid_mask.any().item()) else len(valid_mask)
+        valid_mask: xr.DataArray = ds_daily[variable].isnull().all(dim=["latitude", "longitude"]).compute()
+        first_all_nan = int(valid_mask.argmax().item()) if bool(valid_mask.any().item()) else len(valid_mask)  # type: ignore[union-attr]
         if first_all_nan < len(valid_mask):
             ds_daily = ds_daily.isel(time=slice(None, first_all_nan))
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -9,12 +9,7 @@ import os
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 from uuid import uuid4
-
-if TYPE_CHECKING:
-    import pandas as pd
-    import xarray as xr
 
 import portalocker
 import pyproj
@@ -255,110 +250,59 @@ def _is_derived_source(dataset: dict[str, object]) -> bool:
     return isinstance(sync, dict) and sync.get("kind") == "derived"
 
 
-def _most_recent_complete_init(ds_raw: xr.Dataset, *, variable: str) -> pd.Timestamp:
-    """Return the most recent init_time that has a complete forecast.
-
-    The latest run is often still being distributed and has NaN placeholders
-    at the longer lead_times.  Walk backwards through the last 5 init_times
-    and return the first one whose final lead_time is non-NaN.
-    """
-    import numpy as np
-    import pandas as pd
-
-    init_times = sorted(ds_raw.init_time.values, reverse=True)
-    for candidate in init_times[:5]:
-        t = pd.Timestamp(candidate)
-        sel_kwargs: dict[str, object] = {"init_time": t, "lead_time": ds_raw.lead_time.values[-1]}
-        if "ensemble_member" in ds_raw[variable].dims:
-            sel_kwargs["ensemble_member"] = ds_raw.ensemble_member.values[0]
-        test_val = ds_raw[variable].sel(sel_kwargs).isel(latitude=0, longitude=0).values
-        if not np.isnan(float(test_val)):
-            return t
-    return pd.Timestamp(init_times[0])
-
-
-def _derive_gefs_artifact(
+def _derive_artifact(
     *,
     dataset: dict[str, object],
     publish: bool,
 ) -> ArtifactRecord:
-    """Derive a local zarr artifact from the latest GEFS remote store run.
+    """Derive a local zarr artifact by calling the template's ingestion.function.
 
-    Selects the most recent init_time, averages over ensemble members (if
-    present), maps lead_time → valid_time, subsets to the configured instance
-    extent, resamples 6-hourly steps to daily mean, and writes a standard
-    flat zarr.  The result is registered as a normal ZARR artifact so all
-    existing serving infrastructure (ZarrLayer, pygeoapi, time slider) works
-    without special-casing.
+    The function is resolved from the dotted path in ``ingestion.function`` and
+    called with a standard keyword-only contract:
+
+        derive_fn(
+            *,
+            store_config: dict,       # the template's ``store`` block
+            output_path: Path,        # where to write the zarr
+            extent: dict | None,      # configured instance spatial extent
+            variable: str,            # primary variable name
+            period_type: str,         # e.g. "daily"
+        ) -> None
+
+    After the function returns, the service reads back the zarr to compute
+    coverage and registers the artifact.  The built-in implementation for GEFS
+    is ``climate_api.processing.gefs.derive_dataset``.
     """
-    import pandas as pd
+    from climate_api.data_manager.services.downloader import _get_dynamic_function
 
+    ingestion = dataset.get("ingestion")
+    if not isinstance(ingestion, dict) or not ingestion.get("function"):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Dataset '{dataset['id']}' derived template must define ingestion.function",
+        )
     source_store = dataset.get("store")
     if not isinstance(source_store, dict):
         raise HTTPException(
             status_code=500,
-            detail=f"Dataset '{dataset['id']}' is missing a store block",
+            detail=f"Dataset '{dataset['id']}' derived template must define a store block",
         )
-
-    from climate_api.providers.remote_zarr import open_remote_dataset
 
     variable = str(dataset["variable"])
+    output_path = ARTIFACTS_DIR / f"{dataset['id']}.zarr"
 
-    logger.info("Deriving forecast artifact for '%s'", dataset["id"])
+    derive_fn = _get_dynamic_function(str(ingestion["function"]))
+    logger.info("Deriving artifact for '%s' via %s", dataset["id"], ingestion["function"])
+    derive_fn(
+        store_config=source_store,
+        output_path=output_path,
+        extent=get_extent(),
+        variable=variable,
+        period_type=str(dataset["period_type"]),
+    )
 
-    ds_raw = open_remote_dataset(source_store)
-    try:
-        latest_init = _most_recent_complete_init(ds_raw, variable=variable)
-        logger.info("Selected init_time %s for '%s'", latest_init.date(), dataset["id"])
-        ds_run = ds_raw[[variable]].sel(init_time=latest_init)
-
-        if "ensemble_member" in ds_run.dims:
-            ds_run = ds_run.mean(dim="ensemble_member")
-
-        valid_times = latest_init + pd.to_timedelta(ds_run.lead_time.values)
-        ds_run = (
-            ds_run.assign_coords(time=("lead_time", valid_times.values))
-            .swap_dims({"lead_time": "time"})
-            .drop_vars("lead_time", errors="ignore")
-        )
-        # Drop 2-D auxiliary coords (e.g. valid_time indexed by init_time×lead_time)
-        # that become meaningless after selecting a single init_time.
-        aux = [c for c in ds_run.coords if c not in ds_run.dims and c != variable]
-        if aux:
-            ds_run = ds_run.drop_vars(aux, errors="ignore")
-
-        extent = get_extent()
-        if extent is not None:
-            xmin, ymin, xmax, ymax = extent["bbox"]
-            lat = ds_run.latitude
-            if float(lat.values[0]) > float(lat.values[-1]):
-                ds_run = ds_run.sel(latitude=slice(ymax, ymin), longitude=slice(xmin, xmax))
-            else:
-                ds_run = ds_run.sel(latitude=slice(ymin, ymax), longitude=slice(xmin, xmax))
-
-        ds_daily = ds_run.resample(time="1D").mean()
-
-        # Drop trailing time steps that are entirely NaN — these are unpublished
-        # lead_times that exist as placeholders in the icechunk store but have no
-        # actual forecast data yet (the run is still being distributed).
-        valid_mask: xr.DataArray = ds_daily[variable].isnull().all(dim=["latitude", "longitude"]).compute()
-        first_all_nan = int(valid_mask.argmax().item()) if bool(valid_mask.any().item()) else len(valid_mask)  # type: ignore[union-attr]
-        if first_all_nan < len(valid_mask):
-            ds_daily = ds_daily.isel(time=slice(None, first_all_nan))
-
-        output_path = ARTIFACTS_DIR / f"{dataset['id']}.zarr"
-        output_path_str = str(output_path.resolve())
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info("Writing derived forecast zarr to '%s'", output_path_str)
-        # Ensure ascending lat/lon order (GEFS raw store is lat-descending).
-        ds_daily = ds_daily.sortby(["latitude", "longitude"])
-        # Resampling produces irregular dask chunks; rechunk to uniform before writing.
-        ds_daily = ds_daily.chunk({"time": 10, "latitude": -1, "longitude": -1})
-        ds_daily.to_zarr(output_path, mode="w", consolidated=True)
-    finally:
-        ds_raw.close()
-
-    # Derived GEFS data is always in WGS84 — use EPSG:4326 explicitly so the
+    output_path_str = str(output_path.resolve())
+    # Derived forecast data is WGS84-native — pass native_crs explicitly so the
     # instance CRS (e.g. UTM) is not applied, which would corrupt spatial_wgs84.
     from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
 
@@ -444,7 +388,7 @@ def create_artifact(
     from climate_api.providers.remote_zarr import is_remote_source
 
     if _is_derived_source(dataset):
-        return _derive_gefs_artifact(dataset=dataset, publish=publish)
+        return _derive_artifact(dataset=dataset, publish=publish)
 
     if is_remote_source(dataset):
         return _register_remote_zarr_artifact(dataset=dataset, publish=publish)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import portalocker
 import pyproj
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 from starlette.responses import Response
 
@@ -626,13 +626,13 @@ def _read_zarr_bounds(store_attrs: dict[str, object] | None) -> list[float] | No
     return [xmin, ymin, xmax, ymax]
 
 
-def get_dataset_zarr_store_file_or_404(
-    dataset_id: str, relative_path: str
+async def get_dataset_zarr_store_file_or_404(
+    request: Request, dataset_id: str, relative_path: str
 ) -> FileResponse | Response | dict[str, object]:
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.REMOTE_ZARR:
-        return _proxy_remote_zarr_file(artifact, relative_path)
+        return await _proxy_remote_zarr_file(request, artifact, relative_path)
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -648,13 +648,15 @@ def get_dataset_zarr_store_file_or_404(
     return FileResponse(target, media_type=media_type, filename=target.name)
 
 
-def _proxy_remote_zarr_file(
+async def _proxy_remote_zarr_file(
+    request: Request,
     artifact: ArtifactRecord,
     relative_path: str,
 ) -> Response | JSONResponse:
-    """Proxy a zarr v3 key from the underlying icechunk store."""
+    """Proxy a zarr v3 key from the underlying icechunk store, with HTTP Range support."""
     import asyncio
 
+    from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
     from climate_api.providers.remote_zarr import open_icechunk_store
@@ -668,8 +670,53 @@ def _proxy_remote_zarr_file(
             f"Access the store at: {artifact.path}",
         )
     try:
-        store = open_icechunk_store(store_config)
-        buf = asyncio.run(store.get(relative_path, default_buffer_prototype()))
+        store = await asyncio.to_thread(open_icechunk_store, store_config)
+    except Exception as exc:
+        logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for dataset '{artifact.dataset_id}' is temporarily unavailable",
+        ) from exc
+
+    # HEAD: return object size without downloading content.
+    if request.method == "HEAD":
+        try:
+            size = await store.getsize(relative_path)
+        except Exception:
+            size = 0
+        return Response(
+            status_code=200,
+            headers={"Content-Length": str(size), "Accept-Ranges": "bytes"},
+            media_type="application/octet-stream",
+        )
+
+    # Parse HTTP Range header into a zarr ByteRequest.
+    byte_request = None
+    content_range: str | None = None
+    range_header = request.headers.get("range", "")
+    if range_header.startswith("bytes="):
+        spec = range_header[6:]
+        if spec.startswith("-"):
+            # Suffix form: bytes=-N  (last N bytes)
+            suffix = int(spec[1:])
+            byte_request = SuffixByteRequest(suffix=suffix)
+            total = await store.getsize(relative_path)
+            content_range = f"bytes {total - suffix}-{total - 1}/{total}"
+        elif "-" in spec:
+            parts = spec.split("-", 1)
+            start = int(parts[0])
+            if parts[1]:
+                end_inc = int(parts[1])
+                byte_request = RangeByteRequest(start=start, end=end_inc + 1)
+                content_range = f"bytes {start}-{end_inc}/*"
+            else:
+                # Open-ended: bytes=start-
+                byte_request = RangeByteRequest(start=start, end=None)
+                total = await store.getsize(relative_path)
+                content_range = f"bytes {start}-{total - 1}/{total}"
+
+    try:
+        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
     except Exception as exc:
@@ -683,9 +730,17 @@ def _proxy_remote_zarr_file(
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
 
     data: bytes = bytes(buf.as_array_like())
+
+    if content_range:
+        return Response(
+            content=data,
+            status_code=206,
+            headers={"Accept-Ranges": "bytes", "Content-Range": content_range},
+            media_type="application/octet-stream",
+        )
     if relative_path.endswith(".json"):
-        return JSONResponse(content=json.loads(data))
-    return Response(content=data, media_type="application/octet-stream")
+        return JSONResponse(content=json.loads(data), headers={"Accept-Ranges": "bytes"})
+    return Response(content=data, media_type="application/octet-stream", headers={"Accept-Ranges": "bytes"})
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -169,6 +169,23 @@ def _register_remote_zarr_artifact(
             period_type=str(dataset["period_type"]),
             native_crs="EPSG:4326",
         )
+
+        # Forecast datasets have a lead_time dimension — the actual data horizon extends
+        # beyond the last init_time. Extend the temporal end by max lead_time so the
+        # coverage reflects when the latest forecast reaches, not when it was issued.
+        if coverage_data.get("has_data") and "lead_time" in ds.dims:
+            import pandas as pd
+
+            from climate_api.data_manager.services.utils import get_time_dim
+            from climate_api.shared.time import numpy_datetime_to_period_string
+
+            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
+
+            time_dim = get_time_dim(ds)
+            forecast_end = pd.Timestamp(ds[time_dim].max().item()) + pd.Timedelta(ds["lead_time"].max().item())
+            coverage_data["coverage"]["temporal"]["end"] = _period_string_scalar(
+                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))
+            )
     finally:
         ds.close()
 

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -250,6 +250,28 @@ def _is_derived_source(dataset: dict[str, object]) -> bool:
     return isinstance(sync, dict) and sync.get("kind") == "derived"
 
 
+def _most_recent_complete_init(ds_raw: object, *, variable: str) -> object:
+    """Return the most recent init_time that has a complete forecast.
+
+    The latest run is often still being distributed and has NaN placeholders
+    at the longer lead_times.  Walk backwards through the last 5 init_times
+    and return the first one whose final lead_time is non-NaN.
+    """
+    import numpy as np
+    import pandas as pd
+
+    init_times = sorted(ds_raw.init_time.values, reverse=True)
+    for candidate in init_times[:5]:
+        t = pd.Timestamp(candidate)
+        sel_kwargs: dict[str, object] = {"init_time": t, "lead_time": ds_raw.lead_time.values[-1]}
+        if "ensemble_member" in ds_raw[variable].dims:
+            sel_kwargs["ensemble_member"] = ds_raw.ensemble_member.values[0]
+        test_val = ds_raw[variable].sel(sel_kwargs).isel(latitude=0, longitude=0).values
+        if not np.isnan(float(test_val)):
+            return t
+    return pd.Timestamp(init_times[0])
+
+
 def _derive_gefs_artifact(
     *,
     dataset: dict[str, object],
@@ -281,7 +303,8 @@ def _derive_gefs_artifact(
 
     ds_raw = open_remote_dataset(source_store)
     try:
-        latest_init = pd.Timestamp(ds_raw.init_time.max().item())
+        latest_init = _most_recent_complete_init(ds_raw, variable=variable)
+        logger.info("Selected init_time %s for '%s'", latest_init.date(), dataset["id"])
         ds_run = ds_raw[[variable]].sel(init_time=latest_init)
 
         if "ensemble_member" in ds_run.dims:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -244,6 +244,156 @@ def _upsert_remote_zarr_record(record: ArtifactRecord, *, publish: bool) -> Arti
     return _mutate_records(mutate)
 
 
+def _is_derived_source(dataset: dict[str, object]) -> bool:
+    """Return True when a dataset template declares a derived sync kind."""
+    sync = dataset.get("sync")
+    return isinstance(sync, dict) and sync.get("kind") == "derived"
+
+
+def _derive_gefs_artifact(
+    *,
+    dataset: dict[str, object],
+    publish: bool,
+) -> ArtifactRecord:
+    """Derive a local zarr artifact from the latest GEFS remote store run.
+
+    Selects the most recent init_time, averages over ensemble members (if
+    present), maps lead_time → valid_time, subsets to the configured instance
+    extent, resamples 6-hourly steps to daily mean, and writes a standard
+    flat zarr.  The result is registered as a normal ZARR artifact so all
+    existing serving infrastructure (ZarrLayer, pygeoapi, time slider) works
+    without special-casing.
+    """
+    import pandas as pd
+
+    sync_block = dataset.get("sync")
+    source_dataset_id = str(sync_block.get("source_dataset_id", "") if isinstance(sync_block, dict) else "")
+    if not source_dataset_id:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Dataset '{dataset['id']}' is missing sync.source_dataset_id",
+        )
+    source_template = registry_datasets.get_dataset(source_dataset_id)
+    if source_template is None:
+        raise HTTPException(
+            status_code=409,
+            detail=(f"Source dataset '{source_dataset_id}' not found. Register it before deriving '{dataset['id']}'."),
+        )
+    source_store = source_template.get("store")
+    if not isinstance(source_store, dict):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Source dataset '{source_dataset_id}' has no store block",
+        )
+
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    variable = str(dataset["variable"])
+
+    logger.info(
+        "Deriving forecast artifact for '%s' from remote source '%s'",
+        dataset["id"],
+        source_dataset_id,
+    )
+
+    ds_raw = open_remote_dataset(source_store)
+    try:
+        latest_init = pd.Timestamp(ds_raw.init_time.max().item())
+        ds_run = ds_raw[[variable]].sel(init_time=latest_init)
+
+        if "ensemble_member" in ds_run.dims:
+            ds_run = ds_run.mean(dim="ensemble_member")
+
+        valid_times = latest_init + pd.to_timedelta(ds_run.lead_time.values)
+        ds_run = (
+            ds_run.assign_coords(time=("lead_time", valid_times.values))
+            .swap_dims({"lead_time": "time"})
+            .drop_vars("lead_time", errors="ignore")
+        )
+        # Drop 2-D auxiliary coords (e.g. valid_time indexed by init_time×lead_time)
+        # that become meaningless after selecting a single init_time.
+        aux = [c for c in ds_run.coords if c not in ds_run.dims and c != variable]
+        if aux:
+            ds_run = ds_run.drop_vars(aux, errors="ignore")
+
+        extent = get_extent()
+        if extent is not None:
+            xmin, ymin, xmax, ymax = extent["bbox"]
+            lat = ds_run.latitude
+            if float(lat.values[0]) > float(lat.values[-1]):
+                ds_run = ds_run.sel(latitude=slice(ymax, ymin), longitude=slice(xmin, xmax))
+            else:
+                ds_run = ds_run.sel(latitude=slice(ymin, ymax), longitude=slice(xmin, xmax))
+
+        ds_daily = ds_run.resample(time="1D").mean()
+
+        output_path = ARTIFACTS_DIR / f"{dataset['id']}.zarr"
+        output_path_str = str(output_path.resolve())
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("Writing derived forecast zarr to '%s'", output_path_str)
+        ds_daily.to_zarr(output_path, mode="w", consolidated=True)
+    finally:
+        ds_raw.close()
+
+    coverage_data = get_data_coverage_for_paths(
+        dataset,
+        zarr_path=output_path_str,
+    )
+    if not coverage_data.get("has_data", True):
+        raise HTTPException(status_code=409, detail="Derived forecast artifact contains no data")
+
+    raw_cov = coverage_data["coverage"]
+    coverage = ArtifactCoverage(
+        temporal=CoverageTemporal(**raw_cov["temporal"]),
+        spatial=CoverageSpatial(**raw_cov["spatial"]),
+        spatial_wgs84=CoverageSpatial(**raw_cov["spatial_wgs84"]) if raw_cov.get("spatial_wgs84") else None,
+    )
+    request_scope = ArtifactRequestScope(start=coverage.temporal.start, end=coverage.temporal.end)
+
+    record = ArtifactRecord(
+        artifact_id=str(uuid4()),
+        dataset_id=str(dataset["id"]),
+        dataset_name=str(dataset["name"]),
+        variable=variable,
+        format=ArtifactFormat.ZARR,
+        path=output_path_str,
+        asset_paths=[output_path_str],
+        variables=[variable],
+        request_scope=request_scope,
+        coverage=coverage,
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+    stored_record = _upsert_derived_record(record)
+    logger.info(
+        "Derived artifact '%s' for dataset '%s': coverage=%s..%s",
+        stored_record.artifact_id,
+        dataset["id"],
+        stored_record.coverage.temporal.start,
+        stored_record.coverage.temporal.end,
+    )
+    if publish and stored_record.publication.status != PublicationStatus.PUBLISHED:
+        return publish_artifact_record(stored_record.artifact_id)
+    return stored_record
+
+
+def _upsert_derived_record(record: ArtifactRecord) -> ArtifactRecord:
+    """Replace any existing derived artifact for the same dataset, or insert a new one."""
+
+    def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
+        for index, existing in enumerate(records):
+            if existing.dataset_id == record.dataset_id and existing.format == ArtifactFormat.ZARR:
+                replacement = record.model_copy(
+                    update={"artifact_id": existing.artifact_id, "publication": existing.publication}
+                )
+                records[index] = replacement
+                return replacement
+        records.append(record)
+        return record
+
+    return _mutate_records(mutate)
+
+
 def create_artifact(
     *,
     dataset: dict[str, object],
@@ -262,6 +412,9 @@ def create_artifact(
 
     if is_remote_source(dataset):
         return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
+
+    if _is_derived_source(dataset):
+        return _derive_gefs_artifact(dataset=dataset, publish=publish)
 
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -659,7 +659,7 @@ async def _proxy_remote_zarr_file(
     from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
-    from climate_api.providers.remote_zarr import open_icechunk_store
+    from climate_api.providers.remote_zarr import get_icechunk_key_size, open_icechunk_store
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
     store_config = source_dataset.get("store")
@@ -669,7 +669,9 @@ async def _proxy_remote_zarr_file(
             detail=f"Direct file access not supported for dataset '{artifact.dataset_id}'. "
             f"Access the store at: {artifact.path}",
         )
+    store_url: str = store_config.get("store_url", "")
     try:
+        # open_icechunk_store is cached after the first call — fast dict lookup after warmup.
         store = await asyncio.to_thread(open_icechunk_store, store_config)
     except Exception as exc:
         logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
@@ -681,7 +683,7 @@ async def _proxy_remote_zarr_file(
     # HEAD: return object size without downloading content.
     if request.method == "HEAD":
         try:
-            size = await store.getsize(relative_path)
+            size = await get_icechunk_key_size(store, relative_path, store_url)
         except Exception:
             size = 0
         return Response(
@@ -700,7 +702,7 @@ async def _proxy_remote_zarr_file(
             # Suffix form: bytes=-N  (last N bytes)
             suffix = int(spec[1:])
             byte_request = SuffixByteRequest(suffix=suffix)
-            total = await store.getsize(relative_path)
+            total = await get_icechunk_key_size(store, relative_path, store_url)
             content_range = f"bytes {total - suffix}-{total - 1}/{total}"
         elif "-" in spec:
             parts = spec.split("-", 1)
@@ -712,7 +714,7 @@ async def _proxy_remote_zarr_file(
             else:
                 # Open-ended: bytes=start-
                 byte_request = RangeByteRequest(start=start, end=None)
-                total = await store.getsize(relative_path)
+                total = await get_icechunk_key_size(store, relative_path, store_url)
                 content_range = f"bytes {start}-{total - 1}/{total}"
 
     try:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -159,15 +159,15 @@ def _register_remote_zarr_artifact(
         raise HTTPException(status_code=500, detail=f"Dataset '{dataset['id']}' has invalid store block")
     store_url = str(source["store_url"])
 
+    # Use store.crs when declared; most public remote stores (dynamical.org, ARCO-ERA5) are WGS84.
+    native_crs: str = str(source.get("crs", "EPSG:4326")) or "EPSG:4326"
     logger.info("Opening remote zarr store for dataset '%s': %s", dataset["id"], store_url)
     ds = open_remote_dataset(source)
     try:
-        # Remote datasets carry their own CRS (always WGS84 for dynamical.org stores).
-        # Do not use the instance CRS here — that applies only to locally ingested data.
         coverage_data = _coverage_from_dataset(
             ds=ds,
             period_type=str(dataset["period_type"]),
-            native_crs="EPSG:4326",
+            native_crs=native_crs,
         )
 
         # Forecast datasets have a lead_time dimension — the actual data horizon extends
@@ -862,7 +862,7 @@ async def _proxy_remote_zarr_file(
     from zarr.abc.store import RangeByteRequest, SuffixByteRequest
     from zarr.core.buffer import default_buffer_prototype
 
-    from climate_api.providers.remote_zarr import _store_cache, get_icechunk_key_size, open_icechunk_store
+    from climate_api.providers.remote_zarr import get_icechunk_key_size, get_store_if_cached, open_icechunk_store
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
     store_config = source_dataset.get("store")
@@ -876,7 +876,7 @@ async def _proxy_remote_zarr_file(
     try:
         # Fast path: store already cached — just a dict lookup, no thread needed.
         # Cold path: open_icechunk_store makes blocking S3 calls, so run in a thread.
-        store = _store_cache.get(store_url) or await asyncio.to_thread(open_icechunk_store, store_config)
+        store = get_store_if_cached(store_url) or await asyncio.to_thread(open_icechunk_store, store_config)
     except Exception as exc:
         logger.warning("Failed to open remote store for '%s': %s", artifact.dataset_id, exc)
         raise HTTPException(
@@ -890,8 +890,12 @@ async def _proxy_remote_zarr_file(
             size = await get_icechunk_key_size(store, relative_path, store_url)
         except KeyError:
             raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
-        except Exception:
-            size = 0
+        except Exception as exc:
+            logger.warning("Failed to get size for zarr key '%s' from remote store: %s", relative_path, exc)
+            raise HTTPException(
+                status_code=503,
+                detail=f"Remote zarr store for dataset '{artifact.dataset_id}' is temporarily unavailable",
+            ) from exc
         return Response(
             status_code=200,
             headers={"Content-Length": str(size), "Accept-Ranges": "bytes"},

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -632,13 +632,7 @@ def get_dataset_zarr_store_file_or_404(
     """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.REMOTE_ZARR:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                f"Direct file access for remote zarr dataset '{dataset_id}' is not supported. "
-                f"Access the store directly at: {artifact.path}"
-            ),
-        )
+        return _proxy_remote_zarr_file(artifact, relative_path)
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)
     if not target.exists():
@@ -652,6 +646,46 @@ def get_dataset_zarr_store_file_or_404(
     if media_type is None:
         media_type = "application/octet-stream"
     return FileResponse(target, media_type=media_type, filename=target.name)
+
+
+def _proxy_remote_zarr_file(
+    artifact: ArtifactRecord,
+    relative_path: str,
+) -> Response | JSONResponse:
+    """Proxy a zarr v3 key from the underlying icechunk store."""
+    import asyncio
+
+    from zarr.core.buffer import default_buffer_prototype
+
+    from climate_api.providers.remote_zarr import open_icechunk_store
+
+    source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
+    store_config = source_dataset.get("store")
+    if not isinstance(store_config, dict) or store_config.get("store_format") != "icechunk":
+        raise HTTPException(
+            status_code=501,
+            detail=f"Direct file access not supported for dataset '{artifact.dataset_id}'. "
+            f"Access the store at: {artifact.path}",
+        )
+    try:
+        store = open_icechunk_store(store_config)
+        buf = asyncio.run(store.get(relative_path, default_buffer_prototype()))
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
+    except Exception as exc:
+        logger.warning("Failed to proxy zarr key '%s' from remote store: %s", relative_path, exc)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for dataset '{artifact.dataset_id}' is temporarily unavailable",
+        ) from exc
+
+    if buf is None:
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
+
+    data: bytes = bytes(buf.as_array_like())
+    if relative_path.endswith(".json"):
+        return JSONResponse(content=json.loads(data))
+    return Response(content=data, media_type="application/octet-stream")
 
 
 def _load_records() -> list[ArtifactRecord]:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -307,13 +307,23 @@ def _derive_artifact(
     )
 
     output_path_str = str(output_path.resolve())
+
+    from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
+    from climate_api.data_manager.services.downloader import _run_transforms
+
+    if dataset.get("transforms"):
+        ds_pre = open_zarr_dataset(output_path_str)
+        try:
+            ds_transformed = _run_transforms(ds_pre, dataset)
+            ds_transformed.to_zarr(output_path, mode="w", consolidated=True)
+        finally:
+            ds_pre.close()
+
     # Use store.crs when declared; fall back to EPSG:4326 for the common case of
     # WGS84 remote stores (dynamical.org, ARCO-ERA5, etc.).
     native_crs: str = str(source_store.get("crs", "EPSG:4326")) or "EPSG:4326"
     wgs84_codes = {"EPSG:4326", "OGC:CRS84", "CRS84"}
     is_wgs84 = native_crs.upper() in {c.upper() for c in wgs84_codes}
-
-    from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
 
     ds_written = open_zarr_dataset(output_path_str)
     try:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -176,15 +176,14 @@ def _register_remote_zarr_artifact(
         if coverage_data.get("has_data") and "lead_time" in ds.dims:
             import pandas as pd
 
+            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
             from climate_api.data_manager.services.utils import get_time_dim
             from climate_api.shared.time import numpy_datetime_to_period_string
-
-            from climate_api.data_accessor.services.accessor import _period_string_scalar  # noqa: PLC0415
 
             time_dim = get_time_dim(ds)
             forecast_end = pd.Timestamp(ds[time_dim].max().item()) + pd.Timedelta(ds["lead_time"].max().item())
             coverage_data["coverage"]["temporal"]["end"] = _period_string_scalar(
-                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))
+                numpy_datetime_to_period_string(forecast_end.to_datetime64(), str(dataset["period_type"]))  # type: ignore[arg-type]
             )
     finally:
         ds.close()
@@ -711,7 +710,7 @@ async def _proxy_remote_zarr_file(
         )
 
     # Parse HTTP Range header into a zarr ByteRequest.
-    byte_request = None
+    byte_request: SuffixByteRequest | RangeByteRequest | None = None
     content_range: str | None = None
     range_header = request.headers.get("range", "")
     if range_header.startswith("bytes="):
@@ -731,12 +730,12 @@ async def _proxy_remote_zarr_file(
                 content_range = f"bytes {start}-{end_inc}/*"
             else:
                 # Open-ended: bytes=start-
-                byte_request = RangeByteRequest(start=start, end=None)
                 total = await get_icechunk_key_size(store, relative_path, store_url)
+                byte_request = RangeByteRequest(start=start, end=total)
                 content_range = f"bytes {start}-{total - 1}/{total}"
 
     try:
-        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)
+        buf = await store.get(relative_path, default_buffer_prototype(), byte_request)  # type: ignore[union-attr]
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
     except Exception as exc:

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -269,9 +269,11 @@ def _derive_artifact(
             period_type: str,         # e.g. "daily"
         ) -> None
 
-    After the function returns, the service reads back the zarr to compute
-    coverage and registers the artifact.  The built-in implementation for GEFS
-    is ``climate_api.processing.gefs.derive_dataset``.
+    After the function returns, the service applies any declared transforms,
+    writes GeoZarr root attributes (``spatial:bbox``, ``proj:code``) so map
+    clients can position tiles, computes coverage, and registers the artifact.
+    The built-in implementation for GEFS is
+    ``climate_api.processing.gefs.derive_dataset``.
 
     CRS: ``store.crs`` in the template overrides the default of ``EPSG:4326``.
     Most public remote stores (dynamical.org, ARCO-ERA5) are WGS84 so the
@@ -308,8 +310,13 @@ def _derive_artifact(
 
     output_path_str = str(output_path.resolve())
 
+    from geozarr_toolkit import create_geozarr_attrs
+
+    import zarr as _zarr
+
     from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
     from climate_api.data_manager.services.downloader import _run_transforms
+    from climate_api.data_manager.services.utils import get_x_y_dims
 
     if dataset.get("transforms"):
         ds_pre = open_zarr_dataset(output_path_str)
@@ -331,6 +338,20 @@ def _derive_artifact(
 
     ds_written = open_zarr_dataset(output_path_str)
     try:
+        x_dim, y_dim = get_x_y_dims(ds_written)
+        bbox = [
+            float(ds_written[x_dim].min()),
+            float(ds_written[y_dim].min()),
+            float(ds_written[x_dim].max()),
+            float(ds_written[y_dim].max()),
+        ]
+        shape = (ds_written.sizes[x_dim], ds_written.sizes[y_dim])
+        geozarr_attrs = create_geozarr_attrs(
+            dimensions=[x_dim, y_dim],
+            crs=native_crs,
+            bbox=bbox,
+            shape=shape,
+        )
         coverage_data = _coverage_from_dataset(
             ds=ds_written,
             period_type=str(dataset["period_type"]),
@@ -338,6 +359,12 @@ def _derive_artifact(
         )
     finally:
         ds_written.close()
+
+    # Write GeoZarr root attrs without touching data chunks, then re-consolidate.
+    # The map viewer reads spatial:bbox and proj:code from these attrs to position tiles.
+    root = _zarr.open_group(str(output_path), mode="r+")
+    root.attrs.update(geozarr_attrs)
+    _zarr.consolidate_metadata(str(output_path))
 
     if not coverage_data.get("has_data", True):
         raise HTTPException(status_code=409, detail="Derived forecast artifact contains no data")
@@ -398,7 +425,7 @@ def _upsert_derived_record(record: ArtifactRecord) -> ArtifactRecord:
 def create_artifact(
     *,
     dataset: dict[str, object],
-    start: str,
+    start: str | None,
     end: str | None,
     bbox: list[float] | None,
     country_code: str | None,
@@ -416,6 +443,12 @@ def create_artifact(
 
     if is_remote_source(dataset):
         return _register_remote_zarr_artifact(dataset=dataset, publish=publish)
+
+    if start is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"'start' is required for dataset '{dataset['id']}' (sync kind: {dataset.get('sync', {}).get('kind')})",
+        )
 
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -310,6 +310,14 @@ def _derive_gefs_artifact(
 
         ds_daily = ds_run.resample(time="1D").mean()
 
+        # Drop trailing time steps that are entirely NaN — these are unpublished
+        # lead_times that exist as placeholders in the icechunk store but have no
+        # actual forecast data yet (the run is still being distributed).
+        valid_mask = ds_daily[variable].isnull().all(dim=["latitude", "longitude"]).compute()
+        first_all_nan = int(valid_mask.argmax().item()) if bool(valid_mask.any().item()) else len(valid_mask)
+        if first_all_nan < len(valid_mask):
+            ds_daily = ds_daily.isel(time=slice(None, first_all_nan))
+
         output_path = ARTIFACTS_DIR / f"{dataset['id']}.zarr"
         output_path_str = str(output_path.resolve())
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -887,6 +887,8 @@ async def _proxy_remote_zarr_file(
     if request.method == "HEAD":
         try:
             size = await get_icechunk_key_size(store, relative_path, store_url)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found in remote store")
         except Exception:
             size = 0
         return Response(
@@ -900,25 +902,28 @@ async def _proxy_remote_zarr_file(
     content_range: str | None = None
     range_header = request.headers.get("range", "")
     if range_header.startswith("bytes="):
-        spec = range_header[6:]
-        if spec.startswith("-"):
-            # Suffix form: bytes=-N  (last N bytes)
-            suffix = int(spec[1:])
-            byte_request = SuffixByteRequest(suffix=suffix)
-            total = await get_icechunk_key_size(store, relative_path, store_url)
-            content_range = f"bytes {total - suffix}-{total - 1}/{total}"
-        elif "-" in spec:
-            parts = spec.split("-", 1)
-            start = int(parts[0])
-            if parts[1]:
-                end_inc = int(parts[1])
-                byte_request = RangeByteRequest(start=start, end=end_inc + 1)
-                content_range = f"bytes {start}-{end_inc}/*"
-            else:
-                # Open-ended: bytes=start-
+        try:
+            spec = range_header[6:]
+            if spec.startswith("-"):
+                # Suffix form: bytes=-N  (last N bytes)
+                suffix = int(spec[1:])
+                byte_request = SuffixByteRequest(suffix=suffix)
                 total = await get_icechunk_key_size(store, relative_path, store_url)
-                byte_request = RangeByteRequest(start=start, end=total)
-                content_range = f"bytes {start}-{total - 1}/{total}"
+                content_range = f"bytes {total - suffix}-{total - 1}/{total}"
+            elif "-" in spec:
+                parts = spec.split("-", 1)
+                start = int(parts[0])
+                if parts[1]:
+                    end_inc = int(parts[1])
+                    byte_request = RangeByteRequest(start=start, end=end_inc + 1)
+                    content_range = f"bytes {start}-{end_inc}/*"
+                else:
+                    # Open-ended: bytes=start-
+                    total = await get_icechunk_key_size(store, relative_path, store_url)
+                    byte_request = RangeByteRequest(start=start, end=total)
+                    content_range = f"bytes {start}-{total - 1}/{total}"
+        except (ValueError, KeyError):
+            raise HTTPException(status_code=416, detail=f"Invalid or unsatisfiable Range header: '{range_header}'")
 
     try:
         buf = await store.get(relative_path, default_buffer_prototype(), byte_request)  # type: ignore[union-attr]

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -272,6 +272,11 @@ def _derive_artifact(
     After the function returns, the service reads back the zarr to compute
     coverage and registers the artifact.  The built-in implementation for GEFS
     is ``climate_api.processing.gefs.derive_dataset``.
+
+    CRS: ``store.crs`` in the template overrides the default of ``EPSG:4326``.
+    Most public remote stores (dynamical.org, ARCO-ERA5) are WGS84 so the
+    default is correct.  Set ``crs: "EPSG:32633"`` (or any EPSG code) for
+    stores in a projected coordinate system.
     """
     from climate_api.data_manager.services.downloader import _get_dynamic_function
 
@@ -302,8 +307,12 @@ def _derive_artifact(
     )
 
     output_path_str = str(output_path.resolve())
-    # Derived forecast data is WGS84-native — pass native_crs explicitly so the
-    # instance CRS (e.g. UTM) is not applied, which would corrupt spatial_wgs84.
+    # Use store.crs when declared; fall back to EPSG:4326 for the common case of
+    # WGS84 remote stores (dynamical.org, ARCO-ERA5, etc.).
+    native_crs: str = str(source_store.get("crs", "EPSG:4326")) or "EPSG:4326"
+    wgs84_codes = {"EPSG:4326", "OGC:CRS84", "CRS84"}
+    is_wgs84 = native_crs.upper() in {c.upper() for c in wgs84_codes}
+
     from climate_api.data_accessor.services.accessor import _coverage_from_dataset, open_zarr_dataset
 
     ds_written = open_zarr_dataset(output_path_str)
@@ -311,7 +320,7 @@ def _derive_artifact(
         coverage_data = _coverage_from_dataset(
             ds=ds_written,
             period_type=str(dataset["period_type"]),
-            native_crs="EPSG:4326",
+            native_crs=native_crs,
         )
     finally:
         ds_written.close()
@@ -320,10 +329,11 @@ def _derive_artifact(
         raise HTTPException(status_code=409, detail="Derived forecast artifact contains no data")
 
     raw_cov = coverage_data["coverage"]
+    wgs84_cov = raw_cov.get("spatial_wgs84")
     coverage = ArtifactCoverage(
         temporal=CoverageTemporal(**raw_cov["temporal"]),
         spatial=CoverageSpatial(**raw_cov["spatial"]),
-        spatial_wgs84=None,
+        spatial_wgs84=CoverageSpatial(**wgs84_cov) if wgs84_cov and not is_wgs84 else None,
     )
     request_scope = ArtifactRequestScope(start=coverage.temporal.start, end=coverage.temporal.end)
 

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -75,6 +75,20 @@ def plan_sync(
             target_end=current_end,
             target_end_source="current_coverage",
         )
+
+    if sync_kind == SyncKind.REMOTE:
+        return SyncDetail(
+            source_dataset_id=latest_artifact.dataset_id,
+            sync_kind=sync_kind,
+            action=SyncAction.REMATERIALIZE,
+            reason="remote_store_refresh",
+            message=("Remote zarr store is always live. Sync will re-register the store to refresh coverage metadata."),
+            current_start=current_start,
+            current_end=current_end,
+            target_end=None,
+            target_end_source="remote",
+        )
+
     period_type = str(source_dataset["period_type"])
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
@@ -214,6 +228,26 @@ def run_sync(
             status="not_syncable",
             message="Managed dataset is not syncable under its configured sync policy.",
             dataset=get_dataset_fn(dataset_id),
+            sync_detail=sync_detail,
+        )
+
+    # Remote datasets re-register through create_artifact; start/end are ignored.
+    if sync_detail.sync_kind == SyncKind.REMOTE:
+        artifact = create_artifact_fn(
+            dataset=source_dataset,
+            start=latest_artifact.coverage.temporal.start,
+            end=latest_artifact.coverage.temporal.end,
+            bbox=list(latest_artifact.request_scope.bbox) if latest_artifact.request_scope.bbox is not None else None,
+            country_code=country_code,
+            overwrite=True,
+            prefer_zarr=prefer_zarr,
+            publish=publish,
+        )
+        return SyncResponse(
+            sync_id=artifact.artifact_id,
+            status="completed",
+            message="Remote zarr store coverage metadata has been refreshed.",
+            dataset=get_dataset_fn(managed_dataset_id_for(artifact)),
             sync_detail=sync_detail,
         )
 

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -89,6 +89,19 @@ def plan_sync(
             target_end_source="remote",
         )
 
+    if sync_kind == SyncKind.DERIVED:
+        return SyncDetail(
+            source_dataset_id=latest_artifact.dataset_id,
+            sync_kind=sync_kind,
+            action=SyncAction.REMATERIALIZE,
+            reason="derived_forecast_refresh",
+            message="Derived forecast artifact is re-derived from the latest remote run on every sync.",
+            current_start=current_start,
+            current_end=current_end,
+            target_end=None,
+            target_end_source="remote",
+        )
+
     period_type = str(source_dataset["period_type"])
     normalized_requested_end = requested_end.strip() if isinstance(requested_end, str) else None
     normalized_requested_end = normalized_requested_end or None
@@ -231,8 +244,8 @@ def run_sync(
             sync_detail=sync_detail,
         )
 
-    # Remote datasets re-register through create_artifact; start/end are ignored.
-    if sync_detail.sync_kind == SyncKind.REMOTE:
+    # Remote and derived datasets re-derive through create_artifact; start/end are ignored.
+    if sync_detail.sync_kind in (SyncKind.REMOTE, SyncKind.DERIVED):
         artifact = create_artifact_fn(
             dataset=source_dataset,
             start=latest_artifact.coverage.temporal.start,
@@ -243,10 +256,15 @@ def run_sync(
             prefer_zarr=prefer_zarr,
             publish=publish,
         )
+        message = (
+            "Derived forecast artifact has been re-derived from the latest remote run."
+            if sync_detail.sync_kind == SyncKind.DERIVED
+            else "Remote zarr store coverage metadata has been refreshed."
+        )
         return SyncResponse(
             sync_id=artifact.artifact_id,
             status="completed",
-            message="Remote zarr store coverage metadata has been refreshed.",
+            message=message,
             dataset=get_dataset_fn(managed_dataset_id_for(artifact)),
             sync_detail=sync_detail,
         )

--- a/climate_api/main.py
+++ b/climate_api/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -38,7 +38,7 @@ def _append_vary_value(response: Response, value: str) -> None:
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Run background warmup tasks on startup so first requests hit warm caches."""
     asyncio.get_event_loop().run_in_executor(None, _warmup_remote_zarr_stores)
     yield
@@ -46,10 +46,10 @@ async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
 
 def _warmup_remote_zarr_stores() -> None:
     """Open and cache every published REMOTE_ZARR store at process startup."""
+    from climate_api.data_registry.services import datasets as registry_datasets
     from climate_api.ingestions.schemas import ArtifactFormat
     from climate_api.ingestions.services import _load_records
     from climate_api.providers.remote_zarr import warmup_remote_store
-    from climate_api.data_registry.services import datasets as registry_datasets
 
     for record in _load_records():
         if record.format != ArtifactFormat.REMOTE_ZARR:

--- a/climate_api/main.py
+++ b/climate_api/main.py
@@ -1,7 +1,9 @@
 """DHIS2 Climate API -- Climate and earth observation data API for DHIS2."""
 
+import asyncio
 import os
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -35,6 +37,29 @@ def _append_vary_value(response: Response, value: str) -> None:
         response.headers["Vary"] = ", ".join([*values, value])
 
 
+@asynccontextmanager
+async def _lifespan(app: FastAPI):  # type: ignore[type-arg]
+    """Run background warmup tasks on startup so first requests hit warm caches."""
+    asyncio.get_event_loop().run_in_executor(None, _warmup_remote_zarr_stores)
+    yield
+
+
+def _warmup_remote_zarr_stores() -> None:
+    """Open and cache every published REMOTE_ZARR store at process startup."""
+    from climate_api.ingestions.schemas import ArtifactFormat
+    from climate_api.ingestions.services import _load_records
+    from climate_api.providers.remote_zarr import warmup_remote_store
+    from climate_api.data_registry.services import datasets as registry_datasets
+
+    for record in _load_records():
+        if record.format != ArtifactFormat.REMOTE_ZARR:
+            continue
+        source_dataset = registry_datasets.get_dataset(record.dataset_id) or {}
+        store_config = source_dataset.get("store")
+        if isinstance(store_config, dict):
+            warmup_remote_store(store_config)
+
+
 def create_app() -> FastAPI:
     """Create and configure the Climate API FastAPI application.
 
@@ -43,7 +68,7 @@ def create_app() -> FastAPI:
         from climate_api.main import create_app
         app = create_app()
     """
-    _app = FastAPI()
+    _app = FastAPI(lifespan=_lifespan)
 
     _app.add_middleware(
         CORSMiddleware,

--- a/climate_api/main.py
+++ b/climate_api/main.py
@@ -40,7 +40,7 @@ def _append_vary_value(response: Response, value: str) -> None:
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Run background warmup tasks on startup so first requests hit warm caches."""
-    asyncio.get_event_loop().run_in_executor(None, _warmup_remote_zarr_stores)
+    asyncio.get_running_loop().run_in_executor(None, _warmup_remote_zarr_stores)
     yield
 
 

--- a/climate_api/processing/gefs.py
+++ b/climate_api/processing/gefs.py
@@ -1,0 +1,126 @@
+"""Built-in derivation pipeline for GEFS-like forecast stores from dynamical.org.
+
+This function is the default ``ingestion.function`` for derived GEFS dataset
+templates.  Plugin authors can reference it directly, extend it, or replace it
+with their own function following the same contract:
+
+    def my_derive_fn(
+        *,
+        store_config: dict[str, Any],
+        output_path: Path,
+        extent: dict[str, Any] | None,
+        variable: str,
+        period_type: str,
+    ) -> None: ...
+
+The function must write a valid consolidated Zarr v3 store at ``output_path``
+with dimensions ``(time, latitude, longitude)`` in ascending coordinate order.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+
+def most_recent_complete_init(ds_raw: xr.Dataset, *, variable: str) -> pd.Timestamp:
+    """Return the most recent init_time that has a complete forecast.
+
+    The latest run is often still being distributed and has NaN placeholders
+    at the longer lead_times.  Walk backwards through the last 5 init_times
+    and return the first one whose final lead_time is non-NaN.
+    """
+    import numpy as np
+    import pandas as pd
+
+    init_times = sorted(ds_raw.init_time.values, reverse=True)
+    for candidate in init_times[:5]:
+        t = pd.Timestamp(candidate)
+        sel_kwargs: dict[str, object] = {"init_time": t, "lead_time": ds_raw.lead_time.values[-1]}
+        if "ensemble_member" in ds_raw[variable].dims:
+            sel_kwargs["ensemble_member"] = ds_raw.ensemble_member.values[0]
+        test_val = ds_raw[variable].sel(sel_kwargs).isel(latitude=0, longitude=0).values
+        if not np.isnan(float(test_val)):
+            return t
+    return pd.Timestamp(init_times[0])
+
+
+def derive_dataset(
+    *,
+    store_config: dict[str, Any],
+    output_path: Path,
+    extent: dict[str, Any] | None,
+    variable: str,
+    period_type: str,
+) -> None:
+    """Derive a daily forecast zarr from a GEFS-like icechunk store.
+
+    Steps:
+    1. Select the most recent init_time with a complete forecast
+    2. Average across ensemble members (ensemble mean)
+    3. Map lead_time → valid_time (calendar dates) as the ``time`` dimension
+    4. Subset to the instance extent when configured
+    5. Resample 6-hourly steps to daily mean
+    6. Trim trailing NaN time steps (unpublished lead_times still in transit)
+    7. Write as a consolidated Zarr v3 store with ascending lat/lon order
+    """
+    import pandas as pd
+
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    logger.info("Opening remote store for derived forecast '%s'", variable)
+    ds_raw = open_remote_dataset(store_config)
+    try:
+        latest_init = most_recent_complete_init(ds_raw, variable=variable)
+        logger.info("Selected init_time %s", latest_init.date())
+        ds_run = ds_raw[[variable]].sel(init_time=latest_init)
+
+        if "ensemble_member" in ds_run.dims:
+            ds_run = ds_run.mean(dim="ensemble_member")
+
+        valid_times = latest_init + pd.to_timedelta(ds_run.lead_time.values)
+        ds_run = (
+            ds_run.assign_coords(time=("lead_time", valid_times.values))
+            .swap_dims({"lead_time": "time"})
+            .drop_vars("lead_time", errors="ignore")
+        )
+        # Drop 2-D auxiliary coords (e.g. valid_time indexed by init_time×lead_time)
+        # that become meaningless after selecting a single init_time.
+        aux = [c for c in ds_run.coords if c not in ds_run.dims and c != variable]
+        if aux:
+            ds_run = ds_run.drop_vars(aux, errors="ignore")
+
+        if extent is not None:
+            xmin, ymin, xmax, ymax = extent["bbox"]
+            lat = ds_run.latitude
+            if float(lat.values[0]) > float(lat.values[-1]):
+                ds_run = ds_run.sel(latitude=slice(ymax, ymin), longitude=slice(xmin, xmax))
+            else:
+                ds_run = ds_run.sel(latitude=slice(ymin, ymax), longitude=slice(xmin, xmax))
+
+        ds_daily = ds_run.resample(time="1D").mean()
+
+        # Drop trailing time steps that are entirely NaN — these are unpublished
+        # lead_times that exist as placeholders in the icechunk store but have no
+        # actual forecast data yet (the run is still being distributed).
+        valid_mask = ds_daily[variable].isnull().all(dim=["latitude", "longitude"]).compute()
+        first_all_nan = int(valid_mask.argmax().item()) if bool(valid_mask.any().item()) else len(valid_mask)  # type: ignore[union-attr]
+        if first_all_nan < len(valid_mask):
+            ds_daily = ds_daily.isel(time=slice(None, first_all_nan))
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("Writing derived forecast zarr to '%s'", output_path)
+        # Ensure ascending lat/lon order (GEFS raw store is lat-descending).
+        ds_daily = ds_daily.sortby(["latitude", "longitude"])
+        # Resampling produces irregular dask chunks; rechunk to uniform before writing.
+        ds_daily = ds_daily.chunk({"time": 10, "latitude": -1, "longitude": -1})
+        ds_daily.to_zarr(output_path, mode="w", consolidated=True)
+    finally:
+        ds_raw.close()

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -4,6 +4,10 @@ from typing import Any
 
 import xarray as xr
 
+# Module-level caches keyed by store_url so each remote store is opened once.
+_store_cache: dict[str, Any] = {}
+_store_size_cache: dict[tuple[str, str], int] = {}
+
 
 def is_remote_source(dataset: dict[str, Any]) -> bool:
     """Return True when a dataset template declares a remote zarr store."""
@@ -24,7 +28,10 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
 
 def open_icechunk_store(source: dict[str, Any]) -> Any:
-    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access."""
+    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access.
+
+    The store is cached per store_url so the repository is opened only once per process.
+    """
     try:
         import icechunk
     except ImportError as exc:
@@ -33,6 +40,9 @@ def open_icechunk_store(source: dict[str, Any]) -> Any:
         ) from exc
 
     store_url: str = source["store_url"]
+    if store_url in _store_cache:
+        return _store_cache[store_url]
+
     storage_options: dict[str, Any] = source.get("storage_options", {})
     anon: bool = storage_options.get("anon", False)
     client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
@@ -44,7 +54,19 @@ def open_icechunk_store(source: dict[str, Any]) -> Any:
 
     storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
     repo = icechunk.Repository.open(storage)
-    return repo.readonly_session(branch="main").store
+    store = repo.readonly_session(branch="main").store
+    _store_cache[store_url] = store
+    return store
+
+
+async def get_icechunk_key_size(store: Any, key: str, store_url: str) -> int:
+    """Return the byte size of a key in the store, using a per-process cache."""
+    cache_key = (store_url, key)
+    if cache_key in _store_size_cache:
+        return _store_size_cache[cache_key]
+    size: int = await store.getsize(key)
+    _store_size_cache[cache_key] = size
+    return size
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -7,6 +7,7 @@ import xarray as xr
 # Module-level caches keyed by store_url so each remote store is opened once.
 _store_cache: dict[str, Any] = {}
 _store_size_cache: dict[tuple[str, str], int] = {}
+_dataset_cache: dict[str, xr.Dataset] = {}
 
 
 def is_remote_source(dataset: dict[str, Any]) -> bool:
@@ -20,11 +21,17 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
     Dispatches on source.store_format: 'icechunk' uses the icechunk library;
     anything else falls back to xr.open_zarr with fsspec.
+
+    The opened dataset is cached per store_url so coordinates and metadata are
+    read from S3 only once per process.
     """
+    store_url: str = source.get("store_url", "")
+    if store_url in _dataset_cache:
+        return _dataset_cache[store_url]
     store_format = source.get("store_format", "zarr")
-    if store_format == "icechunk":
-        return _open_icechunk(source)
-    return _open_zarr_url(source)
+    ds = _open_icechunk(source) if store_format == "icechunk" else _open_zarr_url(source)
+    _dataset_cache[store_url] = ds
+    return ds
 
 
 def open_icechunk_store(source: dict[str, Any]) -> Any:
@@ -67,6 +74,23 @@ async def get_icechunk_key_size(store: Any, key: str, store_url: str) -> int:
     size: int = await store.getsize(key)
     _store_size_cache[cache_key] = size
     return size
+
+
+def warmup_remote_store(source: dict[str, Any]) -> None:
+    """Open and cache the store and dataset for a remote source block.
+
+    Intended to be called at server startup (in a background thread) so the
+    first real request hits warm caches instead of cold S3 connections.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    store_url: str = source.get("store_url", "")
+    try:
+        open_remote_dataset(source)
+        logger.info("Warmed up remote zarr store: %s", store_url)
+    except Exception as exc:
+        logger.warning("Failed to warm up remote zarr store '%s': %s", store_url, exc)
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -23,8 +23,8 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
     return _open_zarr_url(source)
 
 
-def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
-    """Open an Icechunk store via the icechunk library (v2 API)."""
+def open_icechunk_store(source: dict[str, Any]) -> Any:
+    """Open an Icechunk store and return the raw zarr v3 Store object for direct key access."""
     try:
         import icechunk
     except ImportError as exc:
@@ -44,7 +44,12 @@ def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
 
     storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
     repo = icechunk.Repository.open(storage)
-    store = repo.readonly_session(branch="main").store
+    return repo.readonly_session(branch="main").store
+
+
+def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
+    """Open an Icechunk store via the icechunk library (v2 API)."""
+    store = open_icechunk_store(source)
     return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
 
 

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -72,6 +72,11 @@ async def get_icechunk_key_size(store: Any, key: str, store_url: str) -> int:
     return size
 
 
+def get_store_if_cached(store_url: str) -> Any | None:
+    """Return the cached raw store for store_url if it was already opened, else None."""
+    return _store_cache.get(store_url)
+
+
 def warmup_remote_store(source: dict[str, Any]) -> None:
     """Open and cache the store and dataset for a remote source block.
 

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -7,7 +7,6 @@ import xarray as xr
 # Module-level caches keyed by store_url so each remote store is opened once.
 _store_cache: dict[str, Any] = {}
 _store_size_cache: dict[tuple[str, str], int] = {}
-_dataset_cache: dict[str, xr.Dataset] = {}
 
 
 def is_remote_source(dataset: dict[str, Any]) -> bool:
@@ -22,16 +21,13 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
     Dispatches on source.store_format: 'icechunk' uses the icechunk library;
     anything else falls back to xr.open_zarr with fsspec.
 
-    The opened dataset is cached per store_url so coordinates and metadata are
-    read from S3 only once per process.
+    The underlying store is cached per store_url (see open_icechunk_store), so
+    reconnecting to S3 happens only once per process.  A fresh xr.Dataset is
+    returned on each call so callers may close it without poisoning a shared
+    dataset instance.
     """
-    store_url: str = source.get("store_url", "")
-    if store_url in _dataset_cache:
-        return _dataset_cache[store_url]
     store_format = source.get("store_format", "zarr")
-    ds = _open_icechunk(source) if store_format == "icechunk" else _open_zarr_url(source)
-    _dataset_cache[store_url] = ds
-    return ds
+    return _open_icechunk(source) if store_format == "icechunk" else _open_zarr_url(source)
 
 
 def open_icechunk_store(source: dict[str, Any]) -> Any:

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -1,0 +1,59 @@
+"""Remote Zarr/Icechunk store access for externally hosted datasets."""
+
+from typing import Any
+
+import xarray as xr
+
+
+def is_remote_source(dataset: dict[str, Any]) -> bool:
+    """Return True when a dataset template declares a remote zarr store."""
+    store = dataset.get("store")
+    return isinstance(store, dict) and store.get("kind") == "remote_zarr"
+
+
+def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
+    """Open a remote dataset from a template source block.
+
+    Dispatches on source.store_format: 'icechunk' uses the icechunk library;
+    anything else falls back to xr.open_zarr with fsspec.
+    """
+    store_format = source.get("store_format", "zarr")
+    if store_format == "icechunk":
+        return _open_icechunk(source)
+    return _open_zarr_url(source)
+
+
+def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
+    """Open an Icechunk store via the icechunk library."""
+    try:
+        import icechunk
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'icechunk' package is required to open Icechunk stores. Install it with: uv add icechunk"
+        ) from exc
+
+    store_url: str = source["store_url"]
+    storage_options: dict[str, Any] = source.get("storage_options", {})
+    anon: bool = storage_options.get("anon", False)
+    client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
+    region: str = client_kwargs.get("region_name", "us-east-1")
+
+    s3_path = store_url.removeprefix("s3://")
+    bucket, _, prefix = s3_path.partition("/")
+
+    if anon:
+        storage = icechunk.StorageConfig.s3_anonymous(bucket=bucket, prefix=prefix, region=region)
+    else:
+        storage = icechunk.StorageConfig.s3_from_env(bucket=bucket, prefix=prefix, region=region)
+
+    store = icechunk.IcechunkStore.open_existing(storage, mode="r")
+    return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
+
+
+def _open_zarr_url(source: dict[str, Any]) -> xr.Dataset:
+    """Open a plain Zarr store (v2/v3) via xarray with optional fsspec storage options."""
+    store_url: str = source["store_url"]
+    storage_options: dict[str, Any] = source.get("storage_options", {})
+    if storage_options:
+        return xr.open_zarr(store_url, storage_options=storage_options, consolidated=None)  # type: ignore[no-any-return]
+    return xr.open_zarr(store_url, consolidated=None)  # type: ignore[no-any-return]

--- a/climate_api/providers/remote_zarr.py
+++ b/climate_api/providers/remote_zarr.py
@@ -24,7 +24,7 @@ def open_remote_dataset(source: dict[str, Any]) -> xr.Dataset:
 
 
 def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
-    """Open an Icechunk store via the icechunk library."""
+    """Open an Icechunk store via the icechunk library (v2 API)."""
     try:
         import icechunk
     except ImportError as exc:
@@ -36,17 +36,15 @@ def _open_icechunk(source: dict[str, Any]) -> xr.Dataset:
     storage_options: dict[str, Any] = source.get("storage_options", {})
     anon: bool = storage_options.get("anon", False)
     client_kwargs: dict[str, Any] = storage_options.get("client_kwargs", {})
-    region: str = client_kwargs.get("region_name", "us-east-1")
+    region: str | None = client_kwargs.get("region_name")
 
     s3_path = store_url.removeprefix("s3://")
     bucket, _, prefix = s3_path.partition("/")
+    prefix = prefix.rstrip("/")
 
-    if anon:
-        storage = icechunk.StorageConfig.s3_anonymous(bucket=bucket, prefix=prefix, region=region)
-    else:
-        storage = icechunk.StorageConfig.s3_from_env(bucket=bucket, prefix=prefix, region=region)
-
-    store = icechunk.IcechunkStore.open_existing(storage, mode="r")
+    storage = icechunk.s3_storage(bucket=bucket, prefix=prefix, region=region, anonymous=anon)
+    repo = icechunk.Repository.open(storage)
+    store = repo.readonly_session(branch="main").store
     return xr.open_zarr(store, consolidated=False)  # type: ignore[no-any-return]
 
 

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -49,6 +49,7 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
     collection_id = managed_dataset_id_for(record)
     data_path = record.path or record.asset_paths[0]
     is_pyramid_zarr = record.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir()
+    is_remote_zarr = record.format == ArtifactFormat.REMOTE_ZARR
     published_record = record.model_copy(
         update={
             "publication": record.publication.model_copy(
@@ -56,8 +57,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
                     "status": PublicationStatus.PUBLISHED,
                     "collection_id": collection_id,
                     "published_at": datetime.now(UTC),
-                    # Pyramid zarr stores are served via the /zarr endpoint, not pygeoapi.
-                    "pygeoapi_path": None if is_pyramid_zarr else f"/ogcapi/collections/{collection_id}",
+                    # Pyramid zarr and remote zarr are served via /zarr, not pygeoapi.
+                    "pygeoapi_path": None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}",
                 }
             )
         }
@@ -71,6 +72,8 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
         data_path = active.path or active.asset_paths[0]
         if active.format == ArtifactFormat.ZARR and (Path(data_path) / "0").is_dir():
             continue  # pyramid zarr: not served via pygeoapi, use /zarr endpoint instead
+        if active.format == ArtifactFormat.REMOTE_ZARR:
+            continue  # remote zarr: served via /zarr redirect, not pygeoapi xarray provider
         assert active.publication.collection_id is not None
         resources[active.publication.collection_id] = _build_collection_resource(active)
 

--- a/climate_api/publications/services.py
+++ b/climate_api/publications/services.py
@@ -58,7 +58,9 @@ def publish_artifact(record: ArtifactRecord) -> ArtifactRecord:
                     "collection_id": collection_id,
                     "published_at": datetime.now(UTC),
                     # Pyramid zarr and remote zarr are served via /zarr, not pygeoapi.
-                    "pygeoapi_path": None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}",
+                    "pygeoapi_path": (
+                        None if (is_pyramid_zarr or is_remote_zarr) else f"/ogcapi/collections/{collection_id}"
+                    ),
                 }
             )
         }

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -345,11 +345,11 @@ def _cube_dimensions_from_dataset(
         elif name == time_dim or np.issubdtype(coord.dtype, np.datetime64):
             start = _to_stac_datetime(values[0])
             end = _to_stac_datetime(values[-1])
-            step = None
+            time_step: str | None = None
             if len(values) > 1:
                 delta = pd.Timestamp(values[1]) - pd.Timestamp(values[0])
-                step = _timedelta_to_iso_duration(delta)
-            dims[name] = {"type": "temporal", "extent": [start, end], "step": step}
+                time_step = _timedelta_to_iso_duration(delta)
+            dims[name] = {"type": "temporal", "extent": [start, end], "step": time_step}
         elif np.issubdtype(coord.dtype, np.timedelta64):
             hours = [int(pd.Timedelta(v).total_seconds() // 3600) for v in values]
             dims[name] = {"type": "ordinal", "values": hours, "climate_api:unit": "hours"}

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -342,7 +342,7 @@ def _cube_dimensions_from_dataset(
                 "step": step,
                 "reference_system": 4326,
             }
-        elif name == time_dim:
+        elif name == time_dim or np.issubdtype(coord.dtype, np.datetime64):
             start = _to_stac_datetime(values[0])
             end = _to_stac_datetime(values[-1])
             step = None

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -294,7 +294,6 @@ def _build_remote_zarr_collection(
         cube_dims = _cube_dimensions_from_dataset(ds, x_dim=x_dim, y_dim=y_dim, time_dim=time_dim)
         cube_vars = _cube_variables_from_dataset(ds, artifact=artifact)
     except Exception as exc:
-        ds.close()
         logger.exception("Failed to build STAC metadata for remote artifact '%s'", artifact.artifact_id)
         raise HTTPException(
             status_code=503,

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -173,7 +173,10 @@ def _build_collection_template(
     )
     from climate_api import config as api_config
 
-    native_crs = "EPSG:4326" if artifact.format == ArtifactFormat.REMOTE_ZARR else (api_config.get_crs() or "EPSG:4326")
+    # REMOTE_ZARR and WGS84-native local zarr (spatial_wgs84 is None → data IS WGS84) both use EPSG:4326.
+    # Local zarr reprojected to instance CRS has spatial_wgs84 set and uses the instance CRS.
+    is_wgs84_native = artifact.format == ArtifactFormat.REMOTE_ZARR or artifact.coverage.spatial_wgs84 is None
+    native_crs = "EPSG:4326" if is_wgs84_native else (api_config.get_crs() or "EPSG:4326")
     template.extra_fields["keywords"] = _keywords(artifact, source_dataset)
     template.extra_fields["proj:code"] = native_crs
     template.clear_links()

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -85,7 +85,12 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     )
     template_links = [_link_to_dict(link) for link in template.links]
 
-    collection_payload = _build_collection_with_xstac(artifact=artifact, template=template)
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        collection_payload = _build_remote_zarr_collection(
+            artifact=artifact, template=template, source_dataset=source_dataset
+        )
+    else:
+        collection_payload = _build_collection_with_xstac(artifact=artifact, template=template)
     collection_payload["id"] = dataset_id
     collection_payload["type"] = "Collection"
     collection_payload["stac_version"] = STAC_VERSION
@@ -131,7 +136,7 @@ def _eligible_artifacts_by_dataset() -> dict[str, ArtifactRecord]:
         latest = max(artifacts, key=lambda artifact: artifact.created_at)
         if latest.publication.status != PublicationStatus.PUBLISHED:
             continue
-        if latest.format != ArtifactFormat.ZARR:
+        if latest.format not in (ArtifactFormat.ZARR, ArtifactFormat.REMOTE_ZARR):
             continue
         result[dataset_id] = latest
     return dict(sorted(result.items()))
@@ -168,7 +173,7 @@ def _build_collection_template(
     )
     from climate_api import config as api_config
 
-    native_crs = api_config.get_crs() or "EPSG:4326"
+    native_crs = "EPSG:4326" if artifact.format == ArtifactFormat.REMOTE_ZARR else (api_config.get_crs() or "EPSG:4326")
     template.extra_fields["keywords"] = _keywords(artifact, source_dataset)
     template.extra_fields["proj:code"] = native_crs
     template.clear_links()
@@ -251,6 +256,146 @@ def _clear_xstac_collection_cache() -> None:
     _xstac_collection_cache.clear()
 
 
+def _build_remote_zarr_collection(
+    *,
+    artifact: ArtifactRecord,
+    template: pystac.Collection,
+    source_dataset: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a STAC collection payload for a REMOTE_ZARR artifact by opening the remote store."""
+    cached = _xstac_collection_cache.get(artifact.artifact_id)
+    if cached is not None:
+        return deepcopy(cached)
+
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    store = source_dataset.get("store")
+    if not isinstance(store, dict):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Remote zarr artifact '{artifact.artifact_id}' has no store config",
+        )
+
+    try:
+        ds = open_remote_dataset(store)
+    except Exception as exc:
+        logger.exception("Failed to open remote zarr store for STAC collection '%s'", artifact.artifact_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for '{artifact.artifact_id}' is temporarily unavailable",
+        ) from exc
+
+    try:
+        x_dim, y_dim = get_x_y_dims(ds)
+        time_dim = get_time_dim(ds)
+        cube_dims = _cube_dimensions_from_dataset(ds, x_dim=x_dim, y_dim=y_dim, time_dim=time_dim)
+        cube_vars = _cube_variables_from_dataset(ds, artifact=artifact)
+    except Exception as exc:
+        ds.close()
+        logger.exception("Failed to build STAC metadata for remote artifact '%s'", artifact.artifact_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Remote zarr store for '{artifact.artifact_id}' is temporarily unavailable",
+        ) from exc
+    finally:
+        ds.close()
+
+    template.clear_links()
+    payload: dict[str, Any] = template.to_dict(include_self_link=False)
+    payload["cube:dimensions"] = cube_dims
+    payload["cube:variables"] = cube_vars
+    _cache_xstac_collection_payload(artifact.artifact_id, payload)
+    return deepcopy(payload)
+
+
+def _cube_dimensions_from_dataset(
+    ds: Any,
+    *,
+    x_dim: str,
+    y_dim: str,
+    time_dim: str,
+) -> dict[str, Any]:
+    import numpy as np
+    import pandas as pd
+
+    dims: dict[str, Any] = {}
+    for name in ds.dims:
+        coord = ds.coords.get(name)
+        if coord is None:
+            continue
+        values = coord.values
+        if name == x_dim:
+            step = round(float(values[1] - values[0]), SPATIAL_STEP_DECIMALS) if len(values) > 1 else None
+            dims[name] = {
+                "type": "spatial",
+                "axis": "x",
+                "extent": [float(values.min()), float(values.max())],
+                "step": step,
+                "reference_system": 4326,
+            }
+        elif name == y_dim:
+            step = round(abs(float(values[1] - values[0])), SPATIAL_STEP_DECIMALS) if len(values) > 1 else None
+            dims[name] = {
+                "type": "spatial",
+                "axis": "y",
+                "extent": [float(values.min()), float(values.max())],
+                "step": step,
+                "reference_system": 4326,
+            }
+        elif name == time_dim:
+            start = _to_stac_datetime(values[0])
+            end = _to_stac_datetime(values[-1])
+            step = None
+            if len(values) > 1:
+                delta = pd.Timestamp(values[1]) - pd.Timestamp(values[0])
+                step = _timedelta_to_iso_duration(delta)
+            dims[name] = {"type": "temporal", "extent": [start, end], "step": step}
+        elif np.issubdtype(coord.dtype, np.timedelta64):
+            hours = [int(pd.Timedelta(v).total_seconds() // 3600) for v in values]
+            dims[name] = {"type": "ordinal", "values": hours, "climate_api:unit": "hours"}
+        else:
+            dims[name] = {"type": "ordinal", "values": values.tolist()}
+    return dims
+
+
+def _cube_variables_from_dataset(ds: Any, *, artifact: ArtifactRecord) -> dict[str, Any]:
+    variables: dict[str, Any] = {}
+    for var_name, data_var in ds.data_vars.items():
+        attrs = data_var.attrs or {}
+        entry: dict[str, Any] = {"type": "data", "dimensions": list(data_var.dims)}
+        long_name = attrs.get("long_name")
+        units = attrs.get("units")
+        if long_name:
+            entry["description"] = str(long_name)
+        if units:
+            entry["unit"] = str(units)
+            entry["attrs"] = {k: str(v) for k, v in attrs.items() if k in ("long_name", "units") and v}
+        variables[str(var_name)] = entry
+    return variables
+
+
+def _to_stac_datetime(value: Any) -> str:
+    import pandas as pd
+
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ts.tz_convert("UTC").strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _timedelta_to_iso_duration(delta: Any) -> str | None:
+    import pandas as pd
+
+    total_seconds = int(pd.Timedelta(delta).total_seconds())
+    if total_seconds <= 0:
+        return None
+    hours = total_seconds // 3600
+    days = hours // 24
+    if hours % 24 == 0 and days > 0:
+        return f"P{days}D"
+    return f"PT{hours}H"
+
+
 def _link_to_dict(link: pystac.Link) -> dict[str, Any]:
     target = link.target
     href = target if isinstance(target, str) else link.href
@@ -298,6 +443,9 @@ def _public_zarr_asset_href(
     artifact: ArtifactRecord,
     source_dataset: dict[str, Any],
 ) -> str:
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        # Route through the API proxy — the icechunk store has no public zarr.json
+        return _abs_url(request, f"/zarr/{dataset_id}")
     artifact_path = _artifact_store_path(artifact)
     if _is_pyramid_zarr(artifact_path):
         return _abs_url(request, f"/zarr/{dataset_id}/0")
@@ -411,6 +559,10 @@ def _keywords(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> list[
 
 def _zarr_asset_metadata(artifact: ArtifactRecord) -> dict[str, object]:
     metadata: dict[str, object] = {"zarr:node_type": "group"}
+    if artifact.format == ArtifactFormat.REMOTE_ZARR:
+        metadata["zarr:zarr_format"] = 3
+        metadata["zarr:consolidated"] = True
+        return metadata
     artifact_path = _artifact_store_path(artifact)
     consolidated = _zarr_consolidated_flag(artifact_path)
     if consolidated is not None:

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -456,32 +456,58 @@
         return String(val);
       }
 
+      function safeDimId(key) {
+        return String(key).replace(/[^A-Za-z0-9_-]/g, "_");
+      }
+
       function renderExtraDimSliders(dims) {
         const container = document.getElementById("extra-dims-container");
         container.innerHTML = "";
         for (const dim of dims) {
+          const safeId = safeDimId(dim.key);
           const section = document.createElement("div");
           section.className = "panel-section";
-          const label = formatDimLabel(dim.key);
-          const unitSuffix = dim["climate_api:unit"] ? ` (${dim["climate_api:unit"]})` : "";
-          section.innerHTML = `
-            <div class="time-header">
-              <label style="margin-bottom:0">${label}${unitSuffix}</label>
-              <span id="dim-count-${dim.key}" class="time-count">1 / ${dim._count}</span>
-            </div>
-            <div style="margin-bottom:0.4rem">
-              <span id="dim-val-${dim.key}" class="time-value">${formatDimValue(dim, 0)}</span>
-            </div>
-            <input type="range" id="dim-slider-${dim.key}" data-dim="${dim.key}" min="0" max="${dim._count - 1}" step="1" value="0" />
-          `;
-          container.appendChild(section);
-          section.querySelector(`#dim-slider-${dim.key}`).addEventListener("input", (e) => {
+
+          const header = document.createElement("div");
+          header.className = "time-header";
+          const labelEl = document.createElement("label");
+          labelEl.style.marginBottom = "0";
+          labelEl.textContent = formatDimLabel(dim.key) + (dim["climate_api:unit"] ? ` (${dim["climate_api:unit"]})` : "");
+          const countEl = document.createElement("span");
+          countEl.id = `dim-count-${safeId}`;
+          countEl.className = "time-count";
+          countEl.textContent = `1 / ${dim._count}`;
+          header.appendChild(labelEl);
+          header.appendChild(countEl);
+
+          const valDiv = document.createElement("div");
+          valDiv.style.marginBottom = "0.4rem";
+          const valEl = document.createElement("span");
+          valEl.id = `dim-val-${safeId}`;
+          valEl.className = "time-value";
+          valEl.textContent = formatDimValue(dim, 0);
+          valDiv.appendChild(valEl);
+
+          const slider = document.createElement("input");
+          slider.type = "range";
+          slider.id = `dim-slider-${safeId}`;
+          slider.dataset.dim = dim.key;
+          slider.min = "0";
+          slider.max = String(dim._count - 1);
+          slider.step = "1";
+          slider.value = "0";
+          slider.addEventListener("input", (e) => {
             const i = parseInt(e.target.value, 10);
-            document.getElementById(`dim-val-${dim.key}`).textContent = formatDimValue(dim, i);
-            document.getElementById(`dim-count-${dim.key}`).textContent = `${i + 1} / ${dim._count}`;
+            valEl.textContent = formatDimValue(dim, i);
+            countEl.textContent = `${i + 1} / ${dim._count}`;
             clearTimeout(_selectorDebounce);
             _selectorDebounce = setTimeout(() => updateSelector(), 150);
           });
+
+          section.appendChild(header);
+          section.appendChild(valDiv);
+          section.appendChild(slider);
+          container.appendChild(section);
         }
       }
 
@@ -489,7 +515,7 @@
         const selector = {};
         if (timeStepCount() > 0) selector[timeDimKey] = parseInt(timeSlider.value, 10);
         for (const dim of extraDims) {
-          const slider = document.getElementById(`dim-slider-${dim.key}`);
+          const slider = document.getElementById(`dim-slider-${safeDimId(dim.key)}`);
           if (slider) selector[dim.key] = parseInt(slider.value, 10);
         }
         return selector;

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -222,6 +222,8 @@
             <input type="range" id="time-slider" min="0" step="1" value="0" />
           </div>
 
+          <div id="extra-dims-container"></div>
+
           <dl id="dataset-meta" class="meta-grid hidden">
             <dt>Source</dt>
             <dd id="meta-source">—</dd>
@@ -323,6 +325,7 @@
       let activeLayer = null;
       let timeSteps = [];
       let timeDimKey = "time";
+      let extraDims = [];
 
       const selectEl = document.getElementById("dataset-select");
       const timeSection = document.getElementById("time-section");
@@ -428,6 +431,76 @@
         }
       }
 
+      // --- Extra dimension helpers ---
+
+      function getExtraDims(dimensions, primaryTimeDimKey) {
+        const result = [];
+        for (const [key, val] of Object.entries(dimensions ?? {})) {
+          if (val.type === "spatial") continue;
+          if (key === primaryTimeDimKey) continue;
+          const count = Array.isArray(val.values) ? val.values.length : 0;
+          if (count < 2) continue;
+          result.push({ key, ...val, _count: count });
+        }
+        return result;
+      }
+
+      function formatDimLabel(key) {
+        return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      }
+
+      function formatDimValue(dim, i) {
+        if (!Array.isArray(dim.values)) return String(i);
+        const val = dim.values[i];
+        if (dim["climate_api:unit"] === "hours") return `${val}h`;
+        return String(val);
+      }
+
+      function renderExtraDimSliders(dims) {
+        const container = document.getElementById("extra-dims-container");
+        container.innerHTML = "";
+        for (const dim of dims) {
+          const section = document.createElement("div");
+          section.className = "panel-section";
+          const label = formatDimLabel(dim.key);
+          const unitSuffix = dim["climate_api:unit"] ? ` (${dim["climate_api:unit"]})` : "";
+          section.innerHTML = `
+            <div class="time-header">
+              <label style="margin-bottom:0">${label}${unitSuffix}</label>
+              <span id="dim-count-${dim.key}" class="time-count">1 / ${dim._count}</span>
+            </div>
+            <div style="margin-bottom:0.4rem">
+              <span id="dim-val-${dim.key}" class="time-value">${formatDimValue(dim, 0)}</span>
+            </div>
+            <input type="range" id="dim-slider-${dim.key}" data-dim="${dim.key}" min="0" max="${dim._count - 1}" step="1" value="0" />
+          `;
+          container.appendChild(section);
+          section.querySelector(`#dim-slider-${dim.key}`).addEventListener("input", (e) => {
+            const i = parseInt(e.target.value, 10);
+            document.getElementById(`dim-val-${dim.key}`).textContent = formatDimValue(dim, i);
+            document.getElementById(`dim-count-${dim.key}`).textContent = `${i + 1} / ${dim._count}`;
+            clearTimeout(_selectorDebounce);
+            _selectorDebounce = setTimeout(() => updateSelector(), 150);
+          });
+        }
+      }
+
+      function buildFullSelector() {
+        const selector = {};
+        if (timeStepCount() > 0) selector[timeDimKey] = parseInt(timeSlider.value, 10);
+        for (const dim of extraDims) {
+          const slider = document.getElementById(`dim-slider-${dim.key}`);
+          if (slider) selector[dim.key] = parseInt(slider.value, 10);
+        }
+        return selector;
+      }
+
+      function updateSelector() {
+        activeLayer?.setSelector(buildFullSelector());
+      }
+
+      // --- Dataset loading ---
+
       async function loadDataset(href) {
         if (!map || mapUnavailable) {
           setStatus(MAP_UNAVAILABLE_MESSAGE, true);
@@ -441,6 +514,8 @@
           } catch {}
           activeLayer = null;
         }
+        extraDims = [];
+        document.getElementById("extra-dims-container").innerHTML = "";
         timeSection.classList.add("hidden");
         datasetMeta.classList.add("hidden");
         legendEl.classList.add("hidden");
@@ -473,6 +548,7 @@
         const dimensions = collection["cube:dimensions"] ?? {};
         timeDimKey = getTimeDimKey(dimensions);
         timeSteps = buildTimeSteps(dimensions);
+        extraDims = getExtraDims(dimensions, timeDimKey);
 
         // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
         // reprojects natively instead of treating coordinates as WGS84 degrees.
@@ -500,8 +576,12 @@
         try {
           cm = buildColormap(colormapName);
           const zarrVersion = zarr["zarr:zarr_format"] ?? null;
-          const selector =
-            timeStepCount() > 0 ? { [timeDimKey]: 0 } : {};
+          const extraInitSel = {};
+          for (const dim of extraDims) extraInitSel[dim.key] = 0;
+          const selector = {
+            ...(timeStepCount() > 0 ? { [timeDimKey]: 0 } : {}),
+            ...extraInitSel,
+          };
           activeLayer = new ZarrLayer({
             id: "zarr-layer",
             source: zarr.href,
@@ -526,7 +606,6 @@
           return;
         }
 
-
         // Time slider.
         if (timeStepCount() > 1) {
           timeSlider.max = timeStepCount() - 1;
@@ -534,6 +613,11 @@
           timeValueEl.textContent = timeStepAt(0);
           timeCountEl.textContent = `1 / ${timeStepCount()}`;
           timeSection.classList.remove("hidden");
+        }
+
+        // Extra dimension sliders (ensemble_member, lead_time, etc.).
+        if (extraDims.length > 0) {
+          renderExtraDimSliders(extraDims);
         }
 
         // Metadata strip.
@@ -566,12 +650,8 @@
         const i = parseInt(e.target.value, 10);
         timeValueEl.textContent = timeStepAt(i) ?? "—";
         timeCountEl.textContent = `${i + 1} / ${timeStepCount()}`;
-        const layer = activeLayer;
-        const dimKey = timeDimKey;
         clearTimeout(_selectorDebounce);
-        _selectorDebounce = setTimeout(() => {
-          layer?.setSelector({ [dimKey]: i });
-        }, 150);
+        _selectorDebounce = setTimeout(() => updateSelector(), 150);
       });
 
       initMap();

--- a/climate_api/transforms/unit_conversion.py
+++ b/climate_api/transforms/unit_conversion.py
@@ -25,3 +25,9 @@ def metres_to_mm(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
     """Convert the dataset variable from metres to millimetres."""
     logger.info("Converting '%s' from m to mm", dataset["variable"])
     return _apply(ds, dataset, scale=1000.0, offset=0.0, units="mm")
+
+
+def flux_to_mm_per_day(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
+    """Convert precipitation flux (kg m-2 s-1) to mm/day."""
+    logger.info("Converting '%s' from kg m-2 s-1 to mm/day", dataset["variable"])
+    return _apply(ds, dataset, scale=86400.0, offset=0.0, units="mm/day")

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -211,6 +211,121 @@ Verify it appears in the STAC catalog:
 curl -s http://127.0.0.1:8000/stac/catalog.json | jq '.links[] | select(.rel == "child")'
 ```
 
+## Derived datasets
+
+Use `sync.kind: derived` when the data source is a remote zarr store that requires a non-trivial transformation before it is useful — for example a forecast store with `init_time × lead_time × ensemble_member` dimensions that need to be collapsed into a simple `time × latitude × longitude` zarr.
+
+A derived template always rematerialises on each sync (like `remote`). After each sync the existing artifact is replaced with a freshly derived zarr.
+
+### Step 1: Write the derivation function
+
+The derivation function writes a zarr to `output_path`. It must be importable as a dotted Python path:
+
+```python
+# my_plugin/forecast.py
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+
+def derive_dataset(
+    *,
+    store_config: dict[str, Any],
+    output_path: Path,
+    extent: dict[str, Any] | None,
+    variable: str,
+    period_type: str,
+) -> None:
+    """Read from the remote store, transform, write to output_path."""
+    from climate_api.providers.remote_zarr import open_remote_dataset
+
+    ds_raw = open_remote_dataset(store_config)
+    try:
+        # ... transform logic ...
+        ds_daily = ...
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        ds_daily.to_zarr(output_path, mode="w", consolidated=True)
+    finally:
+        ds_raw.close()
+```
+
+**Contract:**
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `store_config` | `dict` | The template's `store` block — pass directly to `open_remote_dataset` |
+| `output_path` | `Path` | Write a consolidated Zarr v3 store here |
+| `extent` | `dict \| None` | Instance spatial extent (`bbox`, `country_code`, etc.) — use to subset the data |
+| `variable` | `str` | Primary variable name (from `variable` in the template) |
+| `period_type` | `str` | Temporal resolution (`daily`, `hourly`, etc.) |
+
+The function must produce a zarr with dimensions `(time, latitude, longitude)` in ascending coordinate order and a `time` coordinate of calendar dates.
+
+You can import and extend the built-in GEFS derivation:
+
+```python
+from climate_api.processing.gefs import derive_dataset as gefs_derive
+```
+
+### Step 2: Create the dataset template YAML
+
+```yaml
+# datasets/my_forecast.yaml
+- id: my_forecast_precipitation
+  name: Precipitation forecast — My Source
+  short_name: Precipitation forecast
+  variable: precipitation
+  period_type: daily
+  sync:
+    kind: derived
+  ingestion:
+    function: my_plugin.forecast.derive_dataset
+  transforms:
+    - climate_api.transforms.unit_conversion.flux_to_mm_per_day
+  store:
+    kind: remote_zarr
+    store_url: "s3://my-bucket/my-forecast/v1/"
+    store_format: icechunk        # or "zarr"
+    storage_options:
+      anon: true
+      client_kwargs:
+        region_name: us-east-1
+    crs: "EPSG:4326"              # optional; defaults to EPSG:4326
+  units: "mm/day"
+  resolution: 25 km x 25 km (0.25°)
+  source: My Forecast Source
+  source_url: https://example.org/forecast
+  display:
+    colormap: blues
+    range: [0, 25]
+```
+
+**Derived-specific template fields:**
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `sync.kind` | Yes | Must be `derived` |
+| `ingestion.function` | Yes | Dotted path to the derivation function |
+| `store.kind` | Yes | Must be `remote_zarr` |
+| `store.store_url` | Yes | URL of the remote zarr/icechunk store |
+| `store.store_format` | No | `zarr` (default) or `icechunk` |
+| `store.storage_options` | No | Passed to the fsspec/icechunk opener (credentials, region, etc.) |
+| `store.crs` | No | Native CRS of the derived output. Defaults to `EPSG:4326`. Set this for stores in projected coordinate systems — it controls the `proj:code` in STAC metadata |
+| `transforms` | No | Transforms applied to the written zarr after derivation — same syntax and built-ins as regular datasets |
+
+### Step 3: Trigger sync
+
+Derived artifacts are created by the same ingestion endpoint. No `start`/`end` date is required (the derivation function determines the time range from the remote store):
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/ingestions \
+  -H "Content-Type: application/json" \
+  -d '{"dataset_id": "my_forecast_precipitation", "publish": true}' | jq
+```
+
+Re-syncing the artifact replaces it with a freshly derived zarr. Schedule this daily to keep a rolling forecast window current.
+
+---
+
 ## Minimal example
 
 The smallest valid template for a static dataset with no sync:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Before executing a sync, the engine calls the availability function to clamp the
 
 The platform has five extension points. Each one has a narrow contract — the framework handles everything else automatically.
 
-### Download function (`sync.kind: temporal`, `release`, `static`)
+### Ingestion function (`sync.kind: temporal`, `release`, `static`)
 
 ```python
 def download(
@@ -164,7 +164,7 @@ def download(
 
 The function writes NetCDF files. The framework reads them, normalises coordinate names, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
 
-The download function is called identically by `POST /ingestions` and `POST /sync`. The caller makes no difference to the function — it always receives the same parameters.
+The ingestion function is called identically by `POST /ingestions` and `POST /sync`. The caller makes no difference to the function — it always receives the same parameters.
 
 **Reusing ingestion logic across templates**: multiple YAML templates can reference the same Python function and differentiate via `default_params`. This is the intended pattern for sources that have the same fetching logic but expose different variables:
 
@@ -325,7 +325,7 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 ## What the framework guarantees
 
-Plugin code (download functions, derivation functions, transforms, processes) can rely on the following being handled automatically:
+Plugin code (ingestion functions, derivation functions, transforms, processes) can rely on the following being handled automatically:
 
 | Concern                                               | Where handled                                                     |
 | ----------------------------------------------------- | ----------------------------------------------------------------- |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The platform has four first-class concepts. Understanding the distinction betwee
 
 ### Dataset template
 
-A **template** is a YAML blueprint that describes a data source. Built-ins live in `climate_api/data/datasets/` inside the package (loaded via `importlib.resources`). Custom templates live in `{plugins_dir}/datasets/` where `plugins_dir` is set in `climate-api.yaml`. It has no state — it describes what *could* be ingested, not what *has been* ingested.
+A **template** is a YAML blueprint that describes a data source. Built-ins live in `climate_api/data/datasets/` inside the package (loaded via `importlib.resources`). Custom templates live in `{plugins_dir}/datasets/` where `plugins_dir` is set in `climate-api.yaml`. It has no state — it describes what _could_ be ingested, not what _has been_ ingested.
 
 A template defines:
 
@@ -46,7 +46,7 @@ The relationship is: one template → many artifacts over time → one managed d
 
 The **extent** is the spatial bounding box configured for this Climate API instance. It is set once in `climate-api.yaml` and does not change at runtime. Every ingestion is automatically scoped to this extent — operators do not specify it per-request.
 
-This is a deliberate design constraint: each instance serves one place. A Norway instance serves Norway. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
+This is a deliberate design constraint: each instance serves one place. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
 
 ---
 
@@ -98,15 +98,15 @@ This division means that download and derivation functions do not need to know a
 
 ## Sync kinds
 
-The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion.
+The `sync.kind` field in a template determines how a managed dataset is kept current.
 
-| `sync.kind` | Data lives | On each sync | Use when |
-|-------------|-----------|--------------|----------|
-| `temporal` | Local zarr | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land) |
-| `release` | Local zarr | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
-| `static` | Local zarr | Never synced | One-time fixed dataset with no updates |
-| `derived` | Local zarr, rebuilt from remote | Always rematerialize from remote store | Forecast or model data that requires transformation before it is usable (GEFS) |
-| `remote` | Remote store, no local copy | Re-register latest coverage | Datasets where direct store access is acceptable and no local transformation is needed |
+| `sync.kind` | Data lives                      | On each sync                            | Use when                                                                              |
+| ----------- | ------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `temporal`  | Local zarr                      | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land)                            |
+| `release`   | Local zarr                      | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop)                     |
+| `static`    | Local zarr                      | Never synced                            | One-time fixed dataset with no updates                                                |
+| `derived`   | Local zarr, rebuilt from remote | Always rematerialize from remote store  | Forecast or model data that requires transformation before it is usable (GEFS)        |
+| `remote`    | Remote store, no local copy     | Re-register latest coverage             | Datasets where direct store access is acceptable and no local transformation is needed |
 
 ### When to use `derived` vs `remote`
 
@@ -282,7 +282,7 @@ Every zarr artifact must have GeoZarr root attributes for map rendering to work 
 - `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
 
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to null bounds and the instance CRS, which produces a white or misaligned map.
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map.
 
 **The framework writes these attributes — plugins do not.** For downloaded datasets, they are written in `build_dataset_zarr` after transforms and reprojection. For derived datasets, they are written in `_derive_artifact` after transforms run, using the actual coordinate bounds of the final written data and the CRS from `store.crs`.
 
@@ -296,7 +296,7 @@ The instance CRS is configured in `climate-api.yaml`:
 extent:
   name: Norway
   bbox: [3.0, 57.0, 32.0, 72.5]
-  crs: EPSG:32633   # optional; defaults to EPSG:4326
+  crs: EPSG:32633 # optional; defaults to EPSG:4326
 ```
 
 **Downloaded datasets** are reprojected from their source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is in the instance CRS.
@@ -327,17 +327,17 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 Plugin code (download functions, derivation functions, transforms, processes) can rely on the following being handled automatically:
 
-| Concern | Where handled |
-|---------|---------------|
-| Coordinate name normalisation (`lat` → `y`, etc.) | `build_dataset_zarr` (downloaded data) |
-| Reprojection to instance CRS | `reproject_to_instance_crs` (downloaded data only) |
-| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks` |
-| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr` |
-| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr` (downloaded), `_derive_artifact` (derived) |
-| Artifact coverage computation | `_coverage_from_dataset` |
-| Artifact record persistence | `_store_artifact` / `_upsert_derived_record` |
-| pygeoapi publication | `publish_artifact_record` if `publish=true` |
-| STAC collection generation | Dynamic from artifact record |
+| Concern                                               | Where handled                                                     |
+| ----------------------------------------------------- | ----------------------------------------------------------------- |
+| Coordinate name normalisation (`lat` → `y`, etc.)     | `build_dataset_zarr` (downloaded data)                            |
+| Reprojection to instance CRS                          | `reproject_to_instance_crs` (downloaded data only)                |
+| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks`                              |
+| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr`                                              |
+| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr` (downloaded), `_derive_artifact` (derived)   |
+| Artifact coverage computation                         | `_coverage_from_dataset`                                          |
+| Artifact record persistence                           | `_store_artifact` / `_upsert_derived_record`                      |
+| pygeoapi publication                                  | `publish_artifact_record` if `publish=true`                       |
+| STAC collection generation                            | Dynamic from artifact record                                      |
 
 Plugin code only needs to produce data. Everything else is the framework's responsibility.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The platform has four first-class concepts. Understanding the distinction betwee
 
 ### Dataset template
 
-A **template** is a YAML blueprint that describes a data source. Built-ins live in `climate_api/data/datasets/` inside the package (loaded via `importlib.resources`). Custom templates live in `{plugins_dir}/datasets/` where `plugins_dir` is set in `climate-api.yaml`. It has no state — it describes what _could_ be ingested, not what _has been_ ingested.
+A **template** is a YAML blueprint that describes a data source. Built-ins live in `climate_api/data/datasets/` inside the package (loaded via `importlib.resources`). Custom templates live in `{plugins_dir}/datasets/` where `plugins_dir` is set in `climate-api.yaml`. It has no state — it describes what *could* be ingested, not what *has been* ingested.
 
 A template defines:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ A template defines:
 
 - the dataset identifier and display metadata
 - the variable name, units, and period type
-- how to download the data (`ingestion.function`)
+- how to download or derive the data (`ingestion.function`)
 - what transforms to apply (`transforms`)
 - what sync strategy to use (`sync.kind`, `sync.execution`)
 
@@ -28,7 +28,7 @@ An **artifact** is the internal record of a completed data ingestion. It is the 
 
 - what dataset template it came from
 - the exact spatial extent and time range that was materialized
-- where the data lives on disk (path to the zarr store or netCDF files)
+- where the data lives on disk (path to the zarr store or netCDF files), or the URL of the remote store
 - when it was created
 - whether it has been published
 
@@ -46,19 +46,21 @@ The relationship is: one template → many artifacts over time → one managed d
 
 The **extent** is the spatial bounding box configured for this Climate API instance. It is set once in `climate-api.yaml` and does not change at runtime. Every ingestion is automatically scoped to this extent — operators do not specify it per-request.
 
-This is a deliberate design constraint: each instance serves one place. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
+This is a deliberate design constraint: each instance serves one place. A Norway instance serves Norway. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
 
 ---
 
 ## Data lifecycle
 
+For downloaded data (the common case), the lifecycle is:
+
 ```
 Template (YAML)
     │
-    │  POST /ingestions  (or  POST /sync)
+    │  POST /ingestions
     ▼
 Ingestion
-    │  call ingestion function → NetCDF files on disk
+    │  download data
     │  apply transforms
     │  reproject to instance CRS
     │  write GeoZarr store
@@ -75,32 +77,44 @@ Managed dataset (public API)
     └── /ogcapi/collections/{id} — OGC API access
 ```
 
+For derived data (forecast datasets), a derivation function replaces the download step. The rest of the lifecycle is identical — see [Derived datasets](#derived-datasets) below.
+
 The ingestion function is called identically by both `POST /ingestions` and `POST /sync` — the framework invokes it the same way regardless of the trigger. A correctly written ingestion function works for both without any changes.
 
-The framework is responsible for everything from "write zarr" onward. An ingestion function only needs to write NetCDF files to a given directory. The framework then:
+The framework is responsible for everything from "write zarr" onward. A download or derivation function only needs to produce data at a given path. The framework then:
 
 1. reads and normalises the coordinate names
 2. applies transforms (unit conversion, etc.)
-3. reprojects to the instance CRS
+3. reprojects to the instance CRS (downloaded data only)
 4. builds the zarr store with auto-computed chunking
 5. writes GeoZarr root attributes (`spatial:bbox`, `proj:code`) so map clients can position tiles
 6. computes artifact coverage (spatial bounds + time range) from the written data
 7. stores the artifact record
 8. publishes the managed dataset through pygeoapi if `publish=true`
 
-This division means that ingestion functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data files; the framework handles everything else.
+This division means that download and derivation functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data; the framework handles everything else.
 
 ---
 
 ## Sync kinds
 
-The `sync.kind` field in a template determines how a managed dataset is kept current.
+The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion.
 
-| `sync.kind` | On each sync                            | Use when                                                          |
-| ----------- | --------------------------------------- | ----------------------------------------------------------------- |
-| `temporal`  | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land)        |
-| `release`   | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
-| `static`    | Never synced                            | One-time fixed dataset with no updates                            |
+| `sync.kind` | Data lives | On each sync | Use when |
+|-------------|-----------|--------------|----------|
+| `temporal` | Local zarr | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land) |
+| `release` | Local zarr | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
+| `static` | Local zarr | Never synced | One-time fixed dataset with no updates |
+| `derived` | Local zarr, rebuilt from remote | Always rematerialize from remote store | Forecast or model data that requires transformation before it is usable (GEFS) |
+| `remote` | Remote store, no local copy | Re-register latest coverage | Datasets where direct store access is acceptable and no local transformation is needed |
+
+### When to use `derived` vs `remote`
+
+`remote` is the simplest: the Climate API registers the remote store URL as the artifact path and proxies requests to it directly. Nothing is downloaded or transformed. The trade-off is that the raw store is served as-is — if it has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`), clients see five dimensions.
+
+`derived` performs a transformation step before the data is accessible. The derivation function reads the remote store, collapses it to a usable shape (e.g. ensemble mean, lead_time → calendar dates, daily resample), and writes a local zarr. The local zarr is what clients see. The trade-off is that every sync rewrites the entire local artifact — there is no incremental append.
+
+**Rule of thumb:** use `remote` only when the remote store is already in a shape that map clients and downstream tools can consume directly. Use `derived` when the raw store requires a transformation step to be useful.
 
 ### The sync execution modes
 
@@ -130,9 +144,9 @@ Before executing a sync, the engine calls the availability function to clamp the
 
 ## The plugin contract
 
-The platform has four extension points. Each one has a narrow contract — the framework handles everything else automatically.
+The platform has five extension points. Each one has a narrow contract — the framework handles everything else automatically.
 
-### Ingestion function
+### Download function (`sync.kind: temporal`, `release`, `static`)
 
 ```python
 def download(
@@ -150,7 +164,7 @@ def download(
 
 The function writes NetCDF files. The framework reads them, normalises coordinate names, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
 
-The ingestion function is called identically by `POST /ingestions` and `POST /sync`. The caller makes no difference to the function — it always receives the same parameters.
+The download function is called identically by `POST /ingestions` and `POST /sync`. The caller makes no difference to the function — it always receives the same parameters.
 
 **Reusing ingestion logic across templates**: multiple YAML templates can reference the same Python function and differentiate via `default_params`. This is the intended pattern for sources that have the same fetching logic but expose different variables:
 
@@ -170,16 +184,36 @@ ingestion:
 
 No framework changes are needed to support a new variable from the same source.
 
+### Derivation function (`sync.kind: derived`)
+
+```python
+def derive_dataset(
+    *,
+    store_config: dict,   # the template's store block
+    output_path: Path,    # write a consolidated zarr here
+    extent: dict | None,  # instance spatial extent — use to subset the data
+    variable: str,
+    period_type: str,
+) -> None:
+    # Read from remote store, transform, write zarr to output_path.
+    # Output must have dimensions (time, latitude, longitude) in ascending order.
+    # Do not write GeoZarr root attributes — the framework does this.
+```
+
+The function writes a local zarr. The framework then applies any declared transforms, writes GeoZarr root attributes using the actual coordinate bounds of the final data, computes coverage, and registers the artifact.
+
+**Important:** the derivation function must not write GeoZarr root attributes itself. The framework writes them after transforms run, so they always reflect the final data. If the function writes them pre-transform, they will be overwritten.
+
 ### Transform function
 
 ```python
 def my_transform(ds: xr.Dataset, dataset: dict) -> xr.Dataset:
-    # Receive the dataset after download, return a modified dataset.
+    # Receive the dataset after download or derivation, return a modified dataset.
     # Modify ds[dataset["variable"]] values and variable attributes.
     # Do not modify dataset-level ds.attrs — the framework manages those.
 ```
 
-Transforms are applied in order after the ingestion function returns, before the zarr is written. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They do not write to disk.
+Transforms are applied in order after the download or derivation function returns. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They do not write to disk.
 
 ### Process execution function
 
@@ -195,17 +229,48 @@ Processes are named operations triggered via `POST /processes/{id}/execution`. T
 
 ## The transform pipeline
 
-Transforms are applied at a consistent point in the ingestion lifecycle:
+Transforms are applied at a consistent point in the ingestion lifecycle, regardless of sync kind:
 
-1. ingestion function writes raw NetCDF files to disk
-2. framework reads and normalises the data into an xarray Dataset
+1. download or derivation function writes raw data to disk
+2. framework loads the data into an xarray Dataset
 3. `_run_transforms(ds, dataset)` applies each declared transform in order
-4. result is reprojected to instance CRS
-5. zarr store is written with auto-computed chunking
-6. framework writes GeoZarr root attributes
-7. framework computes coverage from the zarr
+4. result is written to the zarr store
+5. framework writes GeoZarr root attributes
+6. framework computes coverage from the zarr
 
-Transforms see post-download, pre-reproject data. They should only modify data values and variable-level attributes. The framework writes dataset-level attributes (GeoZarr) after the transform pipeline completes.
+For downloaded data, step 4 also includes reprojection to the instance CRS. For derived data, no reprojection is applied — the derivation function is responsible for spatial subsetting.
+
+Transforms see post-function, pre-GeoZarr data. They should only modify data values and variable-level attributes. The framework manages dataset-level `.attrs`.
+
+The transform pipeline is identical for downloaded and derived data. A transform written for a regular dataset works unchanged on a derived dataset.
+
+---
+
+## Derived datasets
+
+`sync.kind: derived` is for datasets sourced from a remote zarr store that requires a non-trivial transformation before it is useful. The canonical example is NOAA GEFS, whose raw store has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`) that need to be collapsed into a simple `time × latitude × longitude` zarr.
+
+The derivation function is called with the same contract each sync. The full pipeline on each sync is:
+
+1. derivation function opens remote store, transforms, writes local zarr
+2. framework applies declared transforms (e.g. unit conversion)
+3. framework writes GeoZarr root attributes from the actual coordinate bounds
+4. framework computes coverage and upserts the artifact record
+
+The artifact is always fully rematerialized — there is no incremental append for derived datasets.
+
+### `store.crs`
+
+For derived datasets, the `store.crs` field in the template sets the CRS for the artifact:
+
+```yaml
+store:
+  kind: remote_zarr
+  store_url: "s3://..."
+  crs: "EPSG:4326"   # optional; defaults to EPSG:4326
+```
+
+Most public remote stores (dynamical.org, ARCO-ERA5) are in `EPSG:4326`. Set `store.crs` only for stores in projected coordinate systems. The value is written as `proj:code` in the GeoZarr root attributes and STAC metadata.
 
 ---
 
@@ -217,9 +282,9 @@ Every zarr artifact must have GeoZarr root attributes for map rendering to work 
 - `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
 
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map.
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to null bounds and the instance CRS, which produces a white or misaligned map.
 
-**The framework writes these attributes — plugins do not.** They are written in `build_dataset_zarr` after transforms and reprojection, using the actual coordinate bounds of the final written data and the instance CRS.
+**The framework writes these attributes — plugins do not.** For downloaded datasets, they are written in `build_dataset_zarr` after transforms and reprojection. For derived datasets, they are written in `_derive_artifact` after transforms run, using the actual coordinate bounds of the final written data and the CRS from `store.crs`.
 
 ---
 
@@ -231,12 +296,14 @@ The instance CRS is configured in `climate-api.yaml`:
 extent:
   name: Norway
   bbox: [3.0, 57.0, 32.0, 72.5]
-  crs: EPSG:32633 # optional; defaults to EPSG:4326
+  crs: EPSG:32633   # optional; defaults to EPSG:4326
 ```
 
-Downloaded data is reprojected from the source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is always in the instance CRS.
+**Downloaded datasets** are reprojected from their source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is in the instance CRS.
 
-If no `crs` is set in the config, data is stored in `EPSG:4326` (WGS84). This is the correct default for instances that do not need a metric CRS.
+**Derived datasets** are never reprojected. They are stored in their native CRS, declared via `store.crs` (default `EPSG:4326`). The derivation function is responsible for spatial subsetting using the `extent` parameter.
+
+If no `crs` is set in the config, downloaded data is stored in `EPSG:4326` (WGS84). This is the correct default for instances that do not need a metric CRS.
 
 ---
 
@@ -250,27 +317,29 @@ When a new ingestion request arrives, the framework checks whether an existing a
 
 If a match exists and `overwrite=false`, the existing artifact is returned without re-downloading. If `overwrite=true`, the existing artifact is replaced.
 
+For derived and remote datasets, the framework always upserts: it replaces the existing record while preserving the `artifact_id`, so publication state (pygeoapi config, STAC entries) is maintained without a re-publish step.
+
 The artifact store keeps the full history of records for sync deduplication and provenance. Old artifacts are not deleted automatically. For long-running instances, `records.json` grows over time. The long-term direction is a proper transactional store, but for the current scale (tens of artifacts per instance) a JSON file is adequate.
 
 ---
 
 ## What the framework guarantees
 
-Plugin code (ingestion functions, transforms, processes) can rely on the following being handled automatically by the framework:
+Plugin code (download functions, derivation functions, transforms, processes) can rely on the following being handled automatically:
 
-| Concern                                               | Where handled                               |
-| ----------------------------------------------------- | ------------------------------------------- |
-| Coordinate name normalisation (`lat` → `y`, etc.)     | `build_dataset_zarr`                        |
-| Reprojection to instance CRS                          | `reproject_to_instance_crs`                 |
-| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks`         |
-| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr`                        |
-| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr`                        |
-| Artifact coverage computation                         | `_coverage_from_dataset`                    |
-| Artifact record persistence                           | `_store_artifact`                           |
-| pygeoapi publication                                  | `publish_artifact_record` if `publish=true` |
-| STAC collection generation                            | Dynamic from artifact record                |
+| Concern | Where handled |
+|---------|---------------|
+| Coordinate name normalisation (`lat` → `y`, etc.) | `build_dataset_zarr` (downloaded data) |
+| Reprojection to instance CRS | `reproject_to_instance_crs` (downloaded data only) |
+| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks` |
+| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr` |
+| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr` (downloaded), `_derive_artifact` (derived) |
+| Artifact coverage computation | `_coverage_from_dataset` |
+| Artifact record persistence | `_store_artifact` / `_upsert_derived_record` |
+| pygeoapi publication | `publish_artifact_record` if `publish=true` |
+| STAC collection generation | Dynamic from artifact record |
 
-Plugin code only needs to produce data files. Everything else is the framework's responsibility.
+Plugin code only needs to produce data. Everything else is the framework's responsibility.
 
 ---
 
@@ -288,6 +357,20 @@ The sync engine validates that new data connects to the end of the existing arti
 
 `append` downloads only the missing range and rebuilds the full zarr from all cached files. This means the local cache (NetCDF files in `data/downloads/`) is the source of truth for the full time series; the zarr is a derived view. If the cache is deleted, a rematerialize is required to recover.
 
-### Transforms run after download, before reproject
+### Derived datasets always rematerialize
 
-Transforms see raw downloaded values in the source CRS and source units. The order is: download → transform → reproject → write zarr.
+`sync.kind: derived` rewrites the full local zarr on every sync. For a 35-day GEFS forecast at 0.25° resolution over a country extent, this takes seconds. For a global high-resolution dataset covering years of history, rematerialization would be impractical — use `temporal` with `append` instead.
+
+### Transforms run after the function writes
+
+Transforms see the exact output of the download or derivation function — raw values before any unit conversion. The order is: function → transform → write zarr → GeoZarr attrs. This means:
+
+- if the function writes values in kg m⁻² s⁻¹, a `flux_to_mm_per_day` transform converts them
+- if the function already converts units, adding a unit conversion transform would double-convert
+- the function and the template's `transforms` list must not both handle the same conversion
+
+For GEFS: the raw store is in kg m⁻² s⁻¹. The derivation function writes raw values. The `flux_to_mm_per_day` transform in the template converts to mm/day. Neither the function nor the template handles both steps.
+
+### GeoZarr attrs are always written by the framework, never by plugins
+
+Writing GeoZarr attrs is a framework concern because they must reflect the data *after* transforms run — the bbox and CRS of the final written zarr, not the intermediate state during derivation. If a plugin writes them during derivation and transforms later change the extent or units, the attrs would be stale. The framework writes them last, guaranteeing they are always consistent with the actual stored data.

--- a/docs/built_in_datasets.md
+++ b/docs/built_in_datasets.md
@@ -1,8 +1,8 @@
 # Built-in datasets
 
-The Climate API ships with four built-in dataset templates covering precipitation, temperature, and population. Each template describes a data source and the rules for downloading, transforming, and syncing it. They are available in every instance without any additional configuration.
+The Climate API ships with built-in dataset templates covering precipitation, temperature, population, and medium-range forecasts. Each template describes a data source and the rules for downloading, transforming, and syncing it. They are available in every instance without any additional configuration.
 
-To ingest a built-in dataset for your configured extent, see the [API reference](managed_data_api_guide.md). To add datasets beyond these four, see [Adding custom datasets](adding_custom_datasets.md).
+To ingest a built-in dataset for your configured extent, see the [API reference](managed_data_api_guide.md). To add datasets beyond these, see [Adding custom datasets](adding_custom_datasets.md).
 
 ---
 
@@ -91,6 +91,55 @@ WorldPop Global2 provides gridded population estimates and projections at 100 m 
 
 ---
 
+## NOAA GEFS — precipitation forecast (daily ensemble mean)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `gefs_precipitation_forecast` |
+| **Variable** | `precipitation_surface` |
+| **Units** | mm/day |
+| **Period** | Daily |
+| **Spatial coverage** | Global |
+| **Spatial resolution** | 25 km (0.25°) |
+| **Forecast horizon** | 35 days |
+| **Source** | [NOAA GEFS via dynamical.org](https://dynamical.org/catalog/noaa-gefs-forecast-35-day/) |
+
+The NOAA Global Ensemble Forecast System (GEFS) provides probabilistic medium-range forecasts out to 35 days at 0.25° resolution. The raw store has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`). The Climate API derives a simple `time × latitude × longitude` zarr from the latest complete run on each sync:
+
+1. Select the most recent `init_time` with a complete forecast (walks back up to 5 runs — the latest run is often still distributing its longer lead_times)
+2. Average across ensemble members (ensemble mean)
+3. Map `lead_time → valid_time` (calendar dates) to produce a standard `time` dimension
+4. Subset to the configured instance extent
+5. Resample 6-hourly steps to daily mean
+6. Trim trailing NaN time steps (unpublished placeholders)
+
+**Sync behaviour** — always rematerialises (full rebuild on each sync). Schedule daily to keep the 35-day window current.
+
+**Transforms** — raw GEFS precipitation is in kg m⁻² s⁻¹ (instantaneous flux). The `flux_to_mm_per_day` transform multiplies by 86400 s/day, so stored values are in mm/day.
+
+---
+
+## NOAA GEFS — 2 m temperature forecast (daily ensemble mean)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `gefs_temperature_2m_forecast` |
+| **Variable** | `temperature_2m` |
+| **Units** | °C |
+| **Period** | Daily |
+| **Spatial coverage** | Global |
+| **Spatial resolution** | 25 km (0.25°) |
+| **Forecast horizon** | 35 days |
+| **Source** | [NOAA GEFS via dynamical.org](https://dynamical.org/catalog/noaa-gefs-forecast-35-day/) |
+
+2 m air temperature forecast from NOAA GEFS, derived from the same icechunk store as the precipitation forecast. The derivation pipeline is identical — ensemble mean, lead_time mapped to calendar dates, daily mean, extent subset.
+
+**Sync behaviour** — always rematerialises. Schedule daily alongside the precipitation forecast.
+
+**Transforms** — none; the dynamical.org store already provides temperature in °C.
+
+---
+
 ## Derived datasets
 
-In addition to the four built-in sources, the API can produce **derived datasets** by resampling any ingested dataset to a coarser temporal resolution. Derived datasets are created on demand via the `resample` process. See [Processes](processes.md) for details.
+In addition to the five built-in sources above, the API can produce **derived datasets** by resampling any ingested dataset to a coarser temporal resolution. Derived datasets are created on demand via the `resample` process. See [Processes](processes.md) for details.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -8,6 +8,7 @@ The same pattern applies at every extension point:
 | --------------- | ------------- | --------------- |
 | [Dataset templates](#dataset-templates) | YAML files | `plugins_dir/datasets/` |
 | [Ingestion functions](#ingestion-functions) | Python function, dotted path in YAML | any importable path |
+| [Derivation functions](#derivation-functions) | Python function, dotted path in YAML | any importable path |
 | [Transform functions](#transform-functions) | Python function, dotted path in YAML | any importable path |
 | [Processes](#processes) | YAML file + Python function | `plugins_dir/processes/` |
 
@@ -44,6 +45,48 @@ ingestion:
 ```
 
 The function must follow the download function contract (see [Adding custom datasets](adding_custom_datasets.md#step-1-write-the-download-function)). It can live anywhere that is importable — either an installed package or a module placed directly under `plugins_dir` (which is automatically added to `sys.path`).
+
+---
+
+## Derivation functions
+
+`sync.kind: derived` is for datasets that cannot be served directly from a remote store — they require a transformation step (e.g. ensemble mean, lead_time remapping, daily resampling) before they are useful. The derivation function is declared with `ingestion.function` and called with a standard contract:
+
+```python
+def derive_dataset(
+    *,
+    store_config: dict,    # the template's store block
+    output_path: Path,     # where to write the zarr
+    extent: dict | None,   # configured instance spatial extent
+    variable: str,
+    period_type: str,
+) -> None: ...
+```
+
+The built-in implementation for GEFS is `climate_api.processing.gefs.derive_dataset`. A plugin can reference it directly or replace it entirely:
+
+```yaml
+- id: ecmwf_ifs_temperature_forecast
+  variable: temperature_2m
+  period_type: daily
+  sync:
+    kind: derived
+  ingestion:
+    function: my_plugin.ecmwf.derive_dataset
+  transforms:
+    - climate_api.transforms.unit_conversion.flux_to_mm_per_day
+  store:
+    kind: remote_zarr
+    store_url: "s3://..."
+    store_format: icechunk
+    storage_options:
+      anon: true
+    crs: "EPSG:4326"   # optional, defaults to EPSG:4326
+```
+
+After the derivation function returns, any `transforms` declared in the template are applied to the written zarr before coverage is computed and the artifact is registered. This means all built-in and custom transforms work identically for derived datasets.
+
+See [Adding custom datasets — Derived datasets](adding_custom_datasets.md#derived-datasets) for the full field reference and a step-by-step example.
 
 ---
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -6,13 +6,19 @@ Transforms are functions applied to a dataset **after download and before the Za
 
 ## How transforms work
 
-When an ingestion runs, the pipeline is:
+Transforms run after data is acquired and before the final Zarr store is written. For regular (downloaded) datasets:
 
 ```
 download → (transforms) → write Zarr
 ```
 
-Transforms are applied in declaration order. Each function receives the full `xr.Dataset` and the dataset template dict, and returns a (possibly modified) `xr.Dataset`. The modified dataset is then passed to the next transform, or written to Zarr if there are no more.
+For `sync.kind: derived` datasets, the derivation function writes a zarr first, and transforms are applied immediately after:
+
+```
+derive_fn writes zarr → (transforms) → rewrite Zarr
+```
+
+In both cases, transforms are applied in declaration order. Each function receives the full `xr.Dataset` and the dataset template dict, and returns a (possibly modified) `xr.Dataset`. The modified dataset is then passed to the next transform, or written to Zarr if there are no more.
 
 Transforms are declared in the dataset YAML as a list of dotted Python paths:
 
@@ -45,6 +51,16 @@ mm = m × 1000
 ```
 
 Used by: ERA5-Land total precipitation (`era5land_precipitation_hourly`).
+
+### `climate_api.transforms.unit_conversion.flux_to_mm_per_day`
+
+Converts a precipitation flux variable from kg m⁻² s⁻¹ to mm/day.
+
+```
+mm/day = kg m⁻² s⁻¹ × 86400 s/day
+```
+
+Used by: NOAA GEFS precipitation forecast (`gefs_precipitation_forecast`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dependencies = [
     "dhis2eo>=1.2.1",
 ]
 
+[project.optional-dependencies]
+forecast = [
+    "icechunk>=0.1.0",
+    "s3fs>=2024.1",
+]
+
 [project.urls]
 Repository = "https://github.com/dhis2/climate-api"
 Documentation = "https://github.com/dhis2/climate-api/tree/main/docs"
@@ -89,7 +95,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac"]
+module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "icechunk"]
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -51,6 +51,25 @@ def _make_gefs_ds() -> xr.Dataset:
     )
 
 
+def _make_gefs_ds_with_lead_time() -> xr.Dataset:
+    """Return a fake GEFS dataset that includes a lead_time dimension (35-day forecast)."""
+    lead_times = pd.to_timedelta(np.arange(0, 841, 6), unit="h")  # 0–840 h in 6-h steps
+    return xr.Dataset(
+        {
+            "precipitation_surface": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                np.ones((3, len(lead_times), 4, 4), dtype="float32"),
+            )
+        },
+        coords={
+            "init_time": pd.date_range("2026-05-01", periods=3, freq="D"),
+            "lead_time": lead_times,
+            "latitude": [10.0, 5.0, 0.0, -5.0],
+            "longitude": [30.0, 35.0, 40.0, 45.0],
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # providers.remote_zarr
 # ---------------------------------------------------------------------------
@@ -175,6 +194,22 @@ def test_register_remote_zarr_artifact_creates_remote_zarr_record(
     assert record.dataset_id == "gefs_precipitation"
     assert record.coverage.temporal.start == "2026-05-01"
     assert record.coverage.temporal.end == "2026-05-03"
+
+
+def test_register_remote_zarr_artifact_extends_end_by_lead_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Temporal end must be last init_time + max lead_time, not just last init_time."""
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds_with_lead_time()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    # last init_time = 2026-05-03, max lead_time = 840 h = 35 days → end = 2026-06-07
+    assert record.coverage.temporal.start == "2026-05-01"
+    assert record.coverage.temporal.end == "2026-06-07"
 
 
 def test_register_remote_zarr_artifact_upserts_on_re_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -290,6 +290,9 @@ def test_zarr_store_info_for_remote_artifact_returns_remote_url(
 ) -> None:
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+    monkeypatch.setattr(
+        registry, "get_dataset", lambda dataset_id: _GEFS_DATASET if dataset_id == "gefs_precipitation" else None
+    )
 
     fake_ds = _make_gefs_ds()
     with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
@@ -315,6 +318,9 @@ def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
 
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+    monkeypatch.setattr(
+        registry, "get_dataset", lambda dataset_id: _GEFS_DATASET if dataset_id == "gefs_precipitation" else None
+    )
 
     fake_ds = _make_gefs_ds()
     with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -272,8 +272,10 @@ def test_zarr_store_info_for_remote_artifact_returns_remote_url(
     assert info["provider"] == "dynamical"
 
 
-def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from fastapi import HTTPException
+def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json as _json
 
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
@@ -287,10 +289,23 @@ def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeyp
     record = services._load_records()[0]
     dataset_id = managed_dataset_id_for(record)
 
-    with pytest.raises(HTTPException) as exc_info:
-        services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+    fake_zarr_json = _json.dumps({"zarr_format": 3, "node_type": "group"}).encode()
 
-    assert exc_info.value.status_code == 501
+    class _FakeBuffer:
+        def as_array_like(self) -> bytes:
+            return fake_zarr_json
+
+    class _FakeStore:
+        async def get(self, key: str, prototype: object) -> _FakeBuffer:  # type: ignore[override]
+            return _FakeBuffer()
+
+    with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=_FakeStore()):
+        response = services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+
+    from fastapi.responses import JSONResponse
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -1,0 +1,337 @@
+"""Tests for remote zarr dataset registration and serving."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from climate_api.data_manager.services.utils import get_time_dim
+from climate_api.data_registry.services import datasets as registry
+from climate_api.ingestions import services
+from climate_api.ingestions.schemas import ArtifactFormat, SyncAction, SyncKind
+from climate_api.ingestions.sync_engine import plan_sync
+from climate_api.providers.remote_zarr import is_remote_source, open_remote_dataset
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_GEFS_STORE: dict[str, Any] = {
+    "kind": "remote_zarr",
+    "provider": "dynamical",
+    "catalog_id": "noaa-gefs-forecast-35-day",
+    "store_url": "s3://dynamical-noaa-gefs/noaa-gefs-forecast-35-day/v0.2.0.icechunk/",
+    "store_format": "icechunk",
+    "storage_options": {"anon": True, "client_kwargs": {"region_name": "us-west-2"}},
+}
+
+_GEFS_DATASET: dict[str, Any] = {
+    "id": "gefs_precipitation",
+    "name": "Total precipitation surface forecast (NOAA GEFS ensemble)",
+    "variable": "precipitation_surface",
+    "period_type": "daily",
+    "sync": {"kind": "remote"},
+    "store": _GEFS_STORE,
+}
+
+
+def _make_gefs_ds() -> xr.Dataset:
+    """Return a minimal fake GEFS dataset with init_time/latitude/longitude dimensions."""
+    return xr.Dataset(
+        {"precipitation_surface": (["init_time", "latitude", "longitude"], np.ones((3, 4, 4), dtype="float32"))},
+        coords={
+            "init_time": pd.date_range("2026-05-01", periods=3, freq="D"),
+            "latitude": [10.0, 5.0, 0.0, -5.0],
+            "longitude": [30.0, 35.0, 40.0, 45.0],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# providers.remote_zarr
+# ---------------------------------------------------------------------------
+
+
+def test_is_remote_source_returns_true_for_remote_zarr_template():
+    assert is_remote_source(_GEFS_DATASET) is True
+
+
+def test_is_remote_source_returns_false_for_ingestion_template():
+    dataset = {
+        "id": "chirps3_precipitation_daily",
+        "ingestion": {"function": "dhis2eo.data.chc.chirps3.daily.download"},
+    }
+    assert is_remote_source(dataset) is False
+
+
+def test_is_remote_source_returns_false_for_missing_source():
+    assert is_remote_source({"id": "foo"}) is False
+
+
+def test_open_remote_dataset_raises_runtime_error_when_icechunk_missing():
+    source = {**_GEFS_STORE, "store_format": "icechunk"}
+    with patch.dict("sys.modules", {"icechunk": None}):
+        with pytest.raises(RuntimeError, match="icechunk"):
+            open_remote_dataset(source)
+
+
+def test_open_remote_dataset_zarr_url_calls_xr_open_zarr():
+    source = {"store_url": "s3://bucket/store.zarr", "store_format": "zarr"}
+    fake_ds = _make_gefs_ds()
+    with patch("xarray.open_zarr", return_value=fake_ds) as mock_open:
+        result = open_remote_dataset(source)
+        mock_open.assert_called_once_with("s3://bucket/store.zarr", consolidated=None)
+        assert result is fake_ds
+
+
+# ---------------------------------------------------------------------------
+# data_manager.services.utils — get_time_dim
+# ---------------------------------------------------------------------------
+
+
+def test_get_time_dim_finds_init_time():
+    ds = _make_gefs_ds()
+    assert get_time_dim(ds) == "init_time"
+
+
+# ---------------------------------------------------------------------------
+# data_registry.services.datasets — template validation
+# ---------------------------------------------------------------------------
+
+
+def test_registry_loads_gefs_template(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: gefs_test
+  name: GEFS test
+  variable: tp
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+    store_url: "s3://bucket/store.icechunk/"
+    store_format: icechunk
+"""
+    (tmp_path / "gefs_test.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    datasets = registry.list_datasets()
+    assert any(d["id"] == "gefs_test" for d in datasets)
+
+
+def test_registry_rejects_remote_zarr_without_store_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: bad_remote
+  name: Bad remote
+  variable: tp
+  period_type: daily
+  sync:
+    kind: remote
+  store:
+    kind: remote_zarr
+"""
+    (tmp_path / "bad.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="store_url"):
+        registry.list_datasets()
+
+
+def test_registry_rejects_ingestion_template_without_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    yaml_content = """
+- id: bad_ingestion
+  name: Bad
+  variable: tp
+  period_type: daily
+  sync:
+    kind: temporal
+  ingestion: {}
+"""
+    (tmp_path / "bad.yaml").write_text(yaml_content, encoding="utf-8")
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="ingestion.function"):
+        registry.list_datasets()
+
+
+# ---------------------------------------------------------------------------
+# ingestions.services — _register_remote_zarr_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_register_remote_zarr_artifact_creates_remote_zarr_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    assert record.format == ArtifactFormat.REMOTE_ZARR
+    assert record.path == _GEFS_STORE["store_url"]
+    assert record.dataset_id == "gefs_precipitation"
+    assert record.coverage.temporal.start == "2026-05-01"
+    assert record.coverage.temporal.end == "2026-05-03"
+
+
+def test_register_remote_zarr_artifact_upserts_on_re_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        first = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+        second = services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    assert first.artifact_id == second.artifact_id
+    records = services._load_records()
+    assert sum(r.dataset_id == "gefs_precipitation" for r in records) == 1
+
+
+def test_create_artifact_routes_to_remote_zarr_for_remote_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        record = services.create_artifact(
+            dataset=_GEFS_DATASET,
+            start="2026-05-01",
+            end=None,
+            bbox=None,
+            country_code=None,
+            overwrite=False,
+            prefer_zarr=True,
+            publish=False,
+        )
+
+    assert record.format == ArtifactFormat.REMOTE_ZARR
+
+
+# ---------------------------------------------------------------------------
+# ingestions.services — storage exists + zarr serving
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_storage_exists_returns_true_for_remote_zarr():
+    from datetime import UTC, datetime
+
+    from climate_api.ingestions.schemas import (
+        ArtifactCoverage,
+        ArtifactPublication,
+        ArtifactRecord,
+        ArtifactRequestScope,
+        CoverageSpatial,
+        CoverageTemporal,
+    )
+
+    record = ArtifactRecord(
+        artifact_id="abc",
+        dataset_id="gefs_precipitation",
+        dataset_name="GEFS",
+        variable="precipitation_surface",
+        format=ArtifactFormat.REMOTE_ZARR,
+        path="s3://bucket/store.icechunk/",
+        asset_paths=["s3://bucket/store.icechunk/"],
+        variables=["precipitation_surface"],
+        request_scope=ArtifactRequestScope(start="2026-05-01", end="2026-05-03"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-05-01", end="2026-05-03"),
+            spatial=CoverageSpatial(xmin=-180.0, ymin=-90.0, xmax=180.0, ymax=90.0),
+        ),
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+    assert services._artifact_storage_exists(record) is True
+
+
+def test_zarr_store_info_for_remote_artifact_returns_remote_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    from climate_api.publications.services import managed_dataset_id_for
+
+    record = services._load_records()[0]
+    dataset_id = managed_dataset_id_for(record)
+
+    info = services.get_dataset_zarr_store_info_or_404(dataset_id)
+
+    assert info["format"] == ArtifactFormat.REMOTE_ZARR
+    assert info["remote_url"] == _GEFS_STORE["store_url"]
+    assert info["provider"] == "dynamical"
+
+
+def test_zarr_store_file_for_remote_artifact_returns_501(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    fake_ds = _make_gefs_ds()
+    with patch("climate_api.providers.remote_zarr.open_remote_dataset", return_value=fake_ds):
+        services._register_remote_zarr_artifact(dataset=_GEFS_DATASET, publish=False)
+
+    from climate_api.publications.services import managed_dataset_id_for
+
+    record = services._load_records()[0]
+    dataset_id = managed_dataset_id_for(record)
+
+    with pytest.raises(HTTPException) as exc_info:
+        services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+
+    assert exc_info.value.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# ingestions.sync_engine — REMOTE sync kind
+# ---------------------------------------------------------------------------
+
+
+def test_plan_sync_remote_always_rematerializes():
+    from datetime import UTC, datetime
+
+    from climate_api.ingestions.schemas import (
+        ArtifactCoverage,
+        ArtifactPublication,
+        ArtifactRecord,
+        ArtifactRequestScope,
+        CoverageSpatial,
+        CoverageTemporal,
+    )
+
+    artifact = ArtifactRecord(
+        artifact_id="abc",
+        dataset_id="gefs_precipitation",
+        dataset_name="GEFS",
+        variable="precipitation_surface",
+        format=ArtifactFormat.REMOTE_ZARR,
+        path="s3://bucket/store.icechunk/",
+        asset_paths=["s3://bucket/store.icechunk/"],
+        variables=["precipitation_surface"],
+        request_scope=ArtifactRequestScope(start="2026-05-01", end="2026-05-03"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-05-01", end="2026-05-03"),
+            spatial=CoverageSpatial(xmin=-180.0, ymin=-90.0, xmax=180.0, ymax=90.0),
+        ),
+        created_at=datetime.now(UTC),
+        publication=ArtifactPublication(),
+    )
+    detail = plan_sync(
+        source_dataset=_GEFS_DATASET,
+        latest_artifact=artifact,
+        requested_end=None,
+    )
+    assert detail.sync_kind == SyncKind.REMOTE
+    assert detail.action == SyncAction.REMATERIALIZE
+    assert detail.reason == "remote_store_refresh"

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -275,7 +275,10 @@ def test_zarr_store_info_for_remote_artifact_returns_remote_url(
 def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import asyncio
     import json as _json
+
+    from starlette.testclient import TestClient
 
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
@@ -296,11 +299,20 @@ def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
             return fake_zarr_json
 
     class _FakeStore:
-        async def get(self, key: str, prototype: object) -> _FakeBuffer:  # type: ignore[override]
+        async def get(self, key: str, prototype: object, byte_range: object = None) -> _FakeBuffer:  # type: ignore[override]
             return _FakeBuffer()
 
-    with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=_FakeStore()):
-        response = services.get_dataset_zarr_store_file_or_404(dataset_id, "zarr.json")
+    fake_store = _FakeStore()
+
+    async def _run() -> object:
+        from starlette.requests import Request as StarletteRequest
+
+        scope = {"type": "http", "method": "GET", "headers": []}
+        request = StarletteRequest(scope)
+        with patch("climate_api.providers.remote_zarr.open_icechunk_store", return_value=fake_store):
+            return await services.get_dataset_zarr_store_file_or_404(request, dataset_id, "zarr.json")
+
+    response = asyncio.run(_run())
 
     from fastapi.responses import JSONResponse
 

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -313,8 +313,6 @@ def test_zarr_store_file_for_remote_artifact_proxies_from_icechunk(
     import asyncio
     import json as _json
 
-    from starlette.testclient import TestClient
-
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
 

--- a/tests/test_remote_zarr.py
+++ b/tests/test_remote_zarr.py
@@ -401,3 +401,118 @@ def test_plan_sync_remote_always_rematerializes():
     assert detail.sync_kind == SyncKind.REMOTE
     assert detail.action == SyncAction.REMATERIALIZE
     assert detail.reason == "remote_store_refresh"
+
+
+# ---------------------------------------------------------------------------
+# processing.gefs — most_recent_complete_init
+# ---------------------------------------------------------------------------
+
+
+def test_most_recent_complete_init_skips_incomplete_run() -> None:
+    """Returns the most recent init_time whose last lead_time is non-NaN."""
+    from climate_api.processing.gefs import most_recent_complete_init
+
+    lead_times = pd.to_timedelta([0, 6, 12], unit="h")
+    # First init_time: all lead_times valid. Second (latest): last lead_time is NaN.
+    data = np.array(
+        [
+            [[1.0, 1.0], [1.0, 1.0]],  # init 0: lead 0 — valid
+            [[1.0, 1.0], [1.0, 1.0]],  # init 0: lead 1 — valid
+            [[1.0, 1.0], [1.0, 1.0]],  # init 0: lead 2 — valid
+            [[1.0, 1.0], [1.0, 1.0]],  # init 1: lead 0 — valid
+            [[1.0, 1.0], [1.0, 1.0]],  # init 1: lead 1 — valid
+            [[np.nan, np.nan], [np.nan, np.nan]],  # init 1: lead 2 — NaN (still distributing)
+        ],
+        dtype="float32",
+    ).reshape(2, 3, 2, 2)
+
+    init_times = pd.to_datetime(["2026-05-11", "2026-05-12"])
+    ds = xr.Dataset(
+        {"precipitation_surface": (["init_time", "lead_time", "latitude", "longitude"], data)},
+        coords={
+            "init_time": init_times,
+            "lead_time": lead_times,
+            "latitude": [0.0, 1.0],
+            "longitude": [0.0, 1.0],
+        },
+    )
+
+    result = most_recent_complete_init(ds, variable="precipitation_surface")
+    assert result == pd.Timestamp("2026-05-11")
+
+
+def test_most_recent_complete_init_returns_latest_when_complete() -> None:
+    """Returns the latest init_time when its forecast is fully distributed."""
+    from climate_api.processing.gefs import most_recent_complete_init
+
+    lead_times = pd.to_timedelta([0, 6], unit="h")
+    data = np.ones((2, 2, 2, 2), dtype="float32")
+    init_times = pd.to_datetime(["2026-05-11", "2026-05-12"])
+    ds = xr.Dataset(
+        {"precipitation_surface": (["init_time", "lead_time", "latitude", "longitude"], data)},
+        coords={
+            "init_time": init_times,
+            "lead_time": lead_times,
+            "latitude": [0.0, 1.0],
+            "longitude": [0.0, 1.0],
+        },
+    )
+
+    result = most_recent_complete_init(ds, variable="precipitation_surface")
+    assert result == pd.Timestamp("2026-05-12")
+
+
+# ---------------------------------------------------------------------------
+# ingestions.services — derived artifact routing
+# ---------------------------------------------------------------------------
+
+_DERIVED_DATASET: dict[str, Any] = {
+    "id": "gefs_precipitation_forecast",
+    "name": "Precipitation forecast (NOAA GEFS)",
+    "variable": "precipitation_surface",
+    "period_type": "daily",
+    "sync": {"kind": "derived"},
+    "ingestion": {"function": "climate_api.processing.gefs.derive_dataset"},
+    "store": _GEFS_STORE,
+}
+
+
+def test_create_artifact_routes_derived_to_derive_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_artifact calls the ingestion.function for sync.kind: derived."""
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+    monkeypatch.setattr(services, "get_extent", lambda: None)
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_derive(
+        *, store_config: object, output_path: Path, extent: object, variable: str, period_type: str
+    ) -> None:
+        calls.append({"store_config": store_config, "variable": variable, "period_type": period_type})
+        # Write a minimal zarr so coverage computation can proceed.
+        ds = xr.Dataset(
+            {"precipitation_surface": (["time", "latitude", "longitude"], np.ones((2, 3, 3), dtype="float32"))},
+            coords={
+                "time": pd.date_range("2026-05-11", periods=2, freq="D"),
+                "latitude": [0.0, 1.0, 2.0],
+                "longitude": [0.0, 1.0, 2.0],
+            },
+        )
+        ds.to_zarr(output_path, mode="w", consolidated=True)
+
+    with patch("climate_api.data_manager.services.downloader._get_dynamic_function", return_value=fake_derive):
+        record = services.create_artifact(
+            dataset=_DERIVED_DATASET,
+            start="2026-05-11",
+            end=None,
+            bbox=None,
+            country_code=None,
+            overwrite=False,
+            prefer_zarr=True,
+            publish=False,
+        )
+
+    assert len(calls) == 1
+    assert calls[0]["variable"] == "precipitation_surface"
+    assert calls[0]["store_config"] == _GEFS_STORE
+    assert record.format == ArtifactFormat.ZARR

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,24 @@ wheels = [
 ]
 
 [[package]]
+name = "aiobotocore"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/75/42cce839c2ec263ff74b10b650fe36b066fbb124cbee6f247eac0983e1ab/aiobotocore-3.7.0.tar.gz", hash = "sha256:c64d871ed5491a6571948dd48eabd185b46c6c23b64e3afd0c059fc7593ada30", size = 127054, upload-time = "2026-05-09T10:02:52.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl", hash = "sha256:680bde7c64679a821a9312641b759d9497f790ba8b2e88c6959e6273ee765b8e", size = 89539, upload-time = "2026-05-09T10:02:50.389Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -90,6 +108,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
     { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
 ]
 
 [[package]]
@@ -168,6 +195,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
 ]
 
 [[package]]
@@ -422,6 +463,12 @@ dependencies = [
     { name = "zarr" },
 ]
 
+[package.optional-dependencies]
+forecast = [
+    { name = "icechunk" },
+    { name = "s3fs" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
@@ -441,6 +488,7 @@ requires-dist = [
     { name = "geojson-pydantic", specifier = ">=2.1.0" },
     { name = "geozarr-toolkit", specifier = "==0.1.*" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "icechunk", marker = "extra == 'forecast'", specifier = ">=0.1.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "metpy", specifier = ">=1.7,<2" },
     { name = "portalocker", specifier = ">=3.2.0" },
@@ -448,12 +496,14 @@ requires-dist = [
     { name = "pystac", specifier = ">=1.10,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rioxarray", specifier = ">=0.17" },
+    { name = "s3fs", marker = "extra == 'forecast'", specifier = ">=2024.1" },
     { name = "starlette", specifier = ">=0.27.0" },
     { name = "topozarr", specifier = "==0.0.*" },
     { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "xstac", specifier = ">=1.0,<2" },
     { name = "zarr", specifier = ">=3.1.6,<4" },
 ]
+provides-extras = ["forecast"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1102,6 +1152,37 @@ wheels = [
 ]
 
 [[package]]
+name = "icechunk"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zarr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/dd/c38e89707affc0a279d97b3ec4226647a42da2f651a34ab60f262ee4cdb6/icechunk-2.0.4.tar.gz", hash = "sha256:21d789be2cf4612cd8a95cf83ededac3265eb181bc837d9eaf86c50f3e10b7f5", size = 3316217, upload-time = "2026-04-29T22:01:55.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/9f/dba7e96f90b38961a875cc100f79be0d63274d1fa72d54a3f45ec67ace18/icechunk-2.0.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:20543ae093a4a34d54f36ceee0eea73185c3679b9c1ad541ee056baae31394ec", size = 16796797, upload-time = "2026-04-29T22:02:28.92Z" },
+    { url = "https://files.pythonhosted.org/packages/89/50/393d04f9e59bfc7577fdbff1cfff9c2564ba34dc8403e107dc2f81c11ed0/icechunk-2.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:321077a01b842dfc86bd3c14d9abe46f4e50112e4eb5d1f00dc82e19893822e4", size = 15494880, upload-time = "2026-04-29T22:02:19.915Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/ed7147dac5f0768a3dbb72be399f3346553252c7627c6560ae40655f31cf/icechunk-2.0.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbdae59b438dea1da1caaa1860c26fca696afd1547a89b1bb66d90a21f4f8337", size = 17179693, upload-time = "2026-04-29T22:02:10.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ac/c49b8c2f611f4eae9eecf1893c0f6c3f4111572d27b79ed307b89c67714d/icechunk-2.0.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5690ffea3f5966e18273a4fe64041038cd43afe01d40067d36640ef24e07192a", size = 16830182, upload-time = "2026-04-29T22:01:49.787Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/15/082f9c9ced590fc2daa63ffe2b34810959c34c434e7877f1dbe20da8beef/icechunk-2.0.4-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:07718b38150ef0c35b094658822d0307993d6cdcde5215ce0332e58587fdebac", size = 16653774, upload-time = "2026-04-29T22:02:01.087Z" },
+    { url = "https://files.pythonhosted.org/packages/25/28/258b7f468b2418af086ce397c785ee972523a8df1ded7baeb34636068a34/icechunk-2.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:887fd0366ed54f281a7791c35b1afc4865264a7aeaba6436f9221744127f19b6", size = 17042662, upload-time = "2026-04-29T22:02:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5d/f2bfd70c279cf3aa601dd483cffebec294c31d3909db2bcefcc560c44094/icechunk-2.0.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:4c9fe9b3494041a3f291d22e3ed7b6157924a0a95476c501f2924297cb070283", size = 16819304, upload-time = "2026-04-29T22:02:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4e/6d97e198e863dd71b0fc82fcb34b3a9eabe46bbac42a9bf5cd0a0f9b11d7/icechunk-2.0.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ea9201f87653950f1a6a5ed9d0b0c9e74d9828f8657822c1e2b2906aadc96614", size = 16901546, upload-time = "2026-04-29T22:02:55.932Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/fb/5229deed47429d944b1065ad4fa404778ff07e2f29a078680f515b15bf2a/icechunk-2.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36d25f1d4e753c783913c5b5a0ffeee235e103b6ad73fac0f46aa9ac21a95be2", size = 17582653, upload-time = "2026-04-29T22:03:05.283Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a5/339d62b471faeb27172e75063d481bc0af3f0ba9ee7bf35988a8617943e8/icechunk-2.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:42d9561c933c3a7a36650aa382eca04a25709a54cfe9378b7bbaf84af3da8484", size = 15895555, upload-time = "2026-04-29T22:03:15.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/25/a1f99c187a01de546f55508c804e464a25e1a5c98d3367139a4915e681d4/icechunk-2.0.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:597dbde7a780fb44d66883b5dcae7ba6350a9e4e1f101839f1eafdd52d64d6f6", size = 16802237, upload-time = "2026-04-29T22:02:32.098Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/dd/d8ee1be3f3e84c231557549cbfeb9f26eafa4ff0d056dff5182cb7de161f/icechunk-2.0.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ce7569f2d2a1af322448c74c2dda3277db1a7927ce151323043ea578b4dc61d", size = 15504080, upload-time = "2026-04-29T22:02:23.026Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b3/8b66d93447a4515b0d6afce9f0fa600cb527532ca271e7846acbc4aff18e/icechunk-2.0.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e5d3d60038424bc9f04da4abcbb225c2a0741ea28ca2c851b5fdb02e4dcd17d", size = 17189150, upload-time = "2026-04-29T22:02:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7f/9e6b4b3ad9d5e1cecd62d2453b997c726ed00e853e9d7561c6ebad419ac9/icechunk-2.0.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c6f73aef9e4bc26bd1889823dba8d4ae14488520efdd599dfa92ec46f4bdfe2c", size = 16843481, upload-time = "2026-04-29T22:01:53.031Z" },
+    { url = "https://files.pythonhosted.org/packages/92/10/4698e602237be3d66c0a33764e1bf2b911927b5c8f4b5db854d6ec8b79af/icechunk-2.0.4-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:ba41c0bf14a2b509dff2142d746b0a285f473994b3cb5d36d2d91e148640f7dc", size = 16663026, upload-time = "2026-04-29T22:02:04.114Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e9/e25c0cb72923cb0bbcd589d3bdd91c4584cf20d0c056de78dcb4d481fb97/icechunk-2.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5ae8f59807cecd87a11abc06ea6a92724adcbb49ac08f3a4e45b9ca975d6ad6c", size = 17058642, upload-time = "2026-04-29T22:02:41.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c6/0452f30e0407b6aea64089c4c4beb5a98b213467887c7acf8872de064ced/icechunk-2.0.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:17b6da024950b20d5126bb903d4717430c0b9164f1c450fd257f7a719744488a", size = 16831074, upload-time = "2026-04-29T22:02:49.928Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8e/045b247bf6691b66ee0bca03bba2784a3813fa42c445189f687fada53e28/icechunk-2.0.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:5a5cbc9e5ea0d8ba1e42c73f7decd72cec389b436de347d28ce286b7c33174d9", size = 16912935, upload-time = "2026-04-29T22:02:59.129Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/47/7190655c250e1e247b7952cc63ac74dfc71321f119c5445971a1c21832f5/icechunk-2.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:12c7adfba219d1c9cb24379a875f72f5991bf88b0a8e49bedaf5c5cb821288cd", size = 17595683, upload-time = "2026-04-29T22:03:08.255Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2b/0dd74453d0c4f5b68a66682051f37e7d88908a27e85c843eba41402262ca/icechunk-2.0.4-cp314-cp314-win_amd64.whl", hash = "sha256:339d8f8584940497c7b69b17613620b3aeb64b394a85b6ff69192709e1eaddeb", size = 15907915, upload-time = "2026-04-29T22:03:18.286Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1138,6 +1219,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2629,6 +2719,20 @@ wheels = [
 ]
 
 [[package]]
+name = "s3fs"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
+    { name = "fsspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/d8/76f3dc1558bdf4494b117a9f7a9cc0a5d9d34edadc9e5d7ceabc5a6a7c37/s3fs-2026.4.0.tar.gz", hash = "sha256:5bdce0abb00b0435ee150807a45fea727451dbc22de4cbc116464f8504ab9d37", size = 85986, upload-time = "2026-04-29T20:52:51.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl", hash = "sha256:de0d2a1f33cdf03831fd2382d278c6e4e31fe57c3bf2f703c61f8aec6b703e2a", size = 32392, upload-time = "2026-04-29T20:52:50.295Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2940,6 +3044,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Depends on

#128 (architecture documentation) — this PR extends that doc and must be rebased on it after merge.

## Summary

Implements `sync.kind: derived` and `sync.kind: remote` for dataset templates, and ships the first two derived datasets: GEFS precipitation forecast and GEFS 2 m temperature forecast via dynamical.org's icechunk store. Closes #125.

The raw GEFS store has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`) which are not suitable for direct serving. This PR derives a simple `time × latitude × longitude` zarr from the latest complete run on each sync.

## Breaking changes

- `CreateIngestionRequest.start` is now optional (`str | None`, default `null`). Required for `temporal` and `release` datasets; omit for `derived` and `remote` datasets. Clients that always supply `start` are unaffected.

## Changes

### New sync kinds

**`sync.kind: derived`** — a derivation function transforms a remote store into a local zarr on each sync. The framework applies declared transforms, writes GeoZarr root attributes, computes coverage, and registers the artifact. The derivation function only needs to write a `(time, latitude, longitude)` zarr; the framework handles everything else.

**`sync.kind: remote`** — registers the remote store URL as the artifact path and proxies requests directly. No local copy. Use only when the remote store is already in a shape clients can consume.

### Framework changes

- GeoZarr root attributes (`spatial:bbox`, `proj:code`) are now written by the framework in `_derive_artifact`, not by the derivation function. This ensures attrs always reflect the data after transforms run. Plugin code must not write them.
- `CreateIngestionRequest.start` made optional with a guard that raises HTTP 422 for `temporal`/`release` datasets where `start` is still required.
- `get_store_if_cached()` added to `remote_zarr.py` as the public accessor for the store cache (replaces private `_store_cache` import).
- `asyncio.get_running_loop()` replaces deprecated `get_event_loop()` in lifespan hook.
- Range header `int()` parsing wrapped in try/except — returns 416 instead of 500 for malformed specs.
- HEAD requests for missing zarr keys return 404 instead of 503.

### GEFS derivation pipeline (`climate_api/processing/gefs.py`)

1. Select the most recent `init_time` with a complete forecast (latest run is often still distributing — walk back up to 5 runs)
2. Average across ensemble members (ensemble mean)
3. Map `lead_time → valid_time` to produce a standard `time` dimension
4. Subset to the configured instance extent
5. Resample 6-hourly steps to daily mean
6. Trim trailing NaN time steps (unpublished lead times still in transit)
7. Sort ascending lat/lon, rechunk, write zarr

`gefs_precipitation_forecast` uses the `flux_to_mm_per_day` transform (×86400 s/day) so stored values are in mm/day rather than the raw GEFS unit of kg m⁻² s⁻¹.

### Map viewer fix (`climate_api/templates/map-viewer.html`)

Dimension selector HTML construction replaced with DOM API (`createElement`/`textContent`) to prevent XSS from dataset dimension keys.

### Documentation

- `docs/architecture.md` — extended from #128 with `derived` and `remote` sync kinds, derivation function contract, GeoZarr/CRS handling for derived artifacts, and design consequences
- `docs/adding_custom_datasets.md` — new guide covering template authoring, plugin layout, and the derivation function contract
- `docs/extensibility.md` — new reference for the five extension points
- `docs/built_in_datasets.md` — GEFS precipitation and temperature datasets added
- `docs/transforms.md` — `flux_to_mm_per_day` documented

### Plugin extensibility

Any country plugin can add any forecast source without core changes:

```yaml
ingestion:
  function: my_plugin.ecmwf.derive_dataset
transforms:
  - climate_api.transforms.unit_conversion.flux_to_mm_per_day
store:
  kind: remote_zarr
  store_url: "s3://..."
  crs: "EPSG:4326"   # optional, defaults to EPSG:4326
```

## Test plan

- [x] Derived artifact written to disk with correct `time` dimension (calendar dates, 35 days)
- [x] Falls back to most recent complete `init_time` when latest run is still distributing
- [x] Trailing NaN time steps trimmed from resampled output
- [x] ZarrLayer renders tiles correctly (WGS84 coordinates, ascending lat/lon)
- [x] Re-sync produces updated artifact with new `init_time`
- [x] Both precipitation and temperature datasets verified on Norway instance
- [x] `ingestion.function` dispatch tested with mock derive function
- [x] `most_recent_complete_init` tested with incomplete and complete run fixtures
- [x] GEFS precipitation stored in mm/day (flux converted via `flux_to_mm_per_day` transform)