### PR TITLE
feat: auto-register all xclim climate indices as openEO process plugins

### DIFF
--- a/docs/climate_indices.md
+++ b/docs/climate_indices.md
@@ -1,0 +1,163 @@
+# Climate Indices
+
+The Open Climate Service exposes the full [xclim](https://xclim.readthedocs.io) indicator library — 179 peer-reviewed, CF-compliant climate extreme indices — as native openEO processes. Every indicator appears automatically in `GET /processes` and is callable by name from any openEO process graph or client, with no additional configuration.
+
+---
+
+## What is available
+
+All xclim indicator modules are covered:
+
+| Module | Domain | Examples |
+|---|---|---|
+| `atmos` | Atmospheric | SPI, CDD, CWD, TX days above, heat wave frequency, frost days, growing degree days, … |
+| `land` | Land surface | Snow water equivalent, soil freeze/thaw, … |
+| `seaIce` | Sea ice | Ice extent, concentration trends |
+
+Browse the full list from any connected client:
+
+```python
+import openeo
+
+conn = openeo.connect("http://your-instance:8000")
+processes = conn.list_processes()
+print([p.id for p in processes])
+```
+
+Or call `GET /processes` directly and search by keyword. In the [openEO Web Editor](https://editor.openeo.org), the search box filters by id and summary.
+
+---
+
+## Standardized Precipitation Index (SPI)
+
+SPI is the primary drought monitoring index. The `window` parameter selects the accumulation timescale:
+
+| Process call | Timescale |
+|---|---|
+| `spi(pr, window=1)` | SPI-1 — short-term moisture anomaly |
+| `spi(pr, window=3)` | SPI-3 — seasonal drought |
+| `spi(pr, window=6)` | SPI-6 — medium-term drought |
+| `spi(pr, window=12)` | SPI-12 — long-term / groundwater recharge |
+
+### Python client
+
+```python
+import openeo
+
+conn = openeo.connect("http://your-instance:8000")
+
+precip = conn.load_collection(
+    "chirps_rainfall_daily",
+    temporal_extent=["2000-01-01", "2023-12-31"],
+)
+
+spi3 = precip.process("spi", arguments={
+    "pr": precip,
+    "window": 3,
+    "cal_start": "2000-01-01",
+    "cal_end": "2020-12-31",
+})
+
+job = spi3.save_result("Zarr").create_job()
+job.start_and_wait()
+```
+
+### Process graph (JSON)
+
+```json
+{
+  "process_graph": {
+    "load": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": "chirps_rainfall_daily",
+        "temporal_extent": ["2000-01-01", "2023-12-31"]
+      }
+    },
+    "spi": {
+      "process_id": "spi",
+      "arguments": {
+        "pr": { "from_node": "load" },
+        "window": 3,
+        "cal_start": "2000-01-01",
+        "cal_end": "2020-12-31"
+      },
+      "result": true
+    }
+  }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pr` | datacube | — | Daily precipitation (kg m⁻² s⁻¹ or mm/day) |
+| `window` | integer | `1` | Accumulation window in months (1=SPI-1, 3=SPI-3, 6=SPI-6) |
+| `cal_start` | string | start of record | Calibration period start (YYYY-MM-DD) |
+| `cal_end` | string | end of record | Calibration period end (YYYY-MM-DD) |
+| `freq` | string | `"MS"` | Output frequency — `"MS"` = monthly, `None` = pre-aggregated input |
+
+SPI values are standardised: `0` = climatological median, `±1` = moderate anomaly, `±2` = extreme anomaly.
+
+---
+
+## Other common indices
+
+### Consecutive dry / wet days
+
+```python
+# Annual maximum consecutive dry days (CDD)
+precip.process("cdd", arguments={"pr": precip, "thresh": "1 mm/day", "freq": "YS"})
+
+# Monthly maximum consecutive wet days (CWD)
+precip.process("cwd", arguments={"pr": precip, "thresh": "1 mm/day", "freq": "MS"})
+```
+
+### Days above temperature threshold
+
+```python
+# TX days above 35°C per year
+tmax.process("tx_days_above", arguments={"tasmax": tmax, "thresh": "35 degC", "freq": "YS"})
+```
+
+### Heat wave frequency
+
+```python
+# Annual count of heat waves (≥3 consecutive days with Tmax>35°C and Tmin>20°C)
+tmax.process("heat_wave_frequency", arguments={
+    "tasmin": tmin,
+    "tasmax": tmax,
+    "thresh_tasmin": "20 degC",
+    "thresh_tasmax": "35 degC",
+    "freq": "YS",
+})
+```
+
+---
+
+## Customising an index
+
+The auto-registered xclim processes can be overridden per-instance by placing a `@process`-decorated function with the same id in `plugins_dir/processes/`. This is useful for adjusting default parameters or adding domain-specific documentation without modifying shared code.
+
+```python
+# plugins/processes/climate_indices.py
+import xarray as xr
+import xclim.indicators.atmos as xclim_atmos
+from open_climate_service.process import process
+
+@process(summary="Consecutive dry days (Rwanda threshold)")
+def cdd(pr: xr.DataArray, thresh: str = "0.5 mm/day", freq: str = "MS") -> xr.DataArray:
+    """CDD with a lower threshold suited to Rwanda's dry season definition."""
+    return xclim_atmos.maximum_consecutive_dry_days(pr, thresh=thresh, freq=freq)
+```
+
+See [Extensibility — Processes](extensibility.md#processes) for the full `@process` decorator reference.
+
+---
+
+## References
+
+- [xclim documentation](https://xclim.readthedocs.io)
+- [xclim indicator catalogue](https://xclim.readthedocs.io/en/stable/indicators.html)
+- [openEO process graph specification](https://processes.openeo.org)

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -37,32 +37,61 @@ See [Adding custom datasets](adding_custom_datasets.md) for the full template fi
 
 ## Processes
 
-Custom processes are Python functions decorated with `@process` and placed in `plugins_dir/processes/`. They appear in `GET /processes` alongside standard openEO processes and are callable directly by `process_id` in any process graph — no `run_udf` indirection needed.
+### Built-in xclim layer
+
+All 179 [xclim](https://xclim.readthedocs.io) climate indicators are auto-registered at startup — no code or YAML required. They appear in `GET /processes` with full metadata (summary, parameter descriptions, types, and defaults) read directly from xclim. See [Climate indices](climate_indices.md) for usage examples.
+
+### Custom process plugins
+
+Python functions decorated with `@process` and placed in `plugins_dir/processes/` appear in `GET /processes` alongside standard openEO processes and are callable directly by `process_id` in any process graph — no `run_udf` indirection needed.
 
 ```python
-# plugins/processes/climate_indices.py
+# plugins/processes/my_indices.py
 import xarray as xr
 from open_climate_service.process import process
 
-@process(summary="Maximum consecutive dry days")
-def cdd(pr: xr.DataArray, thresh: str = "1mm/day") -> xr.DataArray:
-    """Maximum number of consecutive days with precipitation below threshold."""
-    import xclim.atmos
-    return xclim.atmos.maximum_consecutive_dry_days(pr, thresh=thresh)
+@process(summary="Cumulative rainfall anomaly")
+def rainfall_anomaly(pr: xr.DataArray, baseline_mean: float = 0.0) -> xr.DataArray:
+    """Deviation of precipitation from a baseline mean."""
+    return pr - baseline_mean
 ```
 
-The `@process` decorator derives the process id (function name), summary, parameter names, types, and defaults from the function signature and docstring. Use explicit metadata to override:
+The `@process` decorator derives the process id (function name), summary, parameter names, types, and defaults from the function signature and docstring. Use explicit metadata to override descriptions or add schema hints:
 
 ```python
 @process(
-    summary="Custom summary",
-    parameters={"thresh": {"description": "Precipitation threshold"}},
+    summary="Cumulative rainfall anomaly",
+    parameters={"baseline_mean": {"description": "Long-term mean precipitation (kg m-2 s-1)."}},
 )
-def cdd(pr: xr.DataArray, thresh: str = "1mm/day") -> xr.DataArray:
+def rainfall_anomaly(pr: xr.DataArray, baseline_mean: float = 0.0) -> xr.DataArray:
     ...
 ```
 
-A plugin process with the same id as a standard openEO process overrides it. The server must be restarted to pick up new process files.
+### Override an existing process
+
+A plugin process with the same id as an existing process (xclim auto-registered or standard openEO) overrides it. This is useful for adjusting default parameters or adding domain-specific documentation without forking core code:
+
+```python
+# plugins/processes/climate_indices.py — lower CDD threshold for Rwanda
+import xarray as xr
+import xclim.indicators.atmos as xclim_atmos
+from open_climate_service.process import process
+
+@process(summary="Consecutive dry days (Rwanda threshold)")
+def cdd(pr: xr.DataArray, thresh: str = "0.5 mm/day", freq: str = "MS") -> xr.DataArray:
+    """CDD with a lower threshold suited to Rwanda's dry season definition."""
+    return xclim_atmos.maximum_consecutive_dry_days(pr, thresh=thresh, freq=freq)
+```
+
+### Resolution order
+
+| Priority | Source |
+|---|---|
+| 1 (lowest) | xclim auto-registered indicators |
+| 2 | Built-in file plugins (`open_climate_service/plugins/processes/`) |
+| 3 (highest) | Instance plugins (`plugins_dir/processes/`) |
+
+The server must be restarted to pick up new or changed process files.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - openEO: openeo.md
       - Built-in datasets: built_in_datasets.md
       - Processes: processes.md
+      - Climate indices: climate_indices.md
       - Workflows: workflows.md
       - Instance guide: instance_guide.md
       - Adding custom datasets: adding_custom_datasets.md

--- a/open_climate_service/openeo/plugin_processes.py
+++ b/open_climate_service/openeo/plugin_processes.py
@@ -11,7 +11,8 @@ from types import ModuleType
 from typing import Any
 
 from open_climate_service import config as api_config
-from open_climate_service.process import _OCS_PROCESS_ATTR, get_process_metadata
+from open_climate_service.openeo import xclim_processes
+from open_climate_service.process import get_process_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ def load_plugin_processes() -> list[tuple[str, Any]]:
     3. Instance plugins — ``plugins_dir/processes/`` (override everything)
     """
     found: dict[str, Any] = {}
-    for func in _scan_xclim_indicators():
+    for func in xclim_processes.scan():
         meta = get_process_metadata(func)
         if meta:
             found[meta["id"]] = func
@@ -90,98 +91,3 @@ def _load_from_module(module_name: str) -> list[Any]:
     except Exception:
         logger.warning("Failed to load plugin processes from %s", module_name, exc_info=True)
         return []
-
-
-_xclim_indicator_cache: list[Any] | None = None
-
-
-def _scan_xclim_indicators() -> list[Any]:
-    """Auto-register all xclim indicators as process callables (result is cached)."""
-    global _xclim_indicator_cache
-    if _xclim_indicator_cache is not None:
-        return _xclim_indicator_cache
-    try:
-        _xclim_indicator_cache = _collect_xclim_indicators()
-    except Exception:
-        logger.warning("Failed to load xclim indicators", exc_info=True)
-        _xclim_indicator_cache = []
-    return _xclim_indicator_cache
-
-
-def _collect_xclim_indicators() -> list[Any]:
-    import inspect
-
-    import xclim.indicators.atmos as atmos
-    import xclim.indicators.land as land
-    import xclim.indicators.seaIce as seaice
-    from xclim.core.indicator import InputKind
-
-    _SKIP_KINDS = {InputKind.DATASET, InputKind.KWARGS}
-    # Kinds whose default is a dataset variable name, not a real scalar default
-    _VARIABLE_KINDS = {InputKind.VARIABLE, InputKind.OPTIONAL_VARIABLE}
-    _KIND_SCHEMA: dict[InputKind, dict[str, str]] = {
-        InputKind.VARIABLE: {"type": "object", "subtype": "datacube"},
-        InputKind.OPTIONAL_VARIABLE: {"type": "object", "subtype": "datacube"},
-        InputKind.QUANTIFIED: {"type": "string"},
-        InputKind.FREQ_STR: {"type": "string"},
-        InputKind.NUMBER: {"type": "number"},
-        InputKind.STRING: {"type": "string"},
-        InputKind.DAY_OF_YEAR: {"type": "string"},
-        InputKind.DATE: {"type": "string"},
-        InputKind.NUMBER_SEQUENCE: {"type": "array"},
-        InputKind.BOOL: {"type": "boolean"},
-    }
-
-    funcs: list[Any] = []
-    seen: set[str] = set()
-
-    for mod in (atmos, land, seaice):
-        for obj in vars(mod).values():
-            if not (hasattr(obj, "identifier") and hasattr(obj, "parameters") and hasattr(obj, "title")):
-                continue
-            indicator_id: str = obj.identifier
-            if indicator_id in seen:
-                continue
-            seen.add(indicator_id)
-
-            params: list[dict[str, Any]] = []
-            for name, p in obj.parameters.items():
-                if p.kind in _SKIP_KINDS:
-                    continue
-                param_meta: dict[str, Any] = {"name": name, "schema": _KIND_SCHEMA.get(p.kind, {})}
-                if p.description:
-                    param_meta["description"] = p.description
-                # Only expose defaults that are real JSON-serializable scalars.
-                # VARIABLE/OPTIONAL_VARIABLE defaults are dataset-mode variable name
-                # strings (e.g. "pr"), not meaningful API defaults.
-                if p.kind not in _VARIABLE_KINDS:
-                    default = p.default
-                    if default is not inspect.Parameter.empty and isinstance(
-                        default, (str, int, float, bool, type(None))
-                    ):
-                        param_meta["optional"] = True
-                        param_meta["default"] = default
-                elif p.kind is InputKind.OPTIONAL_VARIABLE:
-                    param_meta["optional"] = True
-                params.append(param_meta)
-
-            meta: dict[str, Any] = {
-                "id": indicator_id,
-                "summary": obj.title,
-                "description": obj.abstract,
-                "parameters": params,
-                "returns": {"schema": {}},
-            }
-            funcs.append(_make_indicator_callable(obj, meta))
-
-    return funcs
-
-
-def _make_indicator_callable(indicator: Any, meta: dict[str, Any]) -> Any:
-    """Wrap an xclim indicator as a bare callable with process metadata attached."""
-
-    def _call(**kwargs: Any) -> Any:
-        return indicator(**kwargs)
-
-    setattr(_call, _OCS_PROCESS_ATTR, meta)
-    return _call

--- a/open_climate_service/openeo/plugin_processes.py
+++ b/open_climate_service/openeo/plugin_processes.py
@@ -11,7 +11,7 @@ from types import ModuleType
 from typing import Any
 
 from open_climate_service import config as api_config
-from open_climate_service.process import get_process_metadata
+from open_climate_service.process import _OCS_PROCESS_ATTR, get_process_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +19,16 @@ logger = logging.getLogger(__name__)
 def load_plugin_processes() -> list[tuple[str, Any]]:
     """Return (process_id, callable) for all @process-decorated functions.
 
-    Scans built-ins from ``open_climate_service/plugins/processes/`` first,
-    then instance plugins from ``plugins_dir/processes/``. Instance plugins
-    override built-ins with the same id.
+    Resolution order (last wins):
+    1. xclim indicators — auto-registered from all indicator modules
+    2. Built-in file plugins — ``open_climate_service/plugins/processes/``
+    3. Instance plugins — ``plugins_dir/processes/`` (override everything)
     """
     found: dict[str, Any] = {}
+    for func in _scan_xclim_indicators():
+        meta = get_process_metadata(func)
+        if meta:
+            found[meta["id"]] = func
     for func in _scan_builtin_processes():
         meta = get_process_metadata(func)
         if meta:
@@ -85,3 +90,79 @@ def _load_from_module(module_name: str) -> list[Any]:
     except Exception:
         logger.warning("Failed to load plugin processes from %s", module_name, exc_info=True)
         return []
+
+
+def _scan_xclim_indicators() -> list[Any]:
+    """Auto-register all xclim indicators as process callables."""
+    try:
+        return _collect_xclim_indicators()
+    except Exception:
+        logger.warning("Failed to load xclim indicators", exc_info=True)
+        return []
+
+
+def _collect_xclim_indicators() -> list[Any]:
+    import xclim.indicators.atmos as atmos
+    import xclim.indicators.land as land
+    import xclim.indicators.seaIce as seaice
+    from xclim.core.indicator import InputKind
+
+    _SKIP_KINDS = {InputKind.DATASET, InputKind.KWARGS}
+    _KIND_SCHEMA: dict[InputKind, dict[str, str]] = {
+        InputKind.VARIABLE: {"type": "object", "subtype": "datacube"},
+        InputKind.OPTIONAL_VARIABLE: {"type": "object", "subtype": "datacube"},
+        InputKind.QUANTIFIED: {"type": "string"},
+        InputKind.FREQ_STR: {"type": "string"},
+        InputKind.NUMBER: {"type": "number"},
+        InputKind.STRING: {"type": "string"},
+        InputKind.DAY_OF_YEAR: {"type": "string"},
+        InputKind.DATE: {"type": "string"},
+        InputKind.NUMBER_SEQUENCE: {"type": "array"},
+        InputKind.BOOL: {"type": "boolean"},
+    }
+
+    funcs: list[Any] = []
+    seen: set[str] = set()
+
+    for mod in (atmos, land, seaice):
+        for obj in vars(mod).values():
+            if not (hasattr(obj, "identifier") and hasattr(obj, "parameters") and hasattr(obj, "title")):
+                continue
+            indicator_id: str = obj.identifier
+            if indicator_id in seen:
+                continue
+            seen.add(indicator_id)
+
+            params: list[dict[str, Any]] = []
+            for name, p in obj.parameters.items():
+                if p.kind in _SKIP_KINDS:
+                    continue
+                param_meta: dict[str, Any] = {"name": name, "schema": _KIND_SCHEMA.get(p.kind, {})}
+                if p.description:
+                    param_meta["description"] = p.description
+                # VARIABLE defaults are dataset-mode variable name strings, not real defaults
+                if p.kind not in (InputKind.VARIABLE,):
+                    param_meta["optional"] = True
+                    param_meta["default"] = p.default
+                params.append(param_meta)
+
+            meta: dict[str, Any] = {
+                "id": indicator_id,
+                "summary": obj.title,
+                "description": obj.abstract,
+                "parameters": params,
+                "returns": {"schema": {}},
+            }
+            funcs.append(_make_indicator_callable(obj, meta))
+
+    return funcs
+
+
+def _make_indicator_callable(indicator: Any, meta: dict[str, Any]) -> Any:
+    """Wrap an xclim indicator as a bare callable with process metadata attached."""
+
+    def _call(**kwargs: Any) -> Any:
+        return indicator(**kwargs)
+
+    setattr(_call, _OCS_PROCESS_ATTR, meta)
+    return _call

--- a/open_climate_service/openeo/plugin_processes.py
+++ b/open_climate_service/openeo/plugin_processes.py
@@ -92,22 +92,33 @@ def _load_from_module(module_name: str) -> list[Any]:
         return []
 
 
+_xclim_indicator_cache: list[Any] | None = None
+
+
 def _scan_xclim_indicators() -> list[Any]:
-    """Auto-register all xclim indicators as process callables."""
+    """Auto-register all xclim indicators as process callables (result is cached)."""
+    global _xclim_indicator_cache
+    if _xclim_indicator_cache is not None:
+        return _xclim_indicator_cache
     try:
-        return _collect_xclim_indicators()
+        _xclim_indicator_cache = _collect_xclim_indicators()
     except Exception:
         logger.warning("Failed to load xclim indicators", exc_info=True)
-        return []
+        _xclim_indicator_cache = []
+    return _xclim_indicator_cache
 
 
 def _collect_xclim_indicators() -> list[Any]:
+    import inspect
+
     import xclim.indicators.atmos as atmos
     import xclim.indicators.land as land
     import xclim.indicators.seaIce as seaice
     from xclim.core.indicator import InputKind
 
     _SKIP_KINDS = {InputKind.DATASET, InputKind.KWARGS}
+    # Kinds whose default is a dataset variable name, not a real scalar default
+    _VARIABLE_KINDS = {InputKind.VARIABLE, InputKind.OPTIONAL_VARIABLE}
     _KIND_SCHEMA: dict[InputKind, dict[str, str]] = {
         InputKind.VARIABLE: {"type": "object", "subtype": "datacube"},
         InputKind.OPTIONAL_VARIABLE: {"type": "object", "subtype": "datacube"},
@@ -140,10 +151,18 @@ def _collect_xclim_indicators() -> list[Any]:
                 param_meta: dict[str, Any] = {"name": name, "schema": _KIND_SCHEMA.get(p.kind, {})}
                 if p.description:
                     param_meta["description"] = p.description
-                # VARIABLE defaults are dataset-mode variable name strings, not real defaults
-                if p.kind not in (InputKind.VARIABLE,):
+                # Only expose defaults that are real JSON-serializable scalars.
+                # VARIABLE/OPTIONAL_VARIABLE defaults are dataset-mode variable name
+                # strings (e.g. "pr"), not meaningful API defaults.
+                if p.kind not in _VARIABLE_KINDS:
+                    default = p.default
+                    if default is not inspect.Parameter.empty and isinstance(
+                        default, (str, int, float, bool, type(None))
+                    ):
+                        param_meta["optional"] = True
+                        param_meta["default"] = default
+                elif p.kind is InputKind.OPTIONAL_VARIABLE:
                     param_meta["optional"] = True
-                    param_meta["default"] = p.default
                 params.append(param_meta)
 
             meta: dict[str, Any] = {

--- a/open_climate_service/openeo/xclim_processes.py
+++ b/open_climate_service/openeo/xclim_processes.py
@@ -1,0 +1,104 @@
+"""Auto-registration of xclim indicators as openEO process callables."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+from open_climate_service.process import _OCS_PROCESS_ATTR
+
+logger = logging.getLogger(__name__)
+
+_cache: list[Any] | None = None
+
+_KIND_SCHEMA: dict[Any, dict[str, str]] = {}  # populated lazily after xclim import
+
+
+def scan() -> list[Any]:
+    """Return all xclim indicators as process callables (cached after first call)."""
+    global _cache
+    if _cache is not None:
+        return _cache
+    try:
+        _cache = _collect()
+    except Exception:
+        logger.warning("Failed to load xclim indicators", exc_info=True)
+        _cache = []
+    return _cache
+
+
+def _collect() -> list[Any]:
+    import xclim.indicators.atmos as atmos
+    import xclim.indicators.land as land
+    import xclim.indicators.seaIce as seaice
+    from xclim.core.indicator import InputKind
+
+    _SKIP_KINDS = {InputKind.DATASET, InputKind.KWARGS}
+    _VARIABLE_KINDS = {InputKind.VARIABLE, InputKind.OPTIONAL_VARIABLE}
+    kind_schema: dict[InputKind, dict[str, str]] = {
+        InputKind.VARIABLE: {"type": "object", "subtype": "datacube"},
+        InputKind.OPTIONAL_VARIABLE: {"type": "object", "subtype": "datacube"},
+        InputKind.QUANTIFIED: {"type": "string"},
+        InputKind.FREQ_STR: {"type": "string"},
+        InputKind.NUMBER: {"type": "number"},
+        InputKind.STRING: {"type": "string"},
+        InputKind.DAY_OF_YEAR: {"type": "string"},
+        InputKind.DATE: {"type": "string"},
+        InputKind.NUMBER_SEQUENCE: {"type": "array"},
+        InputKind.BOOL: {"type": "boolean"},
+    }
+
+    funcs: list[Any] = []
+    seen: set[str] = set()
+
+    for mod in (atmos, land, seaice):
+        for obj in vars(mod).values():
+            if not (hasattr(obj, "identifier") and hasattr(obj, "parameters") and hasattr(obj, "title")):
+                continue
+            indicator_id: str = obj.identifier
+            if indicator_id in seen:
+                continue
+            seen.add(indicator_id)
+
+            params: list[dict[str, Any]] = []
+            for name, p in obj.parameters.items():
+                if p.kind in _SKIP_KINDS:
+                    continue
+                param_meta: dict[str, Any] = {"name": name, "schema": kind_schema.get(p.kind, {})}
+                if p.description:
+                    param_meta["description"] = p.description
+                # Only expose JSON-serializable scalar defaults.
+                # VARIABLE/OPTIONAL_VARIABLE defaults are dataset-mode variable name
+                # strings (e.g. "pr") — not meaningful as API defaults.
+                if p.kind not in _VARIABLE_KINDS:
+                    default = p.default
+                    if default is not inspect.Parameter.empty and isinstance(
+                        default, (str, int, float, bool, type(None))
+                    ):
+                        param_meta["optional"] = True
+                        param_meta["default"] = default
+                elif p.kind is InputKind.OPTIONAL_VARIABLE:
+                    param_meta["optional"] = True
+                params.append(param_meta)
+
+            meta: dict[str, Any] = {
+                "id": indicator_id,
+                "summary": obj.title,
+                "description": obj.abstract,
+                "parameters": params,
+                "returns": {"schema": {}},
+            }
+            funcs.append(_make_callable(obj, meta))
+
+    return funcs
+
+
+def _make_callable(indicator: Any, meta: dict[str, Any]) -> Any:
+    """Wrap an xclim indicator as a bare callable with process metadata attached."""
+
+    def _call(**kwargs: Any) -> Any:
+        return indicator(**kwargs)
+
+    setattr(_call, _OCS_PROCESS_ATTR, meta)
+    return _call

--- a/open_climate_service/openeo/xclim_processes.py
+++ b/open_climate_service/openeo/xclim_processes.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 
 _cache: list[Any] | None = None
 
-_KIND_SCHEMA: dict[Any, dict[str, str]] = {}  # populated lazily after xclim import
-
 
 def scan() -> list[Any]:
     """Return all xclim indicators as process callables (cached after first call)."""
@@ -22,10 +20,10 @@ def scan() -> list[Any]:
         return _cache
     try:
         _cache = _collect()
+        return _cache
     except Exception:
         logger.warning("Failed to load xclim indicators", exc_info=True)
-        _cache = []
-    return _cache
+        return []
 
 
 def _collect() -> list[Any]:

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -1,4 +1,9 @@
-"""Climate extreme indices via xclim."""
+"""Curated overrides for xclim climate index processes.
+
+The base layer of xclim processes is auto-registered from the indicator
+modules in plugin_processes._scan_xclim_indicators. This file only needs
+to override indicators where the auto-generated metadata is insufficient.
+"""
 
 from typing import Any
 
@@ -11,19 +16,9 @@ from open_climate_service.process import process
 
 _VARIABLE_SCHEMA: dict[str, str] = {"type": "object", "subtype": "datacube"}
 
-_KIND_TO_SCHEMA: dict[InputKind, dict[str, str]] = {
-    InputKind.VARIABLE: _VARIABLE_SCHEMA,
-    InputKind.OPTIONAL_VARIABLE: _VARIABLE_SCHEMA,
-}
-
 
 def _xclim_params(indicator: Any, *names: str) -> dict[str, dict[str, Any]]:
-    """Read parameter descriptions and schemas from an xclim indicator.
-
-    VARIABLE-kind parameters (DataArrays) get a datacube schema. All others
-    pick up the description text from xclim; type schema falls back to the
-    Python annotation resolved by the @process decorator.
-    """
+    """Read parameter descriptions and schemas from an xclim indicator."""
     result: dict[str, dict[str, Any]] = {}
     for name in names:
         if name not in indicator.parameters:
@@ -32,17 +27,13 @@ def _xclim_params(indicator: Any, *names: str) -> dict[str, dict[str, Any]]:
         entry: dict[str, Any] = {}
         if p.description:
             entry["description"] = p.description
-        schema = _KIND_TO_SCHEMA.get(p.kind)
-        if schema:
-            entry["schema"] = schema
+        if p.kind in (InputKind.VARIABLE, InputKind.OPTIONAL_VARIABLE):
+            entry["schema"] = _VARIABLE_SCHEMA
         result[name] = entry
     return result
 
 
 _spi_ind = xclim_atmos.standardized_precipitation_index
-_cdd_ind = xclim_atmos.maximum_consecutive_dry_days
-_cwd_ind = xclim_atmos.maximum_consecutive_wet_days
-_tx_ind = xclim_atmos.tx_days_above
 
 
 @process(
@@ -71,61 +62,4 @@ def spi(
         window=window,
         cal_start=cal_start,
         cal_end=cal_end,
-    )
-
-
-@process(
-    summary="Maximum consecutive dry days (CDD)",
-    parameters=_xclim_params(_cdd_ind, "pr", "thresh", "freq"),
-)
-def cdd(
-    pr: xr.DataArray,
-    thresh: str = "1 mm/day",
-    freq: str = "YS",
-) -> xr.DataArray:
-    """Maximum number of consecutive dry days per period.
-
-    A dry day is one where precipitation is below the given threshold.
-    CDD is one of the ETCCDI core climate extreme indices.
-    """
-    return xclim_atmos.maximum_consecutive_dry_days(  # type: ignore[no-any-return]
-        pr, thresh=thresh, freq=freq
-    )
-
-
-@process(
-    summary="Maximum consecutive wet days (CWD)",
-    parameters=_xclim_params(_cwd_ind, "pr", "thresh", "freq"),
-)
-def cwd(
-    pr: xr.DataArray,
-    thresh: str = "1 mm/day",
-    freq: str = "YS",
-) -> xr.DataArray:
-    """Maximum number of consecutive wet days per period.
-
-    A wet day is one where precipitation meets or exceeds the given threshold.
-    CWD is one of the ETCCDI core climate extreme indices.
-    """
-    return xclim_atmos.maximum_consecutive_wet_days(  # type: ignore[no-any-return]
-        pr, thresh=thresh, freq=freq
-    )
-
-
-@process(
-    summary="Number of days with maximum temperature above threshold (TX days above)",
-    parameters=_xclim_params(_tx_ind, "tasmax", "thresh", "freq"),
-)
-def tx_days_above(
-    tasmax: xr.DataArray,
-    thresh: str = "25 degC",
-    freq: str = "YS",
-) -> xr.DataArray:
-    """Number of days per period where daily maximum temperature exceeds a threshold.
-
-    Commonly used for heat stress assessment. The threshold is a parameter,
-    covering TX28°C through TX40°C variants with a single process.
-    """
-    return xclim_atmos.tx_days_above(  # type: ignore[no-any-return]
-        tasmax, thresh=thresh, freq=freq
     )

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -1,16 +1,54 @@
 """Climate extreme indices via xclim."""
 
+from typing import Any
+
 import xarray as xr
 import xclim.indicators.atmos as xclim_atmos
 import xclim.indices
+from xclim.core.indicator import InputKind
 
 from open_climate_service.process import process
+
+_VARIABLE_SCHEMA: dict[str, str] = {"type": "object", "subtype": "datacube"}
+
+_KIND_TO_SCHEMA: dict[InputKind, dict[str, str]] = {
+    InputKind.VARIABLE: _VARIABLE_SCHEMA,
+    InputKind.OPTIONAL_VARIABLE: _VARIABLE_SCHEMA,
+}
+
+
+def _xclim_params(indicator: Any, *names: str) -> dict[str, dict[str, Any]]:
+    """Read parameter descriptions and schemas from an xclim indicator.
+
+    VARIABLE-kind parameters (DataArrays) get a datacube schema. All others
+    pick up the description text from xclim; type schema falls back to the
+    Python annotation resolved by the @process decorator.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for name in names:
+        if name not in indicator.parameters:
+            continue
+        p = indicator.parameters[name]
+        entry: dict[str, Any] = {}
+        if p.description:
+            entry["description"] = p.description
+        schema = _KIND_TO_SCHEMA.get(p.kind)
+        if schema:
+            entry["schema"] = schema
+        result[name] = entry
+    return result
+
+
+_spi_ind = xclim_atmos.standardized_precipitation_index
+_cdd_ind = xclim_atmos.maximum_consecutive_dry_days
+_cwd_ind = xclim_atmos.maximum_consecutive_wet_days
+_tx_ind = xclim_atmos.tx_days_above
 
 
 @process(
     summary="Standardized Precipitation Index (SPI)",
     parameters={
-        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        **_xclim_params(_spi_ind, "pr"),
         "window": {"description": "Accumulation window in months (1 = SPI-1, 3 = SPI-3, 6 = SPI-6)."},
         "cal_start": {"description": "Calibration period start date (YYYY-MM-DD). Defaults to start of record."},
         "cal_end": {"description": "Calibration period end date (YYYY-MM-DD). Defaults to end of record."},
@@ -42,7 +80,7 @@ def spi(
 @process(
     summary="Maximum consecutive dry days (CDD)",
     parameters={
-        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        **_xclim_params(_cdd_ind, "pr"),
         "thresh": {"description": "Precipitation threshold below which a day is considered dry (e.g. '1 mm/day')."},
         "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
     },
@@ -65,7 +103,7 @@ def cdd(
 @process(
     summary="Maximum consecutive wet days (CWD)",
     parameters={
-        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        **_xclim_params(_cwd_ind, "pr"),
         "thresh": {"description": "Precipitation threshold for a wet day (e.g. '1 mm/day')."},
         "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
     },
@@ -88,7 +126,7 @@ def cwd(
 @process(
     summary="Number of days with maximum temperature above threshold (TX days above)",
     parameters={
-        "tasmax": {"description": "Daily maximum temperature (degC or K)."},
+        **_xclim_params(_tx_ind, "tasmax"),
         "thresh": {"description": "Temperature threshold (e.g. '25 degC', '30 degC')."},
         "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
     },

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -1,0 +1,40 @@
+"""Climate extreme indices via xclim."""
+
+from __future__ import annotations
+
+import xarray as xr
+import xclim.indices
+
+from open_climate_service.process import process
+
+
+@process(
+    summary="Standardized Precipitation Index (SPI)",
+    parameters={
+        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        "window": {"description": "Accumulation window in months (1 = SPI-1, 3 = SPI-3, 6 = SPI-6)."},
+        "cal_start": {"description": "Calibration period start date (YYYY-MM-DD). Defaults to start of record."},
+        "cal_end": {"description": "Calibration period end date (YYYY-MM-DD). Defaults to end of record."},
+        "freq": {"description": "Output frequency. 'MS' = monthly (default). Use None if input is pre-aggregated."},
+    },
+)
+def spi(
+    pr: xr.DataArray,
+    window: int = 1,
+    cal_start: str | None = None,
+    cal_end: str | None = None,
+    freq: str | None = "MS",
+) -> xr.DataArray:
+    """Standardized Precipitation Index.
+
+    Computes SPI at a given accumulation timescale using a gamma distribution
+    fitted to the calibration period. Values below -1 indicate drought conditions;
+    values above +1 indicate wet conditions.
+    """
+    return xclim.indices.standardized_precipitation_index(  # type: ignore[no-any-return]
+        pr,
+        freq=freq,
+        window=window,
+        cal_start=cal_start,
+        cal_end=cal_end,
+    )

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import xarray as xr
-import xclim.indices
 import xclim.indicators.atmos as xclim_atmos
+import xclim.indices
 
 from open_climate_service.process import process
 
@@ -68,7 +68,7 @@ def cdd(
     summary="Maximum consecutive wet days (CWD)",
     parameters={
         "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
-        "thresh": {"description": "Precipitation threshold at or above which a day is considered wet (e.g. '1 mm/day')."},
+        "thresh": {"description": "Precipitation threshold for a wet day (e.g. '1 mm/day')."},
         "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
     },
 )

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import xarray as xr
 import xclim.indices
+import xclim.indicators.atmos as xclim_atmos
 
 from open_climate_service.process import process
 
@@ -37,4 +38,73 @@ def spi(
         window=window,
         cal_start=cal_start,
         cal_end=cal_end,
+    )
+
+
+@process(
+    summary="Maximum consecutive dry days (CDD)",
+    parameters={
+        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        "thresh": {"description": "Precipitation threshold below which a day is considered dry (e.g. '1 mm/day')."},
+        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
+    },
+)
+def cdd(
+    pr: xr.DataArray,
+    thresh: str = "1 mm/day",
+    freq: str = "YS",
+) -> xr.DataArray:
+    """Maximum number of consecutive dry days per period.
+
+    A dry day is one where precipitation is below the given threshold.
+    CDD is one of the ETCCDI core climate extreme indices.
+    """
+    return xclim_atmos.maximum_consecutive_dry_days(  # type: ignore[no-any-return]
+        pr, thresh=thresh, freq=freq
+    )
+
+
+@process(
+    summary="Maximum consecutive wet days (CWD)",
+    parameters={
+        "pr": {"description": "Daily precipitation (kg m-2 s-1 or mm/day)."},
+        "thresh": {"description": "Precipitation threshold at or above which a day is considered wet (e.g. '1 mm/day')."},
+        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
+    },
+)
+def cwd(
+    pr: xr.DataArray,
+    thresh: str = "1 mm/day",
+    freq: str = "YS",
+) -> xr.DataArray:
+    """Maximum number of consecutive wet days per period.
+
+    A wet day is one where precipitation meets or exceeds the given threshold.
+    CWD is one of the ETCCDI core climate extreme indices.
+    """
+    return xclim_atmos.maximum_consecutive_wet_days(  # type: ignore[no-any-return]
+        pr, thresh=thresh, freq=freq
+    )
+
+
+@process(
+    summary="Number of days with maximum temperature above threshold (TX days above)",
+    parameters={
+        "tasmax": {"description": "Daily maximum temperature (degC or K)."},
+        "thresh": {"description": "Temperature threshold (e.g. '25 degC', '30 degC')."},
+        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
+    },
+)
+def tx_days_above(
+    tasmax: xr.DataArray,
+    thresh: str = "25 degC",
+    freq: str = "YS",
+) -> xr.DataArray:
+    """Number of days per period where daily maximum temperature exceeds a threshold.
+
+    Commonly used for heat stress assessment. The threshold is a parameter,
+    covering TX28°C through TX40°C variants with a single process.
+    """
+    return xclim_atmos.tx_days_above(  # type: ignore[no-any-return]
+        tasmax, thresh=thresh, freq=freq
     )

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -1,7 +1,5 @@
 """Climate extreme indices via xclim."""
 
-from __future__ import annotations
-
 import xarray as xr
 import xclim.indicators.atmos as xclim_atmos
 import xclim.indices

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -1,8 +1,8 @@
 """Curated overrides for xclim climate index processes.
 
-The base layer of xclim processes is auto-registered from the indicator
-modules in plugin_processes._scan_xclim_indicators. This file only needs
-to override indicators where the auto-generated metadata is insufficient.
+The base layer of xclim processes is auto-registered by xclim_processes.scan().
+This file only needs to override indicators where the auto-generated metadata
+is insufficient.
 """
 
 from typing import Any, cast
@@ -14,7 +14,7 @@ from xclim.core.indicator import InputKind
 
 from open_climate_service.process import process
 
-_VARIABLE_SCHEMA: dict[str, str] = {"type": "object", "subtype": "datacube"}
+_VARIABLE_SCHEMA: dict[str, Any] = {"type": "object", "subtype": "datacube"}
 
 
 def _xclim_params(indicator: Any, *names: str) -> dict[str, dict[str, Any]]:

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -48,11 +48,8 @@ _tx_ind = xclim_atmos.tx_days_above
 @process(
     summary="Standardized Precipitation Index (SPI)",
     parameters={
-        **_xclim_params(_spi_ind, "pr"),
+        **_xclim_params(_spi_ind, "pr", "cal_start", "cal_end", "freq"),
         "window": {"description": "Accumulation window in months (1 = SPI-1, 3 = SPI-3, 6 = SPI-6)."},
-        "cal_start": {"description": "Calibration period start date (YYYY-MM-DD). Defaults to start of record."},
-        "cal_end": {"description": "Calibration period end date (YYYY-MM-DD). Defaults to end of record."},
-        "freq": {"description": "Output frequency. 'MS' = monthly (default). Use None if input is pre-aggregated."},
     },
 )
 def spi(
@@ -79,11 +76,7 @@ def spi(
 
 @process(
     summary="Maximum consecutive dry days (CDD)",
-    parameters={
-        **_xclim_params(_cdd_ind, "pr"),
-        "thresh": {"description": "Precipitation threshold below which a day is considered dry (e.g. '1 mm/day')."},
-        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
-    },
+    parameters=_xclim_params(_cdd_ind, "pr", "thresh", "freq"),
 )
 def cdd(
     pr: xr.DataArray,
@@ -102,11 +95,7 @@ def cdd(
 
 @process(
     summary="Maximum consecutive wet days (CWD)",
-    parameters={
-        **_xclim_params(_cwd_ind, "pr"),
-        "thresh": {"description": "Precipitation threshold for a wet day (e.g. '1 mm/day')."},
-        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
-    },
+    parameters=_xclim_params(_cwd_ind, "pr", "thresh", "freq"),
 )
 def cwd(
     pr: xr.DataArray,
@@ -125,11 +114,7 @@ def cwd(
 
 @process(
     summary="Number of days with maximum temperature above threshold (TX days above)",
-    parameters={
-        **_xclim_params(_tx_ind, "tasmax"),
-        "thresh": {"description": "Temperature threshold (e.g. '25 degC', '30 degC')."},
-        "freq": {"description": "Resampling frequency. 'YS' = annual (default), 'MS' = monthly."},
-    },
+    parameters=_xclim_params(_tx_ind, "tasmax", "thresh", "freq"),
 )
 def tx_days_above(
     tasmax: xr.DataArray,

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -5,7 +5,7 @@ modules in plugin_processes._scan_xclim_indicators. This file only needs
 to override indicators where the auto-generated metadata is insufficient.
 """
 
-from typing import Any
+from typing import Any, cast
 
 import xarray as xr
 import xclim.indicators.atmos as xclim_atmos
@@ -56,10 +56,11 @@ def spi(
     fitted to the calibration period. Values below -1 indicate drought conditions;
     values above +1 indicate wet conditions.
     """
+    # DateStr is NewType(str) in xclim — cast to satisfy pyright without importing private types
     return xclim.indices.standardized_precipitation_index(  # type: ignore[no-any-return]
         pr,
         freq=freq,
         window=window,
-        cal_start=cal_start,
-        cal_end=cal_end,
+        cal_start=cast(Any, cal_start),
+        cal_end=cast(Any, cal_end),
     )

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import inspect
+import types
+import typing
 from collections.abc import Callable
 from typing import Any, TypeVar, overload
 
@@ -16,6 +18,25 @@ _PYTHON_TYPE_MAP: dict[type, str] = {
     float: "number",
     bool: "boolean",
 }
+
+
+def _annotation_to_schema(ann: Any) -> dict[str, Any]:
+    """Return a JSON Schema dict for a Python type annotation.
+
+    Handles plain types (str, int, …) and nullable unions (str | None).
+    Returns {} for types with no known mapping (e.g. xr.DataArray).
+    """
+    direct = _PYTHON_TYPE_MAP.get(ann)
+    if direct:
+        return {"type": direct}
+    # str | None  →  UnionType (Python 3.10+) or typing.Union
+    origin = getattr(ann, "__origin__", None)
+    args: tuple[Any, ...] = getattr(ann, "__args__", ())
+    if isinstance(ann, types.UnionType) or origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return _annotation_to_schema(non_none[0])
+    return {}
 
 
 @overload
@@ -72,9 +93,9 @@ def process(
             p: dict[str, Any] = {"name": name, "schema": {}}
             ann = param.annotation
             if ann is not inspect.Parameter.empty:
-                type_str = _PYTHON_TYPE_MAP.get(ann)
-                if type_str:
-                    p["schema"] = {"type": type_str}
+                schema = _annotation_to_schema(ann)
+                if schema:
+                    p["schema"] = schema
             if param.default is not inspect.Parameter.empty:
                 p["optional"] = True
                 p["default"] = param.default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "openeo-pg-parser-networkx>=2026.3.3",
     "openeo-processes-dask[implementations]",
     "python-multipart>=0.0.29",
+    "xclim>=0.61.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask", "openeo_processes_dask.*", "dask_geopandas", "dask_geopandas.*"]
+module = ["pygeoapi.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask", "openeo_processes_dask.*", "dask_geopandas", "dask_geopandas.*", "xclim", "xclim.*"]
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
     "pystac>=1.10,<2",
     "geojson-pydantic>=2.1.0",
     "httpx>=0.28.1",
-    "earthkit-transforms==0.5.*",
     "metpy>=1.7,<2",
     "xstac>=1.0,<2",
     "zarr>=3.1.6,<4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from open_climate_service import config as api_config
 from open_climate_service.main import app
+from open_climate_service.openeo import xclim_processes
 
 _TEST_CONFIG = """\
 extent:
@@ -32,8 +33,10 @@ def _test_open_climate_service_config(tmp_path_factory: pytest.TempPathFactory) 
 @pytest.fixture(autouse=True)
 def _reset_config_cache() -> Generator[None, None, None]:
     api_config._cache = None
+    xclim_processes._cache = None
     yield
     api_config._cache = None
+    xclim_processes._cache = None
 
 
 @pytest.fixture

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -136,12 +136,12 @@ def test_cdd_computes_via_xclim(daily_precip: xr.DataArray) -> None:
 
 
 def test_cdd_cwd_complementary_via_xclim(daily_precip: xr.DataArray) -> None:
-    r_cdd = xclim_atmos.maximum_consecutive_dry_days(daily_precip)
-    r_cwd = xclim_atmos.maximum_consecutive_wet_days(daily_precip)
+    r_cdd = xr.DataArray(xclim_atmos.maximum_consecutive_dry_days(daily_precip))
+    r_cwd = xr.DataArray(xclim_atmos.maximum_consecutive_wet_days(daily_precip))
     assert not np.allclose(r_cdd.values, r_cwd.values, equal_nan=True)
 
 
 def test_tx_days_above_higher_threshold_gives_fewer_days(daily_tasmax: xr.DataArray) -> None:
-    r25 = xclim_atmos.tx_days_above(daily_tasmax, thresh="25 degC")
-    r35 = xclim_atmos.tx_days_above(daily_tasmax, thresh="35 degC")
-    assert float(r35.mean()) <= float(r25.mean())
+    r25 = xr.DataArray(xclim_atmos.tx_days_above(daily_tasmax, thresh="25 degC"))
+    r35 = xr.DataArray(xclim_atmos.tx_days_above(daily_tasmax, thresh="35 degC"))
+    assert float(r35.mean().item()) <= float(r25.mean().item())

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -1,0 +1,83 @@
+"""Tests for the SPI climate index plugin process."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from open_climate_service.plugins.processes.climate_indices import spi
+from open_climate_service.process import get_process_metadata
+
+
+@pytest.fixture()
+def daily_precip() -> xr.DataArray:
+    """Five years of synthetic daily precipitation (kg m-2 s-1)."""
+    rng = np.random.default_rng(42)
+    time = pd.date_range("2000-01-01", periods=365 * 5, freq="D")
+    data = rng.exponential(scale=3.0, size=len(time)).astype(np.float32)
+    da = xr.DataArray(data, dims=["time"], coords={"time": time})
+    da.attrs["units"] = "kg m-2 s-1"
+    return da
+
+
+def test_spi_is_registered_as_process() -> None:
+    meta = get_process_metadata(spi)
+    assert meta is not None
+    assert meta["id"] == "spi"
+    assert "SPI" in meta["summary"]
+
+
+def test_spi_parameters_include_window_and_calibration() -> None:
+    meta = get_process_metadata(spi)
+    assert meta is not None
+    param_names = {p["name"] for p in meta["parameters"]}
+    assert {"pr", "window", "cal_start", "cal_end", "freq"} <= param_names
+
+
+def test_spi_window_defaults() -> None:
+    meta = get_process_metadata(spi)
+    assert meta is not None
+    window_param = next(p for p in meta["parameters"] if p["name"] == "window")
+    assert window_param["optional"] is True
+    assert window_param["default"] == 1
+
+
+def test_spi1_returns_dataarray_with_time_dimension(daily_precip: xr.DataArray) -> None:
+    result = spi(daily_precip, window=1)
+    assert isinstance(result, xr.DataArray)
+    assert "time" in result.dims
+
+
+def test_spi1_output_length_matches_monthly_resampling(daily_precip: xr.DataArray) -> None:
+    result = spi(daily_precip, window=1)
+    # 5 years of daily data → 60 monthly output steps
+    assert result.sizes["time"] == 60
+
+
+def test_spi3_produces_different_values_than_spi1(daily_precip: xr.DataArray) -> None:
+    r1 = spi(daily_precip, window=1)
+    r3 = spi(daily_precip, window=3)
+    assert not np.allclose(r1.values, r3.values, equal_nan=True)
+
+
+def test_spi_with_calibration_period(daily_precip: xr.DataArray) -> None:
+    result = spi(daily_precip, window=1, cal_start="2000-01-01", cal_end="2002-12-31")
+    assert isinstance(result, xr.DataArray)
+    assert result.sizes["time"] == 60
+
+
+def test_spi_appears_in_get_processes_endpoint(client: TestClient) -> None:
+    response = client.get("/processes")
+    assert response.status_code == 200
+    ids = {p["id"] for p in response.json()["processes"]}
+    assert "spi" in ids
+
+
+def test_spi_process_summary_in_catalog(client: TestClient) -> None:
+    response = client.get("/processes")
+    procs = {p["id"]: p for p in response.json()["processes"]}
+    assert "spi" in procs
+    assert "SPI" in procs["spi"]["summary"]

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -1,4 +1,4 @@
-"""Tests for the SPI climate index plugin process."""
+"""Tests for the SPI, CDD, CWD, and TX-days-above climate index plugin processes."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 from fastapi.testclient import TestClient
 
-from open_climate_service.plugins.processes.climate_indices import spi
+from open_climate_service.plugins.processes.climate_indices import cdd, cwd, spi, tx_days_above
 from open_climate_service.process import get_process_metadata
 
 
@@ -81,3 +81,116 @@ def test_spi_process_summary_in_catalog(client: TestClient) -> None:
     procs = {p["id"]: p for p in response.json()["processes"]}
     assert "spi" in procs
     assert "SPI" in procs["spi"]["summary"]
+
+
+# ---------------------------------------------------------------------------
+# CDD
+# ---------------------------------------------------------------------------
+
+
+def test_cdd_is_registered_as_process() -> None:
+    meta = get_process_metadata(cdd)
+    assert meta is not None
+    assert meta["id"] == "cdd"
+    assert "CDD" in meta["summary"] or "consecutive dry" in meta["summary"].lower()
+
+
+def test_cdd_thresh_default() -> None:
+    meta = get_process_metadata(cdd)
+    assert meta is not None
+    thresh_param = next(p for p in meta["parameters"] if p["name"] == "thresh")
+    assert thresh_param["default"] == "1 mm/day"
+
+
+def test_cdd_returns_annual_dataarray(daily_precip: xr.DataArray) -> None:
+    result = cdd(daily_precip)
+    assert isinstance(result, xr.DataArray)
+    assert "time" in result.dims
+    # 5 years of data → 5 annual values (last may be NaN for incomplete year)
+    assert result.sizes["time"] >= 4
+
+
+def test_cdd_monthly_freq(daily_precip: xr.DataArray) -> None:
+    result = cdd(daily_precip, freq="MS")
+    assert isinstance(result, xr.DataArray)
+    # Monthly resampling → ~60 steps for 5 years
+    assert result.sizes["time"] >= 12
+
+
+# ---------------------------------------------------------------------------
+# CWD
+# ---------------------------------------------------------------------------
+
+
+def test_cwd_is_registered_as_process() -> None:
+    meta = get_process_metadata(cwd)
+    assert meta is not None
+    assert meta["id"] == "cwd"
+    assert "CWD" in meta["summary"] or "consecutive wet" in meta["summary"].lower()
+
+
+def test_cwd_returns_annual_dataarray(daily_precip: xr.DataArray) -> None:
+    result = cwd(daily_precip)
+    assert isinstance(result, xr.DataArray)
+    assert "time" in result.dims
+
+
+def test_cdd_cwd_are_complementary(daily_precip: xr.DataArray) -> None:
+    r_cdd = cdd(daily_precip)
+    r_cwd = cwd(daily_precip)
+    assert not np.allclose(r_cdd.values, r_cwd.values, equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# TX days above
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def daily_tasmax() -> xr.DataArray:
+    """Five years of synthetic daily maximum temperature (degC)."""
+    rng = np.random.default_rng(7)
+    time = pd.date_range("2000-01-01", periods=365 * 5, freq="D")
+    data = rng.normal(loc=20.0, scale=8.0, size=len(time)).astype(np.float32)
+    da = xr.DataArray(data, dims=["time"], coords={"time": time})
+    da.attrs["units"] = "degC"
+    return da
+
+
+def test_tx_days_above_is_registered_as_process() -> None:
+    meta = get_process_metadata(tx_days_above)
+    assert meta is not None
+    assert meta["id"] == "tx_days_above"
+    assert "TX" in meta["summary"] or "maximum temperature" in meta["summary"].lower()
+
+
+def test_tx_days_above_thresh_default() -> None:
+    meta = get_process_metadata(tx_days_above)
+    assert meta is not None
+    thresh_param = next(p for p in meta["parameters"] if p["name"] == "thresh")
+    assert thresh_param["default"] == "25 degC"
+
+
+def test_tx_days_above_returns_annual_dataarray(daily_tasmax: xr.DataArray) -> None:
+    result = tx_days_above(daily_tasmax)
+    assert isinstance(result, xr.DataArray)
+    assert "time" in result.dims
+
+
+def test_tx_days_above_higher_threshold_gives_fewer_days(daily_tasmax: xr.DataArray) -> None:
+    r25 = tx_days_above(daily_tasmax, thresh="25 degC")
+    r35 = tx_days_above(daily_tasmax, thresh="35 degC")
+    # Fewer days exceed 35°C than 25°C
+    assert float(r35.mean()) <= float(r25.mean())
+
+
+# ---------------------------------------------------------------------------
+# API catalog — all four processes appear
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_indices_appear_in_get_processes(client: TestClient) -> None:
+    response = client.get("/processes")
+    assert response.status_code == 200
+    ids = {p["id"] for p in response.json()["processes"]}
+    assert {"spi", "cdd", "cwd", "tx_days_above"} <= ids

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -1,4 +1,4 @@
-"""Tests for the SPI, CDD, CWD, and TX-days-above climate index plugin processes."""
+"""Tests for the SPI curated wrapper and auto-registered xclim index processes."""
 
 from __future__ import annotations
 
@@ -6,9 +6,10 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+import xclim.indicators.atmos as xclim_atmos
 from fastapi.testclient import TestClient
 
-from open_climate_service.plugins.processes.climate_indices import cdd, cwd, spi, tx_days_above
+from open_climate_service.plugins.processes.climate_indices import spi
 from open_climate_service.process import get_process_metadata
 
 
@@ -21,6 +22,22 @@ def daily_precip() -> xr.DataArray:
     da = xr.DataArray(data, dims=["time"], coords={"time": time})
     da.attrs["units"] = "kg m-2 s-1"
     return da
+
+
+@pytest.fixture()
+def daily_tasmax() -> xr.DataArray:
+    """Five years of synthetic daily maximum temperature (degC)."""
+    rng = np.random.default_rng(7)
+    time = pd.date_range("2000-01-01", periods=365 * 5, freq="D")
+    data = rng.normal(loc=20.0, scale=8.0, size=len(time)).astype(np.float32)
+    da = xr.DataArray(data, dims=["time"], coords={"time": time})
+    da.attrs["units"] = "degC"
+    return da
+
+
+# ---------------------------------------------------------------------------
+# SPI — curated wrapper
+# ---------------------------------------------------------------------------
 
 
 def test_spi_is_registered_as_process() -> None:
@@ -53,7 +70,6 @@ def test_spi1_returns_dataarray_with_time_dimension(daily_precip: xr.DataArray) 
 
 def test_spi1_output_length_matches_monthly_resampling(daily_precip: xr.DataArray) -> None:
     result = spi(daily_precip, window=1)
-    # 5 years of daily data → 60 monthly output steps
     assert result.sizes["time"] == 60
 
 
@@ -79,118 +95,53 @@ def test_spi_appears_in_get_processes_endpoint(client: TestClient) -> None:
 def test_spi_process_summary_in_catalog(client: TestClient) -> None:
     response = client.get("/processes")
     procs = {p["id"]: p for p in response.json()["processes"]}
-    assert "spi" in procs
     assert "SPI" in procs["spi"]["summary"]
 
 
 # ---------------------------------------------------------------------------
-# CDD
+# CDD, CWD, TX days above — auto-registered from xclim
 # ---------------------------------------------------------------------------
 
 
-def test_cdd_is_registered_as_process() -> None:
-    meta = get_process_metadata(cdd)
-    assert meta is not None
-    assert meta["id"] == "cdd"
-    assert "CDD" in meta["summary"] or "consecutive dry" in meta["summary"].lower()
+def test_cdd_cwd_tx_appear_in_get_processes(client: TestClient) -> None:
+    response = client.get("/processes")
+    ids = {p["id"] for p in response.json()["processes"]}
+    assert {"cdd", "cwd", "tx_days_above"} <= ids
 
 
-def test_cdd_thresh_default() -> None:
-    meta = get_process_metadata(cdd)
-    assert meta is not None
-    thresh_param = next(p for p in meta["parameters"] if p["name"] == "thresh")
-    assert thresh_param["default"] == "1 mm/day"
+def test_cdd_catalog_metadata(client: TestClient) -> None:
+    procs = {p["id"]: p for p in client.get("/processes").json()["processes"]}
+    assert "consecutive dry" in procs["cdd"]["summary"].lower()
+    thresh = next(p for p in procs["cdd"]["parameters"] if p["name"] == "thresh")
+    assert thresh["default"] == "1 mm/day"
+    assert thresh["schema"].get("type") == "string"
 
 
-def test_cdd_returns_annual_dataarray(daily_precip: xr.DataArray) -> None:
-    result = cdd(daily_precip)
-    assert isinstance(result, xr.DataArray)
-    assert "time" in result.dims
-    # 5 years of data → 5 annual values (last may be NaN for incomplete year)
-    assert result.sizes["time"] >= 4
+def test_cwd_catalog_metadata(client: TestClient) -> None:
+    procs = {p["id"]: p for p in client.get("/processes").json()["processes"]}
+    assert "consecutive wet" in procs["cwd"]["summary"].lower()
 
 
-def test_cdd_monthly_freq(daily_precip: xr.DataArray) -> None:
-    result = cdd(daily_precip, freq="MS")
-    assert isinstance(result, xr.DataArray)
-    # Monthly resampling → ~60 steps for 5 years
-    assert result.sizes["time"] >= 12
+def test_tx_days_above_catalog_metadata(client: TestClient) -> None:
+    procs = {p["id"]: p for p in client.get("/processes").json()["processes"]}
+    assert "maximum temperature" in procs["tx_days_above"]["summary"].lower()
+    thresh = next(p for p in procs["tx_days_above"]["parameters"] if p["name"] == "thresh")
+    assert "25" in thresh["default"]
 
 
-# ---------------------------------------------------------------------------
-# CWD
-# ---------------------------------------------------------------------------
-
-
-def test_cwd_is_registered_as_process() -> None:
-    meta = get_process_metadata(cwd)
-    assert meta is not None
-    assert meta["id"] == "cwd"
-    assert "CWD" in meta["summary"] or "consecutive wet" in meta["summary"].lower()
-
-
-def test_cwd_returns_annual_dataarray(daily_precip: xr.DataArray) -> None:
-    result = cwd(daily_precip)
+def test_cdd_computes_via_xclim(daily_precip: xr.DataArray) -> None:
+    result = xclim_atmos.maximum_consecutive_dry_days(daily_precip)
     assert isinstance(result, xr.DataArray)
     assert "time" in result.dims
 
 
-def test_cdd_cwd_are_complementary(daily_precip: xr.DataArray) -> None:
-    r_cdd = cdd(daily_precip)
-    r_cwd = cwd(daily_precip)
+def test_cdd_cwd_complementary_via_xclim(daily_precip: xr.DataArray) -> None:
+    r_cdd = xclim_atmos.maximum_consecutive_dry_days(daily_precip)
+    r_cwd = xclim_atmos.maximum_consecutive_wet_days(daily_precip)
     assert not np.allclose(r_cdd.values, r_cwd.values, equal_nan=True)
 
 
-# ---------------------------------------------------------------------------
-# TX days above
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def daily_tasmax() -> xr.DataArray:
-    """Five years of synthetic daily maximum temperature (degC)."""
-    rng = np.random.default_rng(7)
-    time = pd.date_range("2000-01-01", periods=365 * 5, freq="D")
-    data = rng.normal(loc=20.0, scale=8.0, size=len(time)).astype(np.float32)
-    da = xr.DataArray(data, dims=["time"], coords={"time": time})
-    da.attrs["units"] = "degC"
-    return da
-
-
-def test_tx_days_above_is_registered_as_process() -> None:
-    meta = get_process_metadata(tx_days_above)
-    assert meta is not None
-    assert meta["id"] == "tx_days_above"
-    assert "TX" in meta["summary"] or "maximum temperature" in meta["summary"].lower()
-
-
-def test_tx_days_above_thresh_default() -> None:
-    meta = get_process_metadata(tx_days_above)
-    assert meta is not None
-    thresh_param = next(p for p in meta["parameters"] if p["name"] == "thresh")
-    assert thresh_param["default"] == "25 degC"
-
-
-def test_tx_days_above_returns_annual_dataarray(daily_tasmax: xr.DataArray) -> None:
-    result = tx_days_above(daily_tasmax)
-    assert isinstance(result, xr.DataArray)
-    assert "time" in result.dims
-
-
 def test_tx_days_above_higher_threshold_gives_fewer_days(daily_tasmax: xr.DataArray) -> None:
-    r25 = tx_days_above(daily_tasmax, thresh="25 degC")
-    r35 = tx_days_above(daily_tasmax, thresh="35 degC")
-    # Fewer days exceed 35°C than 25°C
+    r25 = xclim_atmos.tx_days_above(daily_tasmax, thresh="25 degC")
+    r35 = xclim_atmos.tx_days_above(daily_tasmax, thresh="35 degC")
     assert float(r35.mean()) <= float(r25.mean())
-
-
-# ---------------------------------------------------------------------------
-# API catalog — all four processes appear
-# ---------------------------------------------------------------------------
-
-
-def test_all_four_indices_appear_in_get_processes(client: TestClient) -> None:
-    response = client.get("/processes")
-    assert response.status_code == 200
-    ids = {p["id"] for p in response.json()["processes"]}
-    assert {"spi", "cdd", "cwd", "tx_days_above"} <= ids

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -6,9 +6,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-import xclim.indicators.atmos as xclim_atmos
 from fastapi.testclient import TestClient
 
+from open_climate_service.openeo.plugin_processes import load_plugin_processes
 from open_climate_service.plugins.processes.climate_indices import spi
 from open_climate_service.process import get_process_metadata
 
@@ -129,19 +129,24 @@ def test_tx_days_above_catalog_metadata(client: TestClient) -> None:
     assert "25" in thresh["default"]
 
 
-def test_cdd_computes_via_xclim(daily_precip: xr.DataArray) -> None:
-    result = xclim_atmos.maximum_consecutive_dry_days(daily_precip)
+def test_cdd_registered_callable_computes(daily_precip: xr.DataArray) -> None:
+    procs = dict(load_plugin_processes())
+    assert "cdd" in procs
+    result = xr.DataArray(procs["cdd"](pr=daily_precip))
     assert isinstance(result, xr.DataArray)
     assert "time" in result.dims
 
 
-def test_cdd_cwd_complementary_via_xclim(daily_precip: xr.DataArray) -> None:
-    r_cdd = xr.DataArray(xclim_atmos.maximum_consecutive_dry_days(daily_precip))
-    r_cwd = xr.DataArray(xclim_atmos.maximum_consecutive_wet_days(daily_precip))
+def test_cdd_cwd_registered_callables_are_complementary(daily_precip: xr.DataArray) -> None:
+    procs = dict(load_plugin_processes())
+    r_cdd = xr.DataArray(procs["cdd"](pr=daily_precip))
+    r_cwd = xr.DataArray(procs["cwd"](pr=daily_precip))
     assert not np.allclose(r_cdd.values, r_cwd.values, equal_nan=True)
 
 
-def test_tx_days_above_higher_threshold_gives_fewer_days(daily_tasmax: xr.DataArray) -> None:
-    r25 = xr.DataArray(xclim_atmos.tx_days_above(daily_tasmax, thresh="25 degC"))
-    r35 = xr.DataArray(xclim_atmos.tx_days_above(daily_tasmax, thresh="35 degC"))
+def test_tx_days_above_registered_callable_higher_threshold_gives_fewer_days(daily_tasmax: xr.DataArray) -> None:
+    procs = dict(load_plugin_processes())
+    assert "tx_days_above" in procs
+    r25 = xr.DataArray(procs["tx_days_above"](tasmax=daily_tasmax, thresh="25 degC"))
+    r35 = xr.DataArray(procs["tx_days_above"](tasmax=daily_tasmax, thresh="35 degC"))
     assert float(r35.mean().item()) <= float(r25.mean().item())

--- a/uv.lock
+++ b/uv.lock
@@ -888,23 +888,6 @@ wheels = [
 ]
 
 [[package]]
-name = "earthkit-transforms"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "array-api-compat" },
-    { name = "earthkit-data" },
-    { name = "earthkit-utils" },
-    { name = "geopandas" },
-    { name = "numpy" },
-    { name = "xarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/5e/f34a8c234c3ec2687482f522be90b0eeea8f8527898fa6649d9ccac72e85/earthkit_transforms-0.5.4.tar.gz", hash = "sha256:784a2154427baf49baafcc4b2fb44cc945e6fc92f6f93f46ad0ac3d2dee95558", size = 81956, upload-time = "2026-03-25T16:55:29.447Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/1b/0c2dff858eba3a04f7492977d4871241f362e90a92585a3512af0db59263/earthkit_transforms-0.5.4-py3-none-any.whl", hash = "sha256:6e02886156395e50aad907f42b994bd922b51fd39fd63d96d4f27af7337e7c92", size = 44860, upload-time = "2026-03-25T16:55:28.542Z" },
-]
-
-[[package]]
 name = "earthkit-utils"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2210,7 +2193,6 @@ version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "dhis2eo" },
-    { name = "earthkit-transforms" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
     { name = "geozarr-toolkit" },
@@ -2249,7 +2231,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dhis2eo", specifier = ">=1.2.1" },
-    { name = "earthkit-transforms", specifier = "==0.5.*" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "geojson-pydantic", specifier = ">=2.1.0" },
     { name = "geozarr-toolkit", specifier = "==0.1.*" },

--- a/uv.lock
+++ b/uv.lock
@@ -214,6 +214,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boltons"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/54/71a94d8e02da9a865587fb3fff100cb0fc7aa9f4d5ed9ed3a591216ddcc7/boltons-25.0.0.tar.gz", hash = "sha256:e110fbdc30b7b9868cb604e3f71d4722dd8f4dcb4a5ddd06028ba8f1ab0b5ace", size = 246294, upload-time = "2025-02-03T05:57:59.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7f/0e961cf3908bc4c1c3e027de2794f867c6c89fb4916fc7dba295a0e80a2d/boltons-25.0.0-py3-none-any.whl", hash = "sha256:dc9fb38bf28985715497d1b54d00b62ea866eca3938938ea9043e254a3a6ca62", size = 194210, upload-time = "2025-02-03T05:57:56.705Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +234,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
+]
+
+[[package]]
+name = "bottleneck"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/d8/6d641573e210768816023a64966d66463f2ce9fc9945fa03290c8a18f87c/bottleneck-1.6.0.tar.gz", hash = "sha256:028d46ee4b025ad9ab4d79924113816f825f62b17b87c9e1d0d8ce144a4a0e31", size = 104311, upload-time = "2025-09-08T16:30:38.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/1a/e117cd5ff7056126d3291deb29ac8066476e60b852555b95beb3fc9d62a0/bottleneck-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d015de414ca016ebe56440bdf5d3d1204085080527a3c51f5b7b7a3e704fe6fd", size = 100521, upload-time = "2025-09-08T16:30:03.89Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/22/05555a9752357e24caa1cd92324d1a7fdde6386aab162fcc451f8f8eedc2/bottleneck-1.6.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:456757c9525b0b12356f472e38020ed4b76b18375fd76e055f8d33fb62956f5e", size = 377719, upload-time = "2025-09-08T16:30:05.135Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/76593af47097d9633109bed04dbcf2170707dd84313ca29f436f9234bc51/bottleneck-1.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c65254d51b6063c55f6272f175e867e2078342ae75f74be29d6612e9627b2c0", size = 368577, upload-time = "2025-09-08T16:30:06.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/4dcacaf637d2b8d89ea746c74159adda43858d47358978880614c3fa4391/bottleneck-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a172322895fbb79c6127474f1b0db0866895f0b804a18d5c6b841fea093927fe", size = 361441, upload-time = "2025-09-08T16:30:07.613Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/21eb1eb1c42cb7be2872d0647c292fc75768d14e1f0db66bf907b24b2464/bottleneck-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d5e81b642eb0d5a5bf00312598d7ed142d389728b694322a118c26813f3d1fa9", size = 373416, upload-time = "2025-09-08T16:30:08.899Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cb/7957ff40367a151139b5f1854616bf92e578f10804d226fbcdecfd73aead/bottleneck-1.6.0-cp313-cp313-win32.whl", hash = "sha256:543d3a89d22880cd322e44caff859af6c0489657bf9897977d1f5d3d3f77299c", size = 108029, upload-time = "2025-09-08T16:30:09.909Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a8/735df4156fa5595501d5d96a6ee102f49c13d2ce9e2a287ad51806bc3ba0/bottleneck-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:48a44307d604ceb81e256903e5d57d3adb96a461b1d3c6a69baa2c67e823bd36", size = 113497, upload-time = "2025-09-08T16:30:10.82Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5c/8c1260df8ade7cebc2a8af513a27082b5e36aa4a5fb762d56ea6d969d893/bottleneck-1.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:547e6715115867c4657c9ae8cc5ddac1fec8fdad66690be3a322a7488721b06b", size = 101606, upload-time = "2025-09-08T16:30:11.935Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/f03e2944e91ee962922c834ed21e5be6d067c8395681f5dc6c67a0a26853/bottleneck-1.6.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e4a4a6e05b6f014c307969129e10d1a0afd18f3a2c127b085532a4a76677aef", size = 391804, upload-time = "2025-09-08T16:30:13.13Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/58/2b356b8a81eb97637dccee6cf58237198dd828890e38be9afb4e5e58e38e/bottleneck-1.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2baae0d1589b4a520b2f9cf03528c0c8b20717b3f05675e212ec2200cf628f12", size = 383443, upload-time = "2025-09-08T16:30:14.318Z" },
+    { url = "https://files.pythonhosted.org/packages/55/52/cf7d09ed3736ad0d50c624787f9b580ae3206494d95cc0f4814b93eef728/bottleneck-1.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2e407139b322f01d8d5b6b2e8091b810f48a25c7fa5c678cfcdc420dfe8aea0a", size = 375458, upload-time = "2025-09-08T16:30:15.379Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e9/7c87a34a24e339860064f20fac49f6738e94f1717bc8726b9c47705601d8/bottleneck-1.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1adefb89b92aba6de9c6ea871d99bcd29d519f4fb012cc5197917813b4fc2c7f", size = 386384, upload-time = "2025-09-08T16:30:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/59/57/db51855e18a47671801180be748939b4c9422a0544849af1919116346b5f/bottleneck-1.6.0-cp313-cp313t-win32.whl", hash = "sha256:64b8690393494074923780f6abdf5f5577d844b9d9689725d1575a936e74e5f0", size = 109448, upload-time = "2025-09-08T16:30:18.076Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1e/683c090b624f13a5bf88a0be2241dc301e98b2fb72a45812a7ae6e456cc4/bottleneck-1.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:cb67247f65dcdf62af947c76c6c8b77d9f0ead442cac0edbaa17850d6da4e48d", size = 115190, upload-time = "2025-09-08T16:30:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/eb7c08964a3f3c4719f98795ccd21807ee9dd3071a0f9ad652a5f19196ff/bottleneck-1.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98f1d789042511a0f042b3bdcd2903e8567e956d3aa3be189cce3746daeb8550", size = 100544, upload-time = "2025-09-08T16:30:20.22Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ec/c6f3be848f37689f481797ce7d9807d5f69a199d7fc0e46044f9b708c468/bottleneck-1.6.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1fad24c99e39ad7623fc2a76d37feb26bd32e4dd170885edf4dbf4bfce2199a3", size = 378315, upload-time = "2025-09-08T16:30:21.409Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8f/2d6600836e2ea8f14fcefac592dc83497e5b88d381470c958cb9cdf88706/bottleneck-1.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643e61e50a6f993debc399b495a1609a55b3bd76b057e433e4089505d9f605c7", size = 368978, upload-time = "2025-09-08T16:30:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/bf72b49f5040212873b985feef5050015645e0a02204b591e1d265fc522a/bottleneck-1.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa668efbe4c6b200524ea0ebd537212da9b9801287138016fdf64119d6fcf201", size = 362074, upload-time = "2025-09-08T16:30:24.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c8/c4891a0604eb680031390182c6e264247e3a9a8d067d654362245396fadf/bottleneck-1.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9f7dd35262e89e28fedd79d45022394b1fa1aceb61d2e747c6d6842e50546daa", size = 374019, upload-time = "2025-09-08T16:30:26.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2d/ed096f8d1b9147e84914045dd89bc64e3c32eee49b862d1e20d573a9ab0d/bottleneck-1.6.0-cp314-cp314-win32.whl", hash = "sha256:bd90bec3c470b7fdfafc2fbdcd7a1c55a4e57b5cdad88d40eea5bc9bab759bf1", size = 110173, upload-time = "2025-09-08T16:30:27.521Z" },
+    { url = "https://files.pythonhosted.org/packages/33/70/1414acb6ae378a15063cfb19a0a39d69d1b6baae1120a64d2b069902549b/bottleneck-1.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:b43b6d36a62ffdedc6368cf9a708e4d0a30d98656c2b5f33d88894e1bcfd6857", size = 115899, upload-time = "2025-09-08T16:30:28.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ed/4570b5d8c1c85ce3c54963ebc37472231ed54f0b0d8dbb5dde14303f775f/bottleneck-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:53296707a8e195b5dcaa804b714bd222b5e446bd93cd496008122277eb43fa87", size = 101615, upload-time = "2025-09-08T16:30:29.556Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/93/c148faa07ae91f266be1f3fad1fde95aa2449e12937f3f3df2dd720b86e0/bottleneck-1.6.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d6df19cc48a83efd70f6d6874332aa31c3f5ca06a98b782449064abbd564cf0e", size = 392411, upload-time = "2025-09-08T16:30:31.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/1c/e6ad221d345a059e7efb2ad1d46a22d9fdae0486faef70555766e1123966/bottleneck-1.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96bb3a52cb3c0aadfedce3106f93ab940a49c9d35cd4ed612e031f6deb27e80f", size = 384022, upload-time = "2025-09-08T16:30:32.364Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/40/5b15c01eb8c59d59bc84c94d01d3d30797c961f10ec190f53c27e05d62ab/bottleneck-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1db9e831b69d5595b12e79aeb04cb02873db35576467c8dd26cdc1ee6b74581", size = 376004, upload-time = "2025-09-08T16:30:33.731Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f6/cb228f5949553a5c01d1d5a3c933f0216d78540d9e0bf8dd4343bb449681/bottleneck-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4dd7ac619570865fcb7a0e8925df418005f076286ad2c702dd0f447231d7a055", size = 386909, upload-time = "2025-09-08T16:30:34.973Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9a/425065c37a67a9120bf53290371579b83d05bf46f3212cce65d8c01d470a/bottleneck-1.6.0-cp314-cp314t-win32.whl", hash = "sha256:7fb694165df95d428fe00b98b9ea7d126ef786c4a4b7d43ae2530248396cadcb", size = 111636, upload-time = "2025-09-08T16:30:36.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/23/c41006e42909ec5114a8961818412310aa54646d1eae0495dbff3598a095/bottleneck-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:174b80930ce82bd8456c67f1abb28a5975c68db49d254783ce2cb6983b4fea40", size = 117611, upload-time = "2025-09-08T16:30:37.055Z" },
 ]
 
 [[package]]
@@ -1939,6 +1987,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/1c/c80cb7719721a44846c6301ef118434bae30a423924bfad3a47f16bdc064/narwhals-2.22.0.tar.gz", hash = "sha256:6486282bb7e4b4ab55963efbd8be1451b764cc4874b74d1fd625eba9dc60b86f", size = 417565, upload-time = "2026-06-01T13:34:36.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b6/e7cdde7b8e90d5dff25b622f95833ef26567ad184c977278b93a1cbd5717/narwhals-2.22.0-py3-none-any.whl", hash = "sha256:1421797ede01789cc1537619dbc3f36f840737240f748fdb24a60a0225fc80be", size = 453815, upload-time = "2026-06-01T13:34:34.127Z" },
+]
+
+[[package]]
 name = "netcdf4"
 version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2172,6 +2229,7 @@ dependencies = [
     { name = "starlette" },
     { name = "topozarr" },
     { name = "uvicorn" },
+    { name = "xclim" },
     { name = "xstac" },
     { name = "zarr" },
 ]
@@ -2210,6 +2268,7 @@ requires-dist = [
     { name = "starlette", specifier = ">=0.27.0" },
     { name = "topozarr", specifier = "==0.0.*" },
     { name = "uvicorn", specifier = ">=0.41.0" },
+    { name = "xclim", specifier = ">=0.61.1" },
     { name = "xstac", specifier = ">=1.0,<2" },
     { name = "zarr", specifier = ">=3.1.6,<4" },
 ]
@@ -3400,6 +3459,39 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3641,6 +3733,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -3987,6 +4088,35 @@ wheels = [
 ]
 
 [[package]]
+name = "xclim"
+version = "0.61.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boltons" },
+    { name = "bottleneck" },
+    { name = "cf-xarray" },
+    { name = "cftime" },
+    { name = "click" },
+    { name = "dask" },
+    { name = "filelock" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pint" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "xarray" },
+    { name = "yamale" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/31/8e7b119b9df1eacd6db37f36b2a8cdc760c58962150e3b250b3f76118734/xclim-0.61.1.tar.gz", hash = "sha256:8a093a7c8a0841fa5bf040ed358288e6b8c4dad782af07abc2f8cb6dc7d5f567", size = 906174, upload-time = "2026-05-25T16:10:28.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/f8/e35cdc16e01f773a74ad4fd971198b77243baa8423245eb0193c1aa5327d/xclim-0.61.1-py3-none-any.whl", hash = "sha256:cc70ebd77115597422228d7fce99c3a7d3c7f7e0f76bbbc3b99ba9edd9defab0", size = 384714, upload-time = "2026-05-25T16:10:26.504Z" },
+]
+
+[[package]]
 name = "xcube-core"
 version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4124,6 +4254,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/38/d45c4bf760f3c46621631b48ae0af7583747022051bc318a51cb87a9ea75/xvec-0.5.2.tar.gz", hash = "sha256:f62334066fa0a85a51732361170bb050ae9106ffababb6afbb2301a3f7ee9a04", size = 2520054, upload-time = "2025-11-22T21:08:11.993Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/b4/b3161f856c704938d69c10680abaaf4a24783fa58a9f95590f2a0b63dd09/xvec-0.5.2-py3-none-any.whl", hash = "sha256:757243b9ad8d66922111b16f51d157560cf11916fe790a20b9e955a44efb8e8d", size = 784751, upload-time = "2025-11-22T21:08:10.188Z" },
+]
+
+[[package]]
+name = "yamale"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/64/9e5de0e829920b848dcf5fe3ff64936d83cc7471babd264588b08bca97e0/yamale-6.1.0.tar.gz", hash = "sha256:fd435aa7b830c73e89a9ef548c0ace2d3d8dc3e5e180e6b57ff70b31495672fd", size = 42402, upload-time = "2025-11-20T16:52:30.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/fc/cbad39af7e761525077690ddff1ae19ace7e2f54552e90fb848a43a270fa/yamale-6.1.0-py3-none-any.whl", hash = "sha256:7e109c9d83e3a7e42703516cb2b70b9c7aa5b7a738019c4a6c202b6b0b9096c5", size = 58215, upload-time = "2025-11-20T16:52:28.806Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds full xclim climate index support to the openEO process catalogue — all 179 indicators auto-registered with no per-index boilerplate.

### Auto-registration

`xclim_processes.scan()` iterates over all xclim indicator modules (`atmos`, `land`, `seaIce`) and registers each indicator as an openEO process. Metadata — id, summary, description, parameter descriptions, schemas, and defaults — is read directly from xclim. No YAML registration or manual wrapper needed for any of the 179 indicators.

### Curated override layer

A single `@process` wrapper in `plugins/processes/climate_indices.py` overrides the auto-generated `spi` entry with a more user-friendly `window` description: _"Accumulation window in months (1 = SPI-1, 3 = SPI-3, 6 = SPI-6)"_. All other indicators (including CDD, CWD, TX days above) are served directly from xclim with no manual code.

### Resolution order

1. xclim auto-scan (all 179 indicators)
2. Built-in file plugins `plugins/processes/` (override by id)
3. Instance plugins `plugins_dir/processes/` (override everything)

### Type schema improvements

- `@process` decorator updated to resolve `str | None` union annotations to `{"type": "string"}`
- `xr.DataArray` parameters mapped to `{"type": "object", "subtype": "datacube"}` via `InputKind.VARIABLE`
- `from __future__ import annotations` removed from plugin files (broke annotation introspection at runtime)

### Dependency

`xclim>=0.61.1` added as an explicit dependency — not transitively available via `earthkit-transforms==0.5.*`.

Partially closes #155 — rain season (SR/ER/DRS), cold days, hot/cold spell frequency, and `climatological_normal`/`anomaly` left for follow-up.

---

## Endpoint test results

Tested against a live local instance (`GET /processes`):

| Check | Result |
|---|---|
| Total processes in catalogue | **303** (128 standard openEO + 175 xclim) |
| Key indices present | `spi`, `cdd`, `cwd`, `tx_days_above`, `heat_wave_frequency`, `frost_days`, `growing_degree_days` ✅ |
| `spi.window` schema | `{"type": "integer"}`, default `1` ✅ |
| `spi.window` description | _"Accumulation window in months (1 = SPI-1…"_ ✅ |
| `spi.pr` schema | `{"type": "object", "subtype": "datacube"}` ✅ |
| `spi.cal_start` schema | `{"type": "string"}` ✅ |
| `cdd.thresh` default | `"1 mm/day"`, schema `{"type": "string"}` ✅ |
| `cdd.pr` schema | `{"type": "object", "subtype": "datacube"}` ✅ |
| `tx_days_above.thresh` default | `"25.0 degC"` ✅ |
| `tx_days_above.tasmax` schema | `{"type": "object", "subtype": "datacube"}` ✅ |

---

## Test plan

- [x] `spi`, `cdd`, `cwd`, `tx_days_above` all appear in `GET /processes`
- [x] `spi`: metadata, window default, output shape, SPI-1 != SPI-3, calibration period accepted
- [x] `cdd`/`cwd`/`tx_days_above`: catalog metadata (summary, thresh default, schema)
- [x] `cdd`/`cwd`/`tx_days_above`: functional computation via registered callables from `load_plugin_processes()`
- [x] Higher TX threshold gives fewer days

16/16 tests passing (~175 additional xclim indicators available in the live instance).