### PR TITLE
fix: improve manage sync UI and default map viewer to latest timestep

### DIFF
--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -168,6 +168,7 @@ async def manage_sync(request: Request) -> Response:
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", ""))
+        end = str(form.get("end", "")).strip() or None
         publish = "publish" in form
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
@@ -188,7 +189,7 @@ async def manage_sync(request: Request) -> Response:
     async def run() -> None:
         try:
             await asyncio.to_thread(
-                lambda: sync_dataset(dataset_id=dataset_id, end=None, publish=publish, on_progress=on_progress)
+                lambda: sync_dataset(dataset_id=dataset_id, end=end, publish=publish, on_progress=on_progress)
             )
             loop.call_soon_threadsafe(
                 queue.put_nowait,

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -235,6 +235,15 @@
         background: #fef9c3;
         color: #854d0e;
       }
+      .badge-sync-idle {
+        background: #e2e8f0;
+        color: #475569;
+        cursor: pointer;
+      }
+      .badge-sync-active {
+        background: #dbeafe;
+        color: #1d4ed8;
+      }
 
       .sync-form {
         display: flex;
@@ -259,6 +268,12 @@
       .sync-btn:disabled {
         opacity: 0.55;
         cursor: not-allowed;
+      }
+      .sync-trigger {
+        border: none;
+        padding: 0;
+        background: transparent;
+        font: inherit;
       }
       .secondary-btn {
         background: #fff;
@@ -458,8 +473,8 @@
               <th>Name</th>
               <th>Period</th>
               <th>Temporal coverage</th>
-              <th>Status</th>
-              <th></th>
+              <th>Publication</th>
+              <th>Sync</th>
             </tr>
           </thead>
           <tbody>
@@ -479,16 +494,16 @@
               </td>
               <td>
                 <form method="post" action="{{ base }}/manage/sync" class="sync-form"
-                      onsubmit="runJob(event, this, 'btn-sync-{{ ds.dataset_id }}', 'sync-progress-{{ ds.dataset_id }}')">
+                      onsubmit="runJob(event, this, 'sync-trigger-{{ ds.dataset_id }}', 'sync-progress-{{ ds.dataset_id }}', 'sync-status-{{ ds.dataset_id }}')">
                   <input type="hidden" name="dataset_id" value="{{ ds.dataset_id }}" />
                   <input type="hidden" name="publish" value="on" />
                   <button
                     type="button"
-                    id="btn-sync-{{ ds.dataset_id }}"
-                    class="sync-btn"
+                    id="sync-trigger-{{ ds.dataset_id }}"
+                    class="sync-trigger"
                     onclick="openSyncPanel('{{ ds.dataset_id }}')"
                   >
-                    Sync
+                    <span id="sync-status-{{ ds.dataset_id }}" class="badge badge-sync-idle">Start sync</span>
                   </button>
                   <div id="sync-panel-{{ ds.dataset_id }}" class="sync-panel">
                     <div class="field">
@@ -547,12 +562,13 @@
         if (input) input.value = '';
       }
 
-      async function runJob(event, form, btnId, progressId) {
+      async function runJob(event, form, btnId, progressId, statusId = null) {
         event.preventDefault();
         const btn = document.getElementById(btnId);
         const area = document.getElementById(progressId);
         const fill = area.querySelector('.progress-bar-fill');
         const label = area.querySelector('.progress-label');
+        const status = statusId ? document.getElementById(statusId) : null;
         const formData = new FormData(form);
         const controls = form.querySelectorAll('button, input:not([type="hidden"]), select, textarea');
 
@@ -563,6 +579,13 @@
         fill.className = 'progress-bar-fill indeterminate';
         fill.style.width = '0%';
         label.textContent = 'Starting…';
+        if (status) {
+          status.className = 'badge badge-sync-active';
+          status.textContent = 'syncing';
+        }
+        if (btn) {
+          btn.disabled = true;
+        }
 
         try {
           const resp = await fetch(form.action, {
@@ -607,6 +630,13 @@
           controls.forEach(control => {
             control.disabled = false;
           });
+          if (status) {
+            status.className = 'badge badge-sync-idle';
+            status.textContent = 'Start sync';
+          }
+          if (btn) {
+            btn.disabled = false;
+          }
         }
       }
     </script>

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -501,7 +501,8 @@
                     type="button"
                     id="sync-trigger-{{ ds.dataset_id }}"
                     class="sync-trigger"
-                    onclick="openSyncPanel('{{ ds.dataset_id }}')"
+                    data-dataset-id="{{ ds.dataset_id }}"
+                    onclick="openSyncPanel(this.dataset.datasetId)"
                   >
                     <span id="sync-status-{{ ds.dataset_id }}" class="badge badge-sync-idle">Start sync</span>
                   </button>
@@ -518,7 +519,12 @@
                     </div>
                     <div class="sync-panel-actions">
                       <button type="submit" class="sync-btn">Start sync</button>
-                      <button type="button" class="secondary-btn" onclick="closeSyncPanel('{{ ds.dataset_id }}')">Cancel</button>
+                      <button
+                        type="button"
+                        class="secondary-btn"
+                        data-dataset-id="{{ ds.dataset_id }}"
+                        onclick="closeSyncPanel(this.dataset.datasetId)"
+                      >Cancel</button>
                     </div>
                   </div>
                   <div id="sync-progress-{{ ds.dataset_id }}" class="progress-area" style="display:none">

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -568,6 +568,19 @@
         if (input) input.value = '';
       }
 
+      function restoreJobControls(controls, btn, status) {
+        controls.forEach(control => {
+          control.disabled = false;
+        });
+        if (status) {
+          status.className = 'badge badge-sync-idle';
+          status.textContent = 'Start sync';
+        }
+        if (btn) {
+          btn.disabled = false;
+        }
+      }
+
       async function runJob(event, form, btnId, progressId, statusId = null) {
         event.preventDefault();
         const btn = document.getElementById(btnId);
@@ -631,18 +644,12 @@
               }
             }
           }
+          label.textContent = 'Error: Sync ended unexpectedly.';
+          restoreJobControls(controls, btn, status);
         } catch (err) {
-          label.textContent = 'Error: ' + err.message;
-          controls.forEach(control => {
-            control.disabled = false;
-          });
-          if (status) {
-            status.className = 'badge badge-sync-idle';
-            status.textContent = 'Start sync';
-          }
-          if (btn) {
-            btn.disabled = false;
-          }
+          const message = err instanceof Error ? err.message : String(err);
+          label.textContent = 'Error: ' + message;
+          restoreJobControls(controls, btn, status);
         }
       }
     </script>

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -479,6 +479,7 @@
           </thead>
           <tbody>
             {% for ds in datasets %}
