### PR TITLE
feat: standardize Zarr store time dimension to "t" (openEO convention)

### DIFF
--- a/climate_api/data_manager/services/downloader.py
+++ b/climate_api/data_manager/services/downloader.py
@@ -142,7 +142,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
     # Normalise to canonical names so all stored Zarr files are consistent.
     crs = api_config.get_crs()
     time_dim = get_time_dim(ds)
-    rename_map = {k: v for k, v in [(time_dim, "time"), (x_dim, "x"), (y_dim, "y")] if k != v}
+    rename_map = {k: v for k, v in [(time_dim, "t"), (x_dim, "x"), (y_dim, "y")] if k != v}
     if rename_map:
         ds = ds.rename(rename_map)
     x_dim, y_dim = "x", "y"

--- a/climate_api/data_manager/services/utils.py
+++ b/climate_api/data_manager/services/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 
 def get_time_dim(ds: Any) -> str:
     """Return the name of the time dimension in a dataset or dataframe."""
-    for time_name in ["valid_time", "time"]:
+    for time_name in ["t", "valid_time", "time"]:
         if hasattr(ds, time_name):
             return time_name
     raise ValueError(f"Unable to find time dimension: {getattr(ds, 'coords', repr(ds))}")

--- a/climate_api/streaming/plugins/chirps3.py
+++ b/climate_api/streaming/plugins/chirps3.py
@@ -133,4 +133,4 @@ class CHIRPS3DailyPlugin:
         da = da.squeeze("band", drop=True)
         da = da.where(da != _CHIRPS3_NODATA).load()
         ds = da.to_dataset(name="precip")
-        return ds.expand_dims(time=[np.datetime64(period_id, "D")])  # type: ignore[no-any-return]
+        return ds.expand_dims(t=[np.datetime64(period_id, "D")])  # type: ignore[no-any-return]

--- a/climate_api/streaming/plugins/era5_land.py
+++ b/climate_api/streaming/plugins/era5_land.py
@@ -39,7 +39,7 @@ class ERA5LandHourlySingleBandPlugin:
             crs=4326,
             dtype=np.dtype(data.dtype),
             nodata=None,
-            time_dim="valid_time",
+            time_dim="t",
             x_dim="x",
             y_dim="y",
         )
@@ -64,7 +64,7 @@ class ERA5LandHourlySingleBandPlugin:
         timestamp = parse_period_string_to_datetime(period_id).replace(tzinfo=None)
         selected = region.sel(valid_time=slice(timestamp, timestamp))
         ds = selected[[self.variable]].load()
-        rename_map = {"longitude": "x", "latitude": "y"}
+        rename_map = {"longitude": "x", "latitude": "y", "valid_time": "t"}
         return ds.rename(rename_map) if rename_map else ds
 
     def _region_for_bbox(self, bbox: list[float]) -> xr.Dataset:

--- a/climate_api/streaming/plugins/worldpop.py
+++ b/climate_api/streaming/plugins/worldpop.py
@@ -73,9 +73,13 @@ class WorldPopYearlyPlugin:
         return fetch_country_year(year, country_code, self.version)
 
     def _normalize_dataset(self, dataset: xr.Dataset) -> xr.Dataset:
-        rename_map = {}
+        rename_map: dict[str, str] = {}
         if {"lon", "lat"} <= set(dataset.dims):
             rename_map.update({"lon": "x", "lat": "y"})
+        for t_name in ("time", "valid_time"):
+            if t_name in dataset.dims:
+                rename_map[t_name] = "t"
+                break
         if self.variant.source_variable != self.variant.output_variable:
             rename_map[self.variant.source_variable] = self.variant.output_variable
         if rename_map:

--- a/climate_api/streaming/protocol.py
+++ b/climate_api/streaming/protocol.py
@@ -47,7 +47,7 @@ class GridSpec:
     crs: int
     dtype: np.dtype[Any]
     nodata: float | None = None
-    time_dim: str = "time"
+    time_dim: str = "t"
     x_dim: str = "x"
     y_dim: str = "y"
     attrs: dict[str, Any] = field(default_factory=dict)

--- a/climate_api/streaming/store.py
+++ b/climate_api/streaming/store.py
@@ -34,7 +34,7 @@ def open_or_create_repo(store_path: Path) -> Any:
     return icechunk.Repository.create(storage)
 
 
