### PR TITLE
ci: install GDAL system library in Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Create .env from example
         run: cp .env.example .env
 
+      - name: Install GDAL system library
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgdal-dev gdal-bin
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -31,6 +36,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+
+      - name: Pin GDAL Python binding to system libgdal version
+        run: |
+          GDAL_VERSION=$(gdal-config --version)
+          echo "System GDAL: $GDAL_VERSION"
+          sed -i "s/\"gdal==[^\"]*\"/\"gdal==$GDAL_VERSION\"/" pyproject.toml
 
       - name: Install dependencies
         run: uv sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ The config is regenerated on each `publish_artifact` call and also at startup vi
 
 ## Commit conventions
 
-- Use conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`)
-- No attribution lines in commit messages
-- No emojis anywhere — not in commits, code, comments, or documentation
+- **Conventional Commits** for all git activity — commit messages, branch names, and PR titles.
+  - Format: `<type>(<scope>)?: <description>` (e.g. `feat(ci): add docker publish workflow`, `fix(main): correct db path creation`).
+  - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`.
+  - Branch names: `<type>/<short-description>` (e.g. `feat/makefile-and-ci`, `fix/sqlite-path`).
+- **No attribution.** Do not add `Co-Authored-By: Claude ...`, "Generated with Claude Code", or any similar attribution to commits, PRs, or files.
+- **No emojis** anywhere — not in commits, code, comments, or documentation.


### PR DESCRIPTION
## Docker build fix

The `Build and push Docker image` workflow has been failing on `main`. The on-runner `Install dependencies` step (`uv sync`) dies building GDAL from source:

```
× Failed to build `gdal==3.12.2`
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
      FileNotFoundError: [Errno 2] No such file or directory: 'gdal-config'
```

`gdal==3.12.2` ships no wheel, so uv builds it from source, which requires the system `libgdal-dev` / `gdal-config`. The runner doesn't have it.

### Why CI passed but Docker didn't

`ci.yml` already installs `libgdal-dev`/`gdal-bin` and pins the gdal Python binding to `gdal-config --version` before `uv sync`. `docker.yml` was never given the same treatment after GDAL was added as a dependency, so its on-runner `uv sync` (used to generate the OpenAPI spec) breaks.

### Fix

Mirror `ci.yml` in `docker.yml`: install the GDAL system library and pin the gdal binding to the system libgdal version before `uv sync`.

## Docs

Also expands the commit conventions in `AGENTS.md` with the full Conventional Commits format, the complete type list, and branch-naming guidance.