### PR TITLE
feat: add kg/m³ → μg/m³ unit conversion transform

### DIFF
--- a/climate_api/transforms/__init__.py
+++ b/climate_api/transforms/__init__.py
@@ -9,6 +9,6 @@ Functions can be referenced by their dotted module path in the dataset YAML
 
 from .pipeline import run_dataset_transforms
 from .reproject import reproject_to_instance_crs
-from .unit_conversion import kelvin_to_celsius, metres_to_mm
+from .unit_conversion import kelvin_to_celsius, kg_per_m3_to_ug_per_m3, metres_to_mm
 
-__all__ = ["kelvin_to_celsius", "metres_to_mm", "reproject_to_instance_crs", "run_dataset_transforms"]
+__all__ = ["kelvin_to_celsius", "kg_per_m3_to_ug_per_m3", "metres_to_mm", "reproject_to_instance_crs", "run_dataset_transforms"]

--- a/climate_api/transforms/unit_conversion.py
+++ b/climate_api/transforms/unit_conversion.py
@@ -25,3 +25,9 @@ def metres_to_mm(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
     """Convert the dataset variable from metres to millimetres."""
     logger.info("Converting '%s' from m to mm", dataset["variable"])
     return _apply(ds, dataset, scale=1000.0, offset=0.0, units="mm")
+
+
+def kg_per_m3_to_ug_per_m3(ds: xr.Dataset, dataset: dict[str, Any]) -> xr.Dataset:
+    """Convert the dataset variable from kg m⁻³ to μg m⁻³ (×10⁹)."""
+    logger.info("Converting '%s' from kg/m³ to μg/m³", dataset["variable"])
+    return _apply(ds, dataset, scale=1e9, offset=0.0, units="μg m⁻³")


### PR DESCRIPTION
## Summary

- Adds `kg_per_m3_to_ug_per_m3` to `climate_api/transforms/unit_conversion.py` (×10⁹ scale)
- Exports it from `climate_api/transforms/__init__.py`
- Enables dataset templates to declare this transform in their `transforms:` list for air-quality variables (e.g. PM2.5, NO₂)

Ported from `feat/icechunk-ingest` (9bbffb2).

## Test plan

- [x] `uv run ruff check` passes
- [ ] Add to a dataset template's `transforms:` list and verify the converted variable has `units: μg m⁻³`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)