### PR TITLE
fix: mask WorldPop -99999 sentinel to NaN; improve display range

### DIFF
--- a/climate_api/data/datasets/worldpop.yaml
+++ b/climate_api/data/datasets/worldpop.yaml
@@ -28,5 +28,4 @@
   source_url: https://hub.worldpop.org/project/categories?id=3
   display:
     colormap: reds
-    range: [0.0, 25.0]
-    nodata: 0.0
+    range: [0.5, 100.0]

--- a/climate_api/streaming/plugins/worldpop.py
+++ b/climate_api/streaming/plugins/worldpop.py
@@ -84,7 +84,7 @@ class WorldPopYearlyPlugin:
         # store uses its native NaN fill_value for unpopulated / ocean cells.
         var = self.variant.output_variable
         if var in dataset:
-            dataset[var] = dataset[var].where(dataset[var] > -9999)
+            dataset[var] = dataset[var].where(dataset[var] != -99999)
         return dataset
 
 

--- a/climate_api/streaming/plugins/worldpop.py
+++ b/climate_api/streaming/plugins/worldpop.py
@@ -78,7 +78,14 @@ class WorldPopYearlyPlugin:
             rename_map.update({"lon": "x", "lat": "y"})
         if self.variant.source_variable != self.variant.output_variable:
             rename_map[self.variant.source_variable] = self.variant.output_variable
-        return dataset.rename(rename_map) if rename_map else dataset
+        if rename_map:
+            dataset = dataset.rename(rename_map)
+        # Mask the WorldPop sentinel nodata value (-99999) to NaN so the Zarr
+        # store uses its native NaN fill_value for unpopulated / ocean cells.
+        var = self.variant.output_variable
+        if var in dataset:
+            dataset[var] = dataset[var].where(dataset[var] > -9999)
+        return dataset
 
 
 def _resolve_variant(*, product: str, variable: str) -> _WorldPopVariant:

--- a/tests/test_worldpop_plugin.py
+++ b/tests/test_worldpop_plugin.py
@@ -73,3 +73,27 @@ def test_worldpop_plugin_fetch_period_can_rename_output_variable(
 
     assert list(dataset.data_vars) == ["population_total"]
     assert "x" in dataset.dims and "y" in dataset.dims
+
+
+def test_worldpop_plugin_masks_nodata_sentinel_to_nan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Values equal to the WorldPop -99999 sentinel must become NaN, not be stored."""
+    import numpy as np
+
+    plugin = WorldPopYearlyPlugin()
+
+    def fake_fetch_year(year: int, country_code: str) -> xr.Dataset:
+        return xr.Dataset(
+            {"pop_total": (("time", "lon", "lat"), [[[5.0, -99999.0, 12.0]]])},
+            coords={"time": ["2020-01-01"], "lon": [1.0], "lat": [1.0, 2.0, 3.0]},
+        )
+
+    monkeypatch.setattr(plugin, "_fetch_year", fake_fetch_year)
+
+    dataset = asyncio.run(plugin.fetch_period("2020", [0.0, 0.0, 4.0, 4.0], country_code="SLE"))
+
+    values = dataset["pop_total"].values.flatten()
+    assert np.isnan(values[1]), "sentinel -99999 must be masked to NaN"
+    assert values[0] == pytest.approx(5.0), "valid values must be preserved"
+    assert values[2] == pytest.approx(12.0), "valid values must be preserved"


### PR DESCRIPTION
## Summary

Two related fixes to WorldPop rendering and storage quality:

### 1. Plugin: mask -99999 sentinel to NaN during ingest

WorldPop GeoTIFFs use -99999 as the nodata sentinel for ocean and outside-country cells. The plugin was storing this raw value instead of converting it to NaN, which is the Zarr fill_value. ZarrLayer and any Zarr HTTP client renders NaN as transparent by default, so the fix makes ocean/outside-country cells transparent on the map without any client-side configuration.

```python
# _normalize_dataset in WorldPopYearlyPlugin
if var in dataset:
    dataset[var] = dataset[var].where(dataset[var] > -9999)
```

### 2. YAML: remove `nodata: 0.0`; update display range

- `display.nodata: 0.0` was incorrect — 0.0 is a valid population count, not a nodata marker. The Zarr fill_value (NaN) already handles true nodata transparency.
- `display.range` changed from `[0.0, 25.0]` to `[0.5, 100.0]` so that cells with < 0.5 people (effectively uninhabited parcels within the country boundary) fall below the colormap minimum and render transparent, matching what standard WorldPop viewers do.

## Re-ingest required

Existing WorldPop stores need to be re-ingested to apply the NaN masking. Stores ingested before this fix will have -99999 stored as a large negative float rather than NaN.

## Test plan

- [x] `uv run pytest tests/ -q` — 317 passed, 1 skipped; 3 pre-existing failures in `test_datasets_sync.py` (unrelated)
- [x] `uv run ruff check .` — no issues
- [ ] Manual: re-ingest WorldPop and verify ocean cells are transparent on `/map`

Extracted from #157.