### PR TITLE
fix: restore native ingestion job surface

### DIFF
--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -84,7 +84,7 @@ def create_ingestion(
             job_href_base=INGESTION_JOB_HREF_BASE,
         )
         response.status_code = 202
-        response.headers["Location"] = f"/ingestions/jobs/{job.job_id}"
+        response.headers["Location"] = f"{INGESTION_JOB_HREF_BASE}/{job.job_id}"
         return IngestionResponse(ingestion_id=job.job_id, status=job.status, dataset=None)
     dataset = _get_dataset_or_404(request.dataset_id)
     extent = get_extent_or_404()
@@ -182,7 +182,7 @@ def sync_dataset(
             job_href_base=INGESTION_JOB_HREF_BASE,
         )
         response.status_code = 202
-        response.headers["Location"] = f"/ingestions/jobs/{job.job_id}"
+        response.headers["Location"] = f"{INGESTION_JOB_HREF_BASE}/{job.job_id}"
         return SyncResponse(sync_id=None, status=job.status, message="Sync queued", dataset=None, sync_detail=None)
 
     return services.sync_dataset(

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -18,11 +18,14 @@ from open_climate_service.ingestions.schemas import (
     SyncResponse,
 )
 from open_climate_service.jobs.models import JobLink, JobRecord
+from open_climate_service.jobs.service import get_job_service
 
 ingestions_router = APIRouter()
 datasets_router = APIRouter()
 zarr_router = APIRouter()
 sync_router = APIRouter()
+
+INGESTION_JOB_HREF_BASE = "/ingestions/jobs"
 
 
 def _prefer_respond_async(prefer: str | None) -> bool:
@@ -30,6 +33,12 @@ def _prefer_respond_async(prefer: str | None) -> bool:
         return False
     directives = [item.strip().split(";", 1)[0].strip().lower() for item in prefer.split(",")]
     return "respond-async" in directives
+
+
+def _with_ingestion_job_self_link(record: JobRecord) -> JobRecord:
+    self_link = JobLink(href=f"{INGESTION_JOB_HREF_BASE}/{record.job_id}", rel="self", title="Job detail")
+    other_links = [link for link in record.links if link.rel != "self"]
+    return record.model_copy(update={"links": [self_link, *other_links]})
 
 
 @ingestions_router.get("/jobs/{job_id}", response_model=JobRecord)
@@ -40,9 +49,14 @@ def get_ingestion_job(job_id: str) -> JobRecord:
     record = store.get_job_record(job_id)
     if record is None:
         raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
-    return record.model_copy(
-        update={"links": [JobLink(href=f"/ingestions/jobs/{job_id}", rel="self", title="Job detail")]}
-    )
+    return _with_ingestion_job_self_link(record)
+
+
+@ingestions_router.delete("/jobs/{job_id}", response_model=JobRecord, status_code=202)
+def cancel_ingestion_job(job_id: str) -> JobRecord:
+    """Request cooperative cancellation for an async ingestion or sync job."""
+    record = get_job_service().request_cancellation(job_id)
+    return _with_ingestion_job_self_link(record)
 
 
 @ingestions_router.post("")
@@ -67,6 +81,7 @@ def create_ingestion(
             func=execute_ingestion,
             label="ingestion",
             request=request.model_dump(),
+            job_href_base=INGESTION_JOB_HREF_BASE,
         )
         response.status_code = 202
         response.headers["Location"] = f"/ingestions/jobs/{job.job_id}"
@@ -164,6 +179,7 @@ def sync_dataset(
             func=execute_sync,
             label="sync",
             request={"dataset_id": dataset_id, **request.model_dump()},
+            job_href_base=INGESTION_JOB_HREF_BASE,
         )
         response.status_code = 202
         response.headers["Location"] = f"/ingestions/jobs/{job.job_id}"

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -36,6 +36,8 @@ def _retry_delay_seconds(attempt: int) -> int:
 
 def _job_links(job_id: str, href_base: str = "/jobs") -> list[JobLink]:
     base = href_base.rstrip("/")
+    if not base:
+        base = "/jobs"
     return [JobLink(href=f"{base}/{job_id}", rel="self", title="Job detail")]
 
 

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -34,8 +34,9 @@ def _retry_delay_seconds(attempt: int) -> int:
     return int(min(240, 60 * (2**exponent)))
 
 
-def _job_links(job_id: str) -> list[JobLink]:
-    return [JobLink(href=f"/jobs/{job_id}", rel="self", title="Job detail")]
+def _job_links(job_id: str, href_base: str = "/jobs") -> list[JobLink]:
+    base = href_base.rstrip("/")
+    return [JobLink(href=f"{base}/{job_id}", rel="self", title="Job detail")]
 
 
 def _catalog_links() -> list[JobLink]:
@@ -140,6 +141,7 @@ class JobService:
         label: str,
         request: dict[str, Any],
         max_attempts: int = 1,
+        job_href_base: str = "/jobs",
     ) -> JobRecord:
         """Submit a callable directly as a background job — no YAML registry needed.
 
@@ -159,6 +161,7 @@ class JobService:
             process_id=label,
             request=safe_request,
             max_attempts=max_attempts,
+            job_href_base=job_href_base,
         )
 
     def _create_and_enqueue(
@@ -167,6 +170,7 @@ class JobService:
         process_id: str,
         request: dict[str, Any],
         max_attempts: int,
+        job_href_base: str,
     ) -> JobRecord:
         job_id = str(uuid4())
         record = JobRecord(
@@ -177,7 +181,7 @@ class JobService:
             max_attempts=max_attempts,
             executor_kind=self._executor.kind,
             request=request,
-            links=_job_links(job_id),
+            links=_job_links(job_id, href_base=job_href_base),
         )
         store.create_job_record(record)
         self._enqueue_job(record.job_id)

--- a/tests/test_ingestion_async.py
+++ b/tests/test_ingestion_async.py
@@ -128,7 +128,7 @@ def test_post_ingestion_without_prefer_does_not_return_202(client: TestClient, m
         lambda _: {"id": "chirps3_precipitation_daily"},
     )
 
-    def raise_no_extent() -> dict[str, object]:
+    def raise_no_extent() -> NoReturn:
         raise HTTPException(status_code=422, detail="no extent")
 
     monkeypatch.setattr("open_climate_service.ingestions.routes.get_extent_or_404", raise_no_extent)

--- a/tests/test_ingestion_async.py
+++ b/tests/test_ingestion_async.py
@@ -1,11 +1,14 @@
 """Tests for async ingestion and sync via Prefer: respond-async."""
 
+from typing import NoReturn
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from open_climate_service.jobs.models import JobRecord, JobStatus
+from open_climate_service.jobs.models import JobProgress, JobRecord, JobStatus
+from open_climate_service.jobs.service import JobService
 
 
 def _make_job(job_id: str = "job-123") -> JobRecord:
@@ -21,6 +24,10 @@ def _make_job(job_id: str = "job-123") -> JobRecord:
         request={},
         links=[],
     )
+
+
+def _fake_job_callable() -> dict[str, object]:
+    return {"ok": True}
 
 
 def test_post_ingestion_respond_async_returns_202_with_location(
@@ -80,6 +87,32 @@ def test_get_ingestion_job_returns_job_with_correct_self_link(
     assert links["self"] == "/ingestions/jobs/job-789"
 
 
+def test_cancel_ingestion_job_requests_cancellation_and_returns_native_self_link(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job = _make_job("job-cancel")
+    cancelled = job.model_copy(
+        update={
+            "cancel_requested": True,
+            "progress": JobProgress(message="Cancellation requested"),
+        }
+    )
+    monkeypatch.setattr(
+        "open_climate_service.jobs.service.JobService.request_cancellation",
+        lambda self, job_id: cancelled,
+    )
+
+    response = client.delete("/ingestions/jobs/job-cancel")
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["jobID"] == "job-cancel"
+    assert payload["status"] == "accepted"
+    assert payload["cancelRequested"] is True
+    links = {lnk["rel"]: lnk["href"] for lnk in payload["links"]}
+    assert links["self"] == "/ingestions/jobs/job-cancel"
+
+
 def test_get_ingestion_job_returns_404_for_unknown(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("open_climate_service.jobs.store.get_job_record", lambda job_id: None)
 
@@ -94,12 +127,11 @@ def test_post_ingestion_without_prefer_does_not_return_202(client: TestClient, m
         "open_climate_service.ingestions.routes._get_dataset_or_404",
         lambda _: {"id": "chirps3_precipitation_daily"},
     )
-    from fastapi import HTTPException
 
-    monkeypatch.setattr(
-        "open_climate_service.ingestions.routes.get_extent_or_404",
-        lambda: (_ for _ in ()).throw(HTTPException(status_code=422, detail="no extent")),
-    )
+    def raise_no_extent() -> dict[str, object]:
+        raise HTTPException(status_code=422, detail="no extent")
+
+    monkeypatch.setattr("open_climate_service.ingestions.routes.get_extent_or_404", raise_no_extent)
 
     response = client.post(
         "/ingestions",
@@ -108,3 +140,119 @@ def test_post_ingestion_without_prefer_does_not_return_202(client: TestClient, m
 
     assert response.status_code == 422
     assert "Location" not in response.headers
+
+
+def test_post_ingestion_respond_async_validates_dataset_and_extent_before_queueing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def fake_submit_callable_job(
+        *,
+        func: object,
+        label: str,
+        request: dict[str, object],
+        max_attempts: int = 1,
+        **_ignored: object,
+    ) -> JobRecord:
+        del func, label, request, max_attempts, _ignored
+        calls.append("queued")
+        return _make_job("should-not-queue")
+
+    monkeypatch.setattr(
+        "open_climate_service.jobs.service.JobService.submit_callable_job",
+        lambda self, **kw: fake_submit_callable_job(**kw),
+    )
+
+    def raise_missing_dataset(_: str) -> NoReturn:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    monkeypatch.setattr("open_climate_service.ingestions.routes._get_dataset_or_404", raise_missing_dataset)
+
+    response = client.post(
+        "/ingestions",
+        headers={"Prefer": "respond-async"},
+        json={"dataset_id": "missing-dataset", "start": "2024-01-01"},
+    )
+
+    assert response.status_code == 404
+    assert calls == []
+    assert "Location" not in response.headers
+
+
+def test_post_sync_respond_async_validates_plan_before_queueing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def fake_submit_callable_job(
+        *,
+        func: object,
+        label: str,
+        request: dict[str, object],
+        max_attempts: int = 1,
+        **_ignored: object,
+    ) -> JobRecord:
+        del func, label, request, max_attempts, _ignored
+        calls.append("queued")
+        return _make_job("should-not-queue")
+
+    monkeypatch.setattr(
+        "open_climate_service.jobs.service.JobService.submit_callable_job",
+        lambda self, **kw: fake_submit_callable_job(**kw),
+    )
+
+    def raise_invalid_sync_plan(*args: object, **kwargs: object) -> NoReturn:
+        del args, kwargs
+        raise HTTPException(status_code=400, detail="invalid sync plan")
+
+    monkeypatch.setattr("open_climate_service.ingestions.routes.services.plan_sync_dataset", raise_invalid_sync_plan)
+
+    response = client.post(
+        "/sync/chirps3_precipitation_daily",
+        headers={"Prefer": "respond-async"},
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert calls == []
+    assert "Location" not in response.headers
+
+
+def test_submit_callable_job_uses_default_jobs_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted: dict[str, JobRecord] = {}
+
+    monkeypatch.setattr("open_climate_service.jobs.service.JobService._enqueue_job", lambda self, job_id: None)
+    monkeypatch.setattr(
+        "open_climate_service.jobs.store.create_job_record",
+        lambda record: persisted.setdefault(record.job_id, record),
+    )
+    monkeypatch.setattr("open_climate_service.jobs.store.get_job_record", lambda job_id: persisted.get(job_id))
+
+    record = JobService().submit_callable_job(
+        func=_fake_job_callable,
+        label="ingestion",
+        request={},
+    )
+
+    assert [link.href for link in record.links] == [f"/jobs/{record.job_id}"]
+
+
+def test_submit_callable_job_normalizes_custom_jobs_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted: dict[str, JobRecord] = {}
+
+    monkeypatch.setattr("open_climate_service.jobs.service.JobService._enqueue_job", lambda self, job_id: None)
+    monkeypatch.setattr(
+        "open_climate_service.jobs.store.create_job_record",
+        lambda record: persisted.setdefault(record.job_id, record),
+    )
+    monkeypatch.setattr("open_climate_service.jobs.store.get_job_record", lambda job_id: persisted.get(job_id))
+
+    record = JobService().submit_callable_job(
+        func=_fake_job_callable,
+        label="sync",
+        request={},
+        job_href_base="/ingestions/jobs/",
+    )
+
+    assert [link.href for link in record.links] == [f"/ingestions/jobs/{record.job_id}"]


### PR DESCRIPTION
## Summary

This PR restores the native async ingestion/sync job surface after the openEO process/job refactor, while keeping the new openEO routing model intact.

## Changes

- add `DELETE /ingestions/jobs/{job_id}` for cooperative cancellation of native ingestion/sync jobs
- return `202 Accepted` from native cancellation requests
- ensure native ingestion/sync jobs keep self-links under `/ingestions/jobs/{id}`
- propagate `job_href_base` through native job creation so stored job records get the correct canonical self-link at creation time
- normalize custom job href bases to avoid malformed double-slash links
- validate async ingestion requests before queueing
- validate async sync requests before queueing
- add regression coverage for native cancellation and job link generation

## Why

The plugin/openEO overhaul correctly moves process execution toward the openEO surface, but native ingestion and sync still run through the existing native async job runtime. This PR restores the missing operational pieces for that native job path so the transition remains coherent:
- native jobs can be cancelled again
- native job records point to the correct endpoint
- invalid async requests fail before a background job is queued