### PR TITLE
docs: fix .netrc credentials for DestinE Earth Data Hub authentication

### DIFF
--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -165,10 +165,12 @@ Create a free account at [earthdatahub.destine.eu](https://earthdatahub.destine.
 DestinE authentication uses a `.netrc` file in your home directory. Create or append to `~/.netrc`:
 
 ```
-machine earthdatahub.destine.eu
-login your@email.com
-password your-password
+machine data.earthdatahub.destine.eu
+login edh
+password <your-personal-access-token>
 ```
+
+The `login` is the literal string `edh`. The `password` is a personal access token, not your account password — generate one at `earthdatahub.destine.eu/account-settings` under "My Personal Access Tokens"
 
 Set the correct permissions:
 


### PR DESCRIPTION
## Summary

Fixes the incorrect `.netrc` example in `docs/setup_guide.md` for ERA5-Land authentication via DestinE Earth Data Hub.

Closes #130

## What was wrong

The documented `.netrc` entry had three errors:

| Field | Before (incorrect) | After (correct) |
|---|---|---|
| `machine` | `earthdatahub.destine.eu` | `data.earthdatahub.destine.eu` |
| `login` | `your@email.com` | `edh` (literal string) |
| `password` | account password | personal access token |

The actual data requests hit `data.earthdatahub.destine.eu` (with the `data.` subdomain), so a `.netrc` entry scoped to `earthdatahub.destine.eu` never matched, causing every ERA5-Land ingestion to fail with a `401 Unauthorized`.

## Changes

- `docs/setup_guide.md` — corrected the `.netrc` example and added a note clarifying that:
  - `login` must be the literal string `edh`, not the user's email
  - `password` is a personal access token, not the account password
  - Tokens can be generated at [earthdatahub.destine.eu/account-settings](https://earthdatahub.destine.eu/account-settings) under **My Personal Access Tokens**

## Testing

Verified the corrected `.netrc` resolves the 401 error and ERA5-Land ingestion completes successfully when running climate-api in a Docker container.

And the actual file diff to apply to docs/setup_guide.md — replace the auth section with:
markdown

### 2. Configure authentication

DestinE authentication uses a `.netrc` file. Create or append to `~/.netrc`:

```
machine data.earthdatahub.destine.eu
login edh
password <your-personal-access-token>
```
The `login` is the literal string `edh`. The `password` is a personal access token, not your account password — generate one at `earthdatahub.destine.eu/account-settings` under "My Personal Access Tokens"


Set the correct permissions:

```bash
chmod 600 ~/.netrc
```