### PR TITLE
fix: reduce root time-coordinate fan-out in pyramid zarr stores

### DIFF
--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -328,9 +328,7 @@ def _write_root_time_coordinate(zarr_path: Path, ds: xr.Dataset, *, time_dim: st
         encoding={time_dim: {"chunks": (min(ds.sizes[time_dim], _ROOT_TIME_COORD_MAX_CHUNK),)}},
     )
     root = zarr.open_group(str(zarr_path), mode="a", zarr_format=3)
-    for key, value in root_attrs.items():
-        if root.attrs.get(key) != value:
-            root.attrs[key] = value
+    root.attrs.update(root_attrs)
 
 
 def _get_cache_prefix(dataset: dict[str, Any]) -> str:

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -4,12 +4,12 @@ import datetime
 import inspect
 import logging
 import os
-import shutil
 from pathlib import Path
 from typing import Any
 
 import xarray as xr
 import xproj  # noqa: F401  # type: ignore[import-untyped]  # pyright: ignore[reportUnusedImport]
+import zarr
 from fastapi import BackgroundTasks, HTTPException
 from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
 from topozarr.coarsen import create_pyramid
@@ -196,14 +196,9 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
         pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
 
         # zarr-layer looks for the time coordinate at the root of the store, not inside each level.
-        # Copy it from level 0 so browser clients can discover it without knowing the level structure.
-        time_dim = get_time_dim(ds)
-        time_src = zarr_path / "0" / time_dim
-        time_dst = zarr_path / time_dim
-        if time_src.exists():
-            if time_dst.exists():
-                shutil.rmtree(time_dst)
-            shutil.copytree(time_src, time_dst)
+        # Write it as a single root-level chunk so browser clients can discover it without
+        # incurring a fan-out of tiny copied coordinate chunks from level 0.
+        _write_root_time_coordinate(zarr_path, ds, time_dim="t")
 
         pyramid.dt.close()
 
