### PR TITLE
feat: zarr endpoint serves proper OGC GeoZarr multiscales; root redirects to zarr.json

### DIFF
--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -1,7 +1,7 @@
 """Routes for EO ingestion, datasets, and sync operations."""
 
 from fastapi import APIRouter, Header, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from starlette.responses import Response
 
 from open_climate_service.data_registry.routes import _get_dataset_or_404
@@ -146,14 +146,19 @@ def download_artifact_file(dataset_id: str) -> FileResponse:
 
 
 @zarr_router.api_route("/{dataset_id}", methods=["GET", "HEAD"])
-def get_canonical_zarr_store_info(dataset_id: str) -> dict[str, object]:
-    """Return canonical Zarr store listing for a managed dataset."""
-    return services.get_dataset_zarr_store_info_or_404(dataset_id)
+def get_canonical_zarr_store_root(dataset_id: str) -> RedirectResponse:
+    """Redirect to the root zarr.json so the URL is a valid Zarr store entry point for GDAL and zarr clients."""
+    services.get_latest_artifact_for_dataset_or_404(dataset_id)
+    return RedirectResponse(url=f"/zarr/{dataset_id}/zarr.json", status_code=302)
 
 
 @zarr_router.api_route("/{dataset_id}/{relative_path:path}", methods=["GET", "HEAD"], response_model=None)
-def get_canonical_zarr_store_file(dataset_id: str, relative_path: str) -> FileResponse | Response | dict[str, object]:
+def get_canonical_zarr_store_file(
+    dataset_id: str, relative_path: str
+) -> FileResponse | Response | dict[str, object] | RedirectResponse:
     """Serve canonical Zarr store content for a managed dataset."""
