### PR TITLE
docs: update extensibility.md with non-xclim process example and workflow JSON example

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -37,32 +37,31 @@ See [Adding custom datasets](adding_custom_datasets.md) for the full template fi
 
 ## Processes
 
-Custom processes are Python functions decorated with `@process` and placed in `plugins_dir/processes/`. They appear in `GET /processes` alongside standard openEO processes and are callable directly by `process_id` in any process graph — no `run_udf` indirection needed.
+Custom processes are Python functions decorated with `@process` and placed in `plugins_dir/processes/`. They appear in `GET /processes` alongside standard openEO processes and are callable directly by `process_id` in any process graph.
 
 ```python
-# plugins/processes/climate_indices.py
+# plugins/processes/indices.py
 import xarray as xr
 from open_climate_service.process import process
 
-@process(summary="Maximum consecutive dry days")
-def cdd(pr: xr.DataArray, thresh: str = "1mm/day") -> xr.DataArray:
-    """Maximum number of consecutive days with precipitation below threshold."""
-    import xclim.atmos
-    return xclim.atmos.maximum_consecutive_dry_days(pr, thresh=thresh)
+@process(summary="Precipitation anomaly relative to a baseline mean")
+def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray:
+    """Deviation of precipitation from a long-term baseline mean."""
+    return pr - baseline
 ```
 
-The `@process` decorator derives the process id (function name), summary, parameter names, types, and defaults from the function signature and docstring. Use explicit metadata to override:
+The `@process` decorator derives the process id (function name), summary, parameter names, types, and defaults from the function signature and docstring. Use explicit metadata to override descriptions:
 
 ```python
 @process(
-    summary="Custom summary",
-    parameters={"thresh": {"description": "Precipitation threshold"}},
+    summary="Precipitation anomaly relative to a baseline mean",
+    parameters={"baseline": {"description": "Long-term mean precipitation (kg m-2 s-1)."}},
 )
-def cdd(pr: xr.DataArray, thresh: str = "1mm/day") -> xr.DataArray:
+def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray:
     ...
 ```
 
-A plugin process with the same id as a standard openEO process overrides it. The server must be restarted to pick up new process files.
+A plugin process with the same id as an existing process (standard openEO or built-in) overrides it. The server must be restarted to pick up new process files.
 
 ---
 
@@ -73,7 +72,70 @@ Reusable pipeline compositions are implemented as **UDPs** (User Defined Process
 ```
 plugins/
 └── workflows/
-    └── my_workflow.json
+    └── monthly_rainfall.json
+```
+
+### Example: monthly rainfall totals
+
+```json
+{
+  "id": "monthly_rainfall",
+  "summary": "Monthly total precipitation for a collection and time range",
+  "parameters": [
+    {"name": "collection_id", "description": "Collection to load", "schema": {"type": "string"}},
+    {"name": "temporal_extent", "description": "Time range [start, end]", "schema": {"type": "array"}}
+  ],
+  "process_graph": {
+    "load": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": {"from_parameter": "collection_id"},
+        "temporal_extent": {"from_parameter": "temporal_extent"}
+      }
+    },
+    "aggregate": {
+      "process_id": "aggregate_temporal_period",
+      "arguments": {
+        "data": {"from_node": "load"},
+        "period": "month",
+        "reducer": {
+          "process_graph": {
+            "sum": {
+              "process_id": "sum",
+              "arguments": {"data": {"from_parameter": "data"}},
+              "result": true
+            }
+          }
+        }
+      }
+    },
+    "save": {
+      "process_id": "save_result",
+      "arguments": {"data": {"from_node": "aggregate"}, "format": "Zarr"},
+      "result": true
+    }
+  }
+}
+```
+
+Calling the workflow from any openEO client:
+
+```python
+import openeo
+
+conn = openeo.connect("http://your-instance:8000")
+job = conn.execute_batch_job({
+    "process_graph": {
+        "result": {
+            "process_id": "monthly_rainfall",
+            "arguments": {
+                "collection_id": "chirps_rainfall_daily",
+                "temporal_extent": ["2020-01-01", "2023-12-31"]
+            },
+            "result": true
+        }
+    }
+})
 ```
 
 Workflow JSON files are loaded on each request to `GET /process_graphs`, so changes on disk take effect without restarting the server. A plugin workflow with the same `id` as a built-in overrides it.


### PR DESCRIPTION
## Changes

- Remove `" — no run_udf indirection needed"` from the Processes section intro
- Replace the stale xclim-based process example with a plain `precip_anomaly` function — easier to understand without xclim knowledge, better illustrates the `@process` pattern itself
- Expand the Workflows section with a full `monthly_rainfall` UDP JSON example (parameters, load → aggregate → save chain) and a Python client snippet showing how to call it