### PR TITLE
docs: architecture overview — concepts, lifecycle, sync kinds, plugin contracts

### DIFF
--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,7 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.shared.time import period_type_to_iso_step, time_chunk_for_iso_step
+from climate_api.shared.time import resolve_iso_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -294,16 +294,16 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    period_type = dataset["period_type"]
-    iso_step = period_type_to_iso_step(period_type)
+    iso_step = resolve_iso_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
         chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
-            "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",
-            period_type,
+            "No ISO 8601 step for dataset '%s' (period_type=%r); defaulting time chunk to 12. "
+            "Declare 'period_step' in the template to silence this warning.",
             dataset.get("id", "?"),
+            dataset.get("period_type"),
         )
         chunks[dim] = 12
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -200,11 +200,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     else:
         logger.info("Building flat zarr (max dim %d pixels)", max(ds.sizes[x_dim], ds.sizes[y_dim]))
-        # determine optimal chunk sizes
-        ds_autochunk = ds.chunk("auto").unify_chunks()
-        uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
-        time_space_chunks = _compute_time_space_chunks(ds, dataset)
-        uniform_chunks.update(time_space_chunks)
+        uniform_chunks = _compute_time_space_chunks(ds, dataset)
         logger.info(f"--> {uniform_chunks}")
 
         ds.attrs.update(geozarr_attrs)
