### PR TITLE
feat: zarr generation improvements and Zarr/GeoZarr concepts doc

### DIFF
--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,7 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.shared.time import period_type_to_iso_step, time_chunk_for_iso_step
+from climate_api.shared.time import resolve_iso_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -294,16 +294,16 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    period_type = dataset["period_type"]
-    iso_step = period_type_to_iso_step(period_type)
+    iso_step = resolve_iso_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
         chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
-            "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",
-            period_type,
+            "No ISO 8601 step for dataset '%s' (period_type=%r); defaulting time chunk to 12. "
+            "Declare 'period_step' in the template to silence this warning.",
             dataset.get("id", "?"),
+            dataset.get("period_type"),
         )
         chunks[dim] = 12
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -200,11 +200,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 
     else:
         logger.info("Building flat zarr (max dim %d pixels)", max(ds.sizes[x_dim], ds.sizes[y_dim]))
-        # determine optimal chunk sizes
-        ds_autochunk = ds.chunk("auto").unify_chunks()
-        uniform_chunks: dict[str, Any] = {str(dim): ds_autochunk.chunks[dim][0] for dim in ds_autochunk.dims}
-        time_space_chunks = _compute_time_space_chunks(ds, dataset)
-        uniform_chunks.update(time_space_chunks)
+        uniform_chunks = _compute_time_space_chunks(ds, dataset)
         logger.info(f"--> {uniform_chunks}")
 
         ds.attrs.update(geozarr_attrs)
