### PR TITLE
refactor: rename ingestion.default_params to ingestion.params

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -54,7 +54,7 @@ class ENACTSRainfallPlugin:
 
 **`fetch_period`** — fetches exactly one period and returns it as an `xarray.Dataset`. The framework appends it directly to the Icechunk-backed Zarr store. The function should not write to disk.
 
-`**params` in both `probe` and `fetch_period` receives the `default_params` dict from the YAML template, making it possible to reuse the same class for multiple variables.
+`**params` in both `probe` and `fetch_period` receives the `params` dict from the YAML template, making it possible to reuse the same class for multiple variables.
 
 ## Step 2: Create a dataset template YAML
 
@@ -122,21 +122,21 @@ Omit `sync.availability` entirely for `static` datasets or when you always want 
 | Field | Required | Description |
 | ----- | -------- | ----------- |
 | `ingestion.plugin` | Yes | Dotted path to the streaming plugin class |
-| `ingestion.default_params` | No | Extra keyword arguments forwarded to `probe` and `fetch_period` as `**params`, and to the plugin constructor |
+| `ingestion.params` | No | Extra keyword arguments forwarded to `probe` and `fetch_period` as `**params`, and to the plugin constructor |
 
-Multiple templates can share the same plugin class and differ only in `default_params`:
+Multiple templates can share the same plugin class and differ only in `params`:
 
 ```yaml
 - id: era5land_temperature_hourly
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandHourlySingleBandPlugin
-    default_params:
+    params:
       variable: 2m_temperature
 
 - id: era5land_precipitation_hourly
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipitationPlugin
-    default_params:
+    params:
       variable: total_precipitation
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,19 +178,19 @@ class MyStreamingPlugin:
 
 Responsibilities are split: the plugin knows the source; the orchestrator owns resume, concurrency, and store commits; `open_climate_service.ingestions` owns artifacts, publication, and API responses.
 
-Multiple YAML templates can reference the same plugin class and differentiate via `ingestion.default_params`. This is the intended pattern for sources that expose multiple variables:
+Multiple YAML templates can reference the same plugin class and differentiate via `ingestion.params`. This is the intended pattern for sources that expose multiple variables:
 
 ```yaml
 # era5land_temperature_hourly.yaml
 ingestion:
   plugin: dhis2eo.streaming.era5_land.ERA5LandPlugin
-  default_params:
+  params:
     variable: 2m_temperature
 
 # era5land_precipitation_hourly.yaml
 ingestion:
   plugin: dhis2eo.streaming.era5_land.ERA5LandPlugin
-  default_params:
+  params:
     variable: total_precipitation
 ```
 

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -66,7 +66,7 @@ def download_dataset(
     eo_download_func = get_dynamic_function(eo_download_func_path)
     before_files = {path.resolve(): path.stat().st_mtime_ns for path in get_cache_files(dataset)}
 
-    params = dict(ingestion.get("default_params", {}))
+    params = dict(ingestion.get("params", {}))
     params.update(
         {
             "start": start,

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -286,13 +286,13 @@ def _create_streaming_artifact(
         return existing
 
     ingestion = dataset.get("ingestion")
-    raw_params = ingestion.get("default_params") if isinstance(ingestion, dict) else None
+    raw_params = ingestion.get("params") if isinstance(ingestion, dict) else None
     if raw_params is None:
         params: dict[str, object] = {}
     elif isinstance(raw_params, dict):
         params = dict(raw_params)
     else:
-        raise HTTPException(status_code=500, detail="ingestion.default_params must be an object")
+        raise HTTPException(status_code=500, detail="ingestion.params must be an object")
     if country_code is not None:
         params["country_code"] = country_code
 
@@ -383,7 +383,7 @@ def _create_streaming_artifact(
 def _load_streaming_plugin(plugin_path: str, *, params: dict[str, object]) -> IngestionPlugin:
     """Load and instantiate one streaming plugin class from a dotted import path.
 
-    Template-defined `ingestion.default_params` are treated as plugin
+    Template-defined `ingestion.params` are treated as plugin
     configuration and passed to the constructor here. The same params are also
     forwarded later to `probe(...)` and `fetch_period(...)` so plugins may keep
     configuration in constructor state, per-call kwargs, or both.

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -17,7 +17,7 @@
       resolution: PT1H
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandHourlySingleBandPlugin
-    default_params:
+    params:
       variable: t2m
   transforms:
     - open_climate_service.transforms.kelvin_to_celsius
@@ -48,7 +48,7 @@
       resolution: PT1H
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipitationPlugin
-    default_params: {}
+    params: {}
   transforms:
     - open_climate_service.transforms.metres_to_mm
   units: mm

--- a/open_climate_service/plugins/datasets/worldpop.yaml
+++ b/open_climate_service/plugins/datasets/worldpop.yaml
@@ -18,7 +18,7 @@
       resolution: P1Y
   ingestion:
     plugin: open_climate_service.plugins.datasets.worldpop.WorldPopYearlyPlugin
-    default_params:
+    params:
       version: global2
       product: total
       variable: pop_total

--- a/open_climate_service/streaming/protocol.py
+++ b/open_climate_service/streaming/protocol.py
@@ -65,13 +65,13 @@ class IngestionPlugin(Protocol):
     """Minimal source contract for the streaming ingest engine.
 
     Contract notes:
-    - plugin classes may accept template-defined `ingestion.default_params`
+    - plugin classes may accept template-defined `ingestion.params`
       through their constructor for source configuration.
     - `probe(...)` must be cheap and must not transfer full raster data.
     - `periods(...)` must return an ordered, source-valid list of period ids.
     - `fetch_period(...)` must return exactly one logical period normalized to a
       consistent coordinate system for later append.
-    - the same `ingestion.default_params` are forwarded to `probe(...)` and
+    - the same `ingestion.params` are forwarded to `probe(...)` and
       `fetch_period(...)` as `**params` for sources that prefer per-call
       configuration rather than constructor state.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -420,7 +420,7 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
         "period_type": "daily",
         "ingestion": {
             "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
-            "default_params": {"stage": "final"},
+            "params": {"stage": "final"},
         },
     }
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
@@ -510,7 +510,7 @@ def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
         "period_type": "daily",
         "ingestion": {
             "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
-            "default_params": {"stage": "final"},
+            "params": {"stage": "final"},
         },
     }
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
@@ -577,7 +577,7 @@ def test_create_artifact_forwards_country_code_to_streaming_plugin(
         "period_type": "yearly",
         "ingestion": {
             "plugin": "open_climate_service.plugins.datasets.worldpop.WorldPopYearlyPlugin",
-            "default_params": {"version": "global2"},
+            "params": {"version": "global2"},
         },
     }
     plugin = object()


### PR DESCRIPTION
## Summary

Renames the `default_params` key in the `ingestion` section of dataset YAML templates to `params`. The name `default_params` was misleading — the values are not defaults, they are the actual parameters forwarded to the plugin constructor, `probe()`, and `fetch_period()`.

## Files changed

- `plugins/datasets/era5_land.yaml` — template key renamed
- `plugins/datasets/worldpop.yaml` — template key renamed
- `ingestions/services.py` — reads `ingestion.params` instead of `ingestion.default_params`
- `data_manager/services/downloader.py` — same
- `streaming/protocol.py` — docstring updated
- `tests/test_datasets.py` — fixtures updated
- `docs/architecture.md` — examples updated
- `docs/adding_custom_datasets.md` — reference table and examples updated