### PR TITLE
Implement async store-based sync for Icechunk-backed datasets (CLIM-716)

### DIFF
--- a/climate_api/data/processes/sync.yaml
+++ b/climate_api/data/processes/sync.yaml
@@ -1,0 +1,46 @@
+- id: sync
+  title: Dataset sync
+  description: Sync one managed dataset forward using the dataset template's declared sync policy.
+  version: "0.1.0"
+  expose: true
+  keywords:
+    - climate
+    - sync
+    - datasets
+  jobControlOptions:
+    - sync-execute
+    - async-execute
+  inputs:
+    dataset_id:
+      type: string
+      required: true
+      description: Stable managed dataset id to sync.
+    end:
+      type: string
+      required: false
+      description: Optional target end period. Defaults to today's UTC period for the dataset.
+    prefer_zarr:
+      type: boolean
+      required: false
+      default: true
+      description: Preserve the caller's preferred artifact mode where the sync path supports it. Plugin-backed Icechunk sync ignores this and always uses the committed store append path.
+    publish:
+      type: boolean
+      required: false
+      default: true
+      description: Publish the resulting synced artifact after execution.
+  outputs:
+    sync_id:
+      type: string
+      description: Identifier of the sync execution when a new artifact is materialized.
+    status:
+      type: string
+      description: Execution status for the synchronous response.
+    dataset:
+      type: object
+      description: Managed dataset summary after the sync operation.
+    sync_detail:
+      type: object
+      description: Sync planning and execution summary.
+  execution:
+    function: climate_api.ingestions.processes.execute_sync

--- a/climate_api/ingestions/processes.py
+++ b/climate_api/ingestions/processes.py
@@ -1,4 +1,4 @@
-"""Process execution wrappers for ingestion operations."""
+"""Process execution wrappers for ingestion and sync operations."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 from climate_api.data_registry.services import datasets as registry_datasets
 from climate_api.extents.services import get_extent_or_404
 from climate_api.ingestions import services
-from climate_api.ingestions.schemas import IngestionResponse
+from climate_api.ingestions.schemas import IngestionResponse, SyncResponse
 
 
 def execute_ingestion(
@@ -45,3 +45,24 @@ def execute_ingestion(
         save_cursor=save_cursor,
     )
     return services.get_ingestion_or_404(artifact.artifact_id)
+
+
+def execute_sync(
+    *,
+    dataset_id: str,
+    end: str | None = None,
+    prefer_zarr: bool = True,
+    publish: bool = True,
+) -> SyncResponse:
+    """Execute one managed-dataset sync from existing artifact state.
+
+    `prefer_zarr` remains meaningful for legacy sync paths. Plugin-backed
+    Icechunk sync always uses the committed store append path and ignores that
+    preference.
+    """
+    return services.sync_dataset(
+        dataset_id=dataset_id,
+        end=end,
+        prefer_zarr=prefer_zarr,
+        publish=publish,
+    )

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -32,8 +32,14 @@ class SyncKind(StrEnum):
 class SyncAction(StrEnum):
     """Planner-selected sync action.
 
