### PR TITLE
feat: live progress streaming for /manage ingest and sync

### DIFF
--- a/climate_api/ingestions/services.py
+++ b/climate_api/ingestions/services.py
@@ -443,6 +443,7 @@ def sync_dataset(
     dataset_id: str,
     end: str | None,
     publish: bool,
+    on_progress: Callable[[int | None, int | None, str | None], None] | None = None,
 ) -> SyncResponse:
     """Resolve sync inputs and delegate managed-dataset sync to the sync engine.
 
@@ -465,6 +466,7 @@ def sync_dataset(
             publish=publish,
             create_artifact_fn=create_artifact,
             get_dataset_fn=get_dataset_or_404,
+            on_progress=on_progress,
         )
     except SyncConfigurationError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -179,6 +179,7 @@ def run_sync(
     publish: bool,
     create_artifact_fn: Callable[..., ArtifactRecord],
     get_dataset_fn: Callable[[str], Any],
+    on_progress: Callable[..., Any] | None = None,
 ) -> SyncResponse:
     """Plan and execute one sync operation for a managed dataset.
 
@@ -257,6 +258,7 @@ def run_sync(
         country_code=country_code,
         overwrite=False,
         publish=publish,
+        on_progress=on_progress,
     )
     logger.info(
         "Sync completed for dataset '%s': artifact_id=%s action=%s",

--- a/climate_api/system/routes.py
+++ b/climate_api/system/routes.py
@@ -1,17 +1,29 @@
 """Root API endpoints."""
 
+import asyncio
+import json
 import sys
 import urllib.parse
+from collections.abc import AsyncIterator
 from importlib.metadata import version as _pkg_version
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
-from starlette.responses import RedirectResponse
+from starlette.responses import RedirectResponse, StreamingResponse
 
 from .schemas import AppInfo, HealthStatus, Status
 from .templates import ROOT_RESPONSES, app_version, render_landing, render_manage, render_maps, root_json, wants_json
 
 router = APIRouter()
+
+
+async def _sse_events(queue: asyncio.Queue[dict[str, Any] | None]) -> AsyncIterator[str]:
+    while True:
+        item = await queue.get()
+        if item is None:
+            break
+        yield f"data: {json.dumps(item)}\n\n"
 
 
 @router.get("/", response_class=Response, responses=ROOT_RESPONSES)
@@ -42,8 +54,8 @@ def manage(
 
 
 @router.post("/manage/ingest", include_in_schema=False)
-async def manage_ingest(request: Request) -> RedirectResponse:
-    """Handle ingest form submission and redirect to the management page."""
+async def manage_ingest(request: Request) -> Response:
+    """Handle ingest form submission and stream progress via SSE."""
     from fastapi import HTTPException
 
     from climate_api.data_registry.services.datasets import get_dataset
@@ -67,18 +79,6 @@ async def manage_ingest(request: Request) -> RedirectResponse:
         extent = get_extent_or_404()
         resolved_bbox = list(extent["bbox"])
         country_code = extent.get("country_code")
-
-        create_artifact(
-            dataset=template,
-            start=start,
-            end=end,
-            bbox=resolved_bbox,
-            country_code=country_code,
-            overwrite=overwrite,
-            publish=publish,
-        )
-        name = urllib.parse.quote(template.get("name", dataset_id))
-        return RedirectResponse(f"{base}/manage?message=Ingested+{name}", status_code=303)
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
         return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
@@ -86,10 +86,56 @@ async def manage_ingest(request: Request) -> RedirectResponse:
         msg = urllib.parse.quote(str(exc))
         return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
 
+    queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    def on_progress(done: int | None, total: int | None, message: str | None) -> None:
+        loop.call_soon_threadsafe(
+            queue.put_nowait,
+            {"done": done, "total": total, "message": message},
+        )
+
+    async def run() -> None:
+        try:
+            await asyncio.to_thread(
+                lambda: create_artifact(
+                    dataset=template,
+                    start=start,
+                    end=end,
+                    bbox=resolved_bbox,
+                    country_code=country_code,
+                    overwrite=overwrite,
+                    publish=publish,
+                    on_progress=on_progress,
+                )
+            )
+            name = urllib.parse.quote(str(template.get("name", dataset_id)))
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"redirect": f"{base}/manage?message=Ingested+{name}"},
+            )
+        except HTTPException as exc:
+            msg = urllib.parse.quote(str(exc.detail))
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"error": str(exc.detail), "redirect": f"{base}/manage?error={msg}"},
+            )
+        except Exception as exc:
+            msg = urllib.parse.quote(str(exc))
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"error": str(exc), "redirect": f"{base}/manage?error={msg}"},
+            )
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+
+    asyncio.create_task(run())
+    return StreamingResponse(_sse_events(queue), media_type="text/event-stream")
+
 
 @router.post("/manage/sync", include_in_schema=False)