@@ -292,7 +288,7 @@ def _run_transforms(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
 def _compute_time_space_chunks(
     ds: xr.Dataset,
     dataset: dict[str, Any],
-    max_spatial_chunk: int = 256,
+    max_spatial_chunk: int = 512,
 ) -> dict[str, int]:
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
@@ -303,10 +299,21 @@ def _compute_time_space_chunks(
         chunks[dim] = 24 * 7
     elif period_type == "daily":
         chunks[dim] = 30
+    elif period_type == "dekadal":
+        chunks[dim] = 36
+    elif period_type == "weekly":
+        chunks[dim] = 52
     elif period_type == "monthly":
         chunks[dim] = 12
     elif period_type == "yearly":
         chunks[dim] = 1
+    else:
+        logger.warning(
+            "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",
+            period_type,
+            dataset.get("id", "?"),
+        )
+        chunks[dim] = 12
 
     x_dim, y_dim = get_x_y_dims(ds)
     chunks[x_dim] = min(ds.sizes[x_dim], max_spatial_chunk)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,7 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.shared.time import resolve_iso_step, time_chunk_for_iso_step
+from climate_api.shared.time import resolve_iso_period_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -294,7 +294,7 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    iso_step = resolve_iso_step(dataset)
+    iso_step = resolve_iso_period_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
         chunks[dim] = time_chunk_for_iso_step(iso_step)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -300,10 +300,9 @@ def _compute_time_space_chunks(
         chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
-            "No ISO 8601 step for dataset '%s' (period_type=%r); defaulting time chunk to 12. "
-            "Declare 'period_step' in the template to silence this warning.",
+            "No ISO 8601 step for dataset '%s'; defaulting time chunk to 12. "
+            "Declare 'extents.temporal.resolution' in the template to silence this warning.",
             dataset.get("id", "?"),
-            dataset.get("period_type"),
         )
         chunks[dim] = 12
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -297,7 +297,15 @@ def _compute_time_space_chunks(
     iso_step = resolve_iso_period_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
-        chunks[dim] = time_chunk_for_iso_step(iso_step)
+        try:
+            chunks[dim] = time_chunk_for_iso_step(iso_step)
+        except ValueError:
+            logger.warning(
+                "Invalid ISO 8601 step %r for dataset '%s'; defaulting time chunk to 12.",
+                iso_step,
+                dataset.get("id", "?"),
+            )
+            chunks[dim] = 12
     else:
         logger.warning(
             "No ISO 8601 step for dataset '%s'; defaulting time chunk to 12. "

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -212,7 +212,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         # render missing pixels as transparent — not a separately specified fillValue.
         for var in ds_chunked.data_vars:
             ds_chunked[var].encoding.pop("_FillValue", None)
-        ds_chunked.to_zarr(zarr_path, mode="w", consolidated=True)
+        ds_chunked.to_zarr(zarr_path, mode="w", zarr_format=3, consolidated=True)
         ds_chunked.close()
 
     ds.close()

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,6 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
+from climate_api.shared.time import period_type_to_iso_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -293,20 +294,11 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    dim = get_time_dim(ds)
     period_type = dataset["period_type"]
-    if period_type == "hourly":
-        chunks[dim] = 24 * 7
-    elif period_type == "daily":
-        chunks[dim] = 30
-    elif period_type == "dekadal":
-        chunks[dim] = 36
-    elif period_type == "weekly":
-        chunks[dim] = 52
-    elif period_type == "monthly":
-        chunks[dim] = 12
-    elif period_type == "yearly":
-        chunks[dim] = 1
+    iso_step = period_type_to_iso_step(period_type)
+    dim = get_time_dim(ds)
+    if iso_step is not None:
+        chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
             "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,6 +7,56 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
+# Single source of truth for the ISO 8601 duration step for each known period type.
+# Used for STAC cube:dimensions metadata and zarr time chunk sizing.
+# Add an entry here when a new period type is introduced — everything else derives from it.
+_PERIOD_TYPE_ISO_STEP: dict[str, str] = {
+    "hourly": "PT1H",
+    "daily": "P1D",
+    "dekadal": "P10D",
+    "weekly": "P7D",
+    "monthly": "P1M",
+    "yearly": "P1Y",
+}
+
+_ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
+
+
+def period_type_to_iso_step(period_type: str) -> str | None:
+    """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
+    return _PERIOD_TYPE_ISO_STEP.get(period_type)
+
+
+def _iso_step_to_approx_hours(step: str) -> float:
+    """Return the approximate duration in hours for an ISO 8601 duration string.
+
+    Months and years use calendar averages (30.4375 days/month, 365.25 days/year).
+    Raises ValueError for unrecognised formats.
+    """
+    m = _ISO_DURATION_RE.fullmatch(step)
+    if not m:
+        raise ValueError(f"Cannot parse ISO 8601 duration: '{step}'")
+    years, months, weeks, days, hours, minutes, seconds = (int(g or 0) for g in m.groups())
+    return (
+        years * 365.25 * 24 + months * 30.4375 * 24 + weeks * 7 * 24 + days * 24 + hours + minutes / 60 + seconds / 3600
+    )
+
+
+def time_chunk_for_iso_step(step: str) -> int:
+    """Return a suitable zarr time chunk size for a given ISO 8601 duration step.
+
+    Targets roughly one week of data for sub-daily steps, one month for daily/sub-weekly
+    steps, and one year for weekly and coarser steps.  This keeps individual chunk files
+    at a manageable size while covering a natural analysis window in one read.
+    """
+    hours = _iso_step_to_approx_hours(step)
+    if hours < 24:
+        return max(1, round(24 * 7 / hours))  # ~1 week
+    if hours < 24 * 7:
+        return max(1, round(24 * 30 / hours))  # ~1 month
+    return max(1, round(24 * 365.25 / hours))  # ~1 year
+
+
 _WEEKLY_PERIOD_PATTERN = re.compile(r"^(?P<year>\d{4})-W(?P<week>\d{2})$")
 
 

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -5,10 +5,10 @@ import re
 from datetime import UTC, date, datetime
 from typing import Any, cast
 
-logger = logging.getLogger(__name__)
-
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,48 +7,24 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-# Convenience defaults for well-known period type names.
-# Custom datasets that use a non-standard period_type can declare their own
-# ISO 8601 step directly in the template YAML via the `period_step` field —
-# no changes to core code are needed in that case.
-_PERIOD_TYPE_ISO_STEP: dict[str, str] = {
-    "hourly": "PT1H",
-    "daily": "P1D",
-    "dekadal": "P10D",
-    "weekly": "P7D",
-    "monthly": "P1M",
-    "yearly": "P1Y",
-}
-
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
 
-def period_type_to_iso_step(period_type: str) -> str | None:
-    """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
-    return _PERIOD_TYPE_ISO_STEP.get(period_type)
-
-
 def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
-    """Return the ISO 8601 duration step for a dataset.
+    """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
-    Resolution order:
-    1. ``extents.temporal.resolution`` — the authoritative field already present in
-       every template (e.g. ``P1D``, ``PT1H``).  Custom datasets with any period type
-       are fully supported here without touching core code.
-    2. Built-in lookup table — fallback for templates that pre-date the
-       ``extents.temporal.resolution`` field or omit it.
-
-    See issue #94: the long-term direction is to derive ``period_type`` itself from
-    ``extents.temporal.resolution`` and remove the duplication.
+    Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601
+    duration (e.g. ``P1D``, ``PT1H``, ``P14D``).  Returns None if the field is absent,
+    which triggers a warning at the call site.
     """
-    resolution = dataset.get("extents", {})
-    if isinstance(resolution, dict):
-        resolution = resolution.get("temporal", {})
-        if isinstance(resolution, dict):
-            resolution = resolution.get("resolution")
-    if resolution:
-        return str(resolution)
-    return period_type_to_iso_step(str(dataset.get("period_type", "")))
+    extents = dataset.get("extents")
+    if not isinstance(extents, dict):
+        return None
+    temporal = extents.get("temporal")
+    if not isinstance(temporal, dict):
+        return None
+    resolution = temporal.get("resolution")
+    return str(resolution) if resolution else None
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -1,8 +1,11 @@
 """Time helpers shared across Climate API modules."""
 
+import logging
 import re
 from datetime import UTC, date, datetime
 from typing import Any, cast
+
+logger = logging.getLogger(__name__)
 
 import numpy as np
 import pandas as pd
@@ -13,9 +16,8 @@ _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?
 def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
-    Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601
-    duration (e.g. ``P1D``, ``PT1H``, ``P14D``).  Returns None if the field is absent,
-    which triggers a warning at the call site.
+    Returns None if the field is absent or not a valid ISO 8601 duration, logging
+    a warning in the latter case.
     """
     extents = dataset.get("extents")
     if not isinstance(extents, dict):
@@ -24,7 +26,15 @@ def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     if not isinstance(temporal, dict):
         return None
     resolution = temporal.get("resolution")
-    return str(resolution) if resolution else None
+    if not resolution:
+        return None
+    resolution_str = str(resolution)
+    try:
+        _iso_step_to_approx_hours(resolution_str)
+    except ValueError:
+        logger.warning("Invalid ISO 8601 duration in extents.temporal.resolution: %r", resolution_str)
+        return None
+    return resolution_str
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,9 +7,10 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-# Single source of truth for the ISO 8601 duration step for each known period type.
-# Used for STAC cube:dimensions metadata and zarr time chunk sizing.
-# Add an entry here when a new period type is introduced — everything else derives from it.
+# Convenience defaults for well-known period type names.
+# Custom datasets that use a non-standard period_type can declare their own
+# ISO 8601 step directly in the template YAML via the `period_step` field —
+# no changes to core code are needed in that case.
 _PERIOD_TYPE_ISO_STEP: dict[str, str] = {
     "hourly": "PT1H",
     "daily": "P1D",
@@ -25,6 +26,19 @@ _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?
 def period_type_to_iso_step(period_type: str) -> str | None:
     """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
     return _PERIOD_TYPE_ISO_STEP.get(period_type)
+
+
+def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
+    """Return the ISO 8601 duration step for a dataset.
+
+    Reads `period_step` from the template first, so custom datasets can declare
+    any step (e.g. `period_step: P14D`) without touching core code.  Falls back
+    to the built-in lookup table for standard period type names.
+    """
+    explicit = dataset.get("period_step")
+    if explicit:
+        return str(explicit)
+    return period_type_to_iso_step(str(dataset.get("period_type", "")))
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -37,9 +37,12 @@ def _iso_step_to_approx_hours(step: str) -> float:
     if not m:
         raise ValueError(f"Cannot parse ISO 8601 duration: '{step}'")
     years, months, weeks, days, hours, minutes, seconds = (int(g or 0) for g in m.groups())
-    return (
+    result = (
         years * 365.25 * 24 + months * 30.4375 * 24 + weeks * 7 * 24 + days * 24 + hours + minutes / 60 + seconds / 3600
     )
+    if result <= 0:
+        raise ValueError(f"ISO 8601 duration '{step}' resolves to zero — cannot derive chunk size")
+    return result
 
 
 def time_chunk_for_iso_step(step: str) -> int:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -10,7 +10,7 @@ import pandas as pd
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
 
-def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
+def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
     Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -31,13 +31,23 @@ def period_type_to_iso_step(period_type: str) -> str | None:
 def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step for a dataset.
 
-    Reads `period_step` from the template first, so custom datasets can declare
-    any step (e.g. `period_step: P14D`) without touching core code.  Falls back
-    to the built-in lookup table for standard period type names.
+    Resolution order:
+    1. ``extents.temporal.resolution`` — the authoritative field already present in
+       every template (e.g. ``P1D``, ``PT1H``).  Custom datasets with any period type
+       are fully supported here without touching core code.
+    2. Built-in lookup table — fallback for templates that pre-date the
+       ``extents.temporal.resolution`` field or omit it.
+
+    See issue #94: the long-term direction is to derive ``period_type`` itself from
+    ``extents.temporal.resolution`` and remove the duplication.
     """
-    explicit = dataset.get("period_step")
-    if explicit:
-        return str(explicit)
+    resolution = dataset.get("extents", {})
+    if isinstance(resolution, dict):
+        resolution = resolution.get("temporal", {})
+        if isinstance(resolution, dict):
+            resolution = resolution.get("resolution")
+    if resolution:
+        return str(resolution)
     return period_type_to_iso_step(str(dataset.get("period_type", "")))
 
 

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime
+from climate_api.shared.time import parse_period_string_to_datetime, period_type_to_iso_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, _period_step(source_dataset.get("period_type")))
+    _override_time_step(collection_payload, period_type_to_iso_step(str(source_dataset.get("period_type", ""))))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
@@ -316,18 +316,6 @@ def _abs_url(request: Request, path: str) -> str:
     if base_url:
         return f"{base_url.rstrip('/')}{path}"
     return f"{str(request.base_url).rstrip('/')}{path}"
-
-
-def _period_step(period_type: object) -> str | None:
-    if period_type == "hourly":
-        return "PT1H"
-    if period_type == "daily":
-        return "P1D"
-    if period_type == "monthly":
-        return "P1M"
-    if period_type == "yearly":
-        return "P1Y"
-    return None
 
 
 def _override_time_step(collection: dict[str, Any], step: str | None) -> None:

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime, period_type_to_iso_step
+from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, period_type_to_iso_step(str(source_dataset.get("period_type", ""))))
+    _override_time_step(collection_payload, resolve_iso_step(source_dataset))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_step
+from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_period_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, resolve_iso_step(source_dataset))
+    _override_time_step(collection_payload, resolve_iso_period_step(source_dataset))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,10 @@ This is a deliberate design constraint: each instance serves one place. A Sierra
 ```
 Template (YAML)
     │
-    │  POST /ingestions
+    │  POST /ingestions  (or  POST /sync)
     ▼
 Ingestion
-    │  download data
+    │  call ingestion function → NetCDF files on disk
     │  apply transforms
     │  reproject to instance CRS
     │  write GeoZarr store
@@ -75,7 +75,9 @@ Managed dataset (public API)
     └── /ogcapi/collections/{id} — OGC API access
 ```
 
-The framework is responsible for everything from "write zarr" onward. A download function only needs to write NetCDF files to a given directory. The framework then:
+The ingestion function is called identically by both `POST /ingestions` and `POST /sync` — the framework invokes it the same way regardless of the trigger. A correctly written ingestion function works for both without any changes.
+
+The framework is responsible for everything from "write zarr" onward. An ingestion function only needs to write NetCDF files to a given directory. The framework then:
 
 1. reads and normalises the coordinate names
 2. applies transforms (unit conversion, etc.)
@@ -86,7 +88,7 @@ The framework is responsible for everything from "write zarr" onward. A download
 7. stores the artifact record
 8. publishes the managed dataset through pygeoapi if `publish=true`
 
-This division means that download functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data files; the framework handles everything else.
+This division means that ingestion functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data files; the framework handles everything else.
 
 ---
 
@@ -130,7 +132,7 @@ Before executing a sync, the engine calls the availability function to clamp the
 
 The platform has four extension points. Each one has a narrow contract — the framework handles everything else automatically.
 
-### Download function
+### Ingestion function
 
 ```python
 def download(
@@ -148,6 +150,26 @@ def download(
 
 The function writes NetCDF files. The framework reads them, normalises coordinate names, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
 
+The ingestion function is called identically by `POST /ingestions` and `POST /sync`. The caller makes no difference to the function — it always receives the same parameters.
+
+**Reusing ingestion logic across templates**: multiple YAML templates can reference the same Python function and differentiate via `default_params`. This is the intended pattern for sources that have the same fetching logic but expose different variables:
+
+```yaml
+# era5land_temperature_hourly.yaml
+ingestion:
+  function: dhis2eo.data.era5_land.download
+  default_params:
+    variable: 2m_temperature
+
+# era5land_precipitation_hourly.yaml
+ingestion:
+  function: dhis2eo.data.era5_land.download
+  default_params:
+    variable: total_precipitation
+```
+
+No framework changes are needed to support a new variable from the same source.
+
 ### Transform function
 
 ```python
@@ -157,7 +179,7 @@ def my_transform(ds: xr.Dataset, dataset: dict) -> xr.Dataset:
     # Do not modify dataset-level ds.attrs — the framework manages those.
 ```
 
-Transforms are applied in order after the download function returns, before the zarr is written. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They do not write to disk.
+Transforms are applied in order after the ingestion function returns, before the zarr is written. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They do not write to disk.
 
 ### Process execution function
 
@@ -175,7 +197,7 @@ Processes are named operations triggered via `POST /processes/{id}/execution`. T
 
 Transforms are applied at a consistent point in the ingestion lifecycle:
 
-1. download function writes raw NetCDF files to disk
+1. ingestion function writes raw NetCDF files to disk
 2. framework reads and normalises the data into an xarray Dataset
 3. `_run_transforms(ds, dataset)` applies each declared transform in order
 4. result is reprojected to instance CRS
@@ -234,13 +256,13 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 ## What the framework guarantees
 
-Plugin code (download functions, transforms, processes) can rely on the following being handled automatically by the framework:
+Plugin code (ingestion functions, transforms, processes) can rely on the following being handled automatically by the framework:
 
 | Concern                                               | Where handled                               |
 | ----------------------------------------------------- | ------------------------------------------- |
 | Coordinate name normalisation (`lat` → `y`, etc.)     | `build_dataset_zarr`                        |
 | Reprojection to instance CRS                          | `reproject_to_instance_crs`                 |
-| Zarr chunking (auto-sized per `period_type`)          | `_compute_chunk_sizes`                      |
+| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks`         |
 | Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr`                        |
 | GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr`                        |
 | Artifact coverage computation                         | `_coverage_from_dataset`                    |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The platform has four first-class concepts. Understanding the distinction betwee
 
 ### Dataset template
 
-A **template** is a YAML blueprint that describes a data source. It lives in `data/datasets/` (built-ins) or in a `plugins_dir/datasets/` directory (custom). It has no state — it describes what _could_ be ingested, not what _has been_ ingested.
+A **template** is a YAML blueprint that describes a data source. Built-ins live in `climate_api/data/datasets/` inside the package (loaded via `importlib.resources`). Custom templates live in `{plugins_dir}/datasets/` where `plugins_dir` is set in `climate-api.yaml`. It has no state — it describes what _could_ be ingested, not what _has been_ ingested.
 
 A template defines:
 
@@ -34,7 +34,7 @@ An **artifact** is the internal record of a completed data ingestion. It is the 
 
 Multiple artifacts can exist for the same dataset template if data was ingested at different times (they form the version history). The most recent artifact for a given `dataset_id` is what the public API serves.
 
-Artifacts are stored in `data/artifacts/records.json`. This is an internal implementation detail — consumers should never depend on artifact IDs or artifact paths directly.
+Artifacts are stored in `{data_dir}/artifacts/records.json`, where `data_dir` is the path configured in `climate-api.yaml`. This is an internal implementation detail — consumers should never depend on artifact IDs or artifact paths directly.
 
 ### Managed dataset
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,289 @@
+# Architecture
+
+This document explains how the Climate API is structured, why it is structured that way, and what the consequences are of each design decision. It is written for developers who will maintain or extend the platform over time.
+
+---
+
+## Core concepts
+
+The platform has four first-class concepts. Understanding the distinction between them is the foundation for understanding everything else.
+
+### Template
+
+A **template** is a YAML blueprint that describes a data source. It lives in `data/datasets/` (built-ins) or in a `plugins_dir/datasets/` directory (custom). It has no state — it describes what *could* be ingested, not what *has been* ingested.
+
+A template defines:
+- the dataset identifier and display metadata
+- the variable name, units, and period type
+- how to download or derive the data (`ingestion.function`)
+- what transforms to apply (`transforms`)
+- what sync strategy to use (`sync.kind`, `sync.execution`)
+
+Templates are config, not code. If a template needs custom logic, the logic goes into a Python function referenced by dotted path from the YAML.
+
+### Artifact
+
+An **artifact** is the internal record of a completed ingestion. It is the persistence layer — not a public API concept. Each ingestion produces exactly one artifact, which records:
+- what dataset template it came from
+- the exact spatial extent and time range that was materialized
+- where the data lives on disk (path to the zarr store or netCDF files)
+- when it was created
+- whether it has been published
+
+Multiple artifacts can exist for the same dataset template if data was ingested at different times (they form the version history). The most recent artifact for a given `dataset_id` is what the public API serves.
+
+Artifacts are stored in `data/artifacts/records.json`. This is an internal implementation detail — consumers should never depend on artifact IDs or artifact paths directly.
+
+### Managed dataset
+
+A **managed dataset** is the public-facing view of the most recent artifact for a given template. It is what `/datasets`, `/zarr`, `/stac`, and `/ogcapi` expose. When an operator ingests or syncs a dataset, the managed dataset view updates to reflect the new artifact — the public ID stays stable.
+
+The relationship is: one template → many artifacts over time → one managed dataset (the latest).
+
+### Extent
+
+The **extent** is the spatial bounding box configured for this Climate API instance. It is set once in `climate-api.yaml` and does not change at runtime. Every ingestion is automatically scoped to this extent — operators do not specify it per-request.
+
+This is a deliberate design constraint: each instance serves one place. A Norway instance serves Norway. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
+
+---
+
+## Data lifecycle
+
+```
+Template (YAML)
+    │
+    │  POST /ingestions
+    ▼
+Ingestion
+    │  download or derive data
+    │  apply transforms
+    │  write GeoZarr store
+    │  compute coverage (spatial + temporal extent of actual data)
+    ▼
+Artifact (internal record)
+    │
+    │  publish=true
+    ▼
+Managed dataset (public API)
+    ├── /datasets/{id}       — native metadata
+    ├── /zarr/{id}           — raw zarr store access
+    ├── /stac/collections/{id} — STAC discovery
+    └── /ogcapi/collections/{id} — OGC API access
+```
+
+The framework is responsible for everything from "write zarr" onward. A download function or derivation function only needs to produce a zarr file at `output_path`. The framework then:
+
+1. applies transforms (unit conversion, etc.)
+2. writes GeoZarr root attributes (`spatial:bbox`, `proj:code`) so map clients can position tiles
+3. computes artifact coverage (spatial bounds + time range) from the written data
+4. stores the artifact record
+5. publishes the managed dataset through pygeoapi if `publish=true`
+
+This division means that download functions and derivation functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data; the framework handles everything else.
+
+---
+
+## Sync kinds
+
+The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion — the table below is the primary guide.
+
+| `sync.kind` | Data lives | On each sync | Use when |
+|-------------|-----------|--------------|----------|
+| `temporal` | Local zarr | Append new time steps (or rematerialize) | Historical record that grows over time (CHIRPS, ERA5-Land) |
+| `release` | Local zarr | Rematerialize if a newer release exists | Versioned releases (WorldPop yearly) |
+| `static` | Local zarr | Never synced | One-time fixed dataset |
+| `derived` | Local zarr, rebuilt from remote | Always rematerialise from remote store | Forecast data that needs transformation before it is usable (GEFS) |
+| `remote` | Remote store, no local copy | Re-register latest coverage | Datasets where direct store access is acceptable and transformation is not needed |
+
+### When to use `derived` vs `remote`
+
+`remote` is the simplest: the Climate API registers the remote store URL as the artifact path and proxies requests to it directly. Nothing is downloaded or transformed. The trade-off is that the raw store is served as-is — if it has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`), the client sees five dimensions.
+
+`derived` performs a transformation step before the data is accessible. The derivation function reads the remote store, collapses it to a usable shape (e.g. ensemble mean, lead_time → calendar dates, daily resample), and writes a local zarr. The local zarr is what clients see. The trade-off is that a sync rewrites the entire artifact — there is no incremental append.
+
+**Rule of thumb:** use `remote` only if the remote store is already in a shape that map clients and downstream tools can consume directly. Use `derived` when the raw store requires transformation to be useful.
+
+### The sync execution modes
+
+Within `sync.kind: temporal`, two execution modes exist:
+
+- `append` — downloads only the missing time range and appends it to the existing artifact
+- `rematerialize` — discards the existing artifact and rebuilds it from scratch
+
+`append` is efficient for large historical datasets (avoid re-downloading years of data on each sync). `rematerialize` is correct for forecasts and any dataset where old data may change retroactively. `derived` always rematerialises.
+
+---
+
+## The plugin contract
+
+The platform has four extension points. Each one has a narrow contract — the framework handles everything else automatically.
+
+### Download function (`sync.kind: temporal`, `release`, `static`)
+
+```python
+def download(
+    *,
+    start: str,
+    end: str,
+    dirname: Path,
+    prefix: str,
+    overwrite: bool,
+    bbox: list[float],    # optional — only if needed
+    **kwargs,             # default_params from YAML
+) -> None:
+    # Write NetCDF files to dirname using prefix as filename base.
+```
+
+The function writes one or more NetCDF files. The framework reads them, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
+
+### Derivation function (`sync.kind: derived`)
+
+```python
+def derive_dataset(
+    *,
+    store_config: dict,   # the template's store block
+    output_path: Path,    # write a consolidated zarr here
+    extent: dict | None,  # instance spatial extent
+    variable: str,
+    period_type: str,
+) -> None:
+    # Read from remote store, transform, write zarr to output_path.
+    # Output must have dimensions (time, latitude, longitude) in ascending order.
+    # Do not write GeoZarr root attributes — the framework does this.
+```
+
+The framework calls the derivation function, then applies any declared transforms, writes GeoZarr root attributes, computes coverage, and registers the artifact.
+
+**Important:** the derivation function must not write GeoZarr root attributes (`spatial:bbox`, `proj:code`) itself. These are written by the framework after transforms run, using the actual coordinate bounds of the final written data. If the function writes them, the framework will overwrite them anyway; if they are wrong they will confuse map clients.
+
+### Transform function
+
+```python
+def my_transform(ds: xr.Dataset, dataset: dict) -> xr.Dataset:
+    # Modify ds[dataset["variable"]] and return the modified dataset.
+    # Preserve ds.attrs — the framework relies on them.
+```
+
+Transforms are applied in order after the download or derivation function returns. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They should not write to disk — the framework handles writing.
+
+### Process execution function
+
+```python
+def execute(*, source_dataset_id: str, **kwargs) -> dict:
+    # Run a derived computation (e.g. temporal resampling).
+    # Return a JSON-serialisable dict.
+```
+
+Processes are named operations triggered via `POST /processes/{id}/execution`. They are broader than single-dataset transforms — they can read one dataset and produce another (e.g. daily → monthly aggregation).
+
+---
+
+## The transform pipeline
+
+Transforms are applied in a consistent location in the lifecycle:
+
+1. download function / derivation function writes raw data
+2. `_run_transforms(ds, dataset)` applies each transform in the declared order
+3. result is written to the zarr store
+4. framework writes GeoZarr root attributes
+5. framework computes coverage from the zarr
+
+This means transforms always see the raw output of the function, not the GeoZarr-attributed zarr. Transforms should only modify data values and variable attributes. They must not modify dataset-level `.attrs` — the framework manages those.
+
+The transform pipeline runs identically for downloaded data and derived data. A transform written for a regular dataset works unchanged on a derived dataset.
+
+---
+
+## GeoZarr root attributes
+
+Every zarr artifact must have GeoZarr root attributes for map rendering to work correctly. These are stored in the `zarr.json` root metadata:
+
+- `spatial:bbox` — `[xmin, ymin, xmax, ymax]` in the native CRS
+- `proj:code` — the CRS EPSG code (e.g. `EPSG:4326`)
+- `zarr_conventions` — GeoZarr convention declaration
+
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to the instance CRS and null bounds, which produces a white or misaligned map.
+
+**The framework writes these attributes — plugins do not.** For downloaded datasets, they are written in `build_dataset_zarr`. For derived datasets, they are written in `_derive_artifact` after transforms are applied, using the actual coordinate bounds of the final data and the CRS declared in `store.crs` (default: `EPSG:4326`).
+
+---
+
+## CRS handling
+
+The instance CRS is configured in `climate-api.yaml`:
+
+```yaml
+extent:
+  name: Norway
+  bbox: [3.0, 57.0, 32.0, 72.5]
+  crs: EPSG:32633   # optional; defaults to EPSG:4326
+```
+
+**Downloaded datasets** are reprojected from their source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is in the instance CRS.
+
+**Derived datasets** are never reprojected. They are stored in their native CRS, declared via `store.crs` in the template (default `EPSG:4326`). If the remote store is in a projected CRS, set `store.crs` accordingly so STAC metadata reflects the correct projection.
+
+**Remote datasets** follow the same rule as derived: no reprojection, CRS from `store.crs`.
+
+---
+
+## Artifact deduplication and version history
+
+When a new ingestion request arrives, the framework checks whether an existing artifact already covers the requested scope:
+
+- same `dataset_id`
+- same `bbox` (from the configured extent)
+- overlapping time range
+
+If a match exists and `overwrite=false`, the existing artifact is returned without re-downloading. If `overwrite=true`, the existing artifact is replaced.
+
+For derived and remote datasets, the framework always upserts: it replaces the existing record while preserving the `artifact_id`, so publication state (pygeoapi config, STAC entries) is maintained without a re-publish step.
+
+---
+
+## What the framework guarantees
+
+Plugin code (download functions, derivation functions, transforms) can rely on the following being handled automatically:
+
+| Concern | Where handled |
+|---------|---------------|
+| Writing GeoZarr root attributes | `build_dataset_zarr` (download), `_derive_artifact` (derived) |
+| Computing artifact coverage | `_coverage_from_dataset` called after all writes |
+| Reprojecting to instance CRS | `reproject_to_instance_crs` (downloaded data only) |
+| Multiscale pyramid generation | `_needs_pyramid` check in `build_dataset_zarr` |
+| Zarr chunking | Auto-computed from `period_type` in `_compute_chunk_sizes` |
+| Artifact record persistence | `_upsert_derived_record` / `_upsert_remote_zarr_record` |
+| pygeoapi publication | `publish_artifact_record` if `publish=true` |
+| STAC collection generation | Dynamic from artifact record |
+
+Plugin code only needs to produce data at the right path. Everything else is the framework's responsibility.
+
+---
+
+## Consequences of design choices
+
+### Consequence: one extent per instance
+
+Each instance is configured for one place. This keeps the data model simple (no multi-extent artifact records) and the zarr stores small (no global downloads). The trade-off is that a national ministry with sub-national data needs runs multiple instances or a single instance at national extent.
+
+### Consequence: artifacts are append-only in version terms
+
+The artifact store keeps historical records (for sync history and deduplication). Old artifacts are not deleted automatically. For long-running instances, `records.json` will grow. The long-term direction is a proper transactional store, but for the current scale (dozens of artifacts per instance) a JSON file is adequate.
+
+### Consequence: derived datasets always rematerialise
+
+`sync.kind: derived` rewrites the full zarr on every sync. For a 35-day GEFS forecast at 0.25° resolution over a country, this is fast (seconds). For a global 1 km dataset with years of history, rematerialisation is impractical — use `temporal` with `append` instead.
+
+### Consequence: transforms run after the function writes
+
+Transforms see the exact output of the download or derivation function, not raw upstream data. This means:
+- unit conversion transforms work on whatever unit the function wrote
+- if the function already converts units, a unit conversion transform would double-convert
+- the function and the template's `transforms` list must not both handle the same conversion
+
+For GEFS: the raw store is in kg m⁻² s⁻¹. The derivation function (`gefs.py`) writes the raw values. The `flux_to_mm_per_day` transform in the template converts them. Neither the function nor the template does both steps.
+
+### Consequence: the plugin contract is stable but the framework internals are not
+
+The public plugin contract — function signatures, YAML field names, dotted-path resolution — is intended to be stable. Framework internals (`_derive_artifact`, `_run_transforms`, `build_dataset_zarr`) are not public API and may change. Plugins should depend only on the documented contracts, not on importing private framework functions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,11 +8,12 @@ This document explains how the Climate API is structured, why it is structured t
 
 The platform has four first-class concepts. Understanding the distinction between them is the foundation for understanding everything else.
 
-### Template
+### Dataset template
 
-A **template** is a YAML blueprint that describes a data source. It lives in `data/datasets/` (built-ins) or in a `plugins_dir/datasets/` directory (custom). It has no state — it describes what *could* be ingested, not what *has been* ingested.
+A **template** is a YAML blueprint that describes a data source. It lives in `data/datasets/` (built-ins) or in a `plugins_dir/datasets/` directory (custom). It has no state — it describes what _could_ be ingested, not what _has been_ ingested.
 
 A template defines:
+
 - the dataset identifier and display metadata
 - the variable name, units, and period type
 - how to download the data (`ingestion.function`)
@@ -23,7 +24,8 @@ Templates are config, not code. If a template needs custom logic, the logic goes
 
 ### Artifact
 
-An **artifact** is the internal record of a completed ingestion. It is the persistence layer — not a public API concept. Each ingestion produces exactly one artifact, which records:
+An **artifact** is the internal record of a completed data ingestion. It is the persistence layer — not a public API concept. Each ingestion produces exactly one artifact, which records:
+
 - what dataset template it came from
 - the exact spatial extent and time range that was materialized
 - where the data lives on disk (path to the zarr store or netCDF files)
@@ -44,7 +46,7 @@ The relationship is: one template → many artifacts over time → one managed d
 
 The **extent** is the spatial bounding box configured for this Climate API instance. It is set once in `climate-api.yaml` and does not change at runtime. Every ingestion is automatically scoped to this extent — operators do not specify it per-request.
 
-This is a deliberate design constraint: each instance serves one place. A Norway instance serves Norway. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
+This is a deliberate design constraint: each instance serves one place. A Sierra Leone instance serves Sierra Leone. Multi-country coverage requires multiple instances.
 
 ---
 
@@ -90,13 +92,13 @@ This division means that download functions do not need to know about zarr conve
 
 ## Sync kinds
 
-The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion.
+The `sync.kind` field in a template determines how a managed dataset is kept current.
 
-| `sync.kind` | On each sync | Use when |
-|-------------|--------------|----------|
-| `temporal` | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land) |
-| `release` | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
-| `static` | Never synced | One-time fixed dataset with no updates |
+| `sync.kind` | On each sync                            | Use when                                                          |
+| ----------- | --------------------------------------- | ----------------------------------------------------------------- |
+| `temporal`  | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land)        |
+| `release`   | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
+| `static`    | Never synced                            | One-time fixed dataset with no updates                            |
 
 ### The sync execution modes
 
@@ -193,7 +195,7 @@ Every zarr artifact must have GeoZarr root attributes for map rendering to work 
 - `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
 
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to null bounds, which produces a white or misaligned map.
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map.
 
 **The framework writes these attributes — plugins do not.** They are written in `build_dataset_zarr` after transforms and reprojection, using the actual coordinate bounds of the final written data and the instance CRS.
 
@@ -207,7 +209,7 @@ The instance CRS is configured in `climate-api.yaml`:
 extent:
   name: Norway
   bbox: [3.0, 57.0, 32.0, 72.5]
-  crs: EPSG:32633   # optional; defaults to EPSG:4326
+  crs: EPSG:32633 # optional; defaults to EPSG:4326
 ```
 
 Downloaded data is reprojected from the source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is always in the instance CRS.
@@ -234,17 +236,17 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 Plugin code (download functions, transforms, processes) can rely on the following being handled automatically by the framework:
 
-| Concern | Where handled |
-|---------|---------------|
-| Coordinate name normalisation (`lat` → `y`, etc.) | `build_dataset_zarr` |
-| Reprojection to instance CRS | `reproject_to_instance_crs` |
-| Zarr chunking (auto-sized per `period_type`) | `_compute_chunk_sizes` |
-| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr` |
-| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr` |
-| Artifact coverage computation | `_coverage_from_dataset` |
-| Artifact record persistence | `_store_artifact` |
-| pygeoapi publication | `publish_artifact_record` if `publish=true` |
-| STAC collection generation | Dynamic from artifact record |
+| Concern                                               | Where handled                               |
+| ----------------------------------------------------- | ------------------------------------------- |
+| Coordinate name normalisation (`lat` → `y`, etc.)     | `build_dataset_zarr`                        |
+| Reprojection to instance CRS                          | `reproject_to_instance_crs`                 |
+| Zarr chunking (auto-sized per `period_type`)          | `_compute_chunk_sizes`                      |
+| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr`                        |
+| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr`                        |
+| Artifact coverage computation                         | `_coverage_from_dataset`                    |
+| Artifact record persistence                           | `_store_artifact`                           |
+| pygeoapi publication                                  | `publish_artifact_record` if `publish=true` |
+| STAC collection generation                            | Dynamic from artifact record                |
 
 Plugin code only needs to produce data files. Everything else is the framework's responsibility.
 
@@ -266,8 +268,4 @@ The sync engine validates that new data connects to the end of the existing arti
 
 ### Transforms run after download, before reproject
 
-Transforms see raw downloaded values in the source CRS and source units. The order is: download → transform → reproject → write zarr. This means:
-
-- a `kelvin_to_celsius` transform works on raw Kelvin values, not reprojected ones
-- a transform cannot undo reprojection — if you need the source coordinates, the transform must run before reproject (which is the current design)
-- if the download function already converts units, adding a unit conversion transform would double-convert
+Transforms see raw downloaded values in the source CRS and source units. The order is: download → transform → reproject → write zarr.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ A **template** is a YAML blueprint that describes a data source. It lives in `da
 A template defines:
 - the dataset identifier and display metadata
 - the variable name, units, and period type
-- how to download or derive the data (`ingestion.function`)
+- how to download the data (`ingestion.function`)
 - what transforms to apply (`transforms`)
 - what sync strategy to use (`sync.kind`, `sync.execution`)
 
@@ -56,8 +56,9 @@ Template (YAML)
     │  POST /ingestions
     ▼
 Ingestion
-    │  download or derive data
+    │  download data
     │  apply transforms
+    │  reproject to instance CRS
     │  write GeoZarr store
     │  compute coverage (spatial + temporal extent of actual data)
     ▼
@@ -66,52 +67,60 @@ Artifact (internal record)
     │  publish=true
     ▼
 Managed dataset (public API)
-    ├── /datasets/{id}       — native metadata
-    ├── /zarr/{id}           — raw zarr store access
+    ├── /datasets/{id}         — native metadata
+    ├── /zarr/{id}             — raw zarr store access
     ├── /stac/collections/{id} — STAC discovery
     └── /ogcapi/collections/{id} — OGC API access
 ```
 
-The framework is responsible for everything from "write zarr" onward. A download function or derivation function only needs to produce a zarr file at `output_path`. The framework then:
+The framework is responsible for everything from "write zarr" onward. A download function only needs to write NetCDF files to a given directory. The framework then:
 
-1. applies transforms (unit conversion, etc.)
-2. writes GeoZarr root attributes (`spatial:bbox`, `proj:code`) so map clients can position tiles
-3. computes artifact coverage (spatial bounds + time range) from the written data
-4. stores the artifact record
-5. publishes the managed dataset through pygeoapi if `publish=true`
+1. reads and normalises the coordinate names
+2. applies transforms (unit conversion, etc.)
+3. reprojects to the instance CRS
+4. builds the zarr store with auto-computed chunking
+5. writes GeoZarr root attributes (`spatial:bbox`, `proj:code`) so map clients can position tiles
+6. computes artifact coverage (spatial bounds + time range) from the written data
+7. stores the artifact record
+8. publishes the managed dataset through pygeoapi if `publish=true`
 
-This division means that download functions and derivation functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data; the framework handles everything else.
+This division means that download functions do not need to know about zarr conventions, STAC, OGC, or pygeoapi. They write data files; the framework handles everything else.
 
 ---
 
 ## Sync kinds
 
-The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion — the table below is the primary guide.
+The `sync.kind` field in a template determines how a managed dataset is kept current. Choosing the wrong kind is the most common source of confusion.
 
-| `sync.kind` | Data lives | On each sync | Use when |
-|-------------|-----------|--------------|----------|
-| `temporal` | Local zarr | Append new time steps (or rematerialize) | Historical record that grows over time (CHIRPS, ERA5-Land) |
-| `release` | Local zarr | Rematerialize if a newer release exists | Versioned releases (WorldPop yearly) |
-| `static` | Local zarr | Never synced | One-time fixed dataset |
-| `derived` | Local zarr, rebuilt from remote | Always rematerialise from remote store | Forecast data that needs transformation before it is usable (GEFS) |
-| `remote` | Remote store, no local copy | Re-register latest coverage | Datasets where direct store access is acceptable and transformation is not needed |
-
-### When to use `derived` vs `remote`
-
-`remote` is the simplest: the Climate API registers the remote store URL as the artifact path and proxies requests to it directly. Nothing is downloaded or transformed. The trade-off is that the raw store is served as-is — if it has five dimensions (`init_time`, `lead_time`, `ensemble_member`, `latitude`, `longitude`), the client sees five dimensions.
-
-`derived` performs a transformation step before the data is accessible. The derivation function reads the remote store, collapses it to a usable shape (e.g. ensemble mean, lead_time → calendar dates, daily resample), and writes a local zarr. The local zarr is what clients see. The trade-off is that a sync rewrites the entire artifact — there is no incremental append.
-
-**Rule of thumb:** use `remote` only if the remote store is already in a shape that map clients and downstream tools can consume directly. Use `derived` when the raw store requires transformation to be useful.
+| `sync.kind` | On each sync | Use when |
+|-------------|--------------|----------|
+| `temporal` | Append new time steps, or rematerialize | Historical record that grows over time (CHIRPS, ERA5-Land) |
+| `release` | Rematerialize if a newer release exists | Versioned releases where each year/version is discrete (WorldPop) |
+| `static` | Never synced | One-time fixed dataset with no updates |
 
 ### The sync execution modes
 
-Within `sync.kind: temporal`, two execution modes exist:
+Within `sync.kind: temporal`, two execution modes control what happens when new data is available:
 
 - `append` — downloads only the missing time range and appends it to the existing artifact
 - `rematerialize` — discards the existing artifact and rebuilds it from scratch
 
-`append` is efficient for large historical datasets (avoid re-downloading years of data on each sync). `rematerialize` is correct for forecasts and any dataset where old data may change retroactively. `derived` always rematerialises.
+`append` is efficient for large historical datasets (avoid re-downloading years of data on each sync). `rematerialize` is appropriate when old data may change retroactively (e.g. reanalysis products that are corrected after the fact).
+
+### Availability clamping
+
+Providers publish data on a delay. The `sync.availability` block in a template tells the sync engine how far back from today data is reliably available:
+
+```yaml
+sync:
+  kind: temporal
+  execution: append
+  availability:
+    latest_available_function: climate_api.providers.availability.lagged_latest_available
+    lag_hours: 120
+```
+
+Before executing a sync, the engine calls the availability function to clamp the target end date. This prevents requesting data that has not yet been published, which would leave temporal gaps.
 
 ---
 
@@ -119,93 +128,74 @@ Within `sync.kind: temporal`, two execution modes exist:
 
 The platform has four extension points. Each one has a narrow contract — the framework handles everything else automatically.
 
-### Download function (`sync.kind: temporal`, `release`, `static`)
+### Download function
 
 ```python
 def download(
     *,
-    start: str,
+    start: str,       # ISO 8601 date or datetime
     end: str,
-    dirname: Path,
-    prefix: str,
+    dirname: Path,    # write output files here
+    prefix: str,      # use as filename prefix, e.g. f"{prefix}_{year}.nc"
     overwrite: bool,
-    bbox: list[float],    # optional — only if needed
-    **kwargs,             # default_params from YAML
+    bbox: list[float],  # optional — only if the source needs a spatial filter
+    **kwargs,           # default_params from the YAML template
 ) -> None:
-    # Write NetCDF files to dirname using prefix as filename base.
+    # Write one or more NetCDF files to dirname.
 ```
 
-The function writes one or more NetCDF files. The framework reads them, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
-
-### Derivation function (`sync.kind: derived`)
-
-```python
-def derive_dataset(
-    *,
-    store_config: dict,   # the template's store block
-    output_path: Path,    # write a consolidated zarr here
-    extent: dict | None,  # instance spatial extent
-    variable: str,
-    period_type: str,
-) -> None:
-    # Read from remote store, transform, write zarr to output_path.
-    # Output must have dimensions (time, latitude, longitude) in ascending order.
-    # Do not write GeoZarr root attributes — the framework does this.
-```
-
-The framework calls the derivation function, then applies any declared transforms, writes GeoZarr root attributes, computes coverage, and registers the artifact.
-
-**Important:** the derivation function must not write GeoZarr root attributes (`spatial:bbox`, `proj:code`) itself. These are written by the framework after transforms run, using the actual coordinate bounds of the final written data. If the function writes them, the framework will overwrite them anyway; if they are wrong they will confuse map clients.
+The function writes NetCDF files. The framework reads them, normalises coordinate names, applies transforms, reprojects to the instance CRS, builds the zarr, writes GeoZarr attributes, computes coverage, and registers the artifact.
 
 ### Transform function
 
 ```python
 def my_transform(ds: xr.Dataset, dataset: dict) -> xr.Dataset:
-    # Modify ds[dataset["variable"]] and return the modified dataset.
-    # Preserve ds.attrs — the framework relies on them.
+    # Receive the dataset after download, return a modified dataset.
+    # Modify ds[dataset["variable"]] values and variable attributes.
+    # Do not modify dataset-level ds.attrs — the framework manages those.
 ```
 
-Transforms are applied in order after the download or derivation function returns. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They should not write to disk — the framework handles writing.
+Transforms are applied in order after the download function returns, before the zarr is written. They receive the full xarray Dataset and the template dict. They return a modified Dataset. They do not write to disk.
 
 ### Process execution function
 
 ```python
 def execute(*, source_dataset_id: str, **kwargs) -> dict:
-    # Run a derived computation (e.g. temporal resampling).
-    # Return a JSON-serialisable dict.
+    # Run a named operation (e.g. temporal resampling).
+    # Return a JSON-serialisable result dict.
 ```
 
-Processes are named operations triggered via `POST /processes/{id}/execution`. They are broader than single-dataset transforms — they can read one dataset and produce another (e.g. daily → monthly aggregation).
+Processes are named operations triggered via `POST /processes/{id}/execution`. They are broader than single-dataset transforms — they can read one managed dataset and produce another (e.g. daily → monthly aggregation).
 
 ---
 
 ## The transform pipeline
 
-Transforms are applied in a consistent location in the lifecycle:
+Transforms are applied at a consistent point in the ingestion lifecycle:
 
-1. download function / derivation function writes raw data
-2. `_run_transforms(ds, dataset)` applies each transform in the declared order
-3. result is written to the zarr store
-4. framework writes GeoZarr root attributes
-5. framework computes coverage from the zarr
+1. download function writes raw NetCDF files to disk
+2. framework reads and normalises the data into an xarray Dataset
+3. `_run_transforms(ds, dataset)` applies each declared transform in order
+4. result is reprojected to instance CRS
+5. zarr store is written with auto-computed chunking
+6. framework writes GeoZarr root attributes
+7. framework computes coverage from the zarr
 
-This means transforms always see the raw output of the function, not the GeoZarr-attributed zarr. Transforms should only modify data values and variable attributes. They must not modify dataset-level `.attrs` — the framework manages those.
-
-The transform pipeline runs identically for downloaded data and derived data. A transform written for a regular dataset works unchanged on a derived dataset.
+Transforms see post-download, pre-reproject data. They should only modify data values and variable-level attributes. The framework writes dataset-level attributes (GeoZarr) after the transform pipeline completes.
 
 ---
 
 ## GeoZarr root attributes
 
-Every zarr artifact must have GeoZarr root attributes for map rendering to work correctly. These are stored in the `zarr.json` root metadata:
+Every zarr artifact must have GeoZarr root attributes for map rendering to work correctly. These are written into `zarr.json` at the store root:
 
 - `spatial:bbox` — `[xmin, ymin, xmax, ymax]` in the native CRS
-- `proj:code` — the CRS EPSG code (e.g. `EPSG:4326`)
+- `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
 
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to the instance CRS and null bounds, which produces a white or misaligned map.
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Without them, the viewer falls back to null bounds, which produces a white or misaligned map.
 
-**The framework writes these attributes — plugins do not.** For downloaded datasets, they are written in `build_dataset_zarr`. For derived datasets, they are written in `_derive_artifact` after transforms are applied, using the actual coordinate bounds of the final data and the CRS declared in `store.crs` (default: `EPSG:4326`).
+**The framework writes these attributes — plugins do not.** They are written in `build_dataset_zarr` after transforms and reprojection, using the actual coordinate bounds of the final written data and the instance CRS.
 
 ---
 
@@ -220,11 +210,9 @@ extent:
   crs: EPSG:32633   # optional; defaults to EPSG:4326
 ```
 
-**Downloaded datasets** are reprojected from their source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is in the instance CRS.
+Downloaded data is reprojected from the source CRS (`source_crs` in the template, default `EPSG:4326`) to the instance CRS during ingestion. The stored zarr is always in the instance CRS.
 
-**Derived datasets** are never reprojected. They are stored in their native CRS, declared via `store.crs` in the template (default `EPSG:4326`). If the remote store is in a projected CRS, set `store.crs` accordingly so STAC metadata reflects the correct projection.
-
-**Remote datasets** follow the same rule as derived: no reprojection, CRS from `store.crs`.
+If no `crs` is set in the config, data is stored in `EPSG:4326` (WGS84). This is the correct default for instances that do not need a metric CRS.
 
 ---
 
@@ -233,57 +221,53 @@ extent:
 When a new ingestion request arrives, the framework checks whether an existing artifact already covers the requested scope:
 
 - same `dataset_id`
-- same `bbox` (from the configured extent)
+- same bbox (from the configured extent)
 - overlapping time range
 
 If a match exists and `overwrite=false`, the existing artifact is returned without re-downloading. If `overwrite=true`, the existing artifact is replaced.
 
-For derived and remote datasets, the framework always upserts: it replaces the existing record while preserving the `artifact_id`, so publication state (pygeoapi config, STAC entries) is maintained without a re-publish step.
+The artifact store keeps the full history of records for sync deduplication and provenance. Old artifacts are not deleted automatically. For long-running instances, `records.json` grows over time. The long-term direction is a proper transactional store, but for the current scale (tens of artifacts per instance) a JSON file is adequate.
 
 ---
 
 ## What the framework guarantees
 
-Plugin code (download functions, derivation functions, transforms) can rely on the following being handled automatically:
+Plugin code (download functions, transforms, processes) can rely on the following being handled automatically by the framework:
 
 | Concern | Where handled |
 |---------|---------------|
-| Writing GeoZarr root attributes | `build_dataset_zarr` (download), `_derive_artifact` (derived) |
-| Computing artifact coverage | `_coverage_from_dataset` called after all writes |
-| Reprojecting to instance CRS | `reproject_to_instance_crs` (downloaded data only) |
-| Multiscale pyramid generation | `_needs_pyramid` check in `build_dataset_zarr` |
-| Zarr chunking | Auto-computed from `period_type` in `_compute_chunk_sizes` |
-| Artifact record persistence | `_upsert_derived_record` / `_upsert_remote_zarr_record` |
+| Coordinate name normalisation (`lat` → `y`, etc.) | `build_dataset_zarr` |
+| Reprojection to instance CRS | `reproject_to_instance_crs` |
+| Zarr chunking (auto-sized per `period_type`) | `_compute_chunk_sizes` |
+| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr` |
+| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr` |
+| Artifact coverage computation | `_coverage_from_dataset` |
+| Artifact record persistence | `_store_artifact` |
 | pygeoapi publication | `publish_artifact_record` if `publish=true` |
 | STAC collection generation | Dynamic from artifact record |
 
-Plugin code only needs to produce data at the right path. Everything else is the framework's responsibility.
+Plugin code only needs to produce data files. Everything else is the framework's responsibility.
 
 ---
 
 ## Consequences of design choices
 
-### Consequence: one extent per instance
+### Single extent per instance
 
-Each instance is configured for one place. This keeps the data model simple (no multi-extent artifact records) and the zarr stores small (no global downloads). The trade-off is that a national ministry with sub-national data needs runs multiple instances or a single instance at national extent.
+Each instance is configured for one place. This keeps the data model simple (no per-artifact extent tags) and the zarr stores small (country-scale downloads rather than global). The trade-off is that a national ministry with sub-national data needs either runs multiple instances or configures a single instance at national extent.
 
-### Consequence: artifacts are append-only in version terms
+### Temporal gaps are not allowed
 
-The artifact store keeps historical records (for sync history and deduplication). Old artifacts are not deleted automatically. For long-running instances, `records.json` will grow. The long-term direction is a proper transactional store, but for the current scale (dozens of artifacts per instance) a JSON file is adequate.
+The sync engine validates that new data connects to the end of the existing artifact before appending. If a gap exists, the sync fails rather than silently producing a dataset with a hole. This is a deliberate constraint: downstream consumers (DHIS2, CHAP) depend on continuous time series and should not receive data with silent gaps.
 
-### Consequence: derived datasets always rematerialise
+### The append execution mode avoids re-downloading history
 
-`sync.kind: derived` rewrites the full zarr on every sync. For a 35-day GEFS forecast at 0.25° resolution over a country, this is fast (seconds). For a global 1 km dataset with years of history, rematerialisation is impractical — use `temporal` with `append` instead.
+`append` downloads only the missing range and rebuilds the full zarr from all cached files. This means the local cache (NetCDF files in `data/downloads/`) is the source of truth for the full time series; the zarr is a derived view. If the cache is deleted, a rematerialize is required to recover.
 
-### Consequence: transforms run after the function writes
+### Transforms run after download, before reproject
 
-Transforms see the exact output of the download or derivation function, not raw upstream data. This means:
-- unit conversion transforms work on whatever unit the function wrote
-- if the function already converts units, a unit conversion transform would double-convert
-- the function and the template's `transforms` list must not both handle the same conversion
+Transforms see raw downloaded values in the source CRS and source units. The order is: download → transform → reproject → write zarr. This means:
 
-For GEFS: the raw store is in kg m⁻² s⁻¹. The derivation function (`gefs.py`) writes the raw values. The `flux_to_mm_per_day` transform in the template converts them. Neither the function nor the template does both steps.
-
-### Consequence: the plugin contract is stable but the framework internals are not
-
-The public plugin contract — function signatures, YAML field names, dotted-path resolution — is intended to be stable. Framework internals (`_derive_artifact`, `_run_transforms`, `build_dataset_zarr`) are not public API and may change. Plugins should depend only on the documented contracts, not on importing private framework functions.
+- a `kelvin_to_celsius` transform works on raw Kelvin values, not reprojected ones
+- a transform cannot undo reprojection — if you need the source coordinates, the transform must run before reproject (which is the current design)
+- if the download function already converts units, adding a unit conversion transform would double-convert

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -4,6 +4,22 @@ This document explains why the Climate API uses Zarr as its primary storage form
 
 ---
 
+## What is Zarr?
+
+[Zarr](https://zarr.dev) is an open storage format for chunked, compressed N-dimensional arrays. A Zarr store is a directory tree: array metadata lives in `zarr.json` files, and the data itself is split into independent chunk files. Each chunk is compressed independently and can be read in a single HTTP request.
+
+Zarr is designed to work natively in cloud object stores (S3, GCS, Azure Blob) as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard; it consolidates metadata into a single `zarr.json` file and uses a `c/` prefix for chunk keys.
+
+---
+
+## What is GeoZarr?
+
+[GeoZarr](https://github.com/zarr-developers/geozarr-spec) is a draft convention that adds spatial context to Zarr stores. A plain Zarr array has no concept of geography — it is just numbers in a grid. GeoZarr defines a small set of root attributes (`spatial:bbox`, `proj:code`, `zarr_conventions`) that tell a client where the grid is located on Earth and in which coordinate reference system.
+
+The [geozarr-toolkit](https://github.com/zarr-developers/geozarr-toolkit) Python library is used to write these attributes.
+
+---
+
 ## Why Zarr
 
 Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -62,7 +62,7 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 Chunks are sized to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
-Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
+Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). When present and valid, the duration is converted to approximate hours and mapped to a natural analysis window:
 
 | Duration tier       | Approximate hours | Target window | Example                     |
 | ------------------- | ----------------- | ------------- | --------------------------- |
@@ -70,7 +70,7 @@ Time chunk sizes are derived from the dataset's `extents.temporal.resolution` fi
 | Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps    |
 | Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps  |
 
-This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically.
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. If the field is absent or not a valid ISO 8601 duration, a warning is logged and the time chunk falls back to the dataset's `period_type`.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -1,0 +1,137 @@
+# Zarr and GeoZarr
+
+This document explains why the Climate API uses Zarr as its primary storage format, how Zarr stores are structured and served, and how GeoZarr root attributes enable map rendering.
+
+---
+
+## Why Zarr
+
+Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
+
+- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
+- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
+- **Cloud compatibility** — the same directory layout works on local disk, S3, and GCS without code changes. Zarr does not require a local filesystem.
+- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray Dataset, making it trivial to subset, resample, and transform data in the API layer.
+
+Zarr replaces NetCDF as the serving format. NetCDF files are written to disk as a download cache but are converted to Zarr before being exposed through the API.
+
+---
+
+## Store layout on disk
+
+Each managed dataset has exactly one Zarr store on disk, stored under `{data_dir}/downloads/{dataset_id}.zarr`. The store is either:
+
+- **Flat** — a single-resolution Zarr store with dimensions `(time, x, y)`
+- **Pyramid** — a multi-resolution Zarr store with levels `0/`, `1/`, `2/`, … where `0/` is the full resolution
+
+The flat vs. pyramid decision is made at build time based on spatial size (see [Multiscale pyramids](#multiscale-pyramids) below).
+
+---
+
+## Chunk sizing
+
+Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
+
+| `period_type` | Time chunk |
+|---------------|------------|
+| `hourly`      | 168 steps (1 week) |
+| `daily`       | 30 steps (1 month) |
+| `monthly`     | 12 steps (1 year) |
+| `yearly`      | 1 step |
+
+Spatial chunks are capped at 256 × 256 pixels. For small extents where the full spatial dimension is smaller than 256 pixels, the entire dimension fits in one chunk.
+
+Dimension names are normalised to `(time, x, y)` before writing, regardless of the source naming convention (`lat`/`lon`, `latitude`/`longitude`, etc.).
+
+---
+
+## Multiscale pyramids
+
+For large spatial extents, a flat zarr would require the map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
+
+Pyramid levels are computed as:
+
+```
+levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
+```
+
+Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
+
+Pyramids are written in **Zarr v3** format using the [topozarr](https://github.com/carbonplan/topozarr) library. Flat stores use Zarr v2 with `consolidated=True` (`.zmetadata` file).
+
+One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
+
+---
+
+## GeoZarr root attributes
+
+A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
+
+GeoZarr addresses this by writing a small set of attributes into `zarr.json` (or `.zattrs` for v2) at the store root:
+
+| Attribute | Example value | Purpose |
+|-----------|--------------|---------|
+| `spatial:bbox` | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
+| `proj:code` | `EPSG:32633` | CRS of the stored coordinates |
+| `zarr_conventions` | `[{...}]` | Convention declarations |
+
+These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
+
+`zarr_conventions` for a flat store contains the base GeoZarr convention declaration. For pyramid stores it also includes a multiscales entry that declares the level structure.
+
+**Without these attributes**, the map viewer falls back to null bounds and the instance CRS, producing a white or misaligned map.
+
+---
+
+## CRS handling
+
+The instance CRS is configured in `climate-api.yaml`:
+
+```yaml
+extent:
+  bbox: [3.0, 57.0, 32.0, 72.5]
+  crs: EPSG:32633   # optional; defaults to EPSG:4326
+```
+
+Datasets are always stored in the instance CRS. During ingestion, data is reprojected from its source CRS (declared as `source_crs` in the template, default `EPSG:4326`) to the instance CRS. The stored `spatial:bbox` is therefore in the instance CRS — UTM eastings and northings for a UTM instance, degrees for a WGS84 instance.
+
+STAC metadata also stores the WGS84 bounding box alongside the native bbox, so catalogue clients that expect geographic coordinates always get one regardless of the instance CRS.
+
+---
+
+## How Zarr stores are served
+
+The `/zarr/{dataset_id}/` endpoint serves individual files from the Zarr store directory using FastAPI's `FileResponse`. The ZarrLayer client issues one HTTP request per chunk file it needs.
+
+```
+GET /zarr/{dataset_id}/zarr.json          → root metadata (JSON)
+GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
+GET /zarr/{dataset_id}/time/0             → time coordinate chunk
+```
+
+Metadata files (`.zarray`, `.zattrs`, `.zgroup`, `zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
+
+This design means the zarr store is served by ordinary file serving — there is no zarr-specific server middleware.
+
+---
+
+## How the map viewer reads Zarr
+
+The built-in map viewer at `/map` uses [ZarrLayer](https://github.com/carbonplan/zarr-layer) to render zarr tiles on a Leaflet map.
+
+On dataset selection the viewer:
+
+1. Fetches the STAC collection for the dataset (`/stac/collections/{dataset_id}`), which includes `proj:code`, `cube:dimensions`, and the zarr store href
+2. Reads `proj:code` to determine if reprojection is needed for rendering
+3. Reads `cube:dimensions` to discover the time axis and build the time slider
+4. Initialises ZarrLayer with the zarr store URL, the variable name, the colour map, and the CRS
+
+ZarrLayer then requests chunk files directly from `/zarr/{dataset_id}/` as tiles are needed, handling all chunked reads internally.
+
+For non-WGS84 instances (e.g. UTM), the viewer fetches a proj4 string from `epsg.io` and passes it to ZarrLayer so tiles can be reprojected to the Leaflet display CRS on the fly.
+
+---
+
+## Fill values and NaN handling
+
+When writing float data to Zarr, NetCDF sentinel fill values (e.g. `−999.99`) are removed from the encoding before the zarr write. This ensures missing pixels are stored as IEEE `NaN` in the zarr chunks. ZarrLayer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent — no separate `fillValue` configuration is needed in the viewer.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -8,15 +8,13 @@ This document explains why the Climate API uses Zarr as its primary storage form
 
 [Zarr](https://zarr.dev) is an open storage format for chunked, compressed N-dimensional arrays. A Zarr store is a directory tree: array metadata lives in `zarr.json` files, and the data itself is split into independent chunk files. Each chunk is compressed independently and can be read in a single HTTP request.
 
-Zarr is designed to work natively in cloud object stores (S3, GCS, Azure Blob) as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard; it consolidates metadata into a single `zarr.json` file and uses a `c/` prefix for chunk keys.
+Zarr is designed to work natively in cloud object stores as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard.
 
 ---
 
 ## What is GeoZarr?
 
 [GeoZarr](https://github.com/zarr-developers/geozarr-spec) is a draft convention that adds spatial context to Zarr stores. A plain Zarr array has no concept of geography — it is just numbers in a grid. GeoZarr defines a small set of root attributes (`spatial:bbox`, `proj:code`, `zarr_conventions`) that tell a client where the grid is located on Earth and in which coordinate reference system.
-
-The [geozarr-toolkit](https://github.com/zarr-developers/geozarr-toolkit) Python library is used to write these attributes.
 
 ---
 
@@ -26,10 +24,8 @@ Climate datasets are large, multi-dimensional arrays: a daily precipitation data
 
 - **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
 - **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
-- **Cloud compatibility** — the same directory layout works on local disk, S3, and GCS without code changes. Zarr does not require a local filesystem.
-- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray Dataset, making it trivial to subset, resample, and transform data in the API layer.
-
-Zarr replaces NetCDF as the serving format. NetCDF files are written to disk as a download cache but are converted to Zarr before being exposed through the API.
+- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray dataset, making it trivial to subset, resample, and transform data in the API layer.
 
 ---
 
@@ -46,15 +42,15 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 ## Chunk sizing
 
-Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
+Chunks are sized to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
 Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
 
-| Duration tier | Approximate hours | Target window | Example |
-|---------------|-------------------|---------------|---------|
-| Sub-daily     | < 24 h            | ~1 week       | `PT1H` → 168 steps |
-| Daily to sub-weekly | 24 h – 168 h | ~1 month  | `P1D` → 30 steps |
-| Weekly and coarser | ≥ 168 h      | ~1 year       | `P1M` → 12 steps |
+| Duration tier       | Approximate hours | Target window | Example                      |
+| ------------------- | ----------------- | ------------- | ---------------------------- |
+| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps  |
+| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps     |
+| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps   |
 
 This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
 
@@ -88,11 +84,11 @@ A plain Zarr store has no concept of spatial coordinates. A map viewer opening i
 
 GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-| Attribute | Example value | Purpose |
-|-----------|--------------|---------|
-| `spatial:bbox` | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
-| `proj:code` | `EPSG:32633` | CRS of the stored coordinates |
-| `zarr_conventions` | `[{...}]` | Convention declarations |
+| Attribute          | Example value                         | Purpose                        |
+| ------------------ | ------------------------------------- | ------------------------------ |
+| `spatial:bbox`     | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:32633`                          | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                             | Convention declarations        |
 
 These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
 
@@ -109,7 +105,7 @@ The instance CRS is configured in `climate-api.yaml`:
 ```yaml
 extent:
   bbox: [3.0, 57.0, 32.0, 72.5]
-  crs: EPSG:32633   # optional; defaults to EPSG:4326
+  crs: EPSG:32633 # optional; defaults to EPSG:4326
 ```
 
 Datasets are always stored in the instance CRS. During ingestion, data is reprojected from its source CRS (declared as `source_crs` in the template, default `EPSG:4326`) to the instance CRS. The stored `spatial:bbox` is therefore in the instance CRS — UTM eastings and northings for a UTM instance, degrees for a WGS84 instance.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -18,6 +18,16 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ---
 
+## Why Zarr
+
+Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
+
+- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
+- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
+- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+
+---
+
 ## ARCO: Analysis-Ready, Cloud-Optimized
 
 The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access.
@@ -37,17 +47,6 @@ The two halves of the term map directly onto the choices described in this docum
 - The store layout is identical on local disk and cloud object storage.
 
 The Climate API targets the same access pattern at country scale for arbitrary source datasets.
-
----
-
-## Why Zarr
-
-Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
-
-- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
-- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
-- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
-- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray dataset, making it trivial to subset, resample, and transform data in the API layer.
 
 ---
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -108,8 +108,8 @@ The `/zarr/{dataset_id}/` endpoint serves individual files from the Zarr store d
 
 ```
 GET /zarr/{dataset_id}/zarr.json          → root metadata (JSON)
-GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
-GET /zarr/{dataset_id}/time/0             → time coordinate chunk
+GET /zarr/{dataset_id}/precip/c/0/0/0     → chunk at time=0, x=0, y=0
+GET /zarr/{dataset_id}/time/c/0           → time coordinate chunk
 ```
 
 Metadata files (`zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -36,10 +36,12 @@ Chunks are sized in `_compute_time_space_chunks` to match expected access patter
 |---------------|------------|
 | `hourly`      | 168 steps (1 week) |
 | `daily`       | 30 steps (1 month) |
+| `dekadal`     | 36 steps (1 year) |
+| `weekly`      | 52 steps (1 year) |
 | `monthly`     | 12 steps (1 year) |
 | `yearly`      | 1 step |
 
-Spatial chunks are capped at 256 × 256 pixels. For small extents where the full spatial dimension is smaller than 256 pixels, the entire dimension fits in one chunk.
+Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
 Dimension names are normalised to `(time, x, y)` before writing, regardless of the source naming convention (`lat`/`lon`, `latitude`/`longitude`, etc.).
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -25,6 +25,7 @@ Climate datasets are large, multi-dimensional arrays: a daily precipitation data
 - **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
 - **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
 - **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+- **Multiscale pyramids** — GeoZarr defines a multiscales convention that allows a store to contain multiple resolution levels. Map clients request only the level that matches their current zoom, avoiding full-resolution downloads.
 
 ---
 
@@ -40,11 +41,7 @@ The two halves of the term map directly onto the choices described in this docum
 - All datasets in an instance share a single coordinate reference system.
 - Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
 
-**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
-
-- Each chunk is an independent file readable in a single range request.
-- Multiscale pyramids allow map clients to fetch only the resolution level they need.
-- The store layout is identical on local disk and cloud object storage.
+**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file. The Zarr and GeoZarr formats provide all the necessary properties — chunk-level access, HTTP-native serving, multiscale pyramids, and cloud compatibility.
 
 The Climate API targets the same access pattern at country scale for arbitrary source datasets.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -18,6 +18,27 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ---
 
+## ARCO: Analysis-Ready, Cloud-Optimized
+
+The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access. [ARCO-ERA5](https://github.com/google-research/arco-era5) (Google Research, 2023) is the canonical large-scale example: the full ERA5 reanalysis converted to Zarr and served directly from Google Cloud Storage.
+
+The two halves of the term map directly onto the choices described in this document:
+
+**Analysis-ready** means a consumer can open the data and start computing without preprocessing:
+- Dimension names are normalised to `(time, x, y)` regardless of the source convention.
+- All datasets in an instance share a single coordinate reference system.
+- Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
+- Temporal coverage and spatial extent are recorded in the artifact and exposed via STAC and OGC API.
+
+**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
+- Each chunk is an independent file readable in a single range request.
+- Multiscale pyramids allow map clients to fetch only the resolution level they need.
+- The store layout is identical on local disk and cloud object storage — no code changes are required to move between the two.
+
+The Climate API targets the same access pattern as ARCO-ERA5 but at country scale and for arbitrary source datasets, not just ERA5.
+
+---
+
 ## Why Zarr
 
 Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -32,14 +32,15 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
-| `period_type` | Time chunk |
-|---------------|------------|
-| `hourly`      | 168 steps (1 week) |
-| `daily`       | 30 steps (1 month) |
-| `dekadal`     | 36 steps (1 year) |
-| `weekly`      | 52 steps (1 year) |
-| `monthly`     | 12 steps (1 year) |
-| `yearly`      | 1 step |
+Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
+
+| Duration tier | Approximate hours | Target window | Example |
+|---------------|-------------------|---------------|---------|
+| Sub-daily     | < 24 h            | ~1 week       | `PT1H` → 168 steps |
+| Daily to sub-weekly | 24 h – 168 h | ~1 month  | `P1D` → 30 steps |
+| Weekly and coarser | ≥ 168 h      | ~1 year       | `P1M` → 12 steps |
+
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
@@ -69,7 +70,7 @@ One implementation detail: ZarrLayer (the map client) looks for the `time` coord
 
 A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
 
-GeoZarr addresses this by writing a small set of attributes into `zarr.json` (or `.zattrs` for v2) at the store root:
+GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
 | Attribute | Example value | Purpose |
 |-----------|--------------|---------|
@@ -111,7 +112,7 @@ GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
 GET /zarr/{dataset_id}/time/0             → time coordinate chunk
 ```
 
-Metadata files (`.zarray`, `.zattrs`, `.zgroup`, `zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
+Metadata files (`zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
 
 This design means the zarr store is served by ordinary file serving — there is no zarr-specific server middleware.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -46,13 +46,13 @@ Chunks are sized to match expected access patterns. The goal is that reading one
 
 Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
 
-| Duration tier       | Approximate hours | Target window | Example                      |
-| ------------------- | ----------------- | ------------- | ---------------------------- |
-| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps  |
-| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps     |
-| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps   |
+| Duration tier       | Approximate hours | Target window | Example                     |
+| ------------------- | ----------------- | ------------- | --------------------------- |
+| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps |
+| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps    |
+| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps  |
 
-This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
@@ -62,7 +62,7 @@ Dimension names are normalised to `(time, x, y)` before writing, regardless of t
 
 ## Multiscale pyramids
 
-For large spatial extents, a flat zarr would require the map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
+For large spatial extents, a flat zarr would require a map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
 
 Pyramid levels are computed as:
 
@@ -72,23 +72,19 @@ levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
 
 Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
 
-Both flat and pyramid stores are written in **Zarr v3** format. Pyramids use [topozarr](https://github.com/carbonplan/topozarr); flat stores pass `zarr_format=3` to `to_zarr`. Both include consolidated metadata — embedded in `zarr.json` under `consolidated_metadata` — so clients can open the store with a single metadata read.
-
-One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
+Both flat and pyramid stores are written in **Zarr v3** format.
 
 ---
 
 ## GeoZarr root attributes
 
-A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
+A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map. GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
-
-| Attribute          | Example value                         | Purpose                        |
-| ------------------ | ------------------------------------- | ------------------------------ |
-| `spatial:bbox`     | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
-| `proj:code`        | `EPSG:32633`                          | CRS of the stored coordinates  |
-| `zarr_conventions` | `[{...}]`                             | Convention declarations        |
+| Attribute          | Example value                  | Purpose                        |
+| ------------------ | ------------------------------ | ------------------------------ |
+| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]`     | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:4326`                    | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                      | Convention declarations        |
 
 These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -59,7 +59,7 @@ levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
 
 Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
 
-Pyramids are written in **Zarr v3** format using the [topozarr](https://github.com/carbonplan/topozarr) library. Flat stores use Zarr v2 with `consolidated=True` (`.zmetadata` file).
+Both flat and pyramid stores are written in **Zarr v3** format. Pyramids use [topozarr](https://github.com/carbonplan/topozarr); flat stores pass `zarr_format=3` to `to_zarr`. Both include consolidated metadata — embedded in `zarr.json` under `consolidated_metadata` — so clients can open the store with a single metadata read.
 
 One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -20,22 +20,23 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ## ARCO: Analysis-Ready, Cloud-Optimized
 
-The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access. [ARCO-ERA5](https://github.com/google-research/arco-era5) (Google Research, 2023) is the canonical large-scale example: the full ERA5 reanalysis converted to Zarr and served directly from Google Cloud Storage.
+The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access.
 
 The two halves of the term map directly onto the choices described in this document:
 
 **Analysis-ready** means a consumer can open the data and start computing without preprocessing:
+
 - Dimension names are normalised to `(time, x, y)` regardless of the source convention.
 - All datasets in an instance share a single coordinate reference system.
 - Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
-- Temporal coverage and spatial extent are recorded in the artifact and exposed via STAC and OGC API.
 
 **Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
+
 - Each chunk is an independent file readable in a single range request.
 - Multiscale pyramids allow map clients to fetch only the resolution level they need.
-- The store layout is identical on local disk and cloud object storage — no code changes are required to move between the two.
+- The store layout is identical on local disk and cloud object storage.
 
-The Climate API targets the same access pattern as ARCO-ERA5 but at country scale and for arbitrary source datasets, not just ERA5.
+The Climate API targets the same access pattern at country scale for arbitrary source datasets.
 
 ---
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -80,17 +80,15 @@ Both flat and pyramid stores are written in **Zarr v3** format.
 
 A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map. GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-| Attribute          | Example value                  | Purpose                        |
-| ------------------ | ------------------------------ | ------------------------------ |
-| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]`     | Bounding box in the native CRS |
-| `proj:code`        | `EPSG:4326`                    | CRS of the stored coordinates  |
-| `zarr_conventions` | `[{...}]`                      | Convention declarations        |
+| Attribute          | Example value             | Purpose                        |
+| ------------------ | ------------------------- | ------------------------------ |
+| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]` | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:4326`               | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                 | Convention declarations        |
 
-These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
+These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run. This guarantees they always reflect the final stored data.
 
 `zarr_conventions` for a flat store contains the base GeoZarr convention declaration. For pyramid stores it also includes a multiscales entry that declares the level structure.
-
-**Without these attributes**, the map viewer falls back to null bounds and the instance CRS, producing a white or misaligned map.
 
 ---
 
@@ -126,23 +124,6 @@ This design means the zarr store is served by ordinary file serving — there is
 
 ---
 
-## How the map viewer reads Zarr
-
-The built-in map viewer at `/map` uses [ZarrLayer](https://github.com/carbonplan/zarr-layer) to render zarr tiles on a Leaflet map.
-
-On dataset selection the viewer:
-
-1. Fetches the STAC collection for the dataset (`/stac/collections/{dataset_id}`), which includes `proj:code`, `cube:dimensions`, and the zarr store href
-2. Reads `proj:code` to determine if reprojection is needed for rendering
-3. Reads `cube:dimensions` to discover the time axis and build the time slider
-4. Initialises ZarrLayer with the zarr store URL, the variable name, the colour map, and the CRS
-
-ZarrLayer then requests chunk files directly from `/zarr/{dataset_id}/` as tiles are needed, handling all chunked reads internally.
-
-For non-WGS84 instances (e.g. UTM), the viewer fetches a proj4 string from `epsg.io` and passes it to ZarrLayer so tiles can be reprojected to the Leaflet display CRS on the fly.
-
----
-
 ## Fill values and NaN handling
 
-When writing float data to Zarr, NetCDF sentinel fill values (e.g. `−999.99`) are removed from the encoding before the zarr write. This ensures missing pixels are stored as IEEE `NaN` in the zarr chunks. ZarrLayer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent — no separate `fillValue` configuration is needed in the viewer.
+When writing float data to Zarr, missing data is stored as IEEE `NaN`. The map viewer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Get started: setup_guide.md
   - Concepts:
       - Architecture: architecture.md
+      - Zarr and GeoZarr: zarr_and_geozarr.md
       - Project overview: project_description.md
       - Implementation status: implementation-status.md
       - OGC API: ogcapi.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Home: index.md
   - Get started: setup_guide.md
   - Concepts:
+      - Architecture: architecture.md
       - Project overview: project_description.md
       - Implementation status: implementation-status.md
       - OGC API: ogcapi.md

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -128,7 +128,12 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3", "extents": {"temporal": {"resolution": "P1D"}}},
+        lambda _: {
+            "period_type": "daily",
+            "units": "mm",
+            "source": "CHIRPS v3",
+            "extents": {"temporal": {"resolution": "P1D"}},
+        },
     )
     monkeypatch.setattr(
         stac_services,
@@ -250,7 +255,12 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature", "extents": {"temporal": {"resolution": "PT1H"}}},
+        lambda _: {
+            "period_type": "hourly",
+            "source": "ERA5-Land",
+            "short_name": "2m temperature",
+            "extents": {"temporal": {"resolution": "PT1H"}},
+        },
     )
     monkeypatch.setattr(
         stac_services,

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -128,7 +128,7 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3"},
+        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3", "extents": {"temporal": {"resolution": "P1D"}}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -250,7 +250,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature"},
+        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature", "extents": {"temporal": {"resolution": "PT1H"}}},
     )
     monkeypatch.setattr(
         stac_services,


### PR DESCRIPTION
## Summary

Adds `docs/architecture.md` — a developer-facing reference that explains the platform's design, the relationships between its core concepts, and the consequences of key architectural decisions. Wired into the mkdocs nav under **Concepts**.

## Why this document

Before merging feature work (especially new sync kinds from #127), we need a shared understanding of what the platform is, why it is structured this way, and what the rules are. This document is the foundation for that.

## What it covers

- **Core concepts**: Template, Artifact, Managed Dataset, Extent — clear definitions, what each concept is, why it exists, how they relate
- **Data lifecycle**: the complete path from YAML template to published managed dataset, with explicit ownership boundaries
- **Sync kinds**: `temporal`, `release`, and `static` — a decision table with when to use each, what happens on each sync, the trade-offs between `append` and `rematerialize`
- **Plugin contract**: the download function signature — what the plugin must write vs. what the framework handles automatically
- **Transform pipeline**: when transforms run, what they see, what they must not touch
- **GeoZarr root attributes**: why they exist, who writes them (the framework, not the plugin), what breaks if they are absent
- **CRS handling**: how the instance CRS is configured and how downloaded datasets are reprojected
- **Consequences**: explicit write-up of the trade-offs from each design decision (single extent, no temporal gaps, append avoids re-downloading history)

## What it does not cover

`sync.kind: derived` and `sync.kind: remote` are covered in #127, which depends on this PR. API endpoint reference, setup instructions, and provider-specific dataset details remain in their existing docs.