+    if not relative_path:
+        return RedirectResponse(url=f"/zarr/{dataset_id}/zarr.json", status_code=302)
     return services.get_dataset_zarr_store_file_or_404(dataset_id, relative_path)
 
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -544,6 +544,71 @@ def plan_sync_dataset(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _get_pyramid_zarr_path(dataset_id: str) -> Path | None:
+    """Return the pyramid .zarr store path for a dataset if it exists."""
+    from open_climate_service.data_manager.services.downloader import DOWNLOAD_DIR
+
+    path = DOWNLOAD_DIR / f"{dataset_id}.zarr"
+    return path if path.exists() else None
+
+
+def _enrich_root_zarr_json_with_pyramid(response: JSONResponse, dataset_id: str) -> JSONResponse:
+    """Merge multiscales from the pyramid .zarr into an Icechunk root zarr.json response.
+
+    Injects two representations of the pyramid structure:
+    - ``multiscales``: the native GeoZarr-toolkit layout dict (preserved as-is)
+    - ``_multiscales_ogc``: an OGC-compatible list understood by GDAL and qgis-geozarr,
+      where each entry has a ``path`` key pointing to a pyramid level directory
+    """
+    pyramid_path = _get_pyramid_zarr_path(dataset_id)
+    if pyramid_path is None:
+        return response
+    pyramid_zarr_json = pyramid_path / "zarr.json"
+    if not pyramid_zarr_json.exists():
+        return response
+    try:
+        pyramid_attrs = json.loads(pyramid_zarr_json.read_text(encoding="utf-8")).get("attributes", {})
+        multiscales = pyramid_attrs.get("multiscales")
+        if not multiscales:
+            return response
+        # Convert native layout to an OGC-compliant multiscales list with axes and
+        # coordinateTransformations so tools like GDAL and qgis-geozarr can correctly
+        # position each pyramid level in space.
+        layout = multiscales.get("layout", []) if isinstance(multiscales, dict) else []
+        if not layout:
+            return response
+        axes: list[dict[str, object]] = [
+            {"name": "t", "type": "time"},
+            {"name": "y", "type": "space", "unit": "degree"},
+            {"name": "x", "type": "space", "unit": "degree"},
+        ]
+        datasets: list[dict[str, object]] = []
+        for entry in layout:
+            if "asset" not in entry:
+                continue
+            dataset: dict[str, object] = {"path": str(entry["asset"])}
+            st = entry.get("spatial:transform")  # [pixel_w, 0, x_origin, 0, pixel_h, y_origin]
+            if isinstance(st, list) and len(st) == 6:
+                pixel_w, _, x_origin, _, pixel_h, y_origin = (float(v) for v in st)
+                dataset["coordinateTransformations"] = [
+                    {"type": "scale", "scale": [1.0, abs(pixel_h), abs(pixel_w)]},
+                    {"type": "translation", "translation": [0.0, y_origin, x_origin]},
+                ]
+            datasets.append(dataset)
+        if not datasets:
+            return response
+        payload: dict[str, object] = json.loads(response.body)
+        attrs = payload.get("attributes", {})
+        if isinstance(attrs, dict) and "multiscales" not in attrs:
+            attrs["multiscales"] = [{"axes": axes, "datasets": datasets, "type": "gaussian"}]
+            attrs["multiscales_native"] = multiscales
+            payload["attributes"] = attrs
+            return JSONResponse(content=payload)
+    except Exception:
+        pass
+    return response
+
+
 def get_dataset_zarr_store_info_or_404(dataset_id: str) -> dict[str, object]:
     """Return a public Zarr store listing for a managed dataset."""
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
@@ -631,11 +696,20 @@ def _read_zarr_bounds(store_attrs: dict[str, object] | None) -> list[float] | No
 def get_dataset_zarr_store_file_or_404(
     dataset_id: str, relative_path: str
 ) -> FileResponse | Response | dict[str, object]:
-    """Serve a file, metadata document, or directory listing within a dataset Zarr store."""
+    """Serve a file, metadata document, or directory listing within a dataset Zarr store.
+
+    For Icechunk-backed datasets the root zarr.json is enriched with multiscales
+    metadata from the pyramid .zarr when one exists, so external tools (GDAL,
+    qgis-geozarr) see the pyramid structure without a separate serving path.
+    """
     artifact = get_latest_artifact_for_dataset_or_404(dataset_id)
     if artifact.format == ArtifactFormat.ICECHUNK:
         store = _open_icechunk_store_or_404(artifact)
-        return _get_icechunk_store_path_or_404(dataset_id=dataset_id, store=store, relative_path=relative_path)
+        response = _get_icechunk_store_path_or_404(dataset_id=dataset_id, store=store, relative_path=relative_path)
+        # Enrich the root zarr.json with multiscales from pyramid when available
+        if _normalize_icechunk_relative_path(relative_path) == "zarr.json" and isinstance(response, JSONResponse):
+            response = _enrich_root_zarr_json_with_pyramid(response, dataset_id)
+        return response
 
     store_root = _get_zarr_root_or_409(artifact)
     target = _resolve_zarr_path(store_root, relative_path)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -71,37 +71,50 @@ def test_health_returns_healthy_status(client: TestClient) -> None:
     assert result.status == "healthy"
 
 
+def test_zarr_route_redirects_to_zarr_json(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_latest_artifact_for_dataset_or_404",
+        lambda _: object(),
+    )
+
+    response = client.get("/zarr/dataset-1", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/zarr/dataset-1/zarr.json"
+
+
 def test_zarr_route_echoes_origin_for_browser_access(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,
-        "get_dataset_zarr_store_info_or_404",
-        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+        "get_latest_artifact_for_dataset_or_404",
+        lambda _: object(),
     )
 
-    response = client.get("/zarr/dataset-1", headers={"Origin": "https://inspect.geozarr.org"})
+    response = client.get("/zarr/dataset-1", headers={"Origin": "https://inspect.geozarr.org"}, follow_redirects=False)
 
-    assert response.status_code == 200
+    assert response.status_code == 302
     assert response.headers["access-control-allow-origin"] == "https://inspect.geozarr.org"
 
 
 def test_zarr_route_does_not_allow_unconfigured_origin(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,
-        "get_dataset_zarr_store_info_or_404",
-        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+        "get_latest_artifact_for_dataset_or_404",
+        lambda _: object(),
     )
 
-    response = client.get("/zarr/dataset-1", headers={"Origin": "https://example.org"})
+    response = client.get("/zarr/dataset-1", headers={"Origin": "https://example.org"}, follow_redirects=False)
 
-    assert response.status_code == 200
+    assert response.status_code == 302
     assert "access-control-allow-private-network" not in response.headers
 
 
 def test_zarr_route_allows_private_network_preflight(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,
-        "get_dataset_zarr_store_info_or_404",
-        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+        "get_latest_artifact_for_dataset_or_404",
+        lambda _: object(),
     )
 
     response = client.options(
@@ -121,8 +134,8 @@ def test_zarr_route_allows_private_network_preflight(client: TestClient, monkeyp
 def test_zarr_route_preserves_existing_vary_values(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,
-        "get_dataset_zarr_store_info_or_404",
-        lambda _: {"kind": "ZarrListing", "dataset_id": "dataset-1", "path": ".", "entries": []},
+        "get_latest_artifact_for_dataset_or_404",
+        lambda _: object(),
     )
 
     response = client.options(


### PR DESCRIPTION
Closes #209.

## What

Three changes to `GET /zarr/{dataset_id}`:

1. **Root redirects to `zarr.json`** — `GET /zarr/{dataset_id}` (with or without trailing slash) now returns `302 → /zarr/{dataset_id}/zarr.json`. The old `ZarrListing` response was a custom format we invented; neither the map viewer (`zarr-layer` fetches `zarr.json` directly) nor any standard client used it.

2. **`multiscales` injected into the root `zarr.json`** — when a pyramid `.zarr` exists, the root zarr.json response is enriched with a proper OGC GeoZarr `multiscales` entry including `axes` and `coordinateTransformations` derived from the native pyramid layout. The Icechunk store continues to serve all data — it already looks like pure Zarr v3 to clients.

3. **OGC-compliant `multiscales` format** — axes (`t`, `y`, `x` with types and units), per-level `coordinateTransformations` (scale + translation from `spatial:transform`), and `type: gaussian`. The native format is preserved under `multiscales_native`.

## Result

```json
"multiscales": [{
  "axes": [
    {"name": "t", "type": "time"},
    {"name": "y", "type": "space", "unit": "degree"},
    {"name": "x", "type": "space", "unit": "degree"}
  ],
  "datasets": [
    {
      "path": "0",
      "coordinateTransformations": [
        {"type": "scale", "scale": [1.0, 0.000833, 0.000833]},
        {"type": "translation", "translation": [0.0, 10.0, -13.3]}
      ]
    },
    ...
  ],
  "type": "gaussian"
}]
```

## Notes

- Only datasets that have a pyramid `.zarr` on disk get `multiscales` — streaming-ingest datasets (CHIRPS3, ERA5-Land) still serve the plain Icechunk zarr without multiscales until a pyramid build step is added to the streaming orchestrator (tracked in #209).
- `get_dataset_zarr_store_info_or_404` and its `ZarrListing` response are now unused by any route; the function and schema can be cleaned up in a follow-up.