-    APPEND is V1 delta-download execution followed by canonical artifact rebuild;
-    it is not in-place Zarr mutation.
+    APPEND means Climate API updates an existing managed dataset by writing only
+    the missing periods needed to reach the planned target end. The underlying
+    execution path depends on the dataset contract:
+
+    - legacy download-backed datasets use V1 delta-download plus canonical
+      artifact rebuild
+    - plugin-backed Icechunk datasets append missing periods directly into the
+      committed store
     """
 
     REMATERIALIZE = "rematerialize"

--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -165,7 +165,18 @@ def create_artifact(
     is_cancel_requested: Callable[[], bool] | None = None,
     save_cursor: Callable[[dict[str, object]], None] | None = None,
 ) -> ArtifactRecord:
-    """Download a dataset, persist it locally, and store artifact metadata."""
+    """Materialize one managed dataset artifact and persist its metadata.
+
+    For legacy datasets this may download source files and optionally rebuild a
+    canonical Zarr artifact. For plugin-backed datasets the streaming engine is
+    always used and writes an Icechunk-backed store; `prefer_zarr` has no
+    effect there.
+
+    Plugin-backed sync requests may still pass `download_start` and
+    `download_end`, but those only inform the requested sync window. The
+    streaming engine remains store-authoritative and appends only periods that
+    are actually missing from the committed Icechunk store.
+    """
     period_type = str(dataset["period_type"])
     start = _normalize_request_period(start, period_type=period_type, field_name="start")
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
@@ -190,10 +201,12 @@ def create_artifact(
     )
     ingestion = dataset.get("ingestion")
     plugin_path = ingestion.get("plugin") if isinstance(ingestion, dict) else None
-    # Ticket 1 only moves direct ingest onto the streaming engine. Delta ingest
-    # still routes through the legacy download/rebuild path until sync is
-    # refactored to reuse committed store state.
-    if isinstance(plugin_path, str) and plugin_path and download_start is None and download_end is None:
+    # Plugin-backed datasets always route through the streaming engine.
+    # `download_start` / `download_end` may still be present for sync requests,
+    # but they describe the requested append window only. The streaming engine
+    # decides what to fetch from committed store state and always writes an
+    # Icechunk-backed store for plugin datasets.
+    if isinstance(plugin_path, str) and plugin_path:
         return _create_streaming_artifact(
             dataset=dataset,
             plugin_path=plugin_path,
@@ -359,11 +372,12 @@ def _create_streaming_artifact(
     is_cancel_requested: Callable[[], bool] | None = None,
     save_cursor: Callable[[dict[str, object]], None] | None = None,
 ) -> ArtifactRecord:
-    """Create or update one plugin-backed Icechunk artifact for initial ingest.
+    """Create or update one plugin-backed Icechunk artifact.
 
-    This helper is intentionally scoped to the direct ingest path. It does not
-    yet implement delta-download sync semantics or broader publication behavior
-    for Icechunk-backed datasets.
+    The same helper is used for both initial ingest and store-based sync. The
+    streaming orchestrator probes the plugin for the full requested range, then
+    appends only periods that are not already committed in the target
+    Icechunk-backed store.
     """
     if bbox is None:
         raise HTTPException(status_code=400, detail="Streaming ingest requires a bounding box")

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -445,6 +445,8 @@ def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str
             candidate = Path(unquote(parsed.path))
         else:
             candidate = Path(raw_path)
+            if not candidate.is_absolute():
+                return None, "relative path"
     resolved = candidate.resolve(strict=False)
     for root in _artifact_storage_roots():
         try:

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -429,19 +429,19 @@ def _artifact_storage_roots() -> tuple[Path, ...]:
     return ((xdg_data / "climate-api" / "downloads").resolve(),)
 
 
-def _resolve_local_artifact_path(raw_path: str | None) -> Path | None:
-    """Return a trusted local artifact path, or None for non-local/unsupported paths."""
+def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str | None]:
+    """Return a trusted local artifact path plus a fallback reason when unavailable."""
     if raw_path is None:
-        return None
+        return None, None
     if len(raw_path) >= 3 and raw_path[1] == ":" and raw_path[0].isalpha() and raw_path[2] in ("\\", "/"):
         candidate = Path(raw_path)
     else:
         parsed = urlparse(raw_path)
         if parsed.scheme and parsed.scheme != "file":
-            return None
+            return None, "non-local URI"
         if parsed.scheme == "file":
             if parsed.netloc not in ("", "localhost"):
-                return None
+                return None, "non-local file URI"
             candidate = Path(unquote(parsed.path))
         else:
             candidate = Path(raw_path)
@@ -451,8 +451,8 @@ def _resolve_local_artifact_path(raw_path: str | None) -> Path | None:
             resolved.relative_to(root)
         except ValueError:
             continue
-        return resolved
-    return None
+        return resolved, None
+    return None, "untrusted local path"
 
 
 def _sync_current_end(*, source_dataset: dict[str, Any], latest_artifact: ArtifactRecord) -> str:
@@ -474,11 +474,12 @@ def _sync_current_end(*, source_dataset: dict[str, Any], latest_artifact: Artifa
     )
     if raw_artifact_path is None:
         return latest_artifact.coverage.temporal.end
