### PR TITLE
feat: Prefer: respond-async for POST /ingestions and POST /sync/{id}

### DIFF
--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -41,7 +41,7 @@ def create_ingestion(
     """Create or update a managed dataset from a dataset template and configured extent.
 
     Pass ``Prefer: respond-async`` to queue the ingestion as a background job and
-    return immediately with 202 + ``Location: /internal/jobs/{id}``.
+    return immediately with 202 + ``Location: /jobs/{id}``.
     """
     if _prefer_respond_async(prefer):
         from climate_api.ingestions.processes import execute_ingestion
@@ -53,7 +53,7 @@ def create_ingestion(
             request=request.model_dump(),
         )
         response.status_code = 202
-        response.headers["Location"] = f"/internal/jobs/{job.job_id}"
+        response.headers["Location"] = f"/jobs/{job.job_id}"
         return IngestionResponse(ingestion_id=job.job_id, status=job.status, dataset=None)
 
     dataset = _get_dataset_or_404(request.dataset_id)
@@ -137,7 +137,7 @@ def sync_dataset(
     """Sync a managed dataset forward from its latest available time step.
 
     Pass ``Prefer: respond-async`` to queue the sync as a background job and
-    return immediately with 202 + ``Location: /internal/jobs/{id}``.
+    return immediately with 202 + ``Location: /jobs/{id}``.
     """
     if _prefer_respond_async(prefer):
         from climate_api.ingestions.processes import execute_sync
@@ -149,10 +149,8 @@ def sync_dataset(
             request={"dataset_id": dataset_id, **request.model_dump()},
         )
         response.status_code = 202
-        response.headers["Location"] = f"/internal/jobs/{job.job_id}"
-        return SyncResponse(
-            sync_id=job.job_id, status=job.status, message="Sync queued", dataset=None, sync_detail=None
-        )
+        response.headers["Location"] = f"/jobs/{job.job_id}"
+        return SyncResponse(sync_id=None, status=job.status, message="Sync queued", dataset=None, sync_detail=None)
 
     return services.sync_dataset(
         dataset_id=dataset_id,

--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -1,6 +1,6 @@
 """Routes for EO ingestion, datasets, and sync operations."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Header, HTTPException
 from fastapi.responses import FileResponse
 from starlette.responses import Response
 
@@ -18,15 +18,44 @@ from climate_api.ingestions.schemas import (
     SyncResponse,
 )
 
+
+def _prefer_respond_async(prefer: str | None) -> bool:
+    if prefer is None:
+        return False
+    directives = [item.strip().split(";", 1)[0].strip().lower() for item in prefer.split(",")]
+    return "respond-async" in directives
+
+
 ingestions_router = APIRouter()
 datasets_router = APIRouter()
 zarr_router = APIRouter()
 sync_router = APIRouter()
 
 
-@ingestions_router.post("", response_model=IngestionResponse)
-def create_ingestion(request: CreateIngestionRequest) -> IngestionResponse:
-    """Create or update a managed dataset from a dataset template and configured extent."""
+@ingestions_router.post("")
+def create_ingestion(
+    request: CreateIngestionRequest,
+    response: Response,
+    prefer: str | None = Header(default=None),
+) -> IngestionResponse:
+    """Create or update a managed dataset from a dataset template and configured extent.
+
+    Pass ``Prefer: respond-async`` to queue the ingestion as a background job and
+    return immediately with 202 + ``Location: /internal/jobs/{id}``.
+    """
+    if _prefer_respond_async(prefer):
+        from climate_api.ingestions.processes import execute_ingestion
+        from climate_api.jobs.service import get_job_service
+
+        job = get_job_service().submit_callable_job(
+            func=execute_ingestion,
+            label="ingestion",
+            request=request.model_dump(),
+        )
+        response.status_code = 202
+        response.headers["Location"] = f"/internal/jobs/{job.job_id}"
+        return IngestionResponse(ingestion_id=job.job_id, status=job.status, dataset=None)
+
     dataset = _get_dataset_or_404(request.dataset_id)
     extent = get_extent_or_404()
     resolved_bbox = list(extent["bbox"])
@@ -98,9 +127,33 @@ def get_canonical_zarr_store_file(dataset_id: str, relative_path: str) -> FileRe
     return services.get_dataset_zarr_store_file_or_404(dataset_id, relative_path)
 
 
-@sync_router.post("/{dataset_id}", response_model=SyncResponse)
-def sync_dataset(dataset_id: str, request: SyncDatasetRequest) -> SyncResponse:
-    """Sync a managed dataset forward from its latest available time step."""
+@sync_router.post("/{dataset_id}")
+def sync_dataset(
+    dataset_id: str,
+    request: SyncDatasetRequest,
+    response: Response,
+    prefer: str | None = Header(default=None),
+) -> SyncResponse:
+    """Sync a managed dataset forward from its latest available time step.
+
+    Pass ``Prefer: respond-async`` to queue the sync as a background job and
+    return immediately with 202 + ``Location: /internal/jobs/{id}``.
+    """
+    if _prefer_respond_async(prefer):
+        from climate_api.ingestions.processes import execute_sync
+        from climate_api.jobs.service import get_job_service
+
+        job = get_job_service().submit_callable_job(
+            func=execute_sync,
+            label="sync",
+            request={"dataset_id": dataset_id, **request.model_dump()},
+        )
+        response.status_code = 202
+        response.headers["Location"] = f"/internal/jobs/{job.job_id}"
+        return SyncResponse(
+            sync_id=job.job_id, status=job.status, message="Sync queued", dataset=None, sync_detail=None
+        )
+
     return services.sync_dataset(
         dataset_id=dataset_id,
         end=request.end,

--- a/climate_api/ingestions/schemas.py
+++ b/climate_api/ingestions/schemas.py
@@ -201,7 +201,7 @@ class IngestionResponse(BaseModel):
 
     ingestion_id: str = Field(description="Identifier of the ingestion event.")
     status: str = Field(description="Execution status of the ingestion request.")
-    dataset: DatasetRecord = Field(description="Managed dataset summary produced or resolved by the ingestion.")
+    dataset: DatasetRecord | None = Field(default=None, description="Managed dataset summary. None for async requests.")
 
 
 class IngestionListResponse(BaseModel):
@@ -323,7 +323,10 @@ class SyncResponse(BaseModel):
     )
     status: str = Field(description="Execution status, for example completed or up_to_date.")
     message: str | None = Field(default=None, description="Human-readable explanation of the sync outcome.")
-    dataset: DatasetDetailRecord = Field(description="Current dataset detail after the sync operation.")
-    sync_detail: SyncDetail = Field(
-        description="Planner output describing how Climate API interpreted the sync request."
+    dataset: DatasetDetailRecord | None = Field(
+        default=None, description="Current dataset detail. None for async requests."
+    )
+    sync_detail: SyncDetail | None = Field(
+        default=None,
+        description="Planner output describing how Climate API interpreted the sync request.",
     )

--- a/climate_api/jobs/service.py
+++ b/climate_api/jobs/service.py
@@ -145,12 +145,19 @@ class JobService:
 
         ``func`` must be a module-level function so its dotted path can be stored
         in the job record and re-imported on restart.  ``label`` is the human-readable
-        process name shown in GET /internal/jobs/{id} as ``processID``.
+        process name shown in GET /jobs/{id} as ``processID``.
         """
-        fn_path = f"{func.__module__}.{func.__qualname__}"
+        qualname = getattr(func, "__qualname__", "")
+        if "<locals>" in qualname:
+            raise ValueError(f"submit_callable_job requires a module-level function; got {qualname!r}")
+        fn_path = f"{func.__module__}.{qualname}"
+        # Strip any caller-supplied __fn_path__ to prevent function-path injection,
+        # then set the reserved key so it cannot be overridden.
+        safe_request = {k: v for k, v in request.items() if k != "__fn_path__"}
+        safe_request["__fn_path__"] = fn_path
         return self._create_and_enqueue(
             process_id=label,
-            request={"__fn_path__": fn_path, **request},
+            request=safe_request,
             max_attempts=max_attempts,
         )
 
@@ -165,7 +172,9 @@ class JobService:
         process = process_registry.get_process(process_id)
         if process is None or not process["expose"]:
             raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
-        return self._create_and_enqueue(process_id=process_id, request=request, max_attempts=max_attempts)
+        # Strip the reserved key so a caller-supplied __fn_path__ cannot hijack execution.
+        safe_request = {k: v for k, v in request.items() if k != "__fn_path__"}
+        return self._create_and_enqueue(process_id=process_id, request=safe_request, max_attempts=max_attempts)
 
     def _create_and_enqueue(
         self,

--- a/climate_api/jobs/service.py
+++ b/climate_api/jobs/service.py
@@ -133,6 +133,27 @@ class JobService:
             raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
         return record
 
+    def submit_callable_job(
+        self,
+        *,
+        func: Any,
+        label: str,
+        request: dict[str, Any],
+        max_attempts: int = 1,
+    ) -> JobRecord:
+        """Submit a callable directly as a background job — no YAML registry needed.
+
+        ``func`` must be a module-level function so its dotted path can be stored
+        in the job record and re-imported on restart.  ``label`` is the human-readable
+        process name shown in GET /internal/jobs/{id} as ``processID``.
+        """
+        fn_path = f"{func.__module__}.{func.__qualname__}"
+        return self._create_and_enqueue(
+            process_id=label,
+            request={"__fn_path__": fn_path, **request},
+            max_attempts=max_attempts,
+        )
+
     def submit_process_job(
         self,
         *,
@@ -140,11 +161,19 @@ class JobService:
         request: dict[str, Any],
         max_attempts: int = 1,
     ) -> JobRecord:
-        """Create and asynchronously submit one process execution job."""
+        """Submit a YAML-registered process as a background job."""
         process = process_registry.get_process(process_id)
         if process is None or not process["expose"]:
             raise HTTPException(status_code=404, detail=f"Unknown process '{process_id}'")
+        return self._create_and_enqueue(process_id=process_id, request=request, max_attempts=max_attempts)
 
+    def _create_and_enqueue(
+        self,
+        *,
+        process_id: str,
+        request: dict[str, Any],
+        max_attempts: int,
+    ) -> JobRecord:
         job_id = str(uuid4())
         record = JobRecord(
             job_id=job_id,
@@ -388,12 +417,16 @@ class JobService:
                 return
 
     def _invoke_process(self, record: JobRecord) -> Any:
-        process = process_registry.get_process(record.process_id)
-        if process is None or not process["expose"]:
-            raise ValueError(f"Unknown process '{record.process_id}'")
-        func = process_registry.get_process_function(record.process_id)
+        fn_path = record.request.get("__fn_path__")
+        if fn_path and isinstance(fn_path, str):
+            func = process_registry._get_dynamic_function(fn_path)
+        else:
+            process = process_registry.get_process(record.process_id)
+            if process is None or not process["expose"]:
+                raise ValueError(f"Unknown process '{record.process_id}'")
+            func = process_registry.get_process_function(record.process_id)
         context = JobExecutionContext(self, record.job_id)
-        kwargs = dict(record.request)
+        kwargs = {k: v for k, v in record.request.items() if k != "__fn_path__"}
         if _supports_argument(func, "on_progress"):
             kwargs["on_progress"] = context.report_progress
         if _supports_argument(func, "is_cancel_requested"):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -255,6 +255,7 @@ def test_list_ingestions_returns_most_recent_first(monkeypatch: pytest.MonkeyPat
 
     assert result.kind == "IngestionList"
     assert [item.ingestion_id for item in result.items] == ["a2", "a1"]
+    assert result.items[0].dataset is not None
     assert result.items[0].dataset.dataset_id == "chirps3_precipitation_daily"
 
 

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -109,7 +109,9 @@ def test_sync_dataset_returns_up_to_date_when_no_new_period_is_due(monkeypatch: 
     assert result.sync_id is None
     assert result.status == "up_to_date"
     assert result.message == "Managed dataset is already current with upstream source state."
+    assert result.dataset is not None
     assert result.dataset.dataset_id == dataset_id
+    assert result.sync_detail is not None
     assert result.sync_detail.sync_kind == SyncKind.TEMPORAL
     assert result.sync_detail.action == SyncAction.NO_OP
     assert result.sync_detail.reason == "no_new_period"
@@ -146,6 +148,7 @@ def test_sync_dataset_creates_new_version_from_next_period(monkeypatch: pytest.M
     assert result.sync_id == "a2"
     assert result.status == "completed"
     assert result.message == "Managed dataset was rematerialized against the latest planned upstream state."
+    assert result.sync_detail is not None
     assert result.sync_detail.sync_kind == SyncKind.TEMPORAL
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
     assert result.sync_detail.reason == "new_periods_available"
@@ -209,6 +212,7 @@ def test_sync_dataset_append_policy_falls_back_to_rematerialize_without_icechunk
 
     assert "download_start" in captured
     assert captured["download_start"] is None
+    assert result.sync_detail is not None
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
     assert any("requires an existing Icechunk artifact" in message for message in messages)
 
@@ -250,6 +254,7 @@ def test_sync_dataset_append_policy_uses_store_based_append_for_plugin_backed_da
     assert "download_start" in captured
     assert captured["download_start"] == "2026-02-01"
     assert captured["download_end"] == "2026-02-10"
+    assert result.sync_detail is not None
     assert result.sync_detail.action == SyncAction.APPEND
     assert result.sync_detail.reason == "new_periods_available_for_append"
     assert "Data exists through 2026-01-31" in result.sync_detail.message
@@ -710,6 +715,7 @@ def test_sync_dataset_append_policy_falls_back_for_plugin_backed_non_icechunk_ar
     assert "download_start" in captured
     assert captured["download_start"] is None
     assert captured["download_end"] is None
+    assert result.sync_detail is not None
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
     assert result.sync_detail.reason == "new_periods_available"
     assert any("requires an existing Icechunk artifact" in message for message in infos)
@@ -735,6 +741,7 @@ def test_sync_dataset_release_policy_returns_up_to_date_when_release_matches(mon
 
     assert result.sync_id is None
     assert result.status == "up_to_date"
+    assert result.sync_detail is not None
     assert result.sync_detail.sync_kind == SyncKind.RELEASE
     assert result.sync_detail.action == SyncAction.NO_OP
     assert result.sync_detail.reason == "no_new_release"
@@ -785,6 +792,7 @@ def test_sync_dataset_release_policy_clamps_future_year_by_template_availability
     assert captured["start"] == "2026-01-01"
     assert captured["end"] == "2025"
     assert result.status == "completed"
+    assert result.sync_detail is not None
     assert result.sync_detail.sync_kind == SyncKind.RELEASE
     assert result.sync_detail.action == SyncAction.REMATERIALIZE
     assert result.sync_detail.target_end == "2025"
@@ -860,6 +868,7 @@ def test_sync_dataset_static_policy_returns_not_syncable_without_period_arithmet
 
     assert result.sync_id is None
     assert result.status == "not_syncable"
+    assert result.sync_detail is not None
     assert result.sync_detail.sync_kind == SyncKind.STATIC
     assert result.sync_detail.action == SyncAction.NOT_SYNCABLE
     assert result.sync_detail.reason == "static_dataset"

--- a/tests/test_ingestion_sync_async.py
+++ b/tests/test_ingestion_sync_async.py
@@ -1,0 +1,156 @@
+"""Tests for Prefer: respond-async on POST /ingestions and POST /sync/{dataset_id}."""
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from climate_api.ingestions.schemas import IngestionResponse, SyncResponse
+from tests.helpers import dataset_record
+
+
+def test_post_ingestion_respond_async_returns_202_with_location(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.registry_datasets.get_dataset",
+        lambda dataset_id: {
+            "id": dataset_id,
+            "name": "CHIRPS3 precipitation",
+            "variable": "precip",
+            "period_type": "daily",
+            "ingestion": {"plugin": "climate_api.streaming.plugins.chirps3.CHIRPS3DailyPlugin"},
+        },
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.get_extent_or_404",
+        lambda: {"bbox": [1.0, 2.0, 3.0, 4.0], "country_code": "SLE"},
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.services.create_artifact",
+        lambda **kwargs: type("Artifact", (), {"artifact_id": "artifact-123"})(),
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.services.get_ingestion_or_404",
+        lambda artifact_id: IngestionResponse(
+            ingestion_id=artifact_id,
+            status="completed",
+            dataset=dataset_record("chirps3_precipitation_daily"),
+        ),
+    )
+
+    response = client.post(
+        "/ingestions",
+        headers={"Prefer": "respond-async"},
+        json={
+            "dataset_id": "chirps3_precipitation_daily",
+            "start": "2026-01-01",
+            "end": "2026-01-03",
+            "publish": True,
+        },
+    )
+
+    assert response.status_code == 202
+    payload: dict[str, Any] = response.json()
+    job_id = payload["ingestion_id"]
+    assert response.headers["Location"] == f"/jobs/{job_id}"
+    assert payload["dataset"] is None
+
+
+def test_post_ingestion_without_prefer_header_returns_synchronous_response(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes._get_dataset_or_404",
+        lambda dataset_id: {"id": dataset_id},
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.get_extent_or_404",
+        lambda: {"bbox": [1.0, 2.0, 3.0, 4.0]},
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.services.create_artifact",
+        lambda **kwargs: type("Artifact", (), {"artifact_id": "artifact-sync"})(),
+    )
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.services.get_dataset_summary_for_artifact_or_404",
+        lambda artifact_id: dataset_record("chirps3_precipitation_daily"),
+    )
+
+    response = client.post(
+        "/ingestions",
+        json={"dataset_id": "chirps3_precipitation_daily", "start": "2026-01-01"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ingestion_id"] == "artifact-sync"
+
+
+def test_post_sync_respond_async_returns_202_with_location(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.processes.services.sync_dataset",
+        lambda **kwargs: {
+            "sync_id": "artifact-123",
+            "status": "completed",
+            "message": "Synced.",
+            "dataset": dataset_record("chirps3_precipitation_daily"),
+            "sync_detail": {
+                "source_dataset_id": "chirps3_precipitation_daily",
+                "sync_kind": "temporal",
+                "action": "append",
+                "reason": "new_periods_available_for_append",
+                "message": "Sync will append.",
+                "current_start": "2026-01-01",
+                "current_end": "2026-01-31",
+                "target_end": "2026-02-10",
+                "target_end_source": "request",
+                "delta_start": "2026-02-01",
+                "delta_end": "2026-02-10",
+            },
+        },
+    )
+
+    response = client.post(
+        "/sync/chirps3_precipitation_daily",
+        headers={"Prefer": "respond-async"},
+        json={"publish": True},
+    )
+
+    assert response.status_code == 202
+    payload: dict[str, Any] = response.json()
+    location = response.headers["Location"]
+    assert location.startswith("/jobs/")
+    assert payload["sync_id"] is None
+    assert payload["dataset"] is None
+    assert payload["sync_detail"] is None
+    assert payload["message"] == "Sync queued"
+
+
+def test_post_sync_without_prefer_header_returns_synchronous_response(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.services.sync_dataset",
+        lambda **kwargs: SyncResponse(
+            sync_id=None,
+            status="up_to_date",
+            message="Already current.",
+            dataset=None,
+            sync_detail=None,
+        ),
+    )
+
+    response = client.post(
+        "/sync/chirps3_precipitation_daily",
+        json={"publish": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "up_to_date"


### PR DESCRIPTION
## Summary

Adds opt-in async execution to the two long-running write endpoints via the standard \`Prefer: respond-async\` HTTP header.

- \`POST /ingestions\` with \`Prefer: respond-async\` → 202 + \`Location: /jobs/{id}\`
- \`POST /sync/{dataset_id}\` with \`Prefer: respond-async\` → 202 + \`Location: /jobs/{id}\`
- Without the header both endpoints behave exactly as before (synchronous, blocking)

For async responses \`ingestion_id\` holds the job id (poll \`GET /jobs/{id}\` for progress); \`sync_id\` is \`None\` since the artifact id is not yet known.

## Implementation

- \`JobService.submit_callable_job()\` — submits any module-level callable as a background job without a YAML process registry entry; the function dotted path is stored in the job record and re-imported on restart/recovery. Validates that \`func\` is module-level (no \`<locals>\`) and strips any caller-supplied \`__fn_path__\` from the request to prevent function-path injection.
- \`JobService._create_and_enqueue()\` — shared helper extracted from \`submit_process_job\` so both callable and process jobs use one enqueue path. \`submit_process_job\` also strips \`__fn_path__\` from incoming requests to prevent YAML registry bypass.
- \`_invoke_process()\` dispatches callable jobs via the stored \`__fn_path__\` before falling back to the YAML registry lookup.
- \`IngestionResponse.dataset\` and \`SyncResponse.dataset\`/\`sync_detail\` made optional (\`None\` for async responses where the result is not yet available).

Extracted from PR #157 so it can land on \`main\` independently.

## Test plan

- [x] \`uv run pytest tests/ -q\` — 325 passed, 1 skipped
- [x] \`uv run ruff check .\` and \`ruff format --check\` — clean
- [x] \`uv run pyright\` — 0 errors
- [x] \`POST /ingestions\` with \`Prefer: respond-async\` → 202 + \`Location: /jobs/{id}\`
- [x] \`POST /sync/{id}\` with \`Prefer: respond-async\` → 202 + \`Location: /jobs/{id}\`
- [x] Synchronous paths (no header) unchanged — 200 with full response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)