### PR TITLE
docs: update frontpage tagline to lead with fragmentation problem

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -6,8 +6,10 @@
   <div class="home-hero__inner">
     <h1 class="home-hero__headline">Open Climate Service</h1>
     <p class="home-hero__sub">
-      An open-source platform for delivering tailored climate and earth
-      observation data to support informed, climate-smart decisions.
+      Climate and earth observation data is distributed across dozens of
+      providers — each with different APIs, formats, and access mechanisms.
+      Open Climate Service is an open-source platform that cuts through this
+      complexity to deliver tailored data for climate-smart decision-making.
     </p>
     <div class="home-hero__ctas">
       <a href="setup_guide/" class="home-btn home-btn--primary">Get started</a>


### PR DESCRIPTION
Replaces the single-sentence tagline with a two-sentence version that first names the problem (fragmented provider landscape) before positioning Open Climate Service as the solution.