### PR TITLE
docs: add id and name fields to setup and instance guides

### DIFF
--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -100,23 +100,26 @@ run: ## Start the API with uvicorn
 Create `climate-service.yaml`:
 
 ```yaml
+id: rwanda-climate-service             # unique identifier for this instance
+name: Rwanda Climate Service           # display name shown in the web UI
+
 extent:
-  name: My Region
+  name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]    # [xmin, ymin, xmax, ymax] in WGS84
   country_code: RWA                   # ISO 3166-1 alpha-3, required for WorldPop
 
 data_dir: ./data
-crs: EPSG:4326                         # target CRS for Zarr outputs (optional, defaults to EPSG:4326)
 plugins_dir: ./plugins/
 ```
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |
+| `id` | No | Unique instance identifier used as the STAC catalog id. Lowercase, hyphen-separated (e.g. `rwanda-climate-service`). Defaults to `open-climate-service` |
+| `name` | No | Display name shown in the web UI. Defaults to `Open Climate Service` |
 | `extent.bbox` | Yes | Bounding box in WGS84 decimal degrees |
 | `extent.name` | No | Human-readable label shown in API responses |
 | `extent.country_code` | No | ISO 3166-1 alpha-3 — required for WorldPop downloads |
 | `data_dir` | Yes | Directory for downloaded files and Zarr stores, resolved relative to the config file |
-| `crs` | No | EPSG code for the output Zarr CRS. Defaults to `EPSG:4326` |
 | `plugins_dir` | No | Directory containing `datasets/`, `processes/`, and `workflows/` plugin subdirectories |
 
 To find the bounding box for a region, [bboxfinder.com](http://bboxfinder.com) is a useful tool.

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -27,6 +27,9 @@ cp climate-service.yaml.example climate-service.yaml
 ```
 
 ```yaml
+id: rwanda-climate-service
+name: Rwanda Climate Service
+
 extent:
   name: Rwanda
   bbox: [28.8, -2.9, 30.9, -1.0]
@@ -39,7 +42,9 @@ Field reference:
 
 | Field          | Required | Description |
 | -------------- | -------- | ----------- |
-| `name`         | No  | Human-readable name shown in API responses |
+| `id`           | No  | Unique instance identifier used as the STAC catalog id. Lowercase, hyphen-separated. Defaults to `open-climate-service` |
+| `name`         | No  | Display name shown in the web UI. Defaults to `Open Climate Service` |
+| `extent.name`  | No  | Human-readable label shown in API responses |
 | `bbox`         | Yes | Bounding box as `[xmin, ymin, xmax, ymax]` in WGS84 decimal degrees |
 | `country_code` | No  | ISO 3166-1 alpha-3 code — required for WorldPop downloads |
 


### PR DESCRIPTION
## Summary

- Adds `id` and `name` to the example `climate-service.yaml` in both the setup guide and the instance guide
- Removes `crs` from the instance guide example config (it's an advanced field and not needed for a basic setup)
- Updates the field reference tables in both guides to document `id` and `name` with their defaults (`open-climate-service` and `Open Climate Service`)