### PR TITLE
fix: use store's native proj:code in STAC collection instead of instance CRS

### DIFF
--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -204,6 +204,12 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
             detail=f"Published Zarr store for artifact '{artifact.artifact_id}' is temporarily unavailable",
         ) from exc
     try:
+        # The store's native CRS (written by the ingest orchestrator) takes precedence
+        # over the instance-wide CRS set in _build_collection_template. Plugins that
+        # store data in WGS84 (e.g. CHIRPS3) should not inherit the instance UTM CRS.
+        store_crs = ds.attrs.get("proj:code")
+        if store_crs:
+            template.extra_fields["proj:code"] = store_crs
         x_dimension, y_dimension = get_x_y_dims(ds)
         time_dimension = get_time_dim(ds)
         result = xarray_to_stac(

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -534,6 +534,8 @@ def test_build_collection_with_xstac_normalizes_pystac_collection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class DummyDataset:
+        attrs: dict[str, object] = {}
+
         def close(self) -> None:
             pass
 
@@ -566,6 +568,8 @@ def test_collection_reuses_cached_xstac_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class DummyDataset:
+        attrs: dict[str, object] = {}
+
         def close(self) -> None:
             pass
 
@@ -631,6 +635,8 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class DummyDataset:
+        attrs: dict[str, object] = {}
+
         def close(self) -> None:
             pass
 


### PR DESCRIPTION
## Summary

- `_build_collection_template` always sets `proj:code` to the instance-wide CRS (e.g. `EPSG:32645` for a UTM instance)
- Plugins that store data in WGS84 (CHIRPS3, ERA5-Land, CAMS, etc.) inherit this CRS incorrectly
- The map viewer reads `proj:code`, fetches the proj4 string from epsg.io, and passes it to `ZarrLayer` — causing data in WGS84 coordinates to be reprojected with the UTM transform and rendered at the wrong location (near the equator instead of Nepal)

The fix reads `proj:code` from the Zarr store's root attributes (written by the ingest orchestrator from `GridSpec.crs`) and overrides the instance CRS when building the STAC collection.

## Test plan

- [ ] Ingest CHIRPS3 on a UTM instance (e.g. `crs: EPSG:32645`) — collection should report `proj:code: EPSG:4326`
- [ ] Ingest a dataset that IS stored in the instance CRS — collection should report the UTM code
- [ ] Open `/map` and confirm precipitation renders over Nepal, not near the equator