### PR TITLE
feat: enrich Icechunk zarr.json with pyramid multiscales when available

### DIFF
--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -544,6 +544,43 @@ def plan_sync_dataset(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _get_pyramid_zarr_path(dataset_id: str) -> Path | None:
+    """Return the pyramid .zarr store path for a dataset if it exists."""
+    from open_climate_service.data_manager.services.downloader import DOWNLOAD_DIR
+
+    path = DOWNLOAD_DIR / f"{dataset_id}.zarr"
+    return path if path.exists() else None
+
+
+def _enrich_root_zarr_json_with_pyramid(response: JSONResponse, dataset_id: str) -> JSONResponse:
+    """Merge multiscales from the pyramid .zarr into an Icechunk root zarr.json response.
+
+    The Icechunk store is valid Zarr v3 but lacks multiscales metadata. When a
+    pyramid exists, injecting its multiscales attribute makes the endpoint
+    readable by tools that expect the GeoZarr pyramid structure (GDAL, qgis-geozarr).
+    """
+    pyramid_path = _get_pyramid_zarr_path(dataset_id)
+    if pyramid_path is None:
+        return response
+    pyramid_zarr_json = pyramid_path / "zarr.json"
+    if not pyramid_zarr_json.exists():
+        return response
+    try:
+        pyramid_attrs = json.loads(pyramid_zarr_json.read_text(encoding="utf-8")).get("attributes", {})
+        multiscales = pyramid_attrs.get("multiscales")
+        if not multiscales:
+            return response
+        payload: dict[str, object] = json.loads(response.body)
+        attrs = payload.get("attributes", {})
+        if isinstance(attrs, dict) and "multiscales" not in attrs:
+            attrs["multiscales"] = multiscales
+            payload["attributes"] = attrs
+            return JSONResponse(content=payload)
+    except Exception:
+        pass
+    return response
+
+
 def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     """Return a public Zarr store listing for a managed dataset."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
@@ -631,11 +668,20 @@ def _read_zarr_bounds(store_attrs: dict[str, object] | None) -> list[float] | No
 def get_dataset_zarr_store_file_or_404(
     dataset_id: str, relative_path: str
 ) -> FileResponse | Response | dict[str, object]:
-    """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
+    """Serve a file, metadata document, or directory listing within a dataset Zarr store.
+
+    For Icechunk-backed datasets the root zarr.json is enriched with multiscales
+    metadata from the pyramid .zarr when one exists, so external tools (GDAL,
+    qgis-geozarr) see the pyramid structure without a separate serving path.
+    """
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.ICECHUNK:
         store = _open_icechunk_store_or_404(artifact)
-        return _get_icechunk_store_path_or_404(dataset_id=dataset_id, store=store, relative_path=relative_path)
+        response = _get_icechunk_store_path_or_404(dataset_id=dataset_id, store=store, relative_path=relative_path)
+        # Enrich the root zarr.json with multiscales from pyramid when available
+        if _normalize_icechunk_relative_path(relative_path) == "zarr.json" and isinstance(response, JSONResponse):
+            response = _enrich_root_zarr_json_with_pyramid(response, dataset_id)
+        return response
 
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)


### PR DESCRIPTION
Closes #209.

## What

When a pyramid `.zarr` exists for a dataset, its `multiscales` attribute is merged into the root `zarr.json` served by `GET /zarr/{dataset_id}`. The Icechunk store continues to serve all data unchanged — it already looks like pure Zarr v3 to all clients (GDAL, xarray, zarr-python). The only missing piece was `multiscales` metadata.

## Why not serve from the pyramid directly?

No path-switching or new routes needed. One targeted metadata merge in the root `zarr.json` response is sufficient.

## Result

| Dataset | multiscales before | multiscales after |
|---|---|---|
| `worldpop_population_yearly` (has pyramid) | ❌ | ✅ |
| `chirps3_precipitation_daily` (no pyramid yet) | ❌ | ❌ (no-op, correct) |

Streaming-ingest datasets (CHIRPS3, ERA5-Land) don't yet build a pyramid — extending the streaming orchestrator to also build a `.zarr` pyramid is tracked as follow-up in #209.