### PR TITLE
 two issues from abyot review

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -213,7 +213,7 @@ class OpenEOJobService:
         now = utc_now()
         record = OpenEOJobRecord(
             id=job_id,
-            title=body.title,
+            title=body.title if body.title is not None else _derive_job_title(body.process),
             description=body.description,
             process=body.process,
             status=OpenEOJobStatus.CREATED,
@@ -667,6 +667,36 @@ def _write_png(ds: Any, results_dir: Any) -> str | None:
     fig.savefig(path, bbox_inches="tight", dpi=dpi, transparent=True, pad_inches=0)
     plt.close(fig)
     return path
+
+
+def _derive_job_title(process: dict[str, Any]) -> str | None:
+    """Generate a human-readable job title from a process graph when none is provided.
+
+    Looks for a load_collection node and uses the collection id (plus temporal
+    extent if present) to build a short label, e.g. "chirps3_precipitation_daily
+    2023-01-01–2023-12-31". Returns None if no load_collection is found.
+    """
+    graph = process.get("process_graph")
+    if not isinstance(graph, dict):
+        return None
+    for node in graph.values():
+        if not isinstance(node, dict) or node.get("process_id") != "load_collection":
+            continue
+        args = node.get("arguments", {})
+        collection_id = args.get("id")
+        if not isinstance(collection_id, str):
+            continue
+        temporal = args.get("temporal_extent")
+        if isinstance(temporal, (list, tuple)) and len(temporal) == 2:
+            start, end = temporal[0], temporal[1]
+            if start and end:
+                return f"{collection_id} {start}–{end}"
+            if start:
+                return f"{collection_id} from {start}"
+            if end:
+                return f"{collection_id} until {end}"
+        return collection_id
+    return None
 
 
 _service: OpenEOJobService | None = None

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -268,6 +268,55 @@ def test_download_result_file_serves_geojson_with_geojson_media_type(
     assert response.headers["content-type"].startswith("application/geo+json")
 
 
+def test_create_job_uses_explicit_title_when_provided(client: TestClient) -> None:
+    response = client.post(
+        "/jobs",
+        json={
+            "title": "My custom job",
+            "process": {"process_graph": {"result": {"process_id": "constant", "arguments": {"x": 1}, "result": True}}},
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["title"] == "My custom job"
+
+
+def test_create_job_derives_title_from_load_collection(client: TestClient) -> None:
+    response = client.post(
+        "/jobs",
+        json={
+            "process": {
+                "process_graph": {
+                    "load": {
+                        "process_id": "load_collection",
+                        "arguments": {
+                            "id": "chirps3_precipitation_daily",
+                            "temporal_extent": ["2023-01-01", "2023-12-31"],
+                        },
+                    },
+                    "result": {
+                        "process_id": "save_result",
+                        "arguments": {"data": {"from_node": "load"}, "format": "GTiff"},
+                        "result": True,
+                    },
+                }
+            }
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["title"] == "chirps3_precipitation_daily 2023-01-01–2023-12-31"
+
+
+def test_create_job_title_is_none_when_no_load_collection(client: TestClient) -> None:
+    response = client.post(
+        "/jobs",
+        json={
+            "process": {"process_graph": {"result": {"process_id": "constant", "arguments": {"x": 1}, "result": True}}}
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["title"] is None
+
+
 def test_create_job_does_not_advertise_missing_logs_endpoint(client: TestClient) -> None:
     response = client.post(
         "/jobs",


### PR DESCRIPTION
Closes #204.

When a batch job is created via `POST /jobs` without a `title`, derive one automatically from the process graph. Looks for the first `load_collection` node and formats the title as `"{collection_id} {start}–{end}"` (or just `"{collection_id}"` if no temporal extent is set). Explicit titles are always preserved as-is.

## Test results (live instance)

Tested against `http://localhost:8000`:

| Scenario | Resulting title |
|---|---|
| Explicit title provided | `"My named job"` ✅ |
| `load_collection` + temporal extent | `"chirps3_precipitation_daily 2023-01-01–2023-12-31"` ✅ |
| `load_collection` without dates | `"worldpop_population_yearly"` ✅ |
| No `load_collection` node | `null` ✅ |

## Test plan

- [x] Explicit title is preserved when provided
- [x] Title derived from `load_collection` with temporal extent
- [x] Title derived from `load_collection` without temporal extent (collection name only)
- [x] `null` when no `load_collection` in graph