### PR TITLE
fix: handle static datasets with no time dimension in STAC builder

### DIFF
--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -211,7 +211,10 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         if store_crs:
             template.extra_fields["proj:code"] = store_crs
         x_dimension, y_dimension = get_x_y_dims(ds)
-        time_dimension = get_time_dim(ds)
+        try:
+            time_dimension: str | None = get_time_dim(ds)
+        except ValueError:
+            time_dimension = None  # static dataset with no time dimension
         result = xarray_to_stac(
             ds,
             template,


### PR DESCRIPTION
## Summary

- `_build_collection_with_xstac` calls `get_time_dim(ds)` which raises `ValueError` for stores with no time coordinate (e.g. Copernicus DEM GLO-30, a static raster ingested as a single period with `time_dim=False`)
- This caused publication to fail with `500: Unable to find time dimension`
- Fix: catch the `ValueError` and pass `temporal_dimension=None` to `xarray_to_stac`, which already supports timeless collections

## Test plan

- [ ] Ingest Copernicus DEM (static, no time dim) — `/collections/copernicus_dem_elevation` should return without error
- [ ] Temporal datasets (CHIRPS3, ERA5) unaffected