-    local_artifact_path = _resolve_local_artifact_path(raw_artifact_path)
+    local_artifact_path, path_reason = _resolve_local_artifact_path(raw_artifact_path)
     if local_artifact_path is None:
         logger.warning(
-            "Sync planning skipped committed-store inspection for dataset '%s' because artifact path is non-local: %s",
+            "Sync planning skipped committed-store inspection for dataset '%s' because artifact path is %s: %s",
             source_dataset.get("id", "<unknown>"),
+            path_reason or "unsupported",
             raw_artifact_path,
         )
         return latest_artifact.coverage.temporal.end

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -502,7 +502,10 @@ def _sync_current_end(*, source_dataset: dict[str, Any], latest_artifact: Artifa
     if not committed:
         return latest_artifact.coverage.temporal.end
     try:
-        return max(committed, key=parse_period_string_to_datetime)
+        return normalize_period_string(
+            max(committed, key=parse_period_string_to_datetime),
+            str(source_dataset["period_type"]),
+        )
     except Exception as exc:
         logger.warning(
             "Sync planning found malformed committed periods for dataset '%s' in '%s'; "

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -433,7 +433,16 @@ def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str
     """Return a trusted local artifact path plus a fallback reason when unavailable."""
     if raw_path is None:
         return None, None
-    if len(raw_path) >= 3 and raw_path[1] == ":" and raw_path[0].isalpha() and raw_path[2] in ("\\", "/"):
+    # urlparse misreads Windows drive letters as URI schemes — "C:/path" produces
+    # scheme="c". Detect drive-letter paths explicitly so they skip URI parsing
+    # and reach the shared absolute-path and trusted-root checks below.
+    is_windows_path = (
+        len(raw_path) >= 3
+        and raw_path[0].isalpha()
+        and raw_path[1] == ":"
+        and raw_path[2] in ("\\", "/")
+    )
+    if is_windows_path:
         candidate = Path(raw_path)
     else:
         parsed = urlparse(raw_path)
@@ -445,8 +454,8 @@ def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str
             candidate = Path(unquote(parsed.path))
         else:
             candidate = Path(raw_path)
-            if not candidate.is_absolute():
-                return None, "relative path"
+    if not candidate.is_absolute():
+        return None, "relative path"
     resolved = candidate.resolve(strict=False)
     for root in _artifact_storage_roots():
         try:

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -436,12 +436,7 @@ def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str
     # urlparse misreads Windows drive letters as URI schemes — "C:/path" produces
     # scheme="c". Detect drive-letter paths explicitly so they skip URI parsing
     # and reach the shared absolute-path and trusted-root checks below.
-    is_windows_path = (
-        len(raw_path) >= 3
-        and raw_path[0].isalpha()
-        and raw_path[1] == ":"
-        and raw_path[2] in ("\\", "/")
-    )
+    is_windows_path = len(raw_path) >= 3 and raw_path[0].isalpha() and raw_path[1] == ":" and raw_path[2] in ("\\", "/")
     if is_windows_path:
         candidate = Path(raw_path)
     else:

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -14,11 +14,22 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
+from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
-from climate_api.ingestions.schemas import ArtifactRecord, SyncAction, SyncDetail, SyncKind, SyncResponse
+from climate_api import config as api_config
+from climate_api.ingestions.schemas import (
+    ArtifactFormat,
+    ArtifactRecord,
+    SyncAction,
+    SyncDetail,
+    SyncKind,
+    SyncResponse,
+)
 from climate_api.providers import availability as provider_availability
 from climate_api.publications.services import managed_dataset_id_for
 from climate_api.shared.time import (
@@ -29,6 +40,7 @@ from climate_api.shared.time import (
     utc_now,
     utc_today,
 )
+from climate_api.streaming.store import read_committed_period_ids
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +73,7 @@ def plan_sync(
         raise ValueError("source_dataset must define sync.kind for sync planning")
     sync_kind = SyncKind(sync_kind_value)
     current_start = latest_artifact.request_scope.start
-    current_end = latest_artifact.coverage.temporal.end
+    current_end = _sync_current_end(source_dataset=source_dataset, latest_artifact=latest_artifact)
 
     if sync_kind == SyncKind.STATIC:
         return SyncDetail(
@@ -109,6 +121,7 @@ def plan_sync(
             )
         action = SyncAction.APPEND if _supports_append(source_dataset, latest_artifact) else SyncAction.REMATERIALIZE
         reason = "new_periods_available_for_append" if action == SyncAction.APPEND else "new_periods_available"
+        plugin_backed = _is_plugin_backed(source_dataset)
         return SyncDetail(
             source_dataset_id=latest_artifact.dataset_id,
             sync_kind=sync_kind,
@@ -120,6 +133,7 @@ def plan_sync(
                 target_end=latest_available_end,
                 delta_start=next_period_start,
                 delta_end=latest_available_end,
+                plugin_backed=plugin_backed,
             ),
             current_start=current_start,
             current_end=current_end,
@@ -218,13 +232,16 @@ def run_sync(
         )
 
     # Execution always goes through the ingestion materialization path so sync
-    # does not grow a second downloader/storage implementation. APPEND is a V1
-    # delta-download plus canonical rebuild, not in-place Zarr mutation.
+    # does not grow a second downloader/storage implementation. APPEND now has
+    # two concrete execution modes:
+    # - legacy download-backed datasets use delta-download plus canonical rebuild
+    # - plugin-backed Icechunk datasets extend the committed store in place
     if sync_detail.current_start is None:
         raise ValueError("Sync execution requires current_start for rematerialize or append actions")
     if sync_detail.target_end is None:
         raise ValueError("Sync execution requires target_end for rematerialize or append actions")
     download_start = sync_detail.delta_start if sync_detail.action == SyncAction.APPEND else None
+    plugin_backed = _is_plugin_backed(source_dataset)
     logger.info(
         "Sync executing for dataset '%s': action=%s artifact_scope=%s..%s download_scope=%s..%s publish=%s",
         dataset_id,
@@ -256,15 +273,17 @@ def run_sync(
     return SyncResponse(
         sync_id=artifact.artifact_id,
         status="completed",
-        message=_sync_completed_message(sync_detail.action),
+        message=_sync_completed_message(sync_detail.action, plugin_backed=plugin_backed),
         dataset=get_dataset_fn(managed_dataset_id_for(artifact)),
         sync_detail=sync_detail,
     )
 
 
-def _sync_completed_message(action: SyncAction) -> str:
+def _sync_completed_message(action: SyncAction, *, plugin_backed: bool = False) -> str:
     """Return a user-facing completion message for the executed sync action."""
     if action == SyncAction.APPEND:
+        if plugin_backed:
+            return "Managed dataset was synced by appending missing periods to the committed Icechunk store."
         return "Managed dataset was synced by downloading the missing period range and rebuilding the artifact."
     return "Managed dataset was rematerialized against the latest planned upstream state."
 
@@ -276,9 +295,15 @@ def _sync_plan_message(
     target_end: str,
     delta_start: str,
     delta_end: str,
+    plugin_backed: bool = False,
 ) -> str:
     """Return a human-readable sync plan summary."""
     if action == SyncAction.APPEND:
+        if plugin_backed:
+            return (
+                f"Data exists through {current_end}. Sync will append missing periods "
+                f"{delta_start} through {delta_end} and extend coverage through {target_end}."
+            )
         return (
             f"Data exists through {current_end}. Sync will download missing periods "
             f"{delta_start} through {delta_end} and rebuild coverage through {target_end}."
@@ -365,16 +390,15 @@ def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRe
 
     if source_dataset.get("sync", {}).get("execution") != SyncAction.APPEND.value:
         return False
-    ingestion = source_dataset.get("ingestion")
-    if isinstance(ingestion, dict):
-        plugin = ingestion.get("plugin")
-        if isinstance(plugin, str) and plugin:
+    if _is_plugin_backed(source_dataset):
+        if latest_artifact.format != ArtifactFormat.ICECHUNK:
             logger.info(
-                "Sync append execution is not yet supported for plugin-backed dataset '%s'; "
+                "Sync append execution for plugin-backed dataset '%s' requires an existing Icechunk artifact; "
                 "falling back to rematerialize",
                 source_dataset.get("id", "<unknown>"),
             )
             return False
+        return True
     # Pyramid zarr stores cannot be appended to — they must be rebuilt in full.
     # Detect this from the existing artifact's on-disk structure rather than YAML.
     artifact_path = latest_artifact.path
@@ -385,6 +409,106 @@ def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRe
         )
         return False
     return True
+
+
+def _is_plugin_backed(source_dataset: dict[str, Any]) -> bool:
+    """Return whether the source dataset uses the streaming plugin contract."""
+    ingestion = source_dataset.get("ingestion")
+    if not isinstance(ingestion, dict):
+        return False
+    plugin = ingestion.get("plugin")
+    return isinstance(plugin, str) and bool(plugin)
+
+
+def _artifact_storage_roots() -> tuple[Path, ...]:
+    """Return the trusted local roots that may contain managed artifact stores."""
+    data_dir = api_config.get_data_dir()
+    if data_dir is not None:
+        return ((data_dir / "downloads").resolve(),)
+    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return ((xdg_data / "climate-api" / "downloads").resolve(),)
+
+
+def _resolve_local_artifact_path(raw_path: str | None) -> Path | None:
+    """Return a trusted local artifact path, or None for non-local/unsupported paths."""
+    if raw_path is None:
+        return None
+    if len(raw_path) >= 3 and raw_path[1] == ":" and raw_path[0].isalpha() and raw_path[2] in ("\\", "/"):
+        candidate = Path(raw_path)
+    else:
+        parsed = urlparse(raw_path)
+        if parsed.scheme and parsed.scheme != "file":
+            return None
+        if parsed.scheme == "file":
+            if parsed.netloc not in ("", "localhost"):
+                return None
+            candidate = Path(unquote(parsed.path))
+        else:
+            candidate = Path(raw_path)
+    resolved = candidate.resolve(strict=False)
+    for root in _artifact_storage_roots():
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        return resolved
+    return None
+
+
+def _sync_current_end(*, source_dataset: dict[str, Any], latest_artifact: ArtifactRecord) -> str:
+    """Return the current sync end using the same source of truth as execution.
+
+    For plugin-backed Icechunk datasets, sync execution consults committed store
+    periods directly. Planning should do the same so it does not depend on
+    potentially stale artifact metadata after prior interrupted or external
+    updates.
+
+    This adds a small read cost to plan-only requests for plugin-backed
+    datasets, but keeps planning aligned with execution on the committed store
+    state rather than a cached metadata snapshot.
+    """
+    if not _is_plugin_backed(source_dataset) or latest_artifact.format != ArtifactFormat.ICECHUNK:
+        return latest_artifact.coverage.temporal.end
+    raw_artifact_path = latest_artifact.path or (
+        latest_artifact.asset_paths[0] if latest_artifact.asset_paths else None
+    )
+    if raw_artifact_path is None:
+        return latest_artifact.coverage.temporal.end
+    local_artifact_path = _resolve_local_artifact_path(raw_artifact_path)
+    if local_artifact_path is None:
+        logger.warning(
+            "Sync planning skipped committed-store inspection for dataset '%s' because artifact path is non-local: %s",
+            source_dataset.get("id", "<unknown>"),
+            raw_artifact_path,
+        )
+        return latest_artifact.coverage.temporal.end
+    try:
+        committed = read_committed_period_ids(
+            local_artifact_path,
+            str(source_dataset["period_type"]),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Sync planning failed to read committed periods for dataset '%s' from '%s'; "
+            "falling back to artifact metadata: %s",
+            source_dataset.get("id", "<unknown>"),
+            str(local_artifact_path),
+            exc,
+        )
+        return latest_artifact.coverage.temporal.end
+    if not committed:
+        return latest_artifact.coverage.temporal.end
+    try:
+        return max(committed, key=parse_period_string_to_datetime)
+    except Exception as exc:
+        logger.warning(
+            "Sync planning found malformed committed periods for dataset '%s' in '%s'; "
+            "falling back to artifact metadata: %s",
+            source_dataset.get("id", "<unknown>"),
+            str(local_artifact_path),
+            exc,
+        )
+        return latest_artifact.coverage.temporal.end
 
 
 def _provider_latest_available_end(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -473,6 +473,73 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
     assert artifact.asset_paths == [str(store_path.resolve())]
 
 
+def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {
+            "plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin",
+            "default_params": {"stage": "final"},
+        },
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+
+    plugin = object()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+
+    def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
+        captured["run"] = kwargs
+        return type("Result", (), {"periods_written": 2})()
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-02-10"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
+    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
+
+    artifact = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-02-10",
+        download_start="2026-02-01",
+        download_end="2026-02-10",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        prefer_zarr=True,
+        publish=False,
+    )
+
+    run_kwargs = captured["run"]
+    assert isinstance(run_kwargs, dict)
+    assert run_kwargs["plugin"] is plugin
+    assert run_kwargs["params"] == {"stage": "final"}
+    assert run_kwargs["bbox"] == [1.0, 2.0, 3.0, 4.0]
+    assert run_kwargs["start"] == "2026-01-01"
+    assert run_kwargs["end"] == "2026-02-10"
+    assert run_kwargs["store_path"] == store_path
+    assert run_kwargs["period_type"] == "daily"
+    assert artifact.format == ArtifactFormat.ICECHUNK
+    assert artifact.coverage.temporal.end == "2026-02-10"
+
+
 def test_load_streaming_plugin_rejects_non_callable_symbol() -> None:
     with pytest.raises(
         services.HTTPException,

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -519,6 +519,40 @@ def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_unt
     assert any("untrusted local path" in message for message in warnings)
 
 
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_relative_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="data/downloads/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    warnings: list[str] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert any("relative path" in message for message in warnings)
+
+
 def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_committed_period_is_malformed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -338,6 +338,41 @@ def test_plan_sync_for_plugin_backed_icechunk_uses_committed_store_state(
     assert result.current_end == "2026-01-31"
 
 
+def test_plan_sync_for_plugin_backed_icechunk_normalizes_committed_period_before_returning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-04-21T13",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+    latest.coverage.temporal.end = "2026-04-21T13"
+
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(
+        sync_engine,
+        "read_committed_period_ids",
+        lambda *args, **kwargs: {"2026-04-21T13:27:45"},
+    )
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "era5land_temperature_hourly",
+            "period_type": "hourly",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "example.HourlyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-04-21T13",
+    )
+
+    assert result.action == SyncAction.NO_OP
+    assert result.reason == "no_new_period"
+    assert result.current_end == "2026-04-21T13"
+
+
 def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_without_store_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -149,10 +149,8 @@ def test_sync_dataset_creates_new_version_from_next_period(monkeypatch: pytest.M
     assert result.sync_detail.sync_kind == SyncKind.TEMPORAL
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
     assert result.sync_detail.reason == "new_periods_available"
-    assert (
-        result.sync_detail.message
-        == "Data exists through 2026-01-31. Sync will rematerialize the dataset through 2026-02-10."
-    )
+    assert "Data exists through 2026-01-31" in result.sync_detail.message
+    assert "Sync will rematerialize the dataset through 2026-02-10" in result.sync_detail.message
     assert result.sync_detail.current_start == "2026-01-01"
     assert result.sync_detail.current_end == "2026-01-31"
     assert result.sync_detail.target_end == "2026-02-10"
@@ -195,10 +193,9 @@ def test_sync_dataset_append_policy_downloads_only_delta_but_preserves_full_scop
     assert captured["download_end"] == "2026-02-10"
     assert result.sync_detail.action == SyncAction.APPEND
     assert result.sync_detail.reason == "new_periods_available_for_append"
-    assert (
-        result.sync_detail.message == "Data exists through 2026-01-31. Sync will download missing periods "
-        "2026-02-01 through 2026-02-10 and rebuild coverage through 2026-02-10."
-    )
+    assert "Data exists through 2026-01-31" in result.sync_detail.message
+    assert "Sync will download missing periods 2026-02-01 through 2026-02-10" in result.sync_detail.message
+    assert "rebuild coverage through 2026-02-10" in result.sync_detail.message
     assert result.sync_detail.current_start == "2026-01-01"
     assert result.sync_detail.current_end == "2026-01-31"
     assert result.sync_detail.target_end == "2026-02-10"
@@ -263,11 +260,17 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_pyramid_zarr
     assert any("falling back to rematerialize" in message for message in warnings)
 
 
-def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_plugin_backed_dataset(
+def test_sync_dataset_append_policy_uses_store_based_append_for_plugin_backed_dataset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dataset_id = "chirps3_precipitation_daily_sle"
-    latest = _artifact(artifact_id="a1", managed_dataset_id=dataset_id, end="2026-01-31")
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id=dataset_id,
+        end="2026-01-31",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
     monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: latest)
     monkeypatch.setattr(
         services.registry_datasets,
@@ -286,7 +289,301 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_plugin_backe
         captured.update(kwargs)
         return _artifact(artifact_id="a2", managed_dataset_id=dataset_id, end="2026-02-10")
 
+    monkeypatch.setattr(services, "create_artifact", fake_create_artifact)
+    monkeypatch.setattr(services, "get_dataset_or_404", lambda _: _dataset_detail(dataset_id))
+
+    result = services.sync_dataset(dataset_id=dataset_id, end="2026-02-10", prefer_zarr=True, publish=True)
+
+    assert "download_start" in captured
+    assert captured["download_start"] == "2026-02-01"
+    assert captured["download_end"] == "2026-02-10"
+    assert result.sync_detail.action == SyncAction.APPEND
+    assert result.sync_detail.reason == "new_periods_available_for_append"
+    assert "Data exists through 2026-01-31" in result.sync_detail.message
+    assert "Sync will append missing periods 2026-02-01 through 2026-02-10" in result.sync_detail.message
+    assert "extend coverage through 2026-02-10" in result.sync_detail.message
+    assert result.message is not None
+    assert "appending missing periods" in result.message
+    assert "Icechunk store" in result.message
+
+
+def test_plan_sync_for_plugin_backed_icechunk_uses_committed_store_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-31",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+    latest.coverage.temporal.end = "2026-01-15"
+
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: {"2026-01-31"})
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.NO_OP
+    assert result.reason == "no_new_period"
+    assert result.current_end == "2026-01-31"
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_without_store_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+    latest.path = None
+    latest.asset_paths = []
+
+    read_calls: list[tuple[object, ...]] = []
+
+    def fake_read_committed_period_ids(*args: object, **kwargs: object) -> set[str]:
+        read_calls.append(args)
+        return {"2026-01-31"}
+
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", fake_read_committed_period_ids)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert read_calls == []
+
+
+def test_plan_sync_for_plugin_backed_icechunk_skips_non_local_store_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="s3://bucket/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    read_calls: list[tuple[object, ...]] = []
+    warnings: list[str] = []
+
+    def fake_read_committed_period_ids(*args: object, **kwargs: object) -> set[str]:
+        read_calls.append(args)
+        return {"2026-01-31"}
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", fake_read_committed_period_ids)
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert read_calls == []
+    assert any("non-local" in message for message in warnings)
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_store_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(
+        sync_engine,
+        "read_committed_period_ids",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert any("falling back to artifact metadata" in message for message in warnings)
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_committed_set_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: set())
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_untrusted_local_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    warnings: list[str] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/srv/app/data/downloads"),))
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert any("non-local" in message for message in warnings)
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_committed_period_is_malformed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="/tmp/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    warnings: list[str] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: {"not-a-period"})
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert any("malformed committed periods" in message for message in warnings)
+
+
+def test_sync_dataset_append_policy_falls_back_for_plugin_backed_non_icechunk_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_id = "chirps3_precipitation_daily_sle"
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id=dataset_id,
+        end="2026-01-31",
+        path="/tmp/chirps3_precipitation_daily.zarr",
+    )
+    latest.format = ArtifactFormat.ZARR
+    monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: latest)
+    monkeypatch.setattr(
+        services.registry_datasets,
+        "get_dataset",
+        lambda _: {
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+    )
+
+    captured: dict[str, object] = {}
     infos: list[str] = []
+
+    def fake_create_artifact(**kwargs: object) -> ArtifactRecord:
+        captured.update(kwargs)
+        return _artifact(artifact_id="a2", managed_dataset_id=dataset_id, end="2026-02-10")
 
     def fake_info(message: str, *args: object) -> None:
         infos.append(message % args if args else message)
@@ -299,8 +596,10 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_for_plugin_backe
 
     assert "download_start" in captured
     assert captured["download_start"] is None
+    assert captured["download_end"] is None
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
-    assert any("plugin-backed dataset" in message for message in infos)
+    assert result.sync_detail.reason == "new_periods_available"
+    assert any("requires an existing Icechunk artifact" in message for message in infos)
 
 
 def test_sync_dataset_release_policy_returns_up_to_date_when_release_matches(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -450,6 +450,97 @@ def test_plan_sync_for_plugin_backed_icechunk_skips_non_local_store_path(
     assert any("non-local URI" in message for message in warnings)
 
 
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_windows_drive_letter_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Windows drive-letter paths (C:\...) are detected explicitly before urlparse
+    # can misread the drive letter as a URI scheme. On Linux the path is not
+    # absolute, so _resolve_local_artifact_path returns "relative path" and
+    # committed-store inspection falls back to artifact metadata.
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="C:\\data\\downloads\\chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    read_calls: list[tuple[object, ...]] = []
+    warnings: list[str] = []
+
+    def fake_read_committed_period_ids(*args: object, **kwargs: object) -> set[str]:
+        read_calls.append(args)
+        return {"2026-01-31"}
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", fake_read_committed_period_ids)
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert read_calls == []
+    assert any("relative path" in message for message in warnings)
+
+
+def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_file_uri_with_windows_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # file:///C:/... URIs are valid on Windows but not within any trusted storage
+    # root on this Linux service. urlparse produces path "/C:/..." which is
+    # absolute on Linux but won't match any configured storage root, so
+    # _resolve_local_artifact_path returns "untrusted local path" and planning
+    # falls back to artifact metadata.
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-15",
+        path="file:///C:/data/downloads/chirps3_precipitation_daily.icechunk",
+    )
+    latest.format = ArtifactFormat.ICECHUNK
+
+    read_calls: list[tuple[object, ...]] = []
+    warnings: list[str] = []
+
+    def fake_read_committed_period_ids(*args: object, **kwargs: object) -> set[str]:
+        read_calls.append(args)
+        return {"2026-01-31"}
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", fake_read_committed_period_ids)
+    monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_end == "2026-01-15"
+    assert read_calls == []
+    assert any("untrusted local path" in message for message in warnings)
+
+
 def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_store_read_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -412,7 +412,7 @@ def test_plan_sync_for_plugin_backed_icechunk_skips_non_local_store_path(
     assert result.action == SyncAction.APPEND
     assert result.current_end == "2026-01-15"
     assert read_calls == []
-    assert any("non-local" in message for message in warnings)
+    assert any("non-local URI" in message for message in warnings)
 
 
 def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_store_read_fails(
@@ -516,7 +516,7 @@ def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_for_unt
 
     assert result.action == SyncAction.APPEND
     assert result.current_end == "2026-01-15"
-    assert any("non-local" in message for message in warnings)
+    assert any("untrusted local path" in message for message in warnings)
 
 
 def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_committed_period_is_malformed(

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -25,6 +25,7 @@ def test_get_process_detail_returns_public_metadata(client: TestClient) -> None:
     payload = response.json()
     assert payload["id"] == "resample"
     assert payload["title"] == "Temporal resampling"
+    assert len(payload["jobControlOptions"]) == 2
     assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
     assert "execution_function" not in payload
     assert payload["inputs"]["source_dataset_id"]["required"] is True
@@ -38,6 +39,7 @@ def test_get_ingest_process_detail_returns_public_metadata(client: TestClient) -
     assert response.status_code == 200
     payload = response.json()
     assert payload["id"] == "ingestion"
+    assert len(payload["jobControlOptions"]) == 2
     assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
     assert payload["inputs"]["dataset_id"]["required"] is True
     assert payload["inputs"]["publish"]["default"] is True
@@ -50,6 +52,7 @@ def test_get_sync_process_detail_returns_public_metadata(client: TestClient) -> 
     assert response.status_code == 200
     payload = response.json()
     assert payload["id"] == "sync"
+    assert len(payload["jobControlOptions"]) == 2
     assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
     assert payload["inputs"]["dataset_id"]["required"] is True
     assert payload["inputs"]["publish"]["default"] is True

--- a/tests/test_processing_routes.py
+++ b/tests/test_processing_routes.py
@@ -25,7 +25,7 @@ def test_get_process_detail_returns_public_metadata(client: TestClient) -> None:
     payload = response.json()
     assert payload["id"] == "resample"
     assert payload["title"] == "Temporal resampling"
-    assert payload["jobControlOptions"] == ["sync-execute", "async-execute"]
+    assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
     assert "execution_function" not in payload
     assert payload["inputs"]["source_dataset_id"]["required"] is True
     assert payload["inputs"]["publish"]["default"] is True
@@ -38,10 +38,22 @@ def test_get_ingest_process_detail_returns_public_metadata(client: TestClient) -
     assert response.status_code == 200
     payload = response.json()
     assert payload["id"] == "ingestion"
-    assert payload["jobControlOptions"] == ["sync-execute", "async-execute"]
+    assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
     assert payload["inputs"]["dataset_id"]["required"] is True
     assert payload["inputs"]["publish"]["default"] is True
     assert payload["outputs"]["ingestion_id"]["type"] == "string"
+
+
+def test_get_sync_process_detail_returns_public_metadata(client: TestClient) -> None:
+    response = client.get("/processes/sync")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "sync"
+    assert set(payload["jobControlOptions"]) == {"sync-execute", "async-execute"}
+    assert payload["inputs"]["dataset_id"]["required"] is True
+    assert payload["inputs"]["publish"]["default"] is True
+    assert payload["outputs"]["sync_id"]["type"] == "string"
 
 
 def test_get_processes_omits_internal_only_processes(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -253,6 +265,49 @@ def test_post_ingest_execution_returns_404_for_unknown_dataset(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Dataset 'unknown_dataset' not found"
+
+
+def test_post_sync_execution_honors_respond_async(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.services.sync_dataset",
+        lambda **kwargs: {
+            "sync_id": "artifact-123",
+            "status": "completed",
+            "message": "Managed dataset was synced.",
+            "dataset": dataset_record("chirps3_precipitation_daily"),
+            "sync_detail": {
+                "source_dataset_id": "chirps3_precipitation_daily",
+                "sync_kind": "temporal",
+                "action": "append",
+                "reason": "new_periods_available_for_append",
+                "message": "Sync will append new periods.",
+                "current_start": "2026-01-01",
+                "current_end": "2026-01-31",
+                "target_end": "2026-02-10",
+                "target_end_source": "request",
+                "delta_start": "2026-02-01",
+                "delta_end": "2026-02-10",
+            },
+        },
+    )
+
+    response = client.post(
+        "/processes/sync/execution",
+        headers={"Prefer": "respond-async"},
+        json={
+            "dataset_id": "chirps3_precipitation_daily_sle",
+            "end": "2026-02-10",
+            "publish": True,
+        },
+    )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["status"] in {"accepted", "running", "successful"}
+    assert response.headers["Location"].startswith("/jobs/")
 
 
 def test_post_process_execution_rejects_async_when_process_is_sync_only(


### PR DESCRIPTION
## Summary

Add async store-based sync for Icechunk datasets.

Sync now plans and executes against committed store state and appends only missing periods instead of rebuilding full history. Sync is also exposed through the shared process/job framework at `/processes/sync/execution`.

## Changes

- allow `ICECHUNK` artifacts to use `APPEND` sync
- route sync append windows through the streaming/Icechunk materialization path
- make sync planning read committed period state from the store instead of relying only on artifact metadata
- add `sync` as a public process with async execution support
- harden sync planning fallbacks for missing, untrusted, unreadable, or malformed store state
- update tests for sync planning, execution, and process metadata

## Scope notes

This PR covers the generic async store-based sync path for Icechunk datasets.

It does not include:
- migration of additional built-in datasets still on legacy `ingestion.function`
- rechunking
- full pyramid support
- final legacy-path removal
- final serving/publication work for all streaming-backed datasets