### PR TITLE
fix: accept extra kwargs in streaming plugin __init__ methods

### DIFF
--- a/climate_api/streaming/plugins/chirps3.py
+++ b/climate_api/streaming/plugins/chirps3.py
@@ -59,7 +59,7 @@ class CHIRPS3DailyPlugin:
     max_concurrency = 4
     commit_batch_size = 30
 
-    def __init__(self, stage: str = "final", flavor: str = "rnl") -> None:
+    def __init__(self, stage: str = "final", flavor: str = "rnl", **_: Any) -> None:
         if stage not in {"final", "prelim"}:
             raise ValueError(f"stage must be 'final' or 'prelim', got {stage!r}")
         if stage == "final" and flavor not in {"rnl", "sat"}:

--- a/climate_api/streaming/plugins/era5_land.py
+++ b/climate_api/streaming/plugins/era5_land.py
@@ -22,7 +22,7 @@ class ERA5LandHourlySingleBandPlugin:
     max_concurrency = 2
     commit_batch_size = 24
 
-    def __init__(self, variable: str) -> None:
+    def __init__(self, variable: str, **_: Any) -> None:
         if not variable:
             raise ValueError("ERA5LandHourlySingleBandPlugin requires a non-empty variable")
         self.variable = variable
@@ -101,7 +101,7 @@ class ERA5LandPrecipitationPlugin(ERA5LandHourlySingleBandPlugin):
     forcing another dataset-template contract change.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, **_: Any) -> None:
         super().__init__(variable="tp")
 
 

--- a/climate_api/streaming/plugins/worldpop.py
+++ b/climate_api/streaming/plugins/worldpop.py
@@ -35,7 +35,9 @@ class WorldPopYearlyPlugin:
     max_concurrency = 1
     commit_batch_size = 1
 
-    def __init__(self, version: str = "global2", product: str = "total", variable: str = "pop_total") -> None:
+    def __init__(
+        self, version: str = "global2", product: str = "total", variable: str = "pop_total", **_: object
+    ) -> None:
         self.version = version
         self.variant = _resolve_variant(product=product, variable=variable)
 

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -23,7 +23,6 @@ def test_era5_land_precipitation_plugin_accepts_extra_kwargs() -> None:
     assert plugin.variable == "tp"
 
 
-
 def test_era5_land_periods_enumerate_hours() -> None:
     plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
 

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -8,6 +8,22 @@ import xarray as xr
 from climate_api.streaming.plugins.era5_land import ERA5LandHourlySingleBandPlugin, ERA5LandPrecipitationPlugin
 
 
+def test_era5_land_plugin_accepts_extra_kwargs() -> None:
+    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m", unknown_future_field="ignored")
+    assert plugin.variable == "t2m"
+
+
+def test_era5_land_plugin_still_rejects_empty_variable_with_extra_kwargs() -> None:
+    with pytest.raises(ValueError, match="non-empty variable"):
+        ERA5LandHourlySingleBandPlugin(variable="", unknown_future_field="ignored")
+
+
+def test_era5_land_precipitation_plugin_accepts_extra_kwargs() -> None:
+    plugin = ERA5LandPrecipitationPlugin(unknown_future_field="ignored")
+    assert plugin.variable == "tp"
+
+
+
 def test_era5_land_periods_enumerate_hours() -> None:
     plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
 

--- a/tests/test_streaming_chirps3.py
+++ b/tests/test_streaming_chirps3.py
@@ -6,6 +6,18 @@ import pytest
 from climate_api.streaming.plugins.chirps3 import CHIRPS3DailyPlugin
 
 
+def test_chirps3_plugin_accepts_extra_kwargs() -> None:
+    plugin = CHIRPS3DailyPlugin(stage="final", flavor="rnl", unknown_future_field="ignored")
+    assert plugin.stage == "final"
+    assert plugin.flavor == "rnl"
+
+
+def test_chirps3_plugin_still_validates_stage_with_extra_kwargs() -> None:
+    with pytest.raises(ValueError, match="stage must be"):
+        CHIRPS3DailyPlugin(stage="bad", unknown_future_field="ignored")
+
+
+
 def test_chirps3_plugin_probe_estimates_grid_from_bbox() -> None:
     plugin = CHIRPS3DailyPlugin()
 

--- a/tests/test_streaming_chirps3.py
+++ b/tests/test_streaming_chirps3.py
@@ -17,7 +17,6 @@ def test_chirps3_plugin_still_validates_stage_with_extra_kwargs() -> None:
         CHIRPS3DailyPlugin(stage="bad", unknown_future_field="ignored")
 
 
-
 def test_chirps3_plugin_probe_estimates_grid_from_bbox() -> None:
     plugin = CHIRPS3DailyPlugin()
 

--- a/tests/test_worldpop_plugin.py
+++ b/tests/test_worldpop_plugin.py
@@ -11,7 +11,6 @@ def test_worldpop_plugin_accepts_extra_kwargs() -> None:
     assert plugin.version == "global2"
 
 
-
 def test_worldpop_plugin_periods_enumerates_years() -> None:
     plugin = WorldPopYearlyPlugin()
 

--- a/tests/test_worldpop_plugin.py
+++ b/tests/test_worldpop_plugin.py
@@ -6,6 +6,12 @@ import xarray as xr
 from climate_api.streaming.plugins.worldpop import WorldPopYearlyPlugin, _resolve_variant
 
 
+def test_worldpop_plugin_accepts_extra_kwargs() -> None:
+    plugin = WorldPopYearlyPlugin(version="global2", unknown_future_field="ignored")
+    assert plugin.version == "global2"
+
+
+
 def test_worldpop_plugin_periods_enumerates_years() -> None:
     plugin = WorldPopYearlyPlugin()
 


### PR DESCRIPTION
## Summary

- Adds `**_: Any` / `**_: object` to `__init__` in `CHIRPS3DailyPlugin`, `ERA5LandHourlySingleBandPlugin`, `ERA5LandPrecipitationPlugin`, and `WorldPopYearlyPlugin`
- Allows callers to pass arbitrary keyword arguments (e.g. from a YAML dataset template with extra or future fields) without breaking plugin instantiation
- Extracted from PR #157 so it can land on `main` independently

## Test plan

- [x] Existing streaming tests pass unchanged
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)