### PR TITLE
fix: validate async ingest and sync requests before enqueue

### DIFF
--- a/climate_api/ingestions/routes.py
+++ b/climate_api/ingestions/routes.py
@@ -44,6 +44,9 @@ def create_ingestion(
     return immediately with 202 + ``Location: /jobs/{id}``.
     """
     if _prefer_respond_async(prefer):
+        _get_dataset_or_404(request.dataset_id)
+        get_extent_or_404()
+
         from climate_api.ingestions.processes import execute_ingestion
         from climate_api.jobs.service import get_job_service
 
@@ -140,6 +143,8 @@ def sync_dataset(
     return immediately with 202 + ``Location: /jobs/{id}``.
     """
     if _prefer_respond_async(prefer):
+        services.plan_sync_dataset(dataset_id=dataset_id, end=request.end)
+
         from climate_api.ingestions.processes import execute_sync
         from climate_api.jobs.service import get_job_service
 

--- a/tests/test_ingestion_sync_async.py
+++ b/tests/test_ingestion_sync_async.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from climate_api.ingestions.schemas import IngestionResponse, SyncResponse
@@ -89,10 +90,45 @@ def test_post_ingestion_without_prefer_header_returns_synchronous_response(
     assert response.json()["ingestion_id"] == "artifact-sync"
 
 
+def test_post_ingestion_respond_async_rejects_unknown_dataset_immediately(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes._get_dataset_or_404",
+        lambda _dataset_id: (_ for _ in ()).throw(HTTPException(status_code=404, detail="Dataset not found")),
+    )
+
+    response = client.post(
+        "/ingestions",
+        headers={"Prefer": "respond-async"},
+        json={"dataset_id": "unknown_dataset", "start": "2026-01-01"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Dataset not found"
+
+
 def test_post_sync_respond_async_returns_202_with_location(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.services.plan_sync_dataset",
+        lambda **_kwargs: {
+            "source_dataset_id": "chirps3_precipitation_daily",
+            "sync_kind": "temporal",
+            "action": "append",
+            "reason": "new_periods_available_for_append",
+            "message": "Sync will append.",
+            "current_start": "2026-01-01",
+            "current_end": "2026-01-31",
+            "target_end": "2026-02-10",
+            "target_end_source": "request",
+            "delta_start": "2026-02-01",
+            "delta_end": "2026-02-10",
+        },
+    )
     monkeypatch.setattr(
         "climate_api.ingestions.processes.services.sync_dataset",
         lambda **kwargs: {
@@ -130,6 +166,25 @@ def test_post_sync_respond_async_returns_202_with_location(
     assert payload["dataset"] is None
     assert payload["sync_detail"] is None
     assert payload["message"] == "Sync queued"
+
+
+def test_post_sync_respond_async_rejects_unplannable_request_immediately(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "climate_api.ingestions.routes.services.plan_sync_dataset",
+        lambda **_kwargs: (_ for _ in ()).throw(HTTPException(status_code=400, detail="invalid end period")),
+    )
+
+    response = client.post(
+        "/sync/chirps3_precipitation_daily",
+        headers={"Prefer": "respond-async"},
+        json={"end": "bad-period", "publish": True},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid end period"
 
 
 def test_post_sync_without_prefer_header_returns_synchronous_response(


### PR DESCRIPTION
Preserves current request-time validation semantics for the async write endpoints introduced in #172. Async POST /ingestions now resolves dataset and extent before returning 202, and async POST /sync/{dataset_id} now runs sync planning first. Invalid requests still fail immediately with 4xx; only execution-time failures are deferred to the background job.