### PR TITLE
fix: return GeoJSON payload from synchronous openEO results

### DIFF
--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -384,6 +384,8 @@ def execute_synchronous(
 
         if isinstance(result, gpd.GeoDataFrame):
             if fmt == "GEOJSON":
+                if result.crs is not None and result.crs.to_epsg() != 4326:
+                    result = result.to_crs("EPSG:4326")
                 return Response(content=result.to_json(), media_type="application/geo+json")
             if fmt in _VECTOR_FORMATS:
                 with tempfile.TemporaryDirectory() as tmp:

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -277,6 +277,7 @@ _RESULT_MEDIA_TYPES: dict[str, str] = {
     ".tif": "image/tiff; subtype=geotiff",
     ".png": "image/png",
     ".csv": "text/csv",
+    ".geojson": "application/geo+json",
     ".parquet": "application/vnd.apache.parquet",
 }
 
@@ -335,7 +336,7 @@ def execute_synchronous(
     import xarray as xr
 
     from open_climate_service.openeo.execution import SaveResultEnvelope
-    from open_climate_service.openeo.jobs import _write_raster, _write_vector
+    from open_climate_service.openeo.jobs import _VECTOR_FORMATS, _write_raster, _write_vector
 
     # Unwrap save_result envelope to get requested format
     fmt = "ZARR"
@@ -390,14 +391,16 @@ def execute_synchronous(
         import geopandas as gpd
 
         if isinstance(result, gpd.GeoDataFrame):
-            if fmt in {"PARQUET", "CSV"}:
+            if fmt == "GEOJSON":
+                return Response(content=result.to_json(), media_type="application/geo+json")
+            if fmt in _VECTOR_FORMATS:
                 with tempfile.TemporaryDirectory() as tmp:
                     from pathlib import Path
 
                     output = _write_vector(result, Path(tmp), fmt)
                     if output:
                         data = Path(output).read_bytes()
-                        mime = "application/vnd.apache.parquet" if fmt == "PARQUET" else "text/csv"
+                        mime = _VECTOR_FORMATS[fmt][1]
                         return Response(content=data, media_type=mime)
             info = {
                 "type": "vector",

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -366,16 +366,8 @@ def execute_synchronous(
                     detail=f"Format '{fmt}' produced no output",
                 )
             data = Path(output).read_bytes()
-            mime_map = {
-                ".nc": "application/netcdf",
-                ".tif": "image/tiff; subtype=geotiff",
-                ".png": "image/png",
-                ".csv": "text/csv",
-                ".geojson": "application/geo+json",
-                ".parquet": "application/vnd.apache.parquet",
-            }
-            suffix = Path(output).suffix
-            media_type = mime_map.get(suffix, "application/octet-stream")
+            suffix = Path(output).suffix.lower()
+            media_type = _RESULT_MEDIA_TYPES.get(suffix, "application/octet-stream")
             return Response(content=data, media_type=media_type)
 
     # Try vector
@@ -398,10 +390,14 @@ def execute_synchronous(
                     from pathlib import Path
 
                     output = _write_vector(result, Path(tmp), fmt)
-                    if output:
-                        data = Path(output).read_bytes()
-                        mime = _VECTOR_FORMATS[fmt][1]
-                        return Response(content=data, media_type=mime)
+                    if output is None:
+                        raise HTTPException(
+                            status_code=500,
+                            detail=f"Format '{fmt}' produced no output",
+                        )
+                    data = Path(output).read_bytes()
+                    mime = _VECTOR_FORMATS[fmt][1]
+                    return Response(content=data, media_type=mime)
             info = {
                 "type": "vector",
                 "features": len(result),

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -378,3 +378,30 @@ def test_result_route_returns_geojson_payload_for_synchronous_vector_result(
     assert payload["type"] == "FeatureCollection"
     assert len(payload["features"]) == 2
     assert sorted(feature["properties"]["value"] for feature in payload["features"]) == [1.0, 2.0]
+
+
+def test_result_route_reprojects_geojson_payload_to_wgs84(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame({"value": [1.0]}, geometry=[Point(111319.49079327357, 111325.1428663851)], crs="EPSG:3857")
+
+    def return_geojson_result(*args: object, **kwargs: object) -> SaveResultEnvelope:
+        del args, kwargs
+        return SaveResultEnvelope(gdf, "GEOJSON")
+
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        return_geojson_result,
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    coords = payload["features"][0]["geometry"]["coordinates"]
+    assert coords[0] == pytest.approx(1.0, rel=0, abs=1e-6)
+    assert coords[1] == pytest.approx(1.0, rel=0, abs=1e-6)

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -12,6 +12,7 @@ import xarray as xr
 from fastapi.testclient import TestClient
 
 from open_climate_service.openeo.execution import (
+    SaveResultEnvelope,
     _augment_with_workflows,
     _bbox_to_dict,
     _RegistryOverlay,
@@ -252,6 +253,21 @@ def test_result_assets_none_output_returns_empty() -> None:
     assert _result_assets(_record(None)) == {}
 
 
+def test_download_result_file_serves_geojson_with_geojson_media_type(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("open_climate_service.openeo.jobs._JOBS_DIR", tmp_path)
+    results_dir = tmp_path / "job-1" / "results"
+    results_dir.mkdir(parents=True)
+    geojson_path = results_dir / "result.geojson"
+    geojson_path.write_text('{"type":"FeatureCollection","features":[]}')
+
+    response = client.get("/jobs/job-1/results/result.geojson")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/geo+json")
+
+
 def test_create_job_does_not_advertise_missing_logs_endpoint(client: TestClient) -> None:
     response = client.post(
         "/jobs",
@@ -332,3 +348,33 @@ def test_result_route_rejects_synchronous_zarr_datacube(client: TestClient, monk
 
     assert response.status_code == 400
     assert "do not support ZARR output" in response.json()["detail"]
+
+
+def test_result_route_returns_geojson_payload_for_synchronous_vector_result(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame({"value": [1.0, 2.0]}, geometry=[Point(0, 0), Point(1, 1)], crs="EPSG:4326")
+
+    def return_geojson_result(*args: object, **kwargs: object) -> SaveResultEnvelope:
+        del args, kwargs
+        return SaveResultEnvelope(gdf, "GEOJSON")
+
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        return_geojson_result,
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/geo+json")
+    payload = response.json()
+    assert payload["type"] == "FeatureCollection"
+    assert len(payload["features"]) == 2
+    assert sorted(feature["properties"]["value"] for feature in payload["features"]) == [1.0, 2.0]


### PR DESCRIPTION
## Summary

This PR fixes synchronous openEO vector result handling so `POST /result` returns actual GeoJSON payloads instead of a metadata summary.

## Changes

- return in-memory GeoJSON payloads for synchronous `GeoDataFrame` results with `format="GEOJSON"`
- keep synchronous vector file export for other supported vector formats via the shared `_VECTOR_FORMATS` registry
- add `.geojson` to `_RESULT_MEDIA_TYPES` so batch `result.geojson` downloads return `application/geo+json`
- reuse `_RESULT_MEDIA_TYPES` for synchronous raster result MIME detection instead of a duplicated local map
- raise `500` if synchronous vector export produces no output, matching the existing raster error path
- add route-level coverage for:
  - synchronous `POST /result` returning a GeoJSON `FeatureCollection`
  - batch `GET /jobs/{id}/results/result.geojson` returning `application/geo+json`

## Why

Before this change, synchronous POST /result requests that used save_result(format="GEOJSON") returned a metadata summary instead of the requested GeoJSON export payload.

This PR makes synchronous openEO results behave as expected for GeoJSON exports and aligns MIME handling more closely across synchronous and batch result paths.