+            {% set sync_dom_id = "sync-row-" ~ loop.index0 %}
             <tr>
               <td>
                 <a href="{{ base }}/datasets/{{ ds.dataset_id }}">{{ ds.dataset_name }}</a>
@@ -493,25 +494,33 @@
                 {% endif %}
               </td>
               <td>
-                <form method="post" action="{{ base }}/manage/sync" class="sync-form"
-                      onsubmit="runJob(event, this, 'sync-trigger-{{ ds.dataset_id }}', 'sync-progress-{{ ds.dataset_id }}', 'sync-status-{{ ds.dataset_id }}')">
+                <form
+                  method="post"
+                  action="{{ base }}/manage/sync"
+                  class="sync-form"
+                  data-trigger-id="sync-trigger-{{ sync_dom_id }}"
+                  data-progress-id="sync-progress-{{ sync_dom_id }}"
+                  data-status-id="sync-status-{{ sync_dom_id }}"
+                  onsubmit="runJob(event, this, this.dataset.triggerId, this.dataset.progressId, this.dataset.statusId)"
+                >
                   <input type="hidden" name="dataset_id" value="{{ ds.dataset_id }}" />
                   <input type="hidden" name="publish" value="on" />
                   <button
                     type="button"
-                    id="sync-trigger-{{ ds.dataset_id }}"
+                    id="sync-trigger-{{ sync_dom_id }}"
                     class="sync-trigger"
                     data-dataset-id="{{ ds.dataset_id }}"
-                    onclick="openSyncPanel(this.dataset.datasetId)"
+                    data-sync-dom-id="{{ sync_dom_id }}"
+                    onclick="openSyncPanel(this.dataset.syncDomId)"
                   >
-                    <span id="sync-status-{{ ds.dataset_id }}" class="badge badge-sync-idle">Start sync</span>
+                    <span id="sync-status-{{ sync_dom_id }}" class="badge badge-sync-idle">Start sync</span>
                   </button>