-async def manage_sync(request: Request) -> RedirectResponse:
-    """Handle sync form submission and redirect to the management page."""
+async def manage_sync(request: Request) -> Response:
+    """Handle sync form submission and stream progress via SSE."""
     from fastapi import HTTPException
 
     from climate_api.ingestions.services import sync_dataset
@@ -99,15 +145,48 @@ async def manage_sync(request: Request) -> RedirectResponse:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", ""))
         publish = "publish" in form
-
-        sync_dataset(dataset_id=dataset_id, end=None, publish=publish)
-        return RedirectResponse(f"{base}/manage?message=Sync+completed", status_code=303)
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
         return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
     except Exception as exc:
         msg = urllib.parse.quote(str(exc))
         return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+
+    queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    def on_progress(done: int | None, total: int | None, message: str | None) -> None:
+        loop.call_soon_threadsafe(
+            queue.put_nowait,
+            {"done": done, "total": total, "message": message},
+        )
+
+    async def run() -> None:
+        try:
+            await asyncio.to_thread(
+                lambda: sync_dataset(dataset_id=dataset_id, end=None, publish=publish, on_progress=on_progress)
+            )
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"redirect": f"{base}/manage?message=Sync+completed"},
+            )
+        except HTTPException as exc:
+            msg = urllib.parse.quote(str(exc.detail))
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"error": str(exc.detail), "redirect": f"{base}/manage?error={msg}"},
+            )
+        except Exception as exc:
+            msg = urllib.parse.quote(str(exc))
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"error": str(exc), "redirect": f"{base}/manage?error={msg}"},
+            )
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+
+    asyncio.create_task(run())
+    return StreamingResponse(_sse_events(queue), media_type="text/event-stream")
 
 
 @router.get("/health")

--- a/climate_api/templates/manage.html
+++ b/climate_api/templates/manage.html
@@ -168,6 +168,10 @@
       button[type="submit"]:hover {
         background: #263547;
       }
+      button[type="submit"]:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
 
       .note {
         font-size: 0.875rem;
@@ -250,11 +254,45 @@
         background: #f1f5f9;
         border-color: #94a3b8;
       }