-def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: str = "time") -> set[str]:
+def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: str = "t") -> set[str]:
     """Return period ids already committed in the store, or an empty set.
 
     Resume correctness is store-first: if the repository already contains a

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -158,8 +158,8 @@ def test_get_dataset_zarr_store_info_reads_icechunk_listing(tmp_path: Path, monk
     repo = icechunk.Repository.create(storage)
     session = repo.writable_session("main")
     ds = xr.Dataset(
-        {"precip": (("time", "y", "x"), [[[1.0, 2.0], [3.0, 4.0]]])},
-        coords={"time": ["2026-01-01"], "x": [1.0, 2.0], "y": [3.0, 4.0]},
+        {"precip": (("t", "y", "x"), [[[1.0, 2.0], [3.0, 4.0]]])},
+        coords={"t": ["2026-01-01"], "x": [1.0, 2.0], "y": [3.0, 4.0]},
         attrs={"proj:code": "EPSG:4326", "spatial:bbox": [1.0, 3.0, 2.0, 4.0]},
     )
     ds.to_zarr(session.store, mode="w", zarr_format=3)
@@ -177,7 +177,7 @@ def test_get_dataset_zarr_store_info_reads_icechunk_listing(tmp_path: Path, monk
     assert listing["format"] == ArtifactFormat.ICECHUNK
     assert listing["path"] == "."
     names = {entry["name"] for entry in listing["entries"]}  # type: ignore[index]
-    assert {"zarr.json", "precip", "time", "x", "y"} <= names
+    assert {"zarr.json", "precip", "t", "x", "y"} <= names
 
 
 def test_get_dataset_zarr_store_file_reads_icechunk_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -186,8 +186,8 @@ def test_get_dataset_zarr_store_file_reads_icechunk_metadata(tmp_path: Path, mon
     repo = icechunk.Repository.create(storage)
     session = repo.writable_session("main")
     ds = xr.Dataset(
-        {"precip": (("time", "y", "x"), [[[1.0]]])},
-        coords={"time": ["2026-01-01"], "x": [1.0], "y": [2.0]},
+        {"precip": (("t", "y", "x"), [[[1.0]]])},
+        coords={"t": ["2026-01-01"], "x": [1.0], "y": [2.0]},
         attrs={"proj:code": "EPSG:4326"},
     )
     ds.to_zarr(session.store, mode="w", zarr_format=3)
@@ -214,8 +214,8 @@ def test_get_dataset_zarr_store_file_rejects_invalid_icechunk_relative_path(
     repo = icechunk.Repository.create(storage)
     session = repo.writable_session("main")
     ds = xr.Dataset(
-        {"precip": (("time", "y", "x"), [[[1.0]]])},
-        coords={"time": ["2026-01-01"], "x": [1.0], "y": [2.0]},
+        {"precip": (("t", "y", "x"), [[[1.0]]])},
+        coords={"t": ["2026-01-01"], "x": [1.0], "y": [2.0]},
     )
     ds.to_zarr(session.store, mode="w", zarr_format=3)
     session.commit("seed metadata")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -316,9 +316,9 @@ def test_download_dataset_returns_409_for_empty_legacy_function_string() -> None
 
 def _make_dataset() -> xr.Dataset:
     return xr.Dataset(
-        {"pop_total": (["time", "lat", "lon"], np.ones((2, 3, 3), dtype="float32"))},
+        {"pop_total": (["t", "lat", "lon"], np.ones((2, 3, 3), dtype="float32"))},
         coords={
-            "time": pd.date_range("2020-01-01", periods=2, freq="YS"),
+            "t": pd.date_range("2020-01-01", periods=2, freq="YS"),
             "lat": [10.0, 9.0, 8.0],
             "lon": [30.0, 31.0, 32.0],
         },
@@ -329,9 +329,9 @@ def _write_nc_files(tmp_path: Path) -> list[Path]:
     paths = []
     for year in (2020, 2021):
         ds = xr.Dataset(
-            {"pop_total": (["time", "lat", "lon"], np.ones((1, 3, 3), dtype="float32"))},
+            {"pop_total": (["t", "lat", "lon"], np.ones((1, 3, 3), dtype="float32"))},
             coords={
-                "time": [pd.Timestamp(f"{year}-01-01")],
+                "t": [pd.Timestamp(f"{year}-01-01")],
                 "lat": [10.0, 9.0, 8.0],
                 "lon": [30.0, 31.0, 32.0],
             },
@@ -344,9 +344,9 @@ def _write_nc_files(tmp_path: Path) -> list[Path]:
 
 def _write_daily_nc_file(tmp_path: Path) -> list[Path]:
     ds = xr.Dataset(
-        {"precip": (["time", "lat", "lon"], np.ones((29, 3, 3), dtype="float32"))},
+        {"precip": (["t", "lat", "lon"], np.ones((29, 3, 3), dtype="float32"))},
         coords={
-            "time": pd.date_range("2024-02-01", "2024-02-29", freq="D"),
+            "t": pd.date_range("2024-02-01", "2024-02-29", freq="D"),
             "lat": [10.0, 9.0, 8.0],
             "lon": [30.0, 31.0, 32.0],
         },
@@ -385,7 +385,7 @@ def test_open_zarr_dataset_flat(tmp_path: Path) -> None:
     result = open_zarr_dataset(str(zarr_path))
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -399,7 +399,7 @@ def test_open_zarr_dataset_pyramid_falls_back_to_level_0(tmp_path: Path) -> None
     result = open_zarr_dataset(str(zarr_path))
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -408,7 +408,7 @@ def test_open_zarr_dataset_pyramid_with_root_time_still_opens_level_0(tmp_path: 
     """Root-level time coord (copied for zarr-layer) does not confuse the fallback.
 
     The fallback triggers on empty data_vars, not empty dims, so a root group