@@ -230,6 +225,7 @@ def build_dataset_zarr(dataset: dict[str, Any], *, start: str | None = None, end
 _PYRAMID_PIXEL_THRESHOLD = 2048 * 2048
 _PYRAMID_MAX_LEVELS = 8
 _PYRAMID_TARGET_TILE_SIZE = 512
+_ROOT_TIME_COORD_MAX_CHUNK = 4096
 
 
 def _needs_pyramid(ds: xr.Dataset, x_dim: str, y_dim: str) -> bool:
@@ -308,6 +304,33 @@ def _compute_time_space_chunks(
     chunks[y_dim] = min(ds.sizes[y_dim], max_spatial_chunk)
 
     return chunks
+
+
+def _write_root_time_coordinate(zarr_path: Path, ds: xr.Dataset, *, time_dim: str) -> None:
+    """Expose the time coordinate at the pyramid root with bounded chunking for browser clients."""
+    if time_dim not in ds.dims:
+        logger.debug("Skipping root time coordinate write for %s: no %s dimension found", zarr_path, time_dim)
+        return
+    if time_dim not in ds.coords or ds.sizes.get(time_dim, 0) == 0:
+        logger.debug("Skipping root time coordinate write for %s: empty or missing %s coordinate", zarr_path, time_dim)
+        return
+
+    root = zarr.open_group(str(zarr_path), mode="a", zarr_format=3)
+    root_attrs = dict(root.attrs)
+    if time_dim in root:
+        del root[time_dim]
+    time_coord = xr.Dataset(coords={time_dim: ds[time_dim]})
+    time_coord.to_zarr(
+        zarr_path,
+        mode="a",
+        zarr_format=3,
+        consolidated=False,
+        encoding={time_dim: {"chunks": (min(ds.sizes[time_dim], _ROOT_TIME_COORD_MAX_CHUNK),)}},
+    )
+    root = zarr.open_group(str(zarr_path), mode="a", zarr_format=3)
+    for key, value in root_attrs.items():
+        if root.attrs.get(key) != value:
+            root.attrs[key] = value
 
 
 def _get_cache_prefix(dataset: dict[str, Any]) -> str:

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -89,11 +89,14 @@ async def manage_ingest(request: Request) -> Response:
     base = str(request.base_url).rstrip("/")
     try:
         form = await request.form()
-        dataset_id = str(form.get("dataset_id", ""))
-        start = str(form.get("start", ""))
-        end = str(form.get("end", "")) or None
+        dataset_id = str(form.get("dataset_id", "")).strip()
+        start = str(form.get("start", "")).strip()
+        end = str(form.get("end", "")).strip() or None
         publish = "publish" in form
         overwrite = "overwrite" in form
+
+        if not start:
+            raise HTTPException(status_code=400, detail="Start date is required")
 
         template = get_dataset(dataset_id)
         if template is None:
@@ -167,7 +170,7 @@ async def manage_sync(request: Request) -> Response:
     base = str(request.base_url).rstrip("/")
     try:
         form = await request.form()
-        dataset_id = str(form.get("dataset_id", ""))
+        dataset_id = str(form.get("dataset_id", "")).strip()
         end = str(form.get("end", "")).strip() or None
         publish = "publish" in form
     except HTTPException as exc:

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -173,6 +173,9 @@ async def manage_sync(request: Request) -> Response:
         dataset_id = str(form.get("dataset_id", "")).strip()
         end = str(form.get("end", "")).strip() or None
         publish = "publish" in form
+
+        if not dataset_id:
+            raise HTTPException(status_code=400, detail="Dataset ID is required")
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
         return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -604,6 +604,41 @@ def _make_fake_pyramid(ds: xr.Dataset, zarr_path: Path) -> Pyramid:
     return Pyramid(datatree=dt, encoding={})
 
 
+class _FakeDataTree:
+    def __init__(self, ds: xr.Dataset) -> None:
+        self._ds = ds
+        self.attrs: dict[str, Any] = {}
+
+    def to_zarr(self, zarr_path: Path, mode: str, encoding: dict[str, object], zarr_format: int) -> None:
+        _ = encoding
+        assert mode == "w"
+        assert zarr_format == 3
+        level0 = self._ds.chunk({"t": 1})
+        level1 = self._ds.coarsen(y=2, x=2, boundary="trim").mean()  # pyright: ignore[reportAttributeAccessIssue]
+        var_name = next(iter(self._ds.data_vars))
+        var_chunks = tuple(1 if dim == "t" else self._ds.sizes[dim] for dim in self._ds[var_name].dims)
+        level0.to_zarr(
+            zarr_path / "0",
+            mode="w",
+            zarr_format=3,
+            encoding={"t": {"chunks": (1,)}, var_name: {"chunks": var_chunks}},
+        )
+        level1.to_zarr(zarr_path / "1", mode="w", zarr_format=3)
+        root = zarr.open_group(str(zarr_path), mode="a", zarr_format=3)
+        root.attrs["sentinel"] = "kept"
+        for key, value in self.attrs.items():
+            root.attrs[key] = value
+
+    def close(self) -> None:
+        return None
+
+
+class _FakePyramid:
+    def __init__(self, ds: xr.Dataset) -> None:
+        self.dt = _FakeDataTree(ds)
+        self.encoding: dict[str, object] = {}
+
+
 def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Pyramid zarr build copies the time coordinate to the store root for zarr-layer."""
     nc_files = _write_nc_files(tmp_path)
@@ -621,6 +656,81 @@ def test_build_dataset_zarr_pyramid_copies_time_to_root(tmp_path: Path, monkeypa
     zarr_path = tmp_path / "my_dataset.zarr"
     assert (zarr_path / "0").exists(), "pyramid level 0 should exist"
     assert (zarr_path / "t").exists(), "t coordinate must be copied to zarr root"
+
+
+def test_build_dataset_zarr_pyramid_writes_root_time_as_single_chunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    nc_files = _write_nc_files(tmp_path)
+    monkeypatch.setattr(downloader, "DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr(downloader, "get_cache_files", lambda _: nc_files)
+    monkeypatch.setattr(downloader, "_needs_pyramid", lambda *_: True)
+
+    def fake_create_pyramid(ds: xr.Dataset, levels: int, x_dim: str, y_dim: str, method: str) -> _FakePyramid:
+        del levels, x_dim, y_dim, method
+        return _FakePyramid(ds)
+
+    monkeypatch.setattr(downloader, "create_pyramid", fake_create_pyramid)
+
+    downloader.build_dataset_zarr(_PYRAMID_DATASET)
+
+    zarr_path = tmp_path / "my_dataset.zarr"
+    root_time = zarr.open_array(str(zarr_path / "t"), mode="r", zarr_format=3)
+    level0_time = zarr.open_array(str(zarr_path / "0" / "t"), mode="r", zarr_format=3)
+
+    assert level0_time.chunks == (1,)
+    assert root_time.chunks == (2,)
+    root = zarr.open_group(str(zarr_path), mode="r", zarr_format=3)
+    assert root.attrs["sentinel"] == "kept"
+
+
+def test_write_root_time_coordinate_skips_when_time_dimension_missing(tmp_path: Path) -> None:
+    zarr_path = tmp_path / "no-time.zarr"
+    root = zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
+    root.attrs["sentinel"] = "kept"
+    ds = xr.Dataset(
+        {"pop_total": (["y", "x"], np.ones((2, 2), dtype="float32"))},
+        coords={"y": [1.0, 2.0], "x": [3.0, 4.0]},
+    )
+
+    downloader._write_root_time_coordinate(zarr_path, ds, time_dim="t")
+
+    root = zarr.open_group(str(zarr_path), mode="r", zarr_format=3)
+    assert "t" not in root
+    assert root.attrs["sentinel"] == "kept"
+
+
+def test_write_root_time_coordinate_skips_when_time_coordinate_missing(tmp_path: Path) -> None:
+    zarr_path = tmp_path / "missing-time-coord.zarr"
+    root = zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
+    root.attrs["sentinel"] = "kept"
+    ds = xr.Dataset(
+        {"pop_total": (["t", "y", "x"], np.ones((2, 2, 2), dtype="float32"))},
+        coords={"y": [1.0, 2.0], "x": [3.0, 4.0]},
+    )
+
+    downloader._write_root_time_coordinate(zarr_path, ds, time_dim="t")
+
+    root = zarr.open_group(str(zarr_path), mode="r", zarr_format=3)
+    assert "t" not in root
+    assert root.attrs["sentinel"] == "kept"
+
+
+def test_write_root_time_coordinate_replaces_existing_root_time(tmp_path: Path) -> None:
+    zarr_path = tmp_path / "existing-time.zarr"
+    root = zarr.open_group(str(zarr_path), mode="w", zarr_format=3)
+    root.attrs["sentinel"] = "kept"
+    first = xr.Dataset(coords={"t": pd.date_range("2020-01-01", periods=3, freq="D")})
+    second = xr.Dataset(coords={"t": pd.date_range("2020-02-01", periods=2, freq="D")})
+
+    downloader._write_root_time_coordinate(zarr_path, first, time_dim="t")
+    downloader._write_root_time_coordinate(zarr_path, second, time_dim="t")
+
+    root_time = zarr.open_array(str(zarr_path / "t"), mode="r", zarr_format=3)
+    assert root_time.shape == (2,)
+    assert root_time.chunks == (2,)
+    root = zarr.open_group(str(zarr_path), mode="r", zarr_format=3)
+    assert root.attrs["sentinel"] == "kept"
 
 
 def test_build_dataset_zarr_pyramid_is_openable_via_level_0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -132,7 +132,7 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
 
     response = await system_routes.manage_sync(
-        cast(Request, _FakeRequest({"dataset_id": "chirps3_precipitation_daily", "end": "", "publish": "on"}))
+        cast(Request, _FakeRequest({"dataset_id": "  chirps3_precipitation_daily  ", "end": "", "publish": "on"}))
     )
 
     assert isinstance(response, StreamingResponse)
@@ -143,6 +143,109 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
         "end": None,
         "publish": True,
     }
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_ingest_strips_string_inputs_and_treats_blank_end_as_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    scheduled: list[Coroutine[object, object, None]] = []
+
+    def fake_create_artifact(
+        *,
+        dataset: dict[str, object],
+        start: str,
+        end: str | None,
+        bbox: list[float],
+        country_code: str | None,
+        overwrite: bool,
+        publish: bool,
+        on_progress: Callable[[int | None, int | None, str | None], None],
+    ) -> None:
+        captured["dataset"] = dataset
+        captured["start"] = start
+        captured["end"] = end
+        captured["bbox"] = bbox
+        captured["country_code"] = country_code
+        captured["overwrite"] = overwrite
+        captured["publish"] = publish
+        on_progress(1, 1, "done")
+
+    async def fake_to_thread(func: Callable[[], None]) -> None:
+        func()
+
+    def fake_create_task(coro: Coroutine[object, object, None]) -> None:
+        scheduled.append(coro)
+        return None
+
+    template = {"id": "chirps3_precipitation_daily", "name": "CHIRPS3 precipitation"}
+    monkeypatch.setattr(system_routes.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(ingestion_services, "create_artifact", fake_create_artifact)
+    monkeypatch.setattr(
+        "open_climate_service.data_registry.services.datasets.get_dataset",
+        lambda dataset_id: template if dataset_id == template["id"] else None,
+    )
+    monkeypatch.setattr(
+        "open_climate_service.extents.services.get_extent_or_404",
+        lambda: {"bbox": [0.0, 1.0, 2.0, 3.0], "country_code": "SLE"},
+    )
+
+    response = await system_routes.manage_ingest(
+        cast(
+            Request,
+            _FakeRequest(
+                {
+                    "dataset_id": "  chirps3_precipitation_daily  ",
+                    "start": " 2024-02-01 ",
+                    "end": "   ",
+                    "publish": "on",
+                }
+            ),
+        )
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert len(scheduled) == 1
+    await scheduled[0]
+    assert captured == {
+        "dataset": template,
+        "start": "2024-02-01",
+        "end": None,
+        "bbox": [0.0, 1.0, 2.0, 3.0],
+        "country_code": "SLE",
+        "overwrite": False,
+        "publish": True,
+    }
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_ingest_rejects_blank_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "open_climate_service.data_registry.services.datasets.get_dataset",
+        lambda dataset_id: {"id": dataset_id, "name": "CHIRPS3 precipitation"},
+    )
+    monkeypatch.setattr(
+        "open_climate_service.extents.services.get_extent_or_404",
+        lambda: {"bbox": [0.0, 1.0, 2.0, 3.0], "country_code": "SLE"},
+    )
+
+    response = await system_routes.manage_ingest(
+        cast(
+            Request,
+            _FakeRequest(
+                {
+                    "dataset_id": "chirps3_precipitation_daily",
+                    "start": "   ",
+                    "end": "",
+                }
+            ),
+        )
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "http://testserver/manage?error=Start%20date%20is%20required"
 
 
 def test_manage_page_shows_split_publication_and_sync_columns(

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -146,6 +146,24 @@ async def test_manage_sync_treats_blank_end_as_none(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_sync_rejects_blank_dataset_id() -> None:
+    response = await system_routes.manage_sync(
+        cast(
+            Request,
+            _FakeRequest(
+                {
+                    "dataset_id": "   ",
+                    "end": "",
+                }
+            ),
+        )
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "http://testserver/manage?error=Dataset%20ID%20is%20required"
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
 async def test_manage_ingest_strips_string_inputs_and_treats_blank_end_as_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Three independent improvements shipped together:

### 1. Pyramid zarr — write root time coordinate as a single chunk

Replaces `shutil.copytree` which copied every small chunk file from `level-0/t/`
to the store root. The coordinate is now written via `xr.Dataset.to_zarr` as one
contiguous chunk (bounded by `_ROOT_TIME_COORD_MAX_CHUNK = 4096`). GeoZarr root
attributes are snapshotted and restored because xarray's `mode="a"` write clears
them; `consolidated=False` suppresses the zarr v3 consolidated-metadata warning.

### 2. Sync form — optional cutoff end date

Users can now specify how far to sync instead of always pulling to the provider's
latest available period. The sync column is redesigned: the old inline button is
replaced by a badge that expands a panel with an end-date input and explicit
**Start sync** / **Cancel** actions. `manage_sync` and `manage_ingest` are
hardened to strip whitespace from all string form fields.

### 3. Map viewer — initialise at latest timestep

The viewer now opens at the most recent timestep (`timeStepCount() - 1`) instead
of the oldest (index 0).