### PR TITLE
fix: resolve /tmp symlink in sync_engine path trust check (macOS)

### DIFF
--- a/climate_api/ingestions/sync_engine.py
+++ b/climate_api/ingestions/sync_engine.py
@@ -429,7 +429,7 @@ def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str
     resolved = candidate.resolve(strict=False)
     for root in _artifact_storage_roots():
         try:
-            resolved.relative_to(root)
+            resolved.relative_to(root.resolve())
         except ValueError:
             continue
         return resolved, None

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -272,7 +272,7 @@ def test_plan_sync_for_plugin_backed_icechunk_uses_committed_store_state(
     latest.format = ArtifactFormat.ICECHUNK
     latest.coverage.temporal.end = "2026-01-15"
 
-    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp").resolve(),))
     monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: {"2026-01-31"})
 
     result = sync_engine.plan_sync(
@@ -303,7 +303,7 @@ def test_plan_sync_for_plugin_backed_icechunk_normalizes_committed_period_before
     latest.format = ArtifactFormat.ICECHUNK
     latest.coverage.temporal.end = "2026-04-21T13"
 
-    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp").resolve(),))
     monkeypatch.setattr(
         sync_engine,
         "read_committed_period_ids",
@@ -506,7 +506,7 @@ def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_st
     latest.format = ArtifactFormat.ICECHUNK
 
     warnings: list[str] = []
-    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp").resolve(),))
 
     def fake_warning(message: str, *args: object) -> None:
         warnings.append(message % args if args else message)
@@ -545,7 +545,7 @@ def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_co
     )
     latest.format = ArtifactFormat.ICECHUNK
 
-    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp").resolve(),))
     monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: set())
 
     result = sync_engine.plan_sync(
@@ -648,7 +648,7 @@ def test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_co
     def fake_warning(message: str, *args: object) -> None:
         warnings.append(message % args if args else message)
 
-    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp"),))
+    monkeypatch.setattr(sync_engine, "_artifact_storage_roots", lambda: (Path("/tmp").resolve(),))
     monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *args, **kwargs: {"not-a-period"})
     monkeypatch.setattr(sync_engine.logger, "warning", fake_warning)
 


### PR DESCRIPTION
## Problem

Three tests in `test_datasets_sync.py` were permanently failing on macOS:

- `test_plan_sync_for_plugin_backed_icechunk_uses_committed_store_state`
- `test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_store_read_fails`
- `test_plan_sync_for_plugin_backed_icechunk_falls_back_to_artifact_end_when_committed_period_is_malformed`

All three use `Path("/tmp")` as the trusted storage root in the monkeypatch. On macOS, `/tmp` is a symlink to `/private/tmp`, so:

```python
Path("/tmp/store.icechunk").resolve() == Path("/private/tmp/store.icechunk")
Path("/tmp").relative_to(...)  # never matches /private/tmp/...
```

The path trust check in `_resolve_local_artifact_path` rejected every `/tmp` path as "untrusted local path", causing the sync planner to skip committed-store inspection and producing wrong actions.

## Fix

Both sides patched:

1. **`sync_engine.py`**: call `root.resolve()` before `relative_to()` so the comparison is always between fully-resolved paths, regardless of what `_artifact_storage_roots()` returns.

2. **`tests`**: five `lambda: (Path("/tmp"),)` monkeypatches updated to `(Path("/tmp").resolve(),)` to make the intent explicit.

## Test plan

- [x] `uv run pytest tests/ -q` — 321 passed, 1 skipped, 0 failures
- [x] `uv run ruff check .` — no issues