### PR TITLE
build: copy README.md into Docker build context before uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock .python-version ./
 COPY climate_api/ climate_api/
+COPY README.md .
 
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
## Summary

Fixes the Docker build failure caused by `README.md` missing from the build context during `uv sync --frozen --no-dev`.

Closes #134 

## What was wrong

`pyproject.toml` declares `README.md` via the `readme` field. When `uv` resolves the package during `uv sync`, it reads `pyproject.toml` and expects `README.md` to be present. The `Dockerfile` was not copying `README.md` before the sync step, causing the build to fail.

## Changes

- `Dockerfile` — added `COPY README.md .` before the `uv sync --frozen --no-dev` step

## Before

```dockerfile
COPY pyproject.toml uv.lock ./
RUN uv sync --frozen --no-dev
```

## After

```dockerfile
COPY pyproject.toml uv.lock README.md ./
RUN uv sync --frozen --no-dev
```

## Testing

Confirmed the Docker build completes successfully after applying this change.