### PR TITLE
docs: add Windows _netrc note to DestinE auth setup

### DIFF
--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -178,6 +178,8 @@ Set the correct permissions:
 chmod 600 ~/.netrc
 ```
 
+**Windows:** Python's `netrc` module looks for `_netrc` (underscore) instead of `.netrc`. Create the file as `%USERPROFILE%\_netrc` with the same content. The `chmod` step is not needed on Windows.
+
 ### 3. Ingest ERA5-Land data
 
 Once authenticated, ingest ERA5-Land temperature for Rwanda:


### PR DESCRIPTION
On Windows, Python's `netrc` module looks for `_netrc` (underscore) rather than `.netrc` (dot). `curl -n` accepts both, which caused confusion — the curl auth test passed while the actual ingestion failed with 502.

Confirmed working by Yambanso on the Rwanda instance.