### PR TITLE
feat: configurable instance name via name: in climate-api.yaml

### DIFF
--- a/climate_api/config.py
+++ b/climate_api/config.py
@@ -59,6 +59,21 @@ def _load_config() -> dict[str, Any]:
 
 
 DEFAULT_CRS = "EPSG:4326"
+DEFAULT_NAME = "Open Climate Service"
+
+
+def get_name() -> str:
+    """Return the instance display name from CLIMATE_API_CONFIG.
+
+    Set `name: My Climate Service` in climate-api.yaml to customise the title
+    shown in the web UI. Defaults to 'Open Climate Service' when unset.
+    """
+    raw = get_config().get("name")
+    if raw is None:
+        return DEFAULT_NAME
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"name in CLIMATE_API_CONFIG must be a non-empty string, got {type(raw).__name__}")
+    return raw.strip()
 
 
 def get_crs() -> str:

--- a/climate_api/system/templates.py
+++ b/climate_api/system/templates.py
@@ -10,6 +10,7 @@ from typing import Any
 import jinja2
 from fastapi import Request
 
+from climate_api import config as api_config
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.extents.services import get_extent
 from climate_api.ingestions.services import list_datasets
@@ -98,7 +99,7 @@ def wants_json(request: Request) -> bool:
 
 def render_maps(base: str) -> str:
     """Render the map viewer page."""
-    return get_template("map-viewer.html").render(base=base)
+    return get_template("map-viewer.html").render(base=base, name=api_config.get_name())
 
 
 def _load_extent() -> dict[str, Any] | None:
@@ -132,6 +133,7 @@ def render_landing(version: str, base: str) -> str:
     return get_template("landing_page.html").render(
         version=version,
         base=base,
+        name=api_config.get_name(),
         extent=_load_extent(),
         datasets=_load_datasets(),
         templates=_load_templates(),
@@ -145,6 +147,7 @@ def render_manage(version: str, base: str, message: str | None = None, error: st
     return get_template("manage.html").render(
         version=version,
         base=base,
+        name=api_config.get_name(),
         extent=_load_extent(),
         templates=_load_templates(),
         datasets=_load_datasets(),

--- a/climate_api/templates/landing_page.html
+++ b/climate_api/templates/landing_page.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DHIS2 Climate API</title>
+    <title>{{ name }}</title>
     <style>
       *,
       *::before,
@@ -185,7 +185,7 @@
   </head>
   <body>
     <header>
-      <h1>Climate API</h1>
+      <h1>{{ name }}</h1>
       <span class="version">v{{ version }}</span>
     </header>
 

--- a/climate_api/templates/manage.html
+++ b/climate_api/templates/manage.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Manage — DHIS2 Climate API</title>
+    <title>Manage — {{ name }}</title>
     <style>
       *,
       *::before,
@@ -36,22 +36,17 @@
         font-weight: 600;
         letter-spacing: -0.01em;
       }
+      header h1 a {
+        color: inherit;
+        text-decoration: none;
+      }
+      header h1 a:hover {
+        text-decoration: underline;
+      }
       header .subtitle {
         font-size: 0.825rem;
         color: #8fa3b8;
       }
-      header nav {
-        margin-left: auto;
-      }
-      header nav a {
-        color: #8fa3b8;
-        text-decoration: none;
-        font-size: 0.825rem;
-      }
-      header nav a:hover {
-        color: #fff;
-      }
-
       main {
         max-width: 860px;
         margin: 2.5rem auto;
@@ -276,9 +271,8 @@
   </head>
   <body>
     <header>
-      <h1>Climate API</h1>
+      <h1><a href="{{ base }}/">{{ name }}</a></h1>
       <span class="subtitle">Manage</span>
-      <nav><a href="{{ base }}/">Overview</a></nav>
     </header>
 
     <main>

--- a/climate_api/templates/map-viewer.html
+++ b/climate_api/templates/map-viewer.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Map viewer — DHIS2 Climate API</title>
+    <title>Map viewer — {{ name }}</title>
     <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
     <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
     <style>
@@ -49,22 +49,17 @@
         font-weight: 600;
         letter-spacing: -0.01em;
       }
+      header h1 a {
+        color: inherit;
+        text-decoration: none;
+      }
+      header h1 a:hover {
+        text-decoration: underline;
+      }
       header .subtitle {
         font-size: 0.825rem;
         color: #8fa3b8;
       }
-      header nav {
-        margin-left: auto;
-      }
-      header nav a {
-        color: #8fa3b8;
-        text-decoration: none;
-        font-size: 0.825rem;
-      }
-      header nav a:hover {
-        color: #fff;
-      }
-
       .map-container {
         position: relative;
         flex: 1;
@@ -195,9 +190,8 @@
   <body>
     <div class="layout">
       <header>
-        <h1>Climate API</h1>
+        <h1><a href="{{ base }}/">{{ name }}</a></h1>
         <span class="subtitle">Map viewer</span>
-        <nav><a href="{{ base }}/">Overview</a></nav>
       </header>
 
       <div class="map-container">

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from climate_api.config import DEFAULT_CRS, get_config, get_crs, get_data_dir
+from climate_api.config import DEFAULT_CRS, DEFAULT_NAME, get_config, get_crs, get_data_dir, get_name
 from climate_api.data_registry.services import datasets as dataset_registry
 from climate_api.extents import services as extent_services
 
@@ -141,6 +141,41 @@ def test_get_crs_raises_for_unknown_epsg_code(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
     with pytest.raises(ValueError, match="not a valid CRS"):
         get_crs()
+
+
+def test_get_name_defaults_to_open_climate_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLIMATE_API_CONFIG", raising=False)
+    assert get_name() == DEFAULT_NAME
+
+
+def test_get_name_reads_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nname: Nepal Climate Service\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    assert get_name() == "Nepal Climate Service"
+
+
+def test_get_name_trims_whitespace(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nname: '  My Service  '\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    assert get_name() == "My Service"
+
+
+def test_get_name_raises_for_non_string(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nname: 42\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    with pytest.raises(ValueError, match="name in CLIMATE_API_CONFIG must be a non-empty string"):
+        get_name()
+
+
+def test_get_name_raises_for_blank_string(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "climate-api.yaml"
+    config_file.write_text("data_dir: ./data\nname: '   '\n", encoding="utf-8")
+    monkeypatch.setenv("CLIMATE_API_CONFIG", str(config_file))
+    with pytest.raises(ValueError, match="name in CLIMATE_API_CONFIG must be a non-empty string"):
+        get_name()
 
 
 def test_templates_dir_raises_with_migration_hint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -9,7 +9,7 @@ def test_root_returns_html_by_default(client: TestClient) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    assert "DHIS2 Climate API" in response.text
+    assert "Open Climate Service" in response.text
 
 
 def test_root_html_shows_extent(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- Adds `get_name()` to `config.py` reading `name:` from `CLIMATE_API_CONFIG`, defaulting to `"Open Climate Service"`
- Threads the instance name into all three HTML templates (`landing_page.html`, `manage.html`, `map-viewer.html`) via the Jinja2 `{{ name }}` variable
- The `<h1>` on manage and map viewer pages now links back to `/` so users can navigate home without a separate Overview nav link (which is removed)

## Usage

```yaml
# climate-api.yaml
name: Nepal Climate Service
```

## Test plan

- [ ] Default (no `name:` in config): all pages show "Open Climate Service"
- [ ] With `name: Nepal Climate Service`: all page titles and headers show the custom name
- [ ] Clicking the h1 on manage or map viewer navigates back to root
- [ ] No "Overview" link visible in header on sub-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)