+      .sync-btn:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
 
       .divider {
         border: none;
         border-top: 1px solid #f1f5f9;
         margin: 1rem 0;
+      }
+
+      .progress-area {
+        margin-top: 0.75rem;
+      }
+      .progress-bar-track {
+        height: 6px;
+        background: #e2e8f0;
+        border-radius: 99px;
+        overflow: hidden;
+        margin-bottom: 0.35rem;
+      }
+      .progress-bar-fill {
+        height: 100%;
+        width: 0%;
+        background: #0066cc;
+        border-radius: 99px;
+        transition: width 0.3s ease;
+      }
+      .progress-bar-fill.indeterminate {
+        width: 40%;
+        animation: indeterminate 1.4s ease-in-out infinite;
+      }
+      @keyframes indeterminate {
+        0%   { transform: translateX(-100%); }
+        100% { transform: translateX(350%); }
+      }
+      .progress-label {
+        font-size: 0.78rem;
+        color: #64748b;
       }
 
       footer {
@@ -294,7 +332,8 @@
         {% elif not templates %}
         <p class="note">No dataset templates found.</p>
         {% else %}
-        <form method="post" action="{{ base }}/manage/ingest">
+        <form id="ingest-form" method="post" action="{{ base }}/manage/ingest"
+              onsubmit="runJob(event, this, 'btn-ingest', 'ingest-progress')">
           <div class="form-grid">
             <div class="field span-2">
               <label for="dataset_id">Dataset template</label>
@@ -355,8 +394,14 @@
 
           <hr class="divider" />
           <div class="form-actions">
-            <button type="submit">Ingest</button>
-            <span class="note">Ingestion runs synchronously and may take several minutes.</span>
+            <button type="submit" id="btn-ingest">Ingest</button>
+            <span class="note">Ingestion may take several minutes.</span>
+          </div>
+          <div id="ingest-progress" class="progress-area" style="display:none">
+            <div class="progress-bar-track">
+              <div class="progress-bar-fill indeterminate"></div>
+            </div>
+            <span class="progress-label">Starting…</span>
           </div>
         </form>
         {% endif %}
@@ -392,10 +437,17 @@
                 {% endif %}
               </td>
               <td>
-                <form method="post" action="{{ base }}/manage/sync" class="sync-form">
+                <form method="post" action="{{ base }}/manage/sync" class="sync-form"
+                      onsubmit="runJob(event, this, 'btn-sync-{{ ds.dataset_id }}', 'sync-progress-{{ ds.dataset_id }}')">
                   <input type="hidden" name="dataset_id" value="{{ ds.dataset_id }}" />
                   <input type="hidden" name="publish" value="on" />
-                  <button type="submit" class="sync-btn">Sync</button>
+                  <button type="submit" id="btn-sync-{{ ds.dataset_id }}" class="sync-btn">Sync</button>
+                  <div id="sync-progress-{{ ds.dataset_id }}" class="progress-area" style="display:none">
+                    <div class="progress-bar-track">
+                      <div class="progress-bar-fill indeterminate"></div>
+                    </div>
+                    <span class="progress-label">Starting…</span>
+                  </div>
                 </form>
               </td>
             </tr>
@@ -413,5 +465,63 @@
     <footer>
       <a href="https://github.com/dhis2/climate-api">dhis2/climate-api</a>
     </footer>
+
+    <script>
+      async function runJob(event, form, btnId, progressId) {
+        event.preventDefault();
+        const btn = document.getElementById(btnId);
+        const area = document.getElementById(progressId);
+        const fill = area.querySelector('.progress-bar-fill');
+        const label = area.querySelector('.progress-label');
+
+        btn.disabled = true;
+        area.style.display = 'block';
+        fill.className = 'progress-bar-fill indeterminate';
+        label.textContent = 'Starting…';
+
+        try {
+          const resp = await fetch(form.action, {
+            method: 'POST',
+            body: new FormData(form),
+          });
+
+          if (!resp.ok || !resp.body) {
+            window.location.href = form.action.replace('/manage/ingest', '/manage').replace('/manage/sync', '/manage') + '?error=' + encodeURIComponent('Request failed');
+            return;
+          }
+
+          const reader = resp.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+            for (const line of lines) {
+              if (!line.startsWith('data: ')) continue;
+              let evt;
+              try { evt = JSON.parse(line.slice(6)); } catch { continue; }
+              if (evt.redirect) {
+                window.location.href = evt.redirect;
+                return;
+              }
+              if (typeof evt.done === 'number' && typeof evt.total === 'number' && evt.total > 0) {
+                fill.className = 'progress-bar-fill';
+                fill.style.width = Math.round((evt.done / evt.total) * 100) + '%';
+              }
+              if (evt.message) {
+                label.textContent = evt.message;
+              }
+            }
+          }
+        } catch (err) {
+          label.textContent = 'Error: ' + err.message;
+          btn.disabled = false;
+        }
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- `/manage/ingest` and `/manage/sync` now respond with `text/event-stream` (SSE) instead of blocking until completion, fixing the _"run_streaming_ingest_sync cannot be called from a running event loop"_ error that occurred because both handlers were `async def` calling blocking ingest code directly
- The blocking work runs in `asyncio.to_thread()`, freeing the event loop while progress events are forwarded via a shared `asyncio.Queue`
- `on_progress` is threaded through `sync_dataset` → `run_sync` → `create_artifact_fn` so sync jobs emit the same progress events as initial ingest
- `manage.html` intercepts form submissions with `fetch()` + `ReadableStream`, shows an animated progress bar that transitions to a determinate fill as periods are written, and auto-redirects to the success/error URL on completion

## Test plan

- [ ] Start the dev server (`uv run uvicorn climate_api.main:app --reload`)
- [ ] Navigate to `/manage`, select a dataset, click Ingest — progress bar animates during the job and the page redirects to the success message when done
- [ ] Click Sync on an existing dataset — same behaviour
- [ ] Trigger an error (e.g. missing extent) — page redirects to the error flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)