-    that only has a 'time' coordinate array still falls back to /0.
+    that only has a 't' coordinate array still falls back to /0.
     """
     ds = _make_dataset()
     zarr_path = tmp_path / "pyramid.zarr"
@@ -417,7 +417,7 @@ def test_open_zarr_dataset_pyramid_with_root_time_still_opens_level_0(tmp_path: 
     # Simulate what build_dataset_zarr does: copy time to root
     import shutil
 
-    shutil.copytree(str(zarr_path / "0" / "time"), str(zarr_path / "time"))
+    shutil.copytree(str(zarr_path / "0" / "t"), str(zarr_path / "t"))
 
     result = open_zarr_dataset(str(zarr_path))
     try:
@@ -438,7 +438,7 @@ def test_open_icechunk_dataset_falls_back_to_level_0_when_root_has_no_data_vars(
     result = open_icechunk_dataset(store_path)
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -451,13 +451,13 @@ def test_open_icechunk_dataset_with_root_time_still_opens_level_0(tmp_path: Path
     session = repo.writable_session("main")
     ds = _make_dataset()
     ds.to_zarr(session.store, group="0", mode="w", zarr_format=3)
-    ds[["time"]].to_zarr(session.store, mode="a", zarr_format=3)
+    ds[["t"]].to_zarr(session.store, mode="a", zarr_format=3)
     session.commit("seed pyramid root time and level 0")
 
     result = open_icechunk_dataset(store_path)
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -482,7 +482,7 @@ def test_build_dataset_zarr_flat_creates_zarr(tmp_path: Path, monkeypatch: pytes
     result = open_zarr_dataset(str(zarr_path))
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -518,7 +518,7 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
 
     result = open_zarr_dataset(str(tmp_path / "era5land_temperature_hourly.zarr"))
     try:
-        assert "time" in result.coords
+        assert "t" in result.coords
         assert "x" in result.coords
         assert "y" in result.coords
         assert "valid_time" not in result.coords
@@ -531,9 +531,9 @@ def test_build_dataset_zarr_normalises_coordinate_names(tmp_path: Path, monkeypa
 def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Source coordinates already named x/y are preserved as x/y."""
     ds_xy = xr.Dataset(
-        {"precip": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
+        {"precip": (["t", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
         coords={
-            "time": pd.date_range("2024-01-01", periods=2, freq="D"),
+            "t": pd.date_range("2024-01-01", periods=2, freq="D"),
             "y": [10.0, 9.0, 8.0],
             "x": [30.0, 31.0, 32.0],
         },
@@ -554,7 +554,7 @@ def test_build_dataset_zarr_normalises_xy_coordinate_names(tmp_path: Path, monke
 
     result = open_zarr_dataset(str(tmp_path / "chirps3_precipitation_daily.zarr"))
     try:
-        assert "time" in result.coords
+        assert "t" in result.coords
         assert "x" in result.coords
         assert "y" in result.coords
     finally:
@@ -580,9 +580,9 @@ def test_build_dataset_zarr_clips_to_requested_daily_range(
 
     result = open_zarr_dataset(str(tmp_path / "chirps3_precipitation_daily.zarr"))
     try:
-        assert result.sizes["time"] == 10
-        assert pd.Timestamp(result.time.min().item()).strftime("%Y-%m-%d") == "2024-02-01"
-        assert pd.Timestamp(result.time.max().item()).strftime("%Y-%m-%d") == "2024-02-10"
+        assert result.sizes["t"] == 10
+        assert pd.Timestamp(result.t.min().item()).strftime("%Y-%m-%d") == "2024-02-01"
+        assert pd.Timestamp(result.t.max().item()).strftime("%Y-%m-%d") == "2024-02-10"
     finally:
         result.close()
 
@@ -616,7 +616,7 @@ def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypa
 
     zarr_path = tmp_path / "my_dataset.zarr"
     assert (zarr_path / "0").exists(), "pyramid level 0 should exist"
-    assert (zarr_path / "time").exists(), "time coordinate must be copied to zarr root"
+    assert (zarr_path / "t").exists(), "t coordinate must be copied to zarr root"
 
 
 def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -636,7 +636,7 @@ def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monk
     result = open_zarr_dataset(str(tmp_path / "my_dataset.zarr"))
     try:
         assert "pop_total" in result.data_vars
-        assert result.sizes["time"] == 2
+        assert result.sizes["t"] == 2
     finally:
         result.close()
 
@@ -666,7 +666,7 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     ds_in = received[0]
     assert "x" in ds_in.coords
     assert "y" in ds_in.coords
-    assert "time" in ds_in.coords
+    assert "t" in ds_in.coords
     assert "lon" not in ds_in.coords
     assert "lat" not in ds_in.coords
 
@@ -675,7 +675,7 @@ def test_build_dataset_zarr_pyramid_normalises_coordinate_names(
     try:
         assert "x" in result.coords
         assert "y" in result.coords
-        assert "time" in result.coords
+        assert "t" in result.coords
     finally:
         result.close()
 

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -35,7 +35,7 @@ def test_era5_land_probe_uses_region_shape(monkeypatch: pytest.MonkeyPatch) -> N
     spec = asyncio.run(plugin.probe([1.0, 2.0, 3.0, 4.0]))
 
     assert spec.shape == (3, 4)
-    assert spec.time_dim == "valid_time"
+    assert spec.time_dim == "t"
     assert spec.x_dim == "x"
     assert spec.y_dim == "y"
 
@@ -58,7 +58,7 @@ def test_era5_land_fetch_period_normalizes_coordinates(monkeypatch: pytest.Monke
 
     dataset = asyncio.run(plugin.fetch_period("2026-01-01T01", [1.0, 2.0, 3.0, 4.0]))
 
-    assert "valid_time" in dataset.dims
+    assert "t" in dataset.dims
     assert "x" in dataset.dims
     assert "y" in dataset.dims
     assert "longitude" not in dataset.dims

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -49,14 +49,17 @@ class _ShapeMismatchPlugin(_FakePlugin):
 class _CustomTimeDimPlugin(_FakePlugin):
     async def probe(self, bbox: list[float], **params: Any) -> GridSpec:
         _ = bbox, params
-        return GridSpec(shape=(1, 1), crs=4326, dtype=np.dtype("float32"), time_dim="t")
+        # Use a non-default time dimension to exercise the custom-dim code path;
+        # production plugins standardise on "t" but this test must verify the
+        # orchestrator honours an overridden spec.time_dim.
+        return GridSpec(shape=(1, 1), crs=4326, dtype=np.dtype("float32"), time_dim="valid_time")
 
     async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
         _ = bbox, params
         value = float(period_id[-2:])
         return xr.Dataset(
-            {"precip": (("t", "y", "x"), np.array([[[value]]], dtype=np.float32))},
-            coords={"t": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
+            {"precip": (("valid_time", "y", "x"), np.array([[[value]]], dtype=np.float32))},
+            coords={"valid_time": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
         )
 
 

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -30,8 +30,8 @@ class _FakePlugin:
         _ = bbox, params
         value = float(period_id[-2:])
         return xr.Dataset(
-            {"precip": (("time", "y", "x"), np.array([[[value]]], dtype=np.float32))},
-            coords={"time": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
+            {"precip": (("t", "y", "x"), np.array([[[value]]], dtype=np.float32))},
+            coords={"t": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
         )
 
 
@@ -40,8 +40,8 @@ class _ShapeMismatchPlugin(_FakePlugin):
         _ = bbox, params
         if period_id == "2026-01-02":
             return xr.Dataset(
-                {"precip": (("time", "y", "x"), np.array([[[1.0], [2.0]]], dtype=np.float32))},
-                coords={"time": [np.datetime64(period_id, "D")], "y": [0.0, 1.0], "x": [1.0]},
+                {"precip": (("t", "y", "x"), np.array([[[1.0], [2.0]]], dtype=np.float32))},
+                coords={"t": [np.datetime64(period_id, "D")], "y": [0.0, 1.0], "x": [1.0]},
             )
         return await super().fetch_period(period_id, bbox, **params)
 
@@ -49,14 +49,14 @@ class _ShapeMismatchPlugin(_FakePlugin):
 class _CustomTimeDimPlugin(_FakePlugin):
     async def probe(self, bbox: list[float], **params: Any) -> GridSpec:
         _ = bbox, params
-        return GridSpec(shape=(1, 1), crs=4326, dtype=np.dtype("float32"), time_dim="valid_time")
+        return GridSpec(shape=(1, 1), crs=4326, dtype=np.dtype("float32"), time_dim="t")
 
     async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
         _ = bbox, params
         value = float(period_id[-2:])
         return xr.Dataset(
-            {"precip": (("valid_time", "y", "x"), np.array([[[value]]], dtype=np.float32))},
-            coords={"valid_time": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
+            {"precip": (("t", "y", "x"), np.array([[[value]]], dtype=np.float32))},
+            coords={"t": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
         )
 
 
@@ -81,7 +81,7 @@ class _FakeRepo:
         return session
 
 
-def _read_committed_periods_from_zarr(store_path: Path, period_type: str, *, time_dim: str = "time") -> set[str]:
+def _read_committed_periods_from_zarr(store_path: Path, period_type: str, *, time_dim: str = "t") -> set[str]:
     _ = period_type
     if not store_path.exists():
         return set()
@@ -104,7 +104,7 @@ def test_orchestrator_uses_store_state_as_resume_truth(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         streaming_orchestrator,
         "read_committed_period_ids",
-        lambda path, period_type, time_dim="time": _read_committed_periods_from_zarr(
+        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(
             path, period_type, time_dim=time_dim
         ),
     )
@@ -168,7 +168,7 @@ def test_orchestrator_refuses_destructive_first_write_when_existing_store_is_not
 
     monkeypatch.setattr(streaming_orchestrator, "open_or_create_repo", lambda path: repo)
     monkeypatch.setattr(
-        streaming_orchestrator, "read_committed_period_ids", lambda path, period_type, time_dim="time": set()
+        streaming_orchestrator, "read_committed_period_ids", lambda path, period_type, time_dim="t": set()
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: False)
 
@@ -200,7 +200,7 @@ def test_orchestrator_normalizes_invalid_plugin_batching_and_concurrency(
     monkeypatch.setattr(
         streaming_orchestrator,
         "read_committed_period_ids",
-        lambda path, period_type, time_dim="time": _read_committed_periods_from_zarr(
+        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(
             path, period_type, time_dim=time_dim
         ),
     )
@@ -229,8 +229,8 @@ def test_orchestrator_does_not_skip_uncommitted_gaps_before_cursor(
     repo = _FakeRepo(str(store_path))
 
     existing = xr.Dataset(
-        {"precip": (("time", "y", "x"), np.array([[[2.0]]], dtype=np.float32))},
-        coords={"time": [np.datetime64("2026-01-02", "D")], "y": [0.0], "x": [1.0]},
+        {"precip": (("t", "y", "x"), np.array([[[2.0]]], dtype=np.float32))},
+        coords={"t": [np.datetime64("2026-01-02", "D")], "y": [0.0], "x": [1.0]},
     )
     existing.to_zarr(store_path, mode="w", zarr_format=3)
 
@@ -238,7 +238,7 @@ def test_orchestrator_does_not_skip_uncommitted_gaps_before_cursor(
     monkeypatch.setattr(
         streaming_orchestrator,
         "read_committed_period_ids",
-        lambda path, period_type, time_dim="time": {"2026-01-02"},
+        lambda path, period_type, time_dim="t": {"2026-01-02"},
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: False)
 
@@ -255,7 +255,7 @@ def test_orchestrator_does_not_skip_uncommitted_gaps_before_cursor(
     assert result.periods_written == 2
     ds = xr.open_zarr(store_path, consolidated=None)
     try:
-        assert {str(item)[:10] for item in ds["time"].values} == {"2026-01-01", "2026-01-02", "2026-01-03"}
+        assert {str(item)[:10] for item in ds["t"].values} == {"2026-01-01", "2026-01-02", "2026-01-03"}
     finally:
         ds.close()
 
@@ -269,7 +269,7 @@ def test_orchestrator_rejects_spatial_shape_changes_across_appends(
 
     monkeypatch.setattr(streaming_orchestrator, "open_or_create_repo", lambda path: repo)
     monkeypatch.setattr(
-        streaming_orchestrator, "read_committed_period_ids", lambda path, period_type, time_dim="time": set()
+        streaming_orchestrator, "read_committed_period_ids", lambda path, period_type, time_dim="t": set()
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
 
@@ -307,7 +307,7 @@ def test_orchestrator_writes_and_reads_through_real_icechunk_repo(tmp_path: Path
     ds = xr.open_zarr(session.store)
     try:
         assert ds["precip"].values[:, 0, 0].tolist() == [1.0, 2.0, 3.0]
-        assert {str(item)[:10] for item in ds["time"].values} == {"2026-01-01", "2026-01-02", "2026-01-03"}
+        assert {str(item)[:10] for item in ds["t"].values} == {"2026-01-01", "2026-01-02", "2026-01-03"}
     finally:
         ds.close()
 

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -107,9 +107,7 @@ def test_orchestrator_uses_store_state_as_resume_truth(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         streaming_orchestrator,
         "read_committed_period_ids",
-        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(
-            path, period_type, time_dim=time_dim
-        ),
+        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(path, period_type, time_dim=time_dim),
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
 
@@ -203,9 +201,7 @@ def test_orchestrator_normalizes_invalid_plugin_batching_and_concurrency(
     monkeypatch.setattr(
         streaming_orchestrator,
         "read_committed_period_ids",
-        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(
-            path, period_type, time_dim=time_dim
-        ),
+        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(path, period_type, time_dim=time_dim),
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
 


### PR DESCRIPTION
## Summary

All ingest paths now write `t` as the time dimension name instead of `time` or `valid_time`, aligning with the openEO standard and preparing stores for the openEO processing layer in #157.

### Changes

| Plugin / module | Before | After |
|---|---|---|
| `GridSpec.time_dim` default | `"time"` | `"t"` |
| ERA5-Land plugin | renames `valid_time` → `t` | ✓ |
| WorldPop plugin | renames `time`/`valid_time` → `t` | ✓ |
| CHIRPS3 plugin | expands on `"time"` | expands on `"t"` |
| `read_committed_period_ids` default | `"time"` | `"t"` |
| `get_time_dim()` | checks `valid_time`, `time` | checks `t` first, then legacy names |

### Breaking change — re-ingest required

Existing Zarr stores written with `time` or `valid_time` as the time dimension will still open and read correctly (the `get_time_dim()` helper detects all three names), but new stores will use `t`. **Re-ingest any dataset to get the standardised dimension name.**

### Note on `e1a5295`

The second commit from #157 (`refactor: remove backward-compat time dim renaming from openEO layer`) is intentionally excluded — it modifies `climate_api/openeo/execution.py` which does not exist on `main` yet.

## Test plan

- [x] `uv run pytest tests/ -q` — 311 passed, 1 skipped; all failures are pre-existing on `main`
- [x] `uv run ruff check .` — no issues
- [ ] Re-ingest ERA5-Land, CHIRPS3, WorldPop and verify stores have `dims: {t: ...}`

Extracted from #157.