@@ -292,7 +288,7 @@ def _run_transforms(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
 def _compute_time_space_chunks(
     ds: xr.Dataset,
     dataset: dict[str, Any],
-    max_spatial_chunk: int = 256,
+    max_spatial_chunk: int = 512,
 ) -> dict[str, int]:
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
@@ -303,10 +299,21 @@ def _compute_time_space_chunks(
         chunks[dim] = 24 * 7
     elif period_type == "daily":
         chunks[dim] = 30
+    elif period_type == "dekadal":
+        chunks[dim] = 36
+    elif period_type == "weekly":
+        chunks[dim] = 52
     elif period_type == "monthly":
         chunks[dim] = 12
     elif period_type == "yearly":
         chunks[dim] = 1
+    else:
+        logger.warning(
+            "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",
+            period_type,
+            dataset.get("id", "?"),
+        )
+        chunks[dim] = 12
 
     x_dim, y_dim = get_x_y_dims(ds)
     chunks[x_dim] = min(ds.sizes[x_dim], max_spatial_chunk)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,7 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
-from climate_api.shared.time import resolve_iso_step, time_chunk_for_iso_step
+from climate_api.shared.time import resolve_iso_period_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -294,7 +294,7 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    iso_step = resolve_iso_step(dataset)
+    iso_step = resolve_iso_period_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
         chunks[dim] = time_chunk_for_iso_step(iso_step)

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -300,10 +300,9 @@ def _compute_time_space_chunks(
         chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
-            "No ISO 8601 step for dataset '%s' (period_type=%r); defaulting time chunk to 12. "
-            "Declare 'period_step' in the template to silence this warning.",
+            "No ISO 8601 step for dataset '%s'; defaulting time chunk to 12. "
+            "Declare 'extents.temporal.resolution' in the template to silence this warning.",
             dataset.get("id", "?"),
-            dataset.get("period_type"),
         )
         chunks[dim] = 12
 

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -297,7 +297,15 @@ def _compute_time_space_chunks(
     iso_step = resolve_iso_period_step(dataset)
     dim = get_time_dim(ds)
     if iso_step is not None:
-        chunks[dim] = time_chunk_for_iso_step(iso_step)
+        try:
+            chunks[dim] = time_chunk_for_iso_step(iso_step)
+        except ValueError:
+            logger.warning(
+                "Invalid ISO 8601 step %r for dataset '%s'; defaulting time chunk to 12.",
+                iso_step,
+                dataset.get("id", "?"),
+            )
+            chunks[dim] = 12
     else:
         logger.warning(
             "No ISO 8601 step for dataset '%s'; defaulting time chunk to 12. "

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -212,7 +212,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         # render missing pixels as transparent — not a separately specified fillValue.
         for var in ds_chunked.data_vars:
             ds_chunked[var].encoding.pop("_FillValue", None)
-        ds_chunked.to_zarr(zarr_path, mode="w", consolidated=True)
+        ds_chunked.to_zarr(zarr_path, mode="w", zarr_format=3, consolidated=True)
         ds_chunked.close()
 
     ds.close()

--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -17,6 +17,7 @@ from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
 
 from climate_api import config as api_config
+from climate_api.shared.time import period_type_to_iso_step, time_chunk_for_iso_step
 from climate_api.transforms.reproject import reproject_to_instance_crs
 
 from .utils import get_time_dim, get_x_y_dims
@@ -293,20 +294,11 @@ def _compute_time_space_chunks(
     """Compute chunk sizes tuned for common temporal access patterns."""
     chunks: dict[str, int] = {}
 
-    dim = get_time_dim(ds)
     period_type = dataset["period_type"]
-    if period_type == "hourly":
-        chunks[dim] = 24 * 7
-    elif period_type == "daily":
-        chunks[dim] = 30
-    elif period_type == "dekadal":
-        chunks[dim] = 36
-    elif period_type == "weekly":
-        chunks[dim] = 52
-    elif period_type == "monthly":
-        chunks[dim] = 12
-    elif period_type == "yearly":
-        chunks[dim] = 1
+    iso_step = period_type_to_iso_step(period_type)
+    dim = get_time_dim(ds)
+    if iso_step is not None:
+        chunks[dim] = time_chunk_for_iso_step(iso_step)
     else:
         logger.warning(
             "Unknown period_type '%s' for dataset '%s'; defaulting time chunk to 12",

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,6 +7,56 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
+# Single source of truth for the ISO 8601 duration step for each known period type.
+# Used for STAC cube:dimensions metadata and zarr time chunk sizing.
+# Add an entry here when a new period type is introduced — everything else derives from it.
+_PERIOD_TYPE_ISO_STEP: dict[str, str] = {
+    "hourly": "PT1H",
+    "daily": "P1D",
+    "dekadal": "P10D",
+    "weekly": "P7D",
+    "monthly": "P1M",
+    "yearly": "P1Y",
+}
+
+_ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
+
+
+def period_type_to_iso_step(period_type: str) -> str | None:
+    """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
+    return _PERIOD_TYPE_ISO_STEP.get(period_type)
+
+
+def _iso_step_to_approx_hours(step: str) -> float:
+    """Return the approximate duration in hours for an ISO 8601 duration string.
+
+    Months and years use calendar averages (30.4375 days/month, 365.25 days/year).
+    Raises ValueError for unrecognised formats.
+    """
+    m = _ISO_DURATION_RE.fullmatch(step)
+    if not m:
+        raise ValueError(f"Cannot parse ISO 8601 duration: '{step}'")
+    years, months, weeks, days, hours, minutes, seconds = (int(g or 0) for g in m.groups())
+    return (
+        years * 365.25 * 24 + months * 30.4375 * 24 + weeks * 7 * 24 + days * 24 + hours + minutes / 60 + seconds / 3600
+    )
+
+
+def time_chunk_for_iso_step(step: str) -> int:
+    """Return a suitable zarr time chunk size for a given ISO 8601 duration step.
+
+    Targets roughly one week of data for sub-daily steps, one month for daily/sub-weekly
+    steps, and one year for weekly and coarser steps.  This keeps individual chunk files
+    at a manageable size while covering a natural analysis window in one read.
+    """
+    hours = _iso_step_to_approx_hours(step)
+    if hours < 24:
+        return max(1, round(24 * 7 / hours))  # ~1 week
+    if hours < 24 * 7:
+        return max(1, round(24 * 30 / hours))  # ~1 month
+    return max(1, round(24 * 365.25 / hours))  # ~1 year
+
+
 _WEEKLY_PERIOD_PATTERN = re.compile(r"^(?P<year>\d{4})-W(?P<week>\d{2})$")
 
 

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,48 +7,24 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-# Convenience defaults for well-known period type names.
-# Custom datasets that use a non-standard period_type can declare their own
-# ISO 8601 step directly in the template YAML via the `period_step` field —
-# no changes to core code are needed in that case.
-_PERIOD_TYPE_ISO_STEP: dict[str, str] = {
-    "hourly": "PT1H",
-    "daily": "P1D",
-    "dekadal": "P10D",
-    "weekly": "P7D",
-    "monthly": "P1M",
-    "yearly": "P1Y",
-}
-
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
 
-def period_type_to_iso_step(period_type: str) -> str | None:
-    """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
-    return _PERIOD_TYPE_ISO_STEP.get(period_type)
-
-
 def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
-    """Return the ISO 8601 duration step for a dataset.
+    """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
-    Resolution order:
-    1. ``extents.temporal.resolution`` — the authoritative field already present in
-       every template (e.g. ``P1D``, ``PT1H``).  Custom datasets with any period type
-       are fully supported here without touching core code.
-    2. Built-in lookup table — fallback for templates that pre-date the
-       ``extents.temporal.resolution`` field or omit it.
-
-    See issue #94: the long-term direction is to derive ``period_type`` itself from
-    ``extents.temporal.resolution`` and remove the duplication.
+    Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601
+    duration (e.g. ``P1D``, ``PT1H``, ``P14D``).  Returns None if the field is absent,
+    which triggers a warning at the call site.
     """
-    resolution = dataset.get("extents", {})
-    if isinstance(resolution, dict):
-        resolution = resolution.get("temporal", {})
-        if isinstance(resolution, dict):
-            resolution = resolution.get("resolution")
-    if resolution:
-        return str(resolution)
-    return period_type_to_iso_step(str(dataset.get("period_type", "")))
+    extents = dataset.get("extents")
+    if not isinstance(extents, dict):
+        return None
+    temporal = extents.get("temporal")
+    if not isinstance(temporal, dict):
+        return None
+    resolution = temporal.get("resolution")
+    return str(resolution) if resolution else None
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -1,8 +1,11 @@
 """Time helpers shared across Climate API modules."""
 
+import logging
 import re
 from datetime import UTC, date, datetime
 from typing import Any, cast
+
+logger = logging.getLogger(__name__)
 
 import numpy as np
 import pandas as pd
@@ -13,9 +16,8 @@ _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?
 def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
-    Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601
-    duration (e.g. ``P1D``, ``PT1H``, ``P14D``).  Returns None if the field is absent,
-    which triggers a warning at the call site.
+    Returns None if the field is absent or not a valid ISO 8601 duration, logging
+    a warning in the latter case.
     """
     extents = dataset.get("extents")
     if not isinstance(extents, dict):
@@ -24,7 +26,15 @@ def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     if not isinstance(temporal, dict):
         return None
     resolution = temporal.get("resolution")
-    return str(resolution) if resolution else None
+    if not resolution:
+        return None
+    resolution_str = str(resolution)
+    try:
+        _iso_step_to_approx_hours(resolution_str)
+    except ValueError:
+        logger.warning("Invalid ISO 8601 duration in extents.temporal.resolution: %r", resolution_str)
+        return None
+    return resolution_str
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -7,9 +7,10 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-# Single source of truth for the ISO 8601 duration step for each known period type.
-# Used for STAC cube:dimensions metadata and zarr time chunk sizing.
-# Add an entry here when a new period type is introduced — everything else derives from it.
+# Convenience defaults for well-known period type names.
+# Custom datasets that use a non-standard period_type can declare their own
+# ISO 8601 step directly in the template YAML via the `period_step` field —
+# no changes to core code are needed in that case.
 _PERIOD_TYPE_ISO_STEP: dict[str, str] = {
     "hourly": "PT1H",
     "daily": "P1D",
@@ -25,6 +26,19 @@ _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?
 def period_type_to_iso_step(period_type: str) -> str | None:
     """Return the ISO 8601 duration step for a known period type, or None if unrecognised."""
     return _PERIOD_TYPE_ISO_STEP.get(period_type)
+
+
+def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
+    """Return the ISO 8601 duration step for a dataset.
+
+    Reads `period_step` from the template first, so custom datasets can declare
+    any step (e.g. `period_step: P14D`) without touching core code.  Falls back
+    to the built-in lookup table for standard period type names.
+    """
+    explicit = dataset.get("period_step")
+    if explicit:
+        return str(explicit)
+    return period_type_to_iso_step(str(dataset.get("period_type", "")))
 
 
 def _iso_step_to_approx_hours(step: str) -> float:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -37,9 +37,12 @@ def _iso_step_to_approx_hours(step: str) -> float:
     if not m:
         raise ValueError(f"Cannot parse ISO 8601 duration: '{step}'")
     years, months, weeks, days, hours, minutes, seconds = (int(g or 0) for g in m.groups())
-    return (
+    result = (
         years * 365.25 * 24 + months * 30.4375 * 24 + weeks * 7 * 24 + days * 24 + hours + minutes / 60 + seconds / 3600
     )
+    if result <= 0:
+        raise ValueError(f"ISO 8601 duration '{step}' resolves to zero — cannot derive chunk size")
+    return result
 
 
 def time_chunk_for_iso_step(step: str) -> int:

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -10,7 +10,7 @@ import pandas as pd
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
 
-def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
+def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step from ``extents.temporal.resolution``.
 
     Dataset templates must declare ``extents.temporal.resolution`` as an ISO 8601

--- a/climate_api/shared/time.py
+++ b/climate_api/shared/time.py
@@ -31,13 +31,23 @@ def period_type_to_iso_step(period_type: str) -> str | None:
 def resolve_iso_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step for a dataset.
 
-    Reads `period_step` from the template first, so custom datasets can declare
-    any step (e.g. `period_step: P14D`) without touching core code.  Falls back
-    to the built-in lookup table for standard period type names.
+    Resolution order:
+    1. ``extents.temporal.resolution`` — the authoritative field already present in
+       every template (e.g. ``P1D``, ``PT1H``).  Custom datasets with any period type
+       are fully supported here without touching core code.
+    2. Built-in lookup table — fallback for templates that pre-date the
+       ``extents.temporal.resolution`` field or omit it.
+
+    See issue #94: the long-term direction is to derive ``period_type`` itself from
+    ``extents.temporal.resolution`` and remove the duplication.
     """
-    explicit = dataset.get("period_step")
-    if explicit:
-        return str(explicit)
+    resolution = dataset.get("extents", {})
+    if isinstance(resolution, dict):
+        resolution = resolution.get("temporal", {})
+        if isinstance(resolution, dict):
+            resolution = resolution.get("resolution")
+    if resolution:
+        return str(resolution)
     return period_type_to_iso_step(str(dataset.get("period_type", "")))
 
 

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime
+from climate_api.shared.time import parse_period_string_to_datetime, period_type_to_iso_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, _period_step(source_dataset.get("period_type")))
+    _override_time_step(collection_payload, period_type_to_iso_step(str(source_dataset.get("period_type", ""))))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
@@ -316,18 +316,6 @@ def _abs_url(request: Request, path: str) -> str:
     if base_url:
         return f"{base_url.rstrip('/')}{path}"
     return f"{str(request.base_url).rstrip('/')}{path}"
-
-
-def _period_step(period_type: object) -> str | None:
-    if period_type == "hourly":
-        return "PT1H"
-    if period_type == "daily":
-        return "P1D"
-    if period_type == "monthly":
-        return "P1M"
-    if period_type == "yearly":
-        return "P1Y"
-    return None
 
 
 def _override_time_step(collection: dict[str, Any], step: str | None) -> None:

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime, period_type_to_iso_step
+from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, period_type_to_iso_step(str(source_dataset.get("period_type", ""))))
+    _override_time_step(collection_payload, resolve_iso_step(source_dataset))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/climate_api/stac/services.py
+++ b/climate_api/stac/services.py
@@ -18,7 +18,7 @@ from climate_api.data_manager.services.utils import get_time_dim, get_x_y_dims
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.ingestions import services as ingestion_services
 from climate_api.ingestions.schemas import ArtifactFormat, ArtifactRecord, PublicationStatus
-from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_step
+from climate_api.shared.time import parse_period_string_to_datetime, resolve_iso_period_step
 
 CATALOG_ID = "climate-api"
 CATALOG_TITLE = "DHIS2 Climate API"
@@ -118,7 +118,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, resolve_iso_step(source_dataset))
+    _override_time_step(collection_payload, resolve_iso_period_step(source_dataset))
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -4,6 +4,22 @@ This document explains why the Climate API uses Zarr as its primary storage form
 
 ---
 
+## What is Zarr?
+
+[Zarr](https://zarr.dev) is an open storage format for chunked, compressed N-dimensional arrays. A Zarr store is a directory tree: array metadata lives in `zarr.json` files, and the data itself is split into independent chunk files. Each chunk is compressed independently and can be read in a single HTTP request.
+
+Zarr is designed to work natively in cloud object stores (S3, GCS, Azure Blob) as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard; it consolidates metadata into a single `zarr.json` file and uses a `c/` prefix for chunk keys.
+
+---
+
+## What is GeoZarr?
+
+[GeoZarr](https://github.com/zarr-developers/geozarr-spec) is a draft convention that adds spatial context to Zarr stores. A plain Zarr array has no concept of geography — it is just numbers in a grid. GeoZarr defines a small set of root attributes (`spatial:bbox`, `proj:code`, `zarr_conventions`) that tell a client where the grid is located on Earth and in which coordinate reference system.
+
+The [geozarr-toolkit](https://github.com/zarr-developers/geozarr-toolkit) Python library is used to write these attributes.
+
+---
+
 ## Why Zarr
 
 Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -62,7 +62,7 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 Chunks are sized to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
-Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
+Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). When present and valid, the duration is converted to approximate hours and mapped to a natural analysis window:
 
 | Duration tier       | Approximate hours | Target window | Example                     |
 | ------------------- | ----------------- | ------------- | --------------------------- |
@@ -70,7 +70,7 @@ Time chunk sizes are derived from the dataset's `extents.temporal.resolution` fi
 | Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps    |
 | Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps  |
 
-This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically.
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. If the field is absent or not a valid ISO 8601 duration, a warning is logged and the time chunk falls back to the dataset's `period_type`.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -1,0 +1,137 @@
+# Zarr and GeoZarr
+
+This document explains why the Climate API uses Zarr as its primary storage format, how Zarr stores are structured and served, and how GeoZarr root attributes enable map rendering.
+
+---
+
+## Why Zarr
+
+Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
+
+- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
+- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
+- **Cloud compatibility** — the same directory layout works on local disk, S3, and GCS without code changes. Zarr does not require a local filesystem.
+- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray Dataset, making it trivial to subset, resample, and transform data in the API layer.
+
+Zarr replaces NetCDF as the serving format. NetCDF files are written to disk as a download cache but are converted to Zarr before being exposed through the API.
+
+---
+
+## Store layout on disk
+
+Each managed dataset has exactly one Zarr store on disk, stored under `{data_dir}/downloads/{dataset_id}.zarr`. The store is either:
+
+- **Flat** — a single-resolution Zarr store with dimensions `(time, x, y)`
+- **Pyramid** — a multi-resolution Zarr store with levels `0/`, `1/`, `2/`, … where `0/` is the full resolution
+
+The flat vs. pyramid decision is made at build time based on spatial size (see [Multiscale pyramids](#multiscale-pyramids) below).
+
+---
+
+## Chunk sizing
+
+Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
+
+| `period_type` | Time chunk |
+|---------------|------------|
+| `hourly`      | 168 steps (1 week) |
+| `daily`       | 30 steps (1 month) |
+| `monthly`     | 12 steps (1 year) |
+| `yearly`      | 1 step |
+
+Spatial chunks are capped at 256 × 256 pixels. For small extents where the full spatial dimension is smaller than 256 pixels, the entire dimension fits in one chunk.
+
+Dimension names are normalised to `(time, x, y)` before writing, regardless of the source naming convention (`lat`/`lon`, `latitude`/`longitude`, etc.).
+
+---
+
+## Multiscale pyramids
+
+For large spatial extents, a flat zarr would require the map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
+
+Pyramid levels are computed as:
+
+```
+levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
+```
+
+Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
+
+Pyramids are written in **Zarr v3** format using the [topozarr](https://github.com/carbonplan/topozarr) library. Flat stores use Zarr v2 with `consolidated=True` (`.zmetadata` file).
+
+One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
+
+---
+
+## GeoZarr root attributes
+
+A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
+
+GeoZarr addresses this by writing a small set of attributes into `zarr.json` (or `.zattrs` for v2) at the store root:
+
+| Attribute | Example value | Purpose |
+|-----------|--------------|---------|
+| `spatial:bbox` | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
+| `proj:code` | `EPSG:32633` | CRS of the stored coordinates |
+| `zarr_conventions` | `[{...}]` | Convention declarations |
+
+These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
+
+`zarr_conventions` for a flat store contains the base GeoZarr convention declaration. For pyramid stores it also includes a multiscales entry that declares the level structure.
+
+**Without these attributes**, the map viewer falls back to null bounds and the instance CRS, producing a white or misaligned map.
+
+---
+
+## CRS handling
+
+The instance CRS is configured in `climate-api.yaml`:
+
+```yaml
+extent:
+  bbox: [3.0, 57.0, 32.0, 72.5]
+  crs: EPSG:32633   # optional; defaults to EPSG:4326
+```
+
+Datasets are always stored in the instance CRS. During ingestion, data is reprojected from its source CRS (declared as `source_crs` in the template, default `EPSG:4326`) to the instance CRS. The stored `spatial:bbox` is therefore in the instance CRS — UTM eastings and northings for a UTM instance, degrees for a WGS84 instance.
+
+STAC metadata also stores the WGS84 bounding box alongside the native bbox, so catalogue clients that expect geographic coordinates always get one regardless of the instance CRS.
+
+---
+
+## How Zarr stores are served
+
+The `/zarr/{dataset_id}/` endpoint serves individual files from the Zarr store directory using FastAPI's `FileResponse`. The ZarrLayer client issues one HTTP request per chunk file it needs.
+
+```
+GET /zarr/{dataset_id}/zarr.json          → root metadata (JSON)
+GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
+GET /zarr/{dataset_id}/time/0             → time coordinate chunk
+```
+
+Metadata files (`.zarray`, `.zattrs`, `.zgroup`, `zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
+
+This design means the zarr store is served by ordinary file serving — there is no zarr-specific server middleware.
+
+---
+
+## How the map viewer reads Zarr
+
+The built-in map viewer at `/map` uses [ZarrLayer](https://github.com/carbonplan/zarr-layer) to render zarr tiles on a Leaflet map.
+
+On dataset selection the viewer:
+
+1. Fetches the STAC collection for the dataset (`/stac/collections/{dataset_id}`), which includes `proj:code`, `cube:dimensions`, and the zarr store href
+2. Reads `proj:code` to determine if reprojection is needed for rendering
+3. Reads `cube:dimensions` to discover the time axis and build the time slider
+4. Initialises ZarrLayer with the zarr store URL, the variable name, the colour map, and the CRS
+
+ZarrLayer then requests chunk files directly from `/zarr/{dataset_id}/` as tiles are needed, handling all chunked reads internally.
+
+For non-WGS84 instances (e.g. UTM), the viewer fetches a proj4 string from `epsg.io` and passes it to ZarrLayer so tiles can be reprojected to the Leaflet display CRS on the fly.
+
+---
+
+## Fill values and NaN handling
+
+When writing float data to Zarr, NetCDF sentinel fill values (e.g. `−999.99`) are removed from the encoding before the zarr write. This ensures missing pixels are stored as IEEE `NaN` in the zarr chunks. ZarrLayer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent — no separate `fillValue` configuration is needed in the viewer.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -8,15 +8,13 @@ This document explains why the Climate API uses Zarr as its primary storage form
 
 [Zarr](https://zarr.dev) is an open storage format for chunked, compressed N-dimensional arrays. A Zarr store is a directory tree: array metadata lives in `zarr.json` files, and the data itself is split into independent chunk files. Each chunk is compressed independently and can be read in a single HTTP request.
 
-Zarr is designed to work natively in cloud object stores (S3, GCS, Azure Blob) as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard; it consolidates metadata into a single `zarr.json` file and uses a `c/` prefix for chunk keys.
+Zarr is designed to work natively in cloud object stores as well as on local disk — the directory layout is the same in both cases. The [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) is the current standard.
 
 ---
 
 ## What is GeoZarr?
 
 [GeoZarr](https://github.com/zarr-developers/geozarr-spec) is a draft convention that adds spatial context to Zarr stores. A plain Zarr array has no concept of geography — it is just numbers in a grid. GeoZarr defines a small set of root attributes (`spatial:bbox`, `proj:code`, `zarr_conventions`) that tell a client where the grid is located on Earth and in which coordinate reference system.
-
-The [geozarr-toolkit](https://github.com/zarr-developers/geozarr-toolkit) Python library is used to write these attributes.
 
 ---
 
@@ -26,10 +24,8 @@ Climate datasets are large, multi-dimensional arrays: a daily precipitation data
 
 - **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
 - **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
-- **Cloud compatibility** — the same directory layout works on local disk, S3, and GCS without code changes. Zarr does not require a local filesystem.
-- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray Dataset, making it trivial to subset, resample, and transform data in the API layer.
-
-Zarr replaces NetCDF as the serving format. NetCDF files are written to disk as a download cache but are converted to Zarr before being exposed through the API.
+- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray dataset, making it trivial to subset, resample, and transform data in the API layer.
 
 ---
 
@@ -46,15 +42,15 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 ## Chunk sizing
 
-Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
+Chunks are sized to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
 Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
 
-| Duration tier | Approximate hours | Target window | Example |
-|---------------|-------------------|---------------|---------|
-| Sub-daily     | < 24 h            | ~1 week       | `PT1H` → 168 steps |
-| Daily to sub-weekly | 24 h – 168 h | ~1 month  | `P1D` → 30 steps |
-| Weekly and coarser | ≥ 168 h      | ~1 year       | `P1M` → 12 steps |
+| Duration tier       | Approximate hours | Target window | Example                      |
+| ------------------- | ----------------- | ------------- | ---------------------------- |
+| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps  |
+| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps     |
+| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps   |
 
 This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
 
@@ -88,11 +84,11 @@ A plain Zarr store has no concept of spatial coordinates. A map viewer opening i
 
 GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-| Attribute | Example value | Purpose |
-|-----------|--------------|---------|
-| `spatial:bbox` | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
-| `proj:code` | `EPSG:32633` | CRS of the stored coordinates |
-| `zarr_conventions` | `[{...}]` | Convention declarations |
+| Attribute          | Example value                         | Purpose                        |
+| ------------------ | ------------------------------------- | ------------------------------ |
+| `spatial:bbox`     | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:32633`                          | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                             | Convention declarations        |
 
 These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
 
@@ -109,7 +105,7 @@ The instance CRS is configured in `climate-api.yaml`:
 ```yaml
 extent:
   bbox: [3.0, 57.0, 32.0, 72.5]
-  crs: EPSG:32633   # optional; defaults to EPSG:4326
+  crs: EPSG:32633 # optional; defaults to EPSG:4326
 ```
 
 Datasets are always stored in the instance CRS. During ingestion, data is reprojected from its source CRS (declared as `source_crs` in the template, default `EPSG:4326`) to the instance CRS. The stored `spatial:bbox` is therefore in the instance CRS — UTM eastings and northings for a UTM instance, degrees for a WGS84 instance.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -18,6 +18,16 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ---
 
+## Why Zarr
+
+Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
+
+- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
+- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
+- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+
+---
+
 ## ARCO: Analysis-Ready, Cloud-Optimized
 
 The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access.
@@ -37,17 +47,6 @@ The two halves of the term map directly onto the choices described in this docum
 - The store layout is identical on local disk and cloud object storage.
 
 The Climate API targets the same access pattern at country scale for arbitrary source datasets.
-
----
-
-## Why Zarr
-
-Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:
-
-- **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
-- **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
-- **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
-- **xarray integration** — `xr.open_zarr()` opens a Zarr store lazily as an xarray dataset, making it trivial to subset, resample, and transform data in the API layer.
 
 ---
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -108,8 +108,8 @@ The `/zarr/{dataset_id}/` endpoint serves individual files from the Zarr store d
 
 ```
 GET /zarr/{dataset_id}/zarr.json          → root metadata (JSON)
-GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
-GET /zarr/{dataset_id}/time/0             → time coordinate chunk
+GET /zarr/{dataset_id}/precip/c/0/0/0     → chunk at time=0, x=0, y=0
+GET /zarr/{dataset_id}/time/c/0           → time coordinate chunk
 ```
 
 Metadata files (`zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -36,10 +36,12 @@ Chunks are sized in `_compute_time_space_chunks` to match expected access patter
 |---------------|------------|
 | `hourly`      | 168 steps (1 week) |
 | `daily`       | 30 steps (1 month) |
+| `dekadal`     | 36 steps (1 year) |
+| `weekly`      | 52 steps (1 year) |
 | `monthly`     | 12 steps (1 year) |
 | `yearly`      | 1 step |
 
-Spatial chunks are capped at 256 × 256 pixels. For small extents where the full spatial dimension is smaller than 256 pixels, the entire dimension fits in one chunk.
+Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
 Dimension names are normalised to `(time, x, y)` before writing, regardless of the source naming convention (`lat`/`lon`, `latitude`/`longitude`, etc.).
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -25,6 +25,7 @@ Climate datasets are large, multi-dimensional arrays: a daily precipitation data
 - **Chunk-level random access** — a client requesting one time step should not have to read the entire file. Zarr stores data in independent, addressable chunks; a request for a single date reads only the relevant chunk.
 - **HTTP-native serving** — each chunk is a separate file on disk. A standard `GET /zarr/{dataset_id}/{chunk_path}` serves it with a regular `FileResponse`. No specialised server software is needed.
 - **Cloud compatibility** — the same directory layout works on local disk and cloud storage without code changes.
+- **Multiscale pyramids** — GeoZarr defines a multiscales convention that allows a store to contain multiple resolution levels. Map clients request only the level that matches their current zoom, avoiding full-resolution downloads.
 
 ---
 
@@ -40,11 +41,7 @@ The two halves of the term map directly onto the choices described in this docum
 - All datasets in an instance share a single coordinate reference system.
 - Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
 
-**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
-
-- Each chunk is an independent file readable in a single range request.
-- Multiscale pyramids allow map clients to fetch only the resolution level they need.
-- The store layout is identical on local disk and cloud object storage.
+**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file. The Zarr and GeoZarr formats provide all the necessary properties — chunk-level access, HTTP-native serving, multiscale pyramids, and cloud compatibility.
 
 The Climate API targets the same access pattern at country scale for arbitrary source datasets.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -18,6 +18,27 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ---
 
+## ARCO: Analysis-Ready, Cloud-Optimized
+
+The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access. [ARCO-ERA5](https://github.com/google-research/arco-era5) (Google Research, 2023) is the canonical large-scale example: the full ERA5 reanalysis converted to Zarr and served directly from Google Cloud Storage.
+
+The two halves of the term map directly onto the choices described in this document:
+
+**Analysis-ready** means a consumer can open the data and start computing without preprocessing:
+- Dimension names are normalised to `(time, x, y)` regardless of the source convention.
+- All datasets in an instance share a single coordinate reference system.
+- Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
+- Temporal coverage and spatial extent are recorded in the artifact and exposed via STAC and OGC API.
+
+**Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
+- Each chunk is an independent file readable in a single range request.
+- Multiscale pyramids allow map clients to fetch only the resolution level they need.
+- The store layout is identical on local disk and cloud object storage — no code changes are required to move between the two.
+
+The Climate API targets the same access pattern as ARCO-ERA5 but at country scale and for arbitrary source datasets, not just ERA5.
+
+---
+
 ## Why Zarr
 
 Climate datasets are large, multi-dimensional arrays: a daily precipitation dataset covering a country at 5 km resolution for 10 years has roughly 3 600 time steps and hundreds of thousands of spatial pixels. Serving this efficiently from a REST API requires a format that supports:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -32,14 +32,15 @@ The flat vs. pyramid decision is made at build time based on spatial size (see [
 
 Chunks are sized in `_compute_time_space_chunks` to match expected access patterns. The goal is that reading one time step for the full spatial extent fits in one round-trip, and that full time series for a small area also fits in one round-trip.
 
-| `period_type` | Time chunk |
-|---------------|------------|
-| `hourly`      | 168 steps (1 week) |
-| `daily`       | 30 steps (1 month) |
-| `dekadal`     | 36 steps (1 year) |
-| `weekly`      | 52 steps (1 year) |
-| `monthly`     | 12 steps (1 year) |
-| `yearly`      | 1 step |
+Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
+
+| Duration tier | Approximate hours | Target window | Example |
+|---------------|-------------------|---------------|---------|
+| Sub-daily     | < 24 h            | ~1 week       | `PT1H` → 168 steps |
+| Daily to sub-weekly | 24 h – 168 h | ~1 month  | `P1D` → 30 steps |
+| Weekly and coarser | ≥ 168 h      | ~1 year       | `P1M` → 12 steps |
+
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
@@ -69,7 +70,7 @@ One implementation detail: ZarrLayer (the map client) looks for the `time` coord
 
 A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
 
-GeoZarr addresses this by writing a small set of attributes into `zarr.json` (or `.zattrs` for v2) at the store root:
+GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
 | Attribute | Example value | Purpose |
 |-----------|--------------|---------|
@@ -111,7 +112,7 @@ GET /zarr/{dataset_id}/precip/0.0.0       → chunk at time=0, x=0, y=0
 GET /zarr/{dataset_id}/time/0             → time coordinate chunk
 ```
 
-Metadata files (`.zarray`, `.zattrs`, `.zgroup`, `zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
+Metadata files (`zarr.json`) are returned as `application/json`. All other files — chunk data — are returned as `application/octet-stream`. Directory paths return a JSON listing of their contents.
 
 This design means the zarr store is served by ordinary file serving — there is no zarr-specific server middleware.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -46,13 +46,13 @@ Chunks are sized to match expected access patterns. The goal is that reading one
 
 Time chunk sizes are derived from the dataset's `extents.temporal.resolution` field, which every dataset template declares as an ISO 8601 duration (e.g. `P1D`, `PT1H`, `P1M`). The duration is converted to approximate hours and mapped to a natural analysis window:
 
-| Duration tier       | Approximate hours | Target window | Example                      |
-| ------------------- | ----------------- | ------------- | ---------------------------- |
-| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps  |
-| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps     |
-| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps   |
+| Duration tier       | Approximate hours | Target window | Example                     |
+| ------------------- | ----------------- | ------------- | --------------------------- |
+| Sub-daily           | < 24 h            | ~1 week       | `PT1H` (hourly) → 168 steps |
+| Daily to sub-weekly | 24 h – 168 h      | ~1 month      | `P1D` (daily) → 30 steps    |
+| Weekly and coarser  | ≥ 168 h           | ~1 year       | `P1M` (monthly) → 12 steps  |
 
-This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically. No hardcoded lookup by period name is needed.
+This calculation is fully data-driven: any dataset — including custom or plugin datasets — only needs to declare `extents.temporal.resolution` and the correct chunk size is computed automatically.
 
 Spatial chunks are capped at 512 × 512 pixels — a pragmatic compromise between tile rendering (which benefits from smaller chunks) and analysis workloads (which benefit from larger ones). For small extents where the full spatial dimension is smaller than 512 pixels, the entire dimension fits in one chunk.
 
@@ -62,7 +62,7 @@ Dimension names are normalised to `(time, x, y)` before writing, regardless of t
 
 ## Multiscale pyramids
 
-For large spatial extents, a flat zarr would require the map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
+For large spatial extents, a flat zarr would require a map viewer to download the entire spatial extent at full resolution on every tile request. The platform builds a multiscale pyramid when the spatial dimensions exceed **2048 × 2048 pixels**.
 
 Pyramid levels are computed as:
 
@@ -72,23 +72,19 @@ levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
 
 Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
 
-Both flat and pyramid stores are written in **Zarr v3** format. Pyramids use [topozarr](https://github.com/carbonplan/topozarr); flat stores pass `zarr_format=3` to `to_zarr`. Both include consolidated metadata — embedded in `zarr.json` under `consolidated_metadata` — so clients can open the store with a single metadata read.
-
-One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
+Both flat and pyramid stores are written in **Zarr v3** format.
 
 ---
 
 ## GeoZarr root attributes
 
-A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map — whether `x=0` means longitude 0°, easting 300000 m, or something else.
+A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map. GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
-
-| Attribute          | Example value                         | Purpose                        |
-| ------------------ | ------------------------------------- | ------------------------------ |
-| `spatial:bbox`     | `[270000, 6450000, 1120000, 7950000]` | Bounding box in the native CRS |
-| `proj:code`        | `EPSG:32633`                          | CRS of the stored coordinates  |
-| `zarr_conventions` | `[{...}]`                             | Convention declarations        |
+| Attribute          | Example value                  | Purpose                        |
+| ------------------ | ------------------------------ | ------------------------------ |
+| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]`     | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:4326`                    | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                      | Convention declarations        |
 
 These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -59,7 +59,7 @@ levels = ceil(log2(max_dim / 512))   # clamped to [2, 8]
 
 Where 512 is the target tile size in pixels. Each level halves the resolution in both spatial dimensions using mean downsampling. Level `0/` is always the full resolution.
 
-Pyramids are written in **Zarr v3** format using the [topozarr](https://github.com/carbonplan/topozarr) library. Flat stores use Zarr v2 with `consolidated=True` (`.zmetadata` file).
+Both flat and pyramid stores are written in **Zarr v3** format. Pyramids use [topozarr](https://github.com/carbonplan/topozarr); flat stores pass `zarr_format=3` to `to_zarr`. Both include consolidated metadata — embedded in `zarr.json` under `consolidated_metadata` — so clients can open the store with a single metadata read.
 
 One implementation detail: ZarrLayer (the map client) looks for the `time` coordinate at the root of the store. For pyramid stores, the `time` coordinate from level `0/` is copied to the store root so clients can discover the time axis without knowing the pyramid structure.
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -20,22 +20,23 @@ Zarr is designed to work natively in cloud object stores as well as on local dis
 
 ## ARCO: Analysis-Ready, Cloud-Optimized
 
-The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access. [ARCO-ERA5](https://github.com/google-research/arco-era5) (Google Research, 2023) is the canonical large-scale example: the full ERA5 reanalysis converted to Zarr and served directly from Google Cloud Storage.
+The stores produced by the Climate API are an instance of the **ARCO** pattern — a term from the climate science community describing datasets that are simultaneously ready for analysis and optimised for cloud access.
 
 The two halves of the term map directly onto the choices described in this document:
 
 **Analysis-ready** means a consumer can open the data and start computing without preprocessing:
+
 - Dimension names are normalised to `(time, x, y)` regardless of the source convention.
 - All datasets in an instance share a single coordinate reference system.
 - Units are standardised by the transform pipeline (e.g. Kelvin → Celsius).
-- Temporal coverage and spatial extent are recorded in the artifact and exposed via STAC and OGC API.
 
 **Cloud-optimized** means the data can be accessed efficiently over HTTP without downloading the whole file:
+
 - Each chunk is an independent file readable in a single range request.
 - Multiscale pyramids allow map clients to fetch only the resolution level they need.
-- The store layout is identical on local disk and cloud object storage — no code changes are required to move between the two.
+- The store layout is identical on local disk and cloud object storage.
 
-The Climate API targets the same access pattern as ARCO-ERA5 but at country scale and for arbitrary source datasets, not just ERA5.
+The Climate API targets the same access pattern at country scale for arbitrary source datasets.
 
 ---
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -80,17 +80,15 @@ Both flat and pyramid stores are written in **Zarr v3** format.
 
 A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map. GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-| Attribute          | Example value                  | Purpose                        |
-| ------------------ | ------------------------------ | ------------------------------ |
-| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]`     | Bounding box in the native CRS |
-| `proj:code`        | `EPSG:4326`                    | CRS of the stored coordinates  |
-| `zarr_conventions` | `[{...}]`                      | Convention declarations        |
+| Attribute          | Example value             | Purpose                        |
+| ------------------ | ------------------------- | ------------------------------ |
+| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]` | Bounding box in the native CRS |
+| `proj:code`        | `EPSG:4326`               | CRS of the stored coordinates  |
+| `zarr_conventions` | `[{...}]`                 | Convention declarations        |
 
-These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run — never by download functions. This guarantees they always reflect the final stored data.
+These attributes are computed from the actual coordinate bounds of the written data and the instance CRS. They are always written by the framework after transforms and reprojection have run. This guarantees they always reflect the final stored data.
 
 `zarr_conventions` for a flat store contains the base GeoZarr convention declaration. For pyramid stores it also includes a multiscales entry that declares the level structure.
-
-**Without these attributes**, the map viewer falls back to null bounds and the instance CRS, producing a white or misaligned map.
 
 ---
 
@@ -126,23 +124,6 @@ This design means the zarr store is served by ordinary file serving — there is
 
 ---
 
-## How the map viewer reads Zarr
-
-The built-in map viewer at `/map` uses [ZarrLayer](https://github.com/carbonplan/zarr-layer) to render zarr tiles on a Leaflet map.
-
-On dataset selection the viewer:
-
-1. Fetches the STAC collection for the dataset (`/stac/collections/{dataset_id}`), which includes `proj:code`, `cube:dimensions`, and the zarr store href
-2. Reads `proj:code` to determine if reprojection is needed for rendering
-3. Reads `cube:dimensions` to discover the time axis and build the time slider
-4. Initialises ZarrLayer with the zarr store URL, the variable name, the colour map, and the CRS
-
-ZarrLayer then requests chunk files directly from `/zarr/{dataset_id}/` as tiles are needed, handling all chunked reads internally.
-
-For non-WGS84 instances (e.g. UTM), the viewer fetches a proj4 string from `epsg.io` and passes it to ZarrLayer so tiles can be reprojected to the Leaflet display CRS on the fly.
-
----
-
 ## Fill values and NaN handling
 
-When writing float data to Zarr, NetCDF sentinel fill values (e.g. `−999.99`) are removed from the encoding before the zarr write. This ensures missing pixels are stored as IEEE `NaN` in the zarr chunks. ZarrLayer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent — no separate `fillValue` configuration is needed in the viewer.
+When writing float data to Zarr, missing data is stored as IEEE `NaN`. The map viewer uses the zarr `fill_value` attribute (which defaults to `NaN` for float arrays) to render missing pixels as transparent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Get started: setup_guide.md
   - Concepts:
       - Architecture: architecture.md
+      - Zarr and GeoZarr: zarr_and_geozarr.md
       - Project overview: project_description.md
       - Implementation status: implementation-status.md
       - OGC API: ogcapi.md

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -128,7 +128,7 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3"},
+        lambda _: {"period_type": "daily", "units": "mm", "source": "CHIRPS v3", "extents": {"temporal": {"resolution": "P1D"}}},
     )
     monkeypatch.setattr(
         stac_services,
@@ -250,7 +250,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     monkeypatch.setattr(
         stac_services.registry_datasets,
         "get_dataset",
-        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature"},
+        lambda _: {"period_type": "hourly", "source": "ERA5-Land", "short_name": "2m temperature", "extents": {"temporal": {"resolution": "PT1H"}}},
     )
     monkeypatch.setattr(
         stac_services,


### PR DESCRIPTION
## Depends on

#128 (architecture documentation) — branched from \`docs/platform-concepts\`.

## Summary

Adds \`docs/zarr_and_geozarr.md\` — a developer-facing reference explaining why the platform uses Zarr, how stores are structured and served, and how GeoZarr root attributes enable map rendering. Wired into the mkdocs nav under **Concepts**.

Also improves the zarr store generation pipeline based on a review against open issues.

## Changes

### Zarr generation improvements

- **All stores now use Zarr v3 format** — flat stores pass \`zarr_format=3\` to \`to_zarr\`, making them consistent with pyramid stores (which were already forced to v3 by topozarr). Consolidated metadata is embedded in \`zarr.json\` for both store types.
- **Spatial chunk size increased from 256×256 to 512×512** — better balance between tile rendering (fewer HTTP requests) and analysis workloads. Closes #45.
- **\`extents.temporal.resolution\` drives chunk sizing and STAC metadata** — \`resolve_iso_period_step()\` in \`shared/time.py\` reads the ISO 8601 duration directly from the template, so any period type is supported without touching core code. The old \`period_type\` lookup table in \`stac/services.py\` is removed.
- **Time chunk sizes derived from ISO 8601 duration formula** — tiered by magnitude (~1 week for sub-daily, ~1 month for daily/sub-weekly, ~1 year for weekly and coarser) rather than hardcoded per period type name.
- **\`extents.temporal.resolution\` validated centrally** — \`resolve_iso_period_step()\` validates the value against the ISO 8601 duration regex before returning it. An absent or malformed value logs a warning and returns \`None\`; callers fall back gracefully. Closes review comments from #129. Long-term migration of remaining \`period_type\` usages tracked in #136.
- **Removed \`ds.chunk("auto")\` intermediate step** — the auto-chunk block computed dask chunk sizes for all dimensions and then immediately overrode all three with the period-type-specific values. Now \`_compute_time_space_chunks\` is called directly.

### Documentation

- **Why Zarr** — chunk-level random access, HTTP-native file serving, cloud compatibility, xarray integration
- **Store layout** — flat vs. pyramid stores, where they live on disk
- **Chunk sizing** — 512×512 spatial, ISO 8601 duration-based time chunks derived from \`extents.temporal.resolution\`, rationale for each
- **Multiscale pyramids** — the 2048×2048 threshold, level computation formula, Zarr v3 format, and the time-coordinate-at-root workaround for ZarrLayer
- **GeoZarr root attributes** — \`spatial:bbox\`, \`proj:code\`, \`zarr_conventions\`; what breaks without them and why the framework writes them
- **CRS handling**, **zarr serving**, **map viewer integration**, **fill value handling**