-                  <div id="sync-panel-{{ ds.dataset_id }}" class="sync-panel">
+                  <div id="sync-panel-{{ sync_dom_id }}" class="sync-panel">
                     <div class="field">
-                      <label for="sync-end-{{ ds.dataset_id }}">Cutoff end <span style="font-weight:400;text-transform:none;letter-spacing:0">(optional)</span></label>
+                      <label for="sync-end-{{ sync_dom_id }}">Cutoff end <span style="font-weight:400;text-transform:none;letter-spacing:0">(optional)</span></label>
                       <input
                         type="text"
-                        id="sync-end-{{ ds.dataset_id }}"
+                        id="sync-end-{{ sync_dom_id }}"
                         name="end"
                         placeholder="YYYY-MM-DD"
                       />
@@ -523,11 +532,12 @@
                         type="button"
                         class="secondary-btn"
                         data-dataset-id="{{ ds.dataset_id }}"
-                        onclick="closeSyncPanel(this.dataset.datasetId)"
+                        data-sync-dom-id="{{ sync_dom_id }}"
+                        onclick="closeSyncPanel(this.dataset.syncDomId)"
                       >Cancel</button>
                     </div>
                   </div>
-                  <div id="sync-progress-{{ ds.dataset_id }}" class="progress-area" style="display:none">
+                  <div id="sync-progress-{{ sync_dom_id }}" class="progress-area" style="display:none">
                     <div class="progress-bar-track">
                       <div class="progress-bar-fill indeterminate"></div>
                     </div>
@@ -552,17 +562,17 @@
     </footer>
 
     <script>
-      function openSyncPanel(datasetId) {
-        const panel = document.getElementById(`sync-panel-${datasetId}`);
-        const input = document.getElementById(`sync-end-${datasetId}`);
+      function openSyncPanel(syncDomId) {
+        const panel = document.getElementById(`sync-panel-${syncDomId}`);
+        const input = document.getElementById(`sync-end-${syncDomId}`);
         if (!panel) return;
         panel.classList.add('open');
         if (input) input.focus();
       }
 
-      function closeSyncPanel(datasetId) {
-        const panel = document.getElementById(`sync-panel-${datasetId}`);
-        const input = document.getElementById(`sync-end-${datasetId}`);
+      function closeSyncPanel(syncDomId) {
+        const panel = document.getElementById(`sync-panel-${syncDomId}`);
+        const input = document.getElementById(`sync-end-${syncDomId}`);
         if (!panel) return;
         panel.classList.remove('open');
         if (input) input.value = '';

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -237,26 +237,67 @@
       }
 
       .sync-form {
-        display: inline;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.6rem;
       }
       .sync-btn {
-        background: none;
-        border: 1px solid #cbd5e1;
-        border-radius: 4px;
-        padding: 0.2rem 0.6rem;
-        font-size: 0.78rem;
+        background: #1a2332;
+        color: #fff;
+        border: none;
+        border-radius: 5px;
+        padding: 0.5rem 1.25rem;
+        font-size: 0.875rem;
         font-weight: 500;
-        color: #475569;
         cursor: pointer;
         font-family: inherit;
       }
       .sync-btn:hover {
-        background: #f1f5f9;
-        border-color: #94a3b8;
+        background: #263547;
       }
       .sync-btn:disabled {
         opacity: 0.55;
         cursor: not-allowed;
+      }
+      .secondary-btn {
+        background: #fff;
+        color: #475569;
+        border: 1px solid #cbd5e1;
+        border-radius: 5px;
+        padding: 0.45rem 1rem;
+        font-size: 0.82rem;
+        font-weight: 500;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .secondary-btn:hover {
+        background: #f8fafc;
+        border-color: #94a3b8;
+      }
+      .secondary-btn:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+      .sync-panel {
+        display: none;
+        min-width: 260px;
+        padding: 0.85rem 1rem;
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+      }
+      .sync-panel.open {
+        display: block;
+      }
+      .sync-panel .field {
+        gap: 0.35rem;
+      }
+      .sync-panel-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-top: 0.85rem;
       }
 
       .divider {
@@ -441,7 +482,30 @@
                       onsubmit="runJob(event, this, 'btn-sync-{{ ds.dataset_id }}', 'sync-progress-{{ ds.dataset_id }}')">
                   <input type="hidden" name="dataset_id" value="{{ ds.dataset_id }}" />
                   <input type="hidden" name="publish" value="on" />
-                  <button type="submit" id="btn-sync-{{ ds.dataset_id }}" class="sync-btn">Sync</button>
+                  <button
+                    type="button"
+                    id="btn-sync-{{ ds.dataset_id }}"
+                    class="sync-btn"
+                    onclick="openSyncPanel('{{ ds.dataset_id }}')"
+                  >
+                    Sync
+                  </button>
+                  <div id="sync-panel-{{ ds.dataset_id }}" class="sync-panel">
+                    <div class="field">
+                      <label for="sync-end-{{ ds.dataset_id }}">Cutoff end <span style="font-weight:400;text-transform:none;letter-spacing:0">(optional)</span></label>
+                      <input
+                        type="text"
+                        id="sync-end-{{ ds.dataset_id }}"
+                        name="end"
+                        placeholder="YYYY-MM-DD"
+                      />
+                      <span class="hint">Leave blank to sync through the latest available period.</span>
+                    </div>
+                    <div class="sync-panel-actions">
+                      <button type="submit" class="sync-btn">Start sync</button>
+                      <button type="button" class="secondary-btn" onclick="closeSyncPanel('{{ ds.dataset_id }}')">Cancel</button>
+                    </div>
+                  </div>
                   <div id="sync-progress-{{ ds.dataset_id }}" class="progress-area" style="display:none">
                     <div class="progress-bar-track">
                       <div class="progress-bar-fill indeterminate"></div>
@@ -467,22 +531,43 @@
     </footer>
 
     <script>
+      function openSyncPanel(datasetId) {
+        const panel = document.getElementById(`sync-panel-${datasetId}`);
+        const input = document.getElementById(`sync-end-${datasetId}`);
+        if (!panel) return;
+        panel.classList.add('open');
+        if (input) input.focus();
+      }
+
+      function closeSyncPanel(datasetId) {
+        const panel = document.getElementById(`sync-panel-${datasetId}`);
+        const input = document.getElementById(`sync-end-${datasetId}`);
+        if (!panel) return;
+        panel.classList.remove('open');
+        if (input) input.value = '';
+      }
+
       async function runJob(event, form, btnId, progressId) {
         event.preventDefault();
         const btn = document.getElementById(btnId);
         const area = document.getElementById(progressId);
         const fill = area.querySelector('.progress-bar-fill');
         const label = area.querySelector('.progress-label');
+        const formData = new FormData(form);
+        const controls = form.querySelectorAll('button, input:not([type="hidden"]), select, textarea');
 
-        btn.disabled = true;
+        controls.forEach(control => {
+          control.disabled = true;
+        });
         area.style.display = 'block';
         fill.className = 'progress-bar-fill indeterminate';
+        fill.style.width = '0%';
         label.textContent = 'Starting…';
 
         try {
           const resp = await fetch(form.action, {
             method: 'POST',
-            body: new FormData(form),
+            body: formData,
           });
 
           if (!resp.ok || !resp.body) {
@@ -519,7 +604,9 @@
           }
         } catch (err) {
           label.textContent = 'Error: ' + err.message;
-          btn.disabled = false;
+          controls.forEach(control => {
+            control.disabled = false;
+          });
         }
       }
     </script>

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -291,6 +291,10 @@
         return Array.isArray(timeSteps) ? timeSteps.length : timeSteps.count;
       }
 
+      function initialTimeIndex() {
+        return Math.max(0, timeStepCount() - 1);
+      }
+
       function timeStepAt(i) {
         if (Array.isArray(timeSteps)) return timeSteps[i];
         return new Date(new Date(timeSteps.start).getTime() + i * timeSteps.inc)
@@ -495,7 +499,7 @@
           cm = buildColormap(colormapName);
           const zarrVersion = zarr["zarr:zarr_format"] ?? null;
           const selector =
-            timeStepCount() > 0 ? { [timeDimKey]: 0 } : {};
+            timeStepCount() > 0 ? { [timeDimKey]: initialTimeIndex() } : {};
           activeLayer = new ZarrLayer({
             id: "zarr-layer",
             source: zarr.href,
@@ -523,10 +527,11 @@
 
         // Time slider.
         if (timeStepCount() > 1) {
+          const initialIndex = initialTimeIndex();
           timeSlider.max = timeStepCount() - 1;
-          timeSlider.value = 0;
-          timeValueEl.textContent = timeStepAt(0);
-          timeCountEl.textContent = `1 / ${timeStepCount()}`;
+          timeSlider.value = initialIndex;
+          timeValueEl.textContent = timeStepAt(initialIndex);
+          timeCountEl.textContent = `${initialIndex + 1} / ${timeStepCount()}`;
           timeSection.classList.remove("hidden");
         }
 

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -1,0 +1,101 @@
+from collections.abc import Callable, Coroutine
+
+import pytest
+from starlette.datastructures import URL
+from starlette.responses import StreamingResponse
+
+from open_climate_service.ingestions import services as ingestion_services
+from open_climate_service.system import routes as system_routes
+
+
+class _FakeRequest:
+    def __init__(self, form_data: dict[str, str]) -> None:
+        self._form_data = form_data
+        self.base_url = URL("http://testserver/")
+
+    async def form(self) -> dict[str, str]:
+        return self._form_data
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_sync_forwards_provided_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    scheduled: list[Coroutine[object, object, None]] = []
+
+    def fake_sync_dataset(
+        *,
+        dataset_id: str,
+        end: str | None,
+        publish: bool,
+        on_progress: Callable[[int | None, int | None, str | None], None],
+    ) -> None:
+        captured["dataset_id"] = dataset_id
+        captured["end"] = end
+        captured["publish"] = publish
+        on_progress(1, 1, "done")
+
+    async def fake_to_thread(func: Callable[[], None]) -> None:
+        func()
+
+    def fake_create_task(coro: Coroutine[object, object, None]) -> None:
+        scheduled.append(coro)
+        return None
+
+    monkeypatch.setattr(ingestion_services, "sync_dataset", fake_sync_dataset)
+    monkeypatch.setattr(system_routes.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
+
+    response = await system_routes.manage_sync(
+        _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "2026-02-10", "publish": "on"})
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert len(scheduled) == 1
+    await scheduled[0]
+    assert captured == {
+        "dataset_id": "chirps3_precipitation_daily",
+        "end": "2026-02-10",
+        "publish": True,
+    }
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    scheduled: list[Coroutine[object, object, None]] = []
+
+    def fake_sync_dataset(
+        *,
+        dataset_id: str,
+        end: str | None,
+        publish: bool,
+        on_progress: Callable[[int | None, int | None, str | None], None],
+    ) -> None:
+        captured["dataset_id"] = dataset_id
+        captured["end"] = end
+        captured["publish"] = publish
+        on_progress(1, 1, "done")
+
+    async def fake_to_thread(func: Callable[[], None]) -> None:
+        func()
+
+    def fake_create_task(coro: Coroutine[object, object, None]) -> None:
+        scheduled.append(coro)
+        return None
+
+    monkeypatch.setattr(ingestion_services, "sync_dataset", fake_sync_dataset)
+    monkeypatch.setattr(system_routes.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
+
+    response = await system_routes.manage_sync(
+        _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "", "publish": "on"})
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert len(scheduled) == 1
+    await scheduled[0]
+    assert captured == {
+        "dataset_id": "chirps3_precipitation_daily",
+        "end": None,
+        "publish": True,
+    }

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -123,7 +123,7 @@ def test_manage_page_shows_split_publication_and_sync_columns(
                 "Dataset",
                 (),
                 {
-                    "dataset_id": "chirps3_precipitation_daily",
+                    "dataset_id": "chirps3_precipitation_daily'quoted",
                     "dataset_name": "CHIRPS3 precipitation",
                     "period_type": "daily",
                     "extent": type(
@@ -144,6 +144,9 @@ def test_manage_page_shows_split_publication_and_sync_columns(
     assert "<th>Sync</th>" in response.text
     assert "Start sync" in response.text
     assert "Cutoff end" in response.text
+    assert 'data-dataset-id="chirps3_precipitation_daily&#39;quoted"' in response.text
+    assert 'onclick="openSyncPanel(this.dataset.datasetId)"' in response.text
+    assert 'onclick="closeSyncPanel(this.dataset.datasetId)"' in response.text
 
 
 def test_map_viewer_initializes_at_latest_timestep(client: TestClient) -> None:

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -1,11 +1,15 @@
 from collections.abc import Callable, Coroutine
+from typing import cast
 
 import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
 from starlette.datastructures import URL
 from starlette.responses import StreamingResponse
 
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.system import routes as system_routes
+from open_climate_service.system import templates as system_templates
 
 
 class _FakeRequest:
@@ -15,6 +19,11 @@ class _FakeRequest:
 
     async def form(self) -> dict[str, str]:
         return self._form_data
+
+
+@pytest.fixture(autouse=True)
+def _clear_template_cache() -> None:
+    system_templates._cache.clear()
 
 
 @pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
@@ -46,7 +55,7 @@ async def test_manage_sync_forwards_provided_end(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
 
     response = await system_routes.manage_sync(
-        _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "2026-02-10", "publish": "on"})
+        cast(Request, _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "2026-02-10", "publish": "on"}))
     )
 
     assert isinstance(response, StreamingResponse)
@@ -88,7 +97,7 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
 
     response = await system_routes.manage_sync(
-        _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "", "publish": "on"})
+        cast(Request, _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "", "publish": "on"}))
     )
 
     assert isinstance(response, StreamingResponse)
@@ -99,3 +108,48 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
         "end": None,
         "publish": True,
     }
+
+
+def test_manage_page_shows_split_publication_and_sync_columns(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(system_templates, "_load_templates", lambda: [])
+    monkeypatch.setattr(system_templates, "_load_extent", lambda: {"id": "sle", "name": "Sierra Leone", "bbox": []})
+    monkeypatch.setattr(
+        system_templates,
+        "_load_datasets",
+        lambda: [
+            type(
+                "Dataset",
+                (),
+                {
+                    "dataset_id": "chirps3_precipitation_daily",
+                    "dataset_name": "CHIRPS3 precipitation",
+                    "period_type": "daily",
+                    "extent": type(
+                        "Extent",
+                        (),
+                        {"temporal": type("Temporal", (), {"start": "2026-01-01", "end": "2026-01-10"})()},
+                    )(),
+                    "publication": type("Publication", (), {"status": "published"})(),
+                },
+            )()
+        ],
+    )
+
+    response = client.get("/manage")
+
+    assert response.status_code == 200
+    assert "<th>Publication</th>" in response.text
+    assert "<th>Sync</th>" in response.text
+    assert "Start sync" in response.text
+    assert "Cutoff end" in response.text
+
+
+def test_map_viewer_initializes_at_latest_timestep(client: TestClient) -> None:
+    response = client.get("/map")
+
+    assert response.status_code == 200
+    assert "function initialTimeIndex()" in response.text
+    assert "{ [timeDimKey]: initialTimeIndex() }" in response.text
+    assert "timeSlider.value = initialIndex;" in response.text

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -147,6 +147,9 @@ def test_manage_page_shows_split_publication_and_sync_columns(
     assert 'data-dataset-id="chirps3_precipitation_daily&#39;quoted"' in response.text
     assert 'onclick="openSyncPanel(this.dataset.datasetId)"' in response.text
     assert 'onclick="closeSyncPanel(this.dataset.datasetId)"' in response.text
+    assert "function restoreJobControls(controls, btn, status)" in response.text
+    assert "label.textContent = 'Error: Sync ended unexpectedly.';" in response.text
+    assert "const message = err instanceof Error ? err.message : String(err);" in response.text
 
 
 def test_map_viewer_initializes_at_latest_timestep(client: TestClient) -> None:

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Coroutine
+from html.parser import HTMLParser
 from typing import cast
 
 import pytest
@@ -10,6 +11,40 @@ from starlette.responses import StreamingResponse
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.system import routes as system_routes
 from open_climate_service.system import templates as system_templates
+
+
+class _ManageHtmlParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.current_sync_form: dict[str, str] | None = None
+        self.sync_forms_by_dataset_id: dict[str, dict[str, str]] = {}
+        self.sync_triggers: dict[str, dict[str, str]] = {}
+        self.cancel_buttons: dict[str, dict[str, str]] = {}
+
+    @staticmethod
+    def _has_class(attr_map: dict[str, str], class_name: str) -> bool:
+        return class_name in attr_map.get("class", "").split()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key: value for key, value in attrs if value is not None}
+        if tag == "form" and self._has_class(attr_map, "sync-form") and "data-trigger-id" in attr_map:
+            self.current_sync_form = attr_map
+        if (
+            tag == "input"
+            and self.current_sync_form is not None
+            and attr_map.get("type") == "hidden"
+            and attr_map.get("name") == "dataset_id"
+            and "value" in attr_map
+        ):
+            self.sync_forms_by_dataset_id[attr_map["value"]] = self.current_sync_form
+        if tag == "button" and "data-dataset-id" in attr_map and attr_map.get("id", "").startswith("sync-trigger-"):
+            self.sync_triggers[attr_map["data-dataset-id"]] = attr_map
+        if tag == "button" and self._has_class(attr_map, "secondary-btn") and "data-dataset-id" in attr_map:
+            self.cancel_buttons[attr_map["data-dataset-id"]] = attr_map
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form":
+            self.current_sync_form = None
 
 
 class _FakeRequest:
@@ -113,6 +148,7 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
 def test_manage_page_shows_split_publication_and_sync_columns(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    dataset_id = "chirps3_precipitation_daily'quoted"
     monkeypatch.setattr(system_templates, "_load_templates", lambda: [])
     monkeypatch.setattr(system_templates, "_load_extent", lambda: {"id": "sle", "name": "Sierra Leone", "bbox": []})
     monkeypatch.setattr(
@@ -123,7 +159,7 @@ def test_manage_page_shows_split_publication_and_sync_columns(
                 "Dataset",
                 (),
                 {
-                    "dataset_id": "chirps3_precipitation_daily'quoted",
+                    "dataset_id": dataset_id,
                     "dataset_name": "CHIRPS3 precipitation",
                     "period_type": "daily",
                     "extent": type(
@@ -140,13 +176,33 @@ def test_manage_page_shows_split_publication_and_sync_columns(
     response = client.get("/manage")
 
     assert response.status_code == 200
+
+    parser = _ManageHtmlParser()
+    parser.feed(response.text)
+    sync_form_attrs = parser.sync_forms_by_dataset_id.get(dataset_id)
+    sync_trigger_attrs = parser.sync_triggers.get(dataset_id)
+    cancel_button_attrs = parser.cancel_buttons.get(dataset_id)
+
     assert "<th>Publication</th>" in response.text
     assert "<th>Sync</th>" in response.text
     assert "Start sync" in response.text
     assert "Cutoff end" in response.text
-    assert 'data-dataset-id="chirps3_precipitation_daily&#39;quoted"' in response.text
-    assert 'onclick="openSyncPanel(this.dataset.datasetId)"' in response.text
-    assert 'onclick="closeSyncPanel(this.dataset.datasetId)"' in response.text
+    assert sync_form_attrs is not None
+    assert sync_form_attrs["data-trigger-id"].startswith("sync-trigger-sync-row-")
+    assert sync_form_attrs["data-progress-id"].startswith("sync-progress-sync-row-")
+    assert sync_form_attrs["data-status-id"].startswith("sync-status-sync-row-")
+    assert "runJob(" in sync_form_attrs["onsubmit"]
+    assert "this.dataset.triggerId" in sync_form_attrs["onsubmit"]
+    assert "this.dataset.progressId" in sync_form_attrs["onsubmit"]
+    assert "this.dataset.statusId" in sync_form_attrs["onsubmit"]
+    assert sync_trigger_attrs is not None
+    assert sync_trigger_attrs["data-dataset-id"] == dataset_id
+    assert sync_trigger_attrs["data-sync-dom-id"].startswith("sync-row-")
+    assert sync_trigger_attrs["onclick"] == "openSyncPanel(this.dataset.syncDomId)"
+    assert cancel_button_attrs is not None
+    assert cancel_button_attrs["data-dataset-id"] == dataset_id
+    assert cancel_button_attrs["data-sync-dom-id"] == sync_trigger_attrs["data-sync-dom-id"]
+    assert cancel_button_attrs["onclick"] == "closeSyncPanel(this.dataset.syncDomId)"
     assert "function restoreJobControls(controls, btn, status)" in response.text
     assert "label.textContent = 'Error: Sync ended unexpectedly.';" in response.text
     assert "const message = err instanceof Error ? err.message : String(err);" in response.text


### PR DESCRIPTION
## Summary

This PR improves the manage/sync workflow and fixes the map viewer's initial timestep selection.

## Changes

- split the manage table into separate `Publication` and `Sync` columns
- open the cutoff-end panel from the sync action
- show sync status on the inline badge while a sync is running
- default the map viewer to the latest available timestep instead of index `0`