### PR TITLE
feat: dynamic availability cutoffs for CHIRPS3 and ERA5-Land

### DIFF
--- a/climate_api/streaming/plugins/chirps3.py
+++ b/climate_api/streaming/plugins/chirps3.py
@@ -97,16 +97,35 @@ class CHIRPS3DailyPlugin:
         return await asyncio.get_running_loop().run_in_executor(_get_executor(), self._fetch_sync, period_id, bbox)
 
     def _availability_cutoff(self) -> date:
-        """Return the last day of the latest month treated as complete by this plugin."""
+        """Return the last day of the most recently published complete month.
+
+        Scans backward with a HEAD request on the last-day COG URL so the
+        cutoff reflects actual CDN state rather than a hardcoded lag assumption.
+        Falls back to 3 months back if the CDN probe fails.
+        """
+        import requests
+
         today = datetime.now(UTC).date()
-        months_back = 1 if today.day > _COMPLETE_AFTER_DAY else 2
-        year, month = today.year, today.month
-        for _ in range(months_back):
-            month -= 1
-            if month == 0:
-                month = 12
-                year -= 1
-        return date(year, month, calendar.monthrange(year, month)[1])
+        y, m = today.year, today.month
+        for _ in range(6):
+            m -= 1
+            if m == 0:
+                m, y = 12, y - 1
+            last_day = calendar.monthrange(y, m)[1]
+            candidate = date(y, m, last_day)
+            try:
+                resp = requests.head(self._url_for_day(candidate), timeout=10, allow_redirects=True)
+                if resp.status_code == 200:
+                    return candidate
+            except Exception:
+                continue
+        # Fallback: 3 months back (safe)
+        y, m = today.year, today.month
+        for _ in range(3):
+            m -= 1
+            if m == 0:
+                m, y = 12, y - 1
+        return date(y, m, calendar.monthrange(y, m)[1])
 
     def _url_for_day(self, day: date) -> str:
         """Build the remote CHIRPS3 raster URL for one day."""

--- a/climate_api/streaming/plugins/era5_land.py
+++ b/climate_api/streaming/plugins/era5_land.py
@@ -45,8 +45,11 @@ class ERA5LandHourlySingleBandPlugin:
         )
 
     async def periods(self, start: str, end: str) -> list[str]:
+        """Return hourly period IDs up to the last timestamp published in the remote store."""
+        latest = await asyncio.to_thread(self._latest_available)
+        capped_end = min(end, latest)
         current = parse_period_string_to_datetime(start)
-        limit = parse_period_string_to_datetime(end)
+        limit = parse_period_string_to_datetime(capped_end)
         if current > limit:
             return []
         periods: list[str] = []
@@ -54,6 +57,14 @@ class ERA5LandHourlySingleBandPlugin:
             periods.append(datetime_to_period_string(current, "hourly"))
             current += timedelta(hours=1)
         return periods
+
+    def _latest_available(self) -> str:
+        """Read the last valid_time from the remote store (metadata only, no data loaded)."""
+        module = import_module("dhis2eo.data.destine.era5_land.hourly")
+        open_zarr = cast(Callable[[list[str]], xr.Dataset], getattr(module, "open_zarr"))
+        ds = open_zarr([self.variable])
+        import numpy as np
+        return str(np.datetime64(ds.valid_time.values[-1], "h"))
 
     async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
         _ = params


### PR DESCRIPTION
## Summary

- **CHIRPS3**: replaces the hardcoded 2-month publication lag with a live CDN probe — scans backward with `HEAD` requests on the last-day COG URL to find the actual latest published month. Falls back to 3 months if the CDN is unreachable. Avoids requesting months that haven't been released yet, and also avoids unnecessary lag when data is published earlier than the conservative estimate.
- **ERA5-Land**: `periods()` now caps the end date at the last `valid_time` in the remote DestinE Zarr store (metadata-only open, no data loaded), preventing generation of period IDs that don't exist in the source.

Ported from `feat/icechunk-ingest` (3fb4d45, c03ca95).

## Test plan

- [x] `uv run pytest tests/test_streaming_chirps3.py tests/test_era5_land_plugin.py -q` — 8 passed
- [x] `uv run ruff check` passes
- [ ] Manual: ingest CHIRPS3 with end date in the future — verify it clamps to the actual latest available month

🤖 Generated with [Claude Code](https://claude.ai/claude-code)