### PR TITLE
 ERA5-Land plugin suite — 6 datasets EDH+CDS sources deaccumulation bulk fetch

### DIFF
--- a/climate-service.yaml.example
+++ b/climate-service.yaml.example
@@ -14,3 +14,4 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 
 # plugins_dir: ./plugins/   # optional — plugin root: YAML templates in plugins/datasets/, Python modules importable by dotted path
 # crs: EPSG:4326             # optional — CRS for stored GeoZarr files (default: EPSG:4326); use e.g. EPSG:25833 for UTM33
+# utc_offset_hours: 0        # optional — UTC offset in hours for local-day aggregation in daily_from_hourly datasets (default: 0 = UTC)

--- a/docs/built_in_datasets.md
+++ b/docs/built_in_datasets.md
@@ -1,8 +1,8 @@
 # Built-in datasets
 
-The Open Climate Service ships with four built-in dataset templates covering precipitation, temperature, and population. Each template describes a data source and the rules for downloading, transforming, and syncing it. They are available in every instance without any additional configuration.
+The Open Climate Service ships with built-in dataset templates covering precipitation, temperature, and population. Each template describes a data source and the rules for downloading, transforming, and syncing it. They are available in every instance without any additional configuration.
 
-To ingest a built-in dataset for your configured extent, see the [API reference](managed_data_api_guide.md). To add datasets beyond these four, see [Adding custom datasets](adding_custom_datasets.md).
+To ingest a built-in dataset for your configured extent, see the [API reference](managed_data_api_guide.md). To add datasets beyond these, see [Adding custom datasets](adding_custom_datasets.md).
 
 ---
 
@@ -27,45 +27,11 @@ CHIRPS (Climate Hazards Group InfraRed Precipitation with Station data) v3 is a 
 
 ---
 
-## ERA5-Land — 2 m temperature (hourly)
+## ERA5-Land — temperature and precipitation
 
-| Property | Value |
-| --- | --- |
-| **Dataset ID** | `era5land_temperature_hourly` |
-| **Variable** | `t2m` |
-| **Units** | °C |
-| **Period** | Hourly |
-| **Spatial coverage** | Global |
-| **Spatial resolution** | ~9 km |
-| **Record start** | 1950-01-01 |
-| **Source** | [ERA5-Land Reanalysis via DestinE Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+ERA5-Land provides temperature and precipitation at hourly, daily, and monthly resolution. Nine dataset templates are available covering both variables and all resolutions, with options for UTC or local-timezone daily aggregation.
 
-ERA5-Land is a global atmospheric reanalysis produced by ECMWF. The 2 m temperature variable (`t2m`) represents the air temperature 2 metres above the land surface, including corrections for topography relative to the ERA5 pressure levels.
-
-**Sync behaviour** — new hours are appended incrementally. ERA5-Land is published with a nominal 5-day lag; the API will not request data closer than 120 hours to the current time.
-
-**Transforms** — raw values are in Kelvin. The `kelvin_to_celsius` transform is applied at ingest time, so stored values are in °C.
-
----
-
-## ERA5-Land — total precipitation (hourly)
-
-| Property | Value |
-| --- | --- |
-| **Dataset ID** | `era5land_precipitation_hourly` |
-| **Variable** | `tp` |
-| **Units** | mm |
-| **Period** | Hourly |
-| **Spatial coverage** | Global |
-| **Spatial resolution** | ~9 km |
-| **Record start** | 1950-01-01 |
-| **Source** | [ERA5-Land Reanalysis via DestinE Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
-
-Total precipitation (`tp`) from ERA5-Land is an accumulated hourly value representing the sum of large-scale and convective precipitation falling onto the land surface. It is useful as a high-resolution complement to CHIRPS for countries outside CHIRPS's 50°N–50°S band, or for sub-daily analysis.
-
-**Sync behaviour** — same 5-day lag as ERA5-Land temperature; hours are appended incrementally.
-
-**Transforms** — raw values are in metres per hour. The `metres_to_mm` transform converts to mm at ingest time.
+See **[ERA5-Land datasets](era5_land_datasets.md)** for the full reference, including dataset IDs, coverage, lag times, and guidance on choosing the right dataset for your use case.
 
 ---
 

--- a/docs/era5_land_datasets.md
+++ b/docs/era5_land_datasets.md
@@ -1,0 +1,197 @@
+# ERA5-Land datasets
+
+ERA5-Land is a global reanalysis of land surface variables produced by ECMWF. It provides a consistent record from 1950 to the near-present at ~9 km resolution. The Open Climate Service ships six ERA5-Land dataset templates covering temperature and precipitation at daily and monthly resolution.
+
+## Setup
+
+ERA5-Land data is fetched from two sources depending on the dataset. Both are free but require registration.
+
+### Earth Data Hub (hourly and daily datasets)
+
+1. Create a free account at [earthdatahub.destine.eu](https://earthdatahub.destine.eu).
+2. Go to **Account settings → My API keys → Standard API keys** and generate a key.
+3. Add it to `~/.netrc`:
+
+```
+machine api.earthdatahub.destine.eu
+  password <your-standard-api-key>
+```
+
+```bash
+chmod 600 ~/.netrc
+```
+
+**Windows:** use `%USERPROFILE%\_netrc` (underscore prefix) with the same content.
+
+### Copernicus Climate Data Store (monthly datasets)
+
+1. Register at [cds.climate.copernicus.eu](https://cds.climate.copernicus.eu) and get your API key from your profile.
+2. Create `~/.ecmwfdatastoresrc`:
+
+```
+url: https://cds.climate.copernicus.eu/api
+key: <your-cds-api-key>
+```
+
+### Ingest your first ERA5-Land dataset
+
+Once authenticated, ingest ERA5-Land daily temperature:
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/ingestions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dataset_id": "era5land_temperature_daily",
+    "start": "2024-01-01",
+    "end": "2024-01-31",
+    "publish": true
+  }' | jq
+```
+
+---
+
+## Temperature datasets
+
+### Daily (pre-computed)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_temperature_daily` |
+| **Variable** | `t2m` |
+| **Units** | °C |
+| **Period** | Daily |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily) |
+| **Lag** | ~4 weeks |
+
+Daily mean temperature for the **UTC calendar day** (00:00–23:59 UTC). For most instances this is the right choice.
+
+For instances where health data is reported using a local calendar that does not align with UTC (e.g. UTC+3 East Africa), use `era5land_temperature_daily_from_hourly` instead.
+
+**Sync** — new days are appended incrementally. Earth Data Hub provides pre-computed daily means; this dataset uses those directly for efficiency and falls back to a CDS-derived daily mean for the most recent ~4 weeks not yet published by Earth Data Hub.
+
+---
+
+### Daily (from hourly, timezone-aware)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_temperature_daily_from_hourly` |
+| **Variable** | `t2m` |
+| **Units** | °C |
+| **Period** | Daily |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+| **Lag** | ~4 weeks |
+
+Daily mean temperature computed by averaging the 24 hourly values that fall within the **local calendar day**. The local day is defined by `utc_offset_hours` in `climate-service.yaml` (default: 0 = UTC).
+
+For a UTC+3 instance, "January 1" covers 21:00 UTC December 31 through 20:59 UTC January 1 — matching the calendar day as experienced locally.
+
+**When to use this instead of `era5land_temperature_daily`:** when your health data is reported by local date and your instance has a non-zero `utc_offset_hours`.
+
+---
+
+### Monthly
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_temperature_monthly` |
+| **Variable** | `t2m` |
+| **Units** | °C |
+| **Period** | Monthly |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [CDS reanalysis-era5-land-monthly-means](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means) |
+| **Lag** | ~2 months |
+
+Monthly mean 2 m temperature, downloaded directly from the Copernicus monthly averages product. Each value is the mean of all hourly temperature readings in the calendar month.
+
+---
+
+## Precipitation datasets
+
+Precipitation values represent **total precipitation reaching the surface**, including rain and snow as liquid-equivalent water. Units are always **mm** (millimetres of water depth).
+
+!!! note "About daily totals"
+    Daily precipitation values represent the **total water that fell during that calendar day**. Summing the daily values over a month matches the monthly total dataset to within rounding.
+
+### Daily (UTC calendar day)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_precipitation_daily` |
+| **Variable** | `tp` |
+| **Units** | mm |
+| **Period** | Daily |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+| **Lag** | ~4 weeks |
+
+Total precipitation for the **UTC calendar day**. Each value is the sum of all precipitation that fell within 00:00–23:59 UTC.
+
+For instances where health data is reported using a local calendar, use `era5land_precipitation_daily_from_hourly` instead.
+
+**Sync** — Earth Data Hub covers history. For the most recent ~4 weeks not yet published by Earth Data Hub, daily totals are derived from an hourly download from CDS.
+
+---
+
+### Daily (timezone-aware)
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_precipitation_daily_from_hourly` |
+| **Variable** | `tp` |
+| **Units** | mm |
+| **Period** | Daily |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [Earth Data Hub](https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land) |
+| **Lag** | ~4 weeks |
+
+Total precipitation summed over the **local calendar day**, defined by `utc_offset_hours` in `climate-service.yaml`.
+
+**When to use this instead of `era5land_precipitation_daily`:** when your health data is reported by local date and your instance has a non-zero `utc_offset_hours`.
+
+---
+
+### Monthly
+
+| Property | Value |
+| --- | --- |
+| **Dataset ID** | `era5land_precipitation_monthly` |
+| **Variable** | `tp` |
+| **Units** | mm |
+| **Period** | Monthly |
+| **Coverage** | Global, 1950–present |
+| **Resolution** | ~9 km |
+| **Source** | [CDS reanalysis-era5-land-monthly-means](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means) |
+| **Lag** | ~2 months |
+
+Total precipitation for the calendar month in mm. The CDS monthly-means product provides the mean daily precipitation; this is multiplied by the number of days in the month at ingest time to give a directly comparable monthly total.
+
+This is the recommended dataset for monthly precipitation analysis and climate–health modelling. It is produced by Copernicus and represents the most authoritative ERA5-Land precipitation product.
+
+---
+
+## Choosing the right dataset
+
+| Use case | Recommended dataset |
+| --- | --- |
+| Daily health modelling, UTC-aligned | `era5land_temperature_daily` / `era5land_precipitation_daily` |
+| Daily health modelling, local calendar | `era5land_temperature_daily_from_hourly` / `era5land_precipitation_daily_from_hourly` |
+| Monthly climate–health modelling | `era5land_temperature_monthly` / `era5land_precipitation_monthly` |
+| CHAP integration (South Sudan, East Africa) | `era5land_precipitation_monthly` |
+
+## UTC offset configuration
+
+For instances in non-UTC time zones, set `utc_offset_hours` in `climate-service.yaml`:
+
+```yaml
+utc_offset_hours: 3   # East Africa (UTC+3)
+```
+
+This affects all daily datasets — both the UTC and local-time variants use the offset when computing day boundaries.

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -47,6 +47,7 @@ Field reference:
 | `extent.name`  | No  | Human-readable label shown in API responses |
 | `bbox`         | Yes | Bounding box as `[xmin, ymin, xmax, ymax]` in WGS84 decimal degrees |
 | `country_code` | No  | ISO 3166-1 alpha-3 code — required for WorldPop downloads |
+| `utc_offset_hours` | No  | UTC offset in hours (e.g. `3` for East Africa). Affects daily datasets computed from hourly data — the "local day" is shifted accordingly. Defaults to `0` (UTC) |
 
 `data_dir` sets the directory where downloaded NetCDF files and Zarr stores are kept. It is required when a config file is present and is resolved relative to the config file. Each instance must have its own `data_dir` to avoid mixing data between deployments.
 
@@ -70,7 +71,7 @@ cp .env.example .env
 
 `CLIMATE_SERVICE_CONFIG=./climate-service.yaml` is already set in `.env.example`. The remaining defaults are sufficient to run the API and ingest CHIRPS3 and WorldPop data. Review the file and adjust as needed — the comments explain each variable.
 
-For ERA5-Land downloads see [ERA5-Land setup](#era5-land-via-destine-earth-data-hub) below.
+For ERA5-Land downloads see [ERA5-Land datasets](era5_land_datasets.md).
 
 ## Step 4: Start the API
 
@@ -157,51 +158,9 @@ See [user_guide.md](user_guide.md) for more usage examples.
 
 ---
 
-## ERA5-Land via DestinE Earth Data Hub
+## ERA5-Land datasets
 
-ERA5-Land hourly temperature and precipitation data is downloaded from the [DestinE Earth Data Hub](https://earthdatahub.destine.eu). Access is free but requires registration.
-
-### 1. Register
-
-Create a free account at [earthdatahub.destine.eu](https://earthdatahub.destine.eu). Free accounts include a monthly request limit of 500,000 — sufficient for national-scale downloads.
-
-### 2. Configure authentication
-
-DestinE authentication uses a `.netrc` file in your home directory. Create or append to `~/.netrc`:
-
-```
-machine data.earthdatahub.destine.eu
-login edh
-password <your-personal-access-token>
-```
-
-The `login` is the literal string `edh`. The `password` is a personal access token, not your account password — generate one at `earthdatahub.destine.eu/account-settings` under "My Personal Access Tokens"
-
-Set the correct permissions:
-
-```bash
-chmod 600 ~/.netrc
-```
-
-**Windows:** Python's `netrc` module looks for `_netrc` (underscore) instead of `.netrc`. Create the file as `%USERPROFILE%\_netrc` with the same content. The `chmod` step is not needed on Windows.
-
-### 3. Ingest ERA5-Land data
-
-Once authenticated, ingest ERA5-Land temperature for Rwanda:
-
-```bash
-curl -s -X POST http://127.0.0.1:8000/ingestions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "dataset_id": "era5land_temperature_hourly",
-    "start": "2024-01-01T00",
-    "end": "2024-01-31T23",
-    "prefer_zarr": true,
-    "publish": true
-  }' | jq
-```
-
-ERA5-Land data has a configured lag of 120 hours (5 days) — the sync planner will not request data from the last 120 hours. This can be adjusted by placing a custom `era5_land.yaml` in `plugins_dir/datasets/` — see `adding_custom_datasets.md`.
+ERA5-Land temperature and precipitation data requires registration with the DestinE Earth Data Hub and/or the Copernicus Climate Data Store. See **[ERA5-Land datasets](era5_land_datasets.md)** for setup instructions and the full list of available datasets.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Accessing data: user_guide.md
       - openEO: openeo.md
       - Built-in datasets: built_in_datasets.md
+      - ERA5-Land datasets: era5_land_datasets.md
       - Processes: processes.md
       - Workflows: workflows.md
       - Instance guide: instance_guide.md

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -1,5 +1,6 @@
 """Instance configuration loaded from CLIMATE_SERVICE_CONFIG."""
 
+import datetime
 import os
 import re
 from pathlib import Path
@@ -142,3 +143,26 @@ def get_data_dir() -> Path | None:
     if not isinstance(raw, (str, Path)):
         raise ValueError(f"data_dir in CLIMATE_SERVICE_CONFIG must be a path string, got {type(raw).__name__}")
     return (config_path.parent / raw).resolve()
+
+
+def get_utc_offset_hours() -> float:
+    """Return the UTC offset in hours for daily period boundaries, defaulting to 0 (UTC).
+
+    Set ``utc_offset_hours: 5.5`` in climate-service.yaml for UTC+5:30 (India),
+    ``utc_offset_hours: 3`` for East Africa (UTC+3), etc.
+    """
+    raw = get_config().get("utc_offset_hours", 0)
+    if not isinstance(raw, (int, float)):
+        raise ValueError(f"utc_offset_hours in CLIMATE_SERVICE_CONFIG must be a number, got {type(raw).__name__}")
+    if not -12 <= float(raw) <= 14:
+        raise ValueError(f"utc_offset_hours must be between -12 and 14, got {raw}")
+    return float(raw)
+
+
+def get_utc_offset() -> datetime.timedelta:
+    """Return the UTC offset as a timedelta, supporting fractional-hour zones (e.g. UTC+5:30).
+
+    Prefer this over ``get_utc_offset_hours()`` wherever a timedelta is needed,
+    as it correctly handles half- and quarter-hour offsets rather than truncating.
+    """
+    return datetime.timedelta(hours=get_utc_offset_hours())

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -3,35 +3,445 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from datetime import timedelta
-from importlib import import_module
+import calendar
+import math
+import os
+import tempfile
+from datetime import date, datetime, timedelta
+from pathlib import Path
 from threading import Lock
 from typing import Any, cast
+from urllib.parse import urlparse, urlunparse
 
 import numpy as np
 import xarray as xr
+from ecmwf.datastores import Client as _CdsClient
 
 from open_climate_service.shared.time import datetime_to_period_string, parse_period_string_to_datetime
 from open_climate_service.streaming.protocol import GridSpec
+from open_climate_service.transforms.unit_conversion import kelvin_to_celsius, metres_to_mm
+
+_ERA5_LAND_RES_DEG = 0.1
+
+# CDS API long-name variables for reanalysis-era5-land-monthly-means
+_CDS_VARIABLE_NAMES: dict[str, str] = {
+    "t2m": "2m_temperature",
+    "tp": "total_precipitation",
+}
 
 
-class ERA5LandHourlySingleBandPlugin:
-    """Streaming plugin for direct single-band ERA5-Land hourly variables."""
+def _iter_days(start_dt: date, end_dt: date) -> list[str]:
+    """Enumerate ISO date strings from start_dt to end_dt inclusive."""
+    result: list[str] = []
+    current = start_dt
+    while current <= end_dt:
+        result.append(current.isoformat())
+        current += timedelta(days=1)
+    return result
 
-    max_concurrency = 2
+
+def _era5land_probe(bbox: list[float]) -> GridSpec:
+    """Return a GridSpec for the given bbox at ERA5-Land 0.1° resolution."""
+    xmin, ymin, xmax, ymax = map(float, bbox)
+    nx = max(1, math.ceil((xmax - xmin) / _ERA5_LAND_RES_DEG))
+    ny = max(1, math.ceil((ymax - ymin) / _ERA5_LAND_RES_DEG))
+    return GridSpec(
+        shape=(ny, nx), crs=4326, dtype=np.dtype("float32"), nodata=None, time_dim="t", x_dim="x", y_dim="y"
+    )
+
+
+class ERA5LandCDSHourlyPlugin:
+    """Streaming plugin for hourly ERA5-Land variables from the Copernicus CDS.
+
+    Fetches one full calendar month per CDS API call and caches the result so
+    that consecutive hourly ``fetch_period`` calls within the same month share
+    a single remote request.
+    """
+
+    max_concurrency = 1
     commit_batch_size = 24
 
+    def __init__(self, variable: str, **_: Any) -> None:
+        if variable not in _CDS_VARIABLE_NAMES:
+            raise ValueError(
+                f"ERA5LandCDSHourlyPlugin: unsupported variable {variable!r}; "
+                f"expected one of {list(_CDS_VARIABLE_NAMES)}"
+            )
+        self.variable = variable
+        self._cache_lock = Lock()
+        self._cached_month: tuple[int, int] | None = None
+        self._cached_bbox: tuple[float, float, float, float] | None = None
+        self._cached_ds: xr.Dataset | None = None
+
+    async def probe(self, bbox: list[float], **_: Any) -> GridSpec:
+        return _era5land_probe(bbox)
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        cutoff = await asyncio.to_thread(_hourly_availability_cutoff)
+        current = parse_period_string_to_datetime(start)
+        limit = min(parse_period_string_to_datetime(end), cutoff)
+        if current > limit:
+            return []
+        result: list[str] = []
+        while current <= limit:
+            result.append(datetime_to_period_string(current, "hourly"))
+            current += timedelta(hours=1)
+        return result
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        return await asyncio.to_thread(self._fetch_sync, period_id, bbox)
+
+    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        dt = parse_period_string_to_datetime(period_id)
+        bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
+        with self._cache_lock:
+            if self._cached_month != (dt.year, dt.month) or self._cached_bbox != bbox_tuple:
+                self._cached_ds = self._fetch_month(dt.year, dt.month, bbox_tuple)
+                self._cached_month = (dt.year, dt.month)
+                self._cached_bbox = bbox_tuple
+            monthly_ds = self._cached_ds
+        assert monthly_ds is not None
+        timestamp = np.datetime64(dt.replace(tzinfo=None), "h").astype("datetime64[ns]")
+        return monthly_ds.sel(t=timestamp)
+
+    def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        xmin, ymin, xmax, ymax = bbox
+        _, last_day = calendar.monthrange(year, month)
+        # Cap to availability cutoff so we don't request future days from CDS
+        cutoff = _hourly_availability_cutoff()
+        if cutoff.year == year and cutoff.month == month:
+            last_day = min(last_day, cutoff.day)
+        params = {
+            "variable": [_CDS_VARIABLE_NAMES[self.variable]],
+            "year": str(year),
+            "month": str(month).zfill(2),
+            "day": [str(d).zfill(2) for d in range(1, last_day + 1)],
+            "time": [f"{h:02d}:00" for h in range(24)],
+            "area": [ymax, xmin, ymin, xmax],  # N, W, S, E
+            "data_format": "netcdf",
+            "download_format": "unarchived",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "era5land_hourly.nc"
+            remote = _CdsClient().submit("reanalysis-era5-land", params)
+            remote.download(str(target))
+            ds = xr.open_dataset(target, engine="netcdf4").load()
+        ds = ds[[self.variable]]
+        time_dim = "valid_time" if "valid_time" in ds.dims else "time"
+        ds = ds.rename({"longitude": "x", "latitude": "y", time_dim: "t"})
+        if self.variable == "t2m":
+            ds = kelvin_to_celsius(ds, {"variable": self.variable})
+        return ds
+
+
+class ERA5LandPrecipitationPlugin(ERA5LandCDSHourlyPlugin):
+    """ERA5-Land hourly precipitation plugin (metres → millimetres)."""
+
+    def __init__(self, **_: Any) -> None:
+        super().__init__(variable="tp")
+
+    def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        ds = super()._fetch_month(year, month, bbox)
+        ds = ds.assign(tp=_deaccumulate_tp(ds["tp"], time_dim="t"))
+        return metres_to_mm(ds, {"variable": self.variable})
+
+
+class ERA5LandDailyTemperaturePlugin:
+    """Streaming plugin for daily ERA5-Land 2m temperature from the Copernicus CDS.
+
+    Uses the ``derived-era5-land-daily-statistics`` dataset. Fetches one full
+    calendar month per CDS API call and caches the result in memory so that
+    consecutive daily ``fetch_period`` calls within the same month only submit
+    one remote request.  ``max_concurrency = 1`` ensures the cache is never
+    accessed by concurrent fetches.
+    """
+
+    max_concurrency = 1
+    commit_batch_size = 31
+
+    def __init__(self, **_: Any) -> None:
+        self._cache_lock = Lock()
+        self._cached_month: tuple[int, int] | None = None
+        self._cached_bbox: tuple[float, float, float, float] | None = None
+        self._cached_ds: xr.Dataset | None = None
+
+    async def probe(self, bbox: list[float], **_: Any) -> GridSpec:
+        return _era5land_probe(bbox)
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        cutoff = await asyncio.to_thread(_daily_availability_cutoff)
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), cutoff)
+        if start_dt > end_dt:
+            return []
+        return _iter_days(start_dt, end_dt)
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        return await asyncio.to_thread(self._fetch_sync, period_id, bbox)
+
+    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        day = date.fromisoformat(period_id)
+        bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
+
+        with self._cache_lock:
+            if self._cached_month != (day.year, day.month) or self._cached_bbox != bbox_tuple:
+                self._cached_ds = self._fetch_month(day.year, day.month, bbox_tuple)
+                self._cached_month = (day.year, day.month)
+                self._cached_bbox = bbox_tuple
+            monthly_ds = self._cached_ds
+
+        assert monthly_ds is not None
+        timestamp = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        return monthly_ds.sel(t=slice(timestamp, timestamp))
+
+    def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        xmin, ymin, xmax, ymax = bbox
+        _, last_day = calendar.monthrange(year, month)
+        cutoff = _daily_availability_cutoff()
+        if cutoff.year == year and cutoff.month == month:
+            last_day = min(last_day, cutoff.day)
+        params = {
+            "variable": ["2m_temperature"],
+            "year": str(year),
+            "month": str(month).zfill(2),
+            "day": [str(d).zfill(2) for d in range(1, last_day + 1)],
+            "daily_statistic": "daily_mean",
+            "time_zone": "utc+00:00",
+            "frequency": "1_hourly",
+            "area": [ymax, xmin, ymin, xmax],  # N, W, S, E
+            "data_format": "netcdf",
+            "download_format": "unarchived",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "era5land_daily.nc"
+            remote = _CdsClient().submit("derived-era5-land-daily-statistics", params)
+            remote.download(str(target))
+            ds = xr.open_dataset(target, engine="netcdf4").load()
+
+        ds = ds[["t2m"]]
+        time_dim = "valid_time" if "valid_time" in ds.dims else "time"
+        ds = ds.rename({"longitude": "x", "latitude": "y", time_dim: "t"})
+        return kelvin_to_celsius(ds, {"variable": "t2m"})
+
+
+class ERA5LandMonthlyPlugin:
+    """Streaming plugin for monthly ERA5-Land means from the Copernicus CDS.
+
+    Fetches one calendar month at a time from the ``reanalysis-era5-land-monthly-means``
+    dataset via the CDS API (``ecmwf-datastores``). Credentials are read from
+    ``~/.cdsapirc`` or the ``CDSAPI_URL`` / ``CDSAPI_KEY`` environment variables.
+    """
+
+    max_concurrency = 1
+    commit_batch_size = 12
+
+    def __init__(self, variable: str, **_: Any) -> None:
+        if variable not in _CDS_VARIABLE_NAMES:
+            raise ValueError(
+                f"ERA5LandMonthlyPlugin: unsupported variable {variable!r}; expected one of {list(_CDS_VARIABLE_NAMES)}"
+            )
+        self.variable = variable
+
+    async def probe(self, bbox: list[float], **_: Any) -> GridSpec:
+        return _era5land_probe(bbox)
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        cutoff = await asyncio.to_thread(_monthly_availability_cutoff)
+        start_dt = _parse_monthly(start)
+        end_dt = min(_parse_monthly(end), datetime(cutoff.year, cutoff.month, 1))
+        if start_dt > end_dt:
+            return []
+        result: list[str] = []
+        current = start_dt
+        while current <= end_dt:
+            result.append(f"{current.year:04d}-{current.month:02d}")
+            month = current.month % 12 + 1
+            year = current.year + (1 if current.month == 12 else 0)
+            current = datetime(year, month, 1)
+        return result
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        return await asyncio.to_thread(self._fetch_sync, period_id, bbox)
+
+    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        year, month = int(period_id[:4]), int(period_id[5:7])
+        xmin, ymin, xmax, ymax = map(float, bbox)
+
+        params = {
+            "product_type": [_era5land_monthly_product_type(year, month, self.variable)],
+            "variable": [_CDS_VARIABLE_NAMES[self.variable]],
+            "year": [str(year)],
+            "month": [str(month).zfill(2)],
+            "time": ["00:00"],
+            "area": [ymax, xmin, ymin, xmax],  # N, W, S, E
+            "data_format": "netcdf",
+            "download_format": "unarchived",
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "era5land_monthly.nc"
+            remote = _CdsClient().submit("reanalysis-era5-land-monthly-means", params)
+            remote.download(str(target))
+            ds = xr.open_dataset(target, engine="netcdf4").load()
+
+        ds = ds[[self.variable]]
+        time_dim = "valid_time" if "valid_time" in ds.dims else "time"
+        rename_map = {"longitude": "x", "latitude": "y", time_dim: "t"}
+        ds = ds.rename({k: v for k, v in rename_map.items() if k in ds})
+
+        if self.variable == "t2m":
+            ds = kelvin_to_celsius(ds, {"variable": self.variable})
+        return ds
+
+
+class ERA5LandMonthlyPrecipitationPlugin(ERA5LandMonthlyPlugin):
+    """ERA5-Land monthly total precipitation plugin.
+
+    CDS returns the monthly mean of daily totals (m/day). Multiplying by the
+    number of days in the month converts this to the calendar-month total in mm,
+    which is the natural unit for DHIS2 and climate-health reporting.
+    """
+
+    def __init__(self, **_: Any) -> None:
+        super().__init__(variable="tp")
+
+    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        year = int(period_id[:4])
+        month = int(period_id[5:7])
+        _, days_in_month = calendar.monthrange(year, month)
+        ds = super()._fetch_sync(period_id, bbox)
+        ds = metres_to_mm(ds, {"variable": self.variable})
+        return ds.assign(tp=ds["tp"] * days_in_month)
+
+
+def _parse_monthly(period: str) -> datetime:
+    """Parse a monthly period string (YYYY-MM or full ISO) to the first of the month."""
+    if len(period) == 7:
+        return datetime(int(period[:4]), int(period[5:7]), 1)
+    dt = parse_period_string_to_datetime(period)
+    return datetime(dt.year, dt.month, 1)
+
+
+_CDS_CATALOGUE_URL = "https://cds.climate.copernicus.eu/api"
+_CDS_HOURLY_COLLECTION = "reanalysis-era5-land"
+_CDS_DAILY_COLLECTION = "derived-era5-land-daily-statistics"
+_CDS_MONTHLY_COLLECTION = "reanalysis-era5-land-monthly-means"
+
+
+def _era5land_monthly_product_type(year: int, month: int, variable: str) -> str:
+    """Return the correct CDS product_type for ERA5-Land monthly means.
+
+    The standard ``monthly_averaged_reanalysis`` product contains incorrect
+    data for **accumulated variables** (tp) for September 2022 – February 2024.
+    For that range, ``monthly_averaged_reanalysis_by_hour_of_day`` at
+    time=00:00 returns the monthly mean of daily step-24 values, which is
+    unaffected by the bug and gives the correct monthly totals.
+
+    For instantaneous variables (t2m), switching product type would change the
+    semantics from "monthly mean" to "mean at 00:00 UTC" — so the workaround
+    is intentionally skipped for non-accumulated variables.
+
+    Reference: https://forum.ecmwf.int/t/2370
+    """
+    accumulated = {"tp"}
+    if variable in accumulated and (2022, 9) <= (year, month) <= (2024, 2):
+        return "monthly_averaged_reanalysis_by_hour_of_day"
+    return "monthly_averaged_reanalysis"
+
+
+def _cds_end_datetime(collection: str) -> datetime:
+    """Query the CDS catalogue for the end_datetime of a collection."""
+    col = _CdsClient(url=_CDS_CATALOGUE_URL, key="").get_collection(collection)
+    if col.end_datetime is None:
+        raise RuntimeError(f"CDS collection '{collection}' returned no end_datetime")
+    return col.end_datetime
+
+
+def _hourly_availability_cutoff() -> datetime:
+    """Return the latest hour for which CDS ERA5-Land hourly data are published."""
+    return _cds_end_datetime(_CDS_HOURLY_COLLECTION)
+
+
+def _daily_availability_cutoff() -> date:
+    """Return the latest date for which CDS ERA5-Land daily statistics are published."""
+    return _cds_end_datetime(_CDS_DAILY_COLLECTION).date()
+
+
+def _monthly_availability_cutoff() -> date:
+    """Return the latest month for which CDS ERA5-Land monthly means are published."""
+    return _cds_end_datetime(_CDS_MONTHLY_COLLECTION).date().replace(day=1)
+
+
+def _normalize_lon(ds: xr.Dataset) -> xr.Dataset:
+    """Normalize longitude coordinates from 0–360 to –180/180."""
+    return ds.assign_coords(longitude=((ds.longitude + 180) % 360) - 180)
+
+
+def _deaccumulate_tp(tp: xr.DataArray, time_dim: str = "valid_time") -> xr.DataArray:
+    """Deaccumulate ERA5-Land total precipitation to hourly rates.
+
+    ERA5-Land ``tp`` accumulates continuously within each calendar day,
+    resetting to zero at 01:00 UTC.  At the reset boundary the raw diff is
+    negative; the correct hourly rate for that step is the current ``tp``
+    value itself (accumulated since the new period start), so we substitute
+    the current value rather than clipping to zero.  This recovers all
+    precipitation with no lost hours.
+    """
+    diff = tp.diff(time_dim)
+    # At the reset boundary diff is negative; the current tp IS the 1-hour rate
+    hourly = diff.where(diff >= 0, tp.isel({time_dim: slice(1, None)}))
+    return xr.concat([tp.isel({time_dim: slice(0, 1)}), hourly], dim=time_dim)
+
+
+# ---------------------------------------------------------------------------
+# Earth Data Hub (EDH) plugins — lazy Zarr access, no per-period downloads
+# ---------------------------------------------------------------------------
+
+# Hourly ERA5-Land: Zarr v2
+_EDH_HOURLY_URL = "https://api.earthdatahub.destine.eu/era5/reanalysis-era5-land-no-antartica-v0.zarr"
+# Daily ERA5-Land: new DestinE API, Zarr v3, requires an additional subscription
+_EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v1.zarr"
+_EDH_API_KEY_ENV = "EDH_API_KEY"
+
+
+def _edh_open_zarr(url: str, *, consolidated: bool | None = None) -> xr.Dataset:
+    """Open an Earth Data Hub Zarr store.
+
+    Injects the ``EDH_API_KEY`` environment variable as HTTP Basic Auth
+    (username ``edh``, password = key).  Falls back to netrc when the
+    variable is not set.
+
+    Pass ``consolidated=True`` for Zarr v2 stores (the hourly ERA5-Land store).
+    """
+    token = os.environ.get(_EDH_API_KEY_ENV, "")
+    if token:
+        parts = urlparse(url)
+        url = urlunparse(parts._replace(netloc=f"edh:{token}@{parts.netloc}"))
+    return xr.open_zarr(  # type: ignore[no-any-return]
+        url,
+        consolidated=consolidated,
+        storage_options={"client_kwargs": {"trust_env": True}},
+    )
+
+
+class _ERA5LandEDHBase:
+    """Shared cache and probe logic for EDH Zarr plugins."""
+
+    _edh_url: str  # set by subclass
+    _edh_consolidated: bool | None = None  # True for Zarr v2 stores
+    _edh_lon_360: bool = False  # True when longitude is stored 0–360
+
     def __init__(self, variable: str) -> None:
-        if not variable:
-            raise ValueError("ERA5LandHourlySingleBandPlugin requires a non-empty variable")
+        if variable not in _CDS_VARIABLE_NAMES:
+            raise ValueError(
+                f"{type(self).__name__}: unsupported variable {variable!r}; expected one of {list(_CDS_VARIABLE_NAMES)}"
+            )
         self.variable = variable
         self._cache_lock = Lock()
         self._cached_bbox: tuple[float, float, float, float] | None = None
         self._cached_region: xr.Dataset | None = None
 
-    async def probe(self, bbox: list[float], **params: Any) -> GridSpec:
-        _ = params
+    async def probe(self, bbox: list[float], **_: Any) -> GridSpec:
         region = await asyncio.to_thread(self._region_for_bbox, bbox)
         data = region[self.variable]
         return GridSpec(
@@ -44,72 +454,347 @@ class ERA5LandHourlySingleBandPlugin:
             y_dim="y",
         )
 
-    async def periods(self, start: str, end: str) -> list[str]:
-        current = parse_period_string_to_datetime(start)
-        limit = parse_period_string_to_datetime(end)
-        if current > limit:
-            return []
-        periods: list[str] = []
-        while current <= limit:
-            periods.append(datetime_to_period_string(current, "hourly"))
-            current += timedelta(hours=1)
-        return periods
-
-    async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
-        _ = params
-        return await asyncio.to_thread(self._fetch_sync, period_id, bbox)
-
-    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
-        region = self._region_for_bbox(bbox)
-        timestamp = parse_period_string_to_datetime(period_id).replace(tzinfo=None)
-        selected = region.sel(valid_time=slice(timestamp, timestamp))
-        ds = selected[[self.variable]].load()
-        rename_map = {"longitude": "x", "latitude": "y", "valid_time": "t"}
-        return ds.rename(rename_map) if rename_map else ds
-
     def _region_for_bbox(self, bbox: list[float]) -> xr.Dataset:
         bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
         with self._cache_lock:
             if self._cached_region is not None and self._cached_bbox == bbox_tuple:
                 return self._cached_region
-            self._close_cached_region_locked()
-            region = _open_era5_land_region(self.variable, bbox_tuple)
+            self._close_cached_locked()
+            xmin, ymin, xmax, ymax = bbox_tuple
+            ds = _edh_open_zarr(self._edh_url, consolidated=self._edh_consolidated)
+            # Extend bbox by half a grid step (0.05°) to avoid floating-point
+            # boundary exclusion (e.g. 360 - 10.1 = 349.8999... misses the 349.9
+            # grid point). CDS API is inclusive of boundary points; this aligns
+            # the EDH selection so both sources return the same spatial grid.
+            _eps = 0.05
+            if self._edh_lon_360:
+                xmin_sel = (xmin % 360) - _eps
+                xmax_sel = (xmax % 360) + _eps
+            else:
+                xmin_sel, xmax_sel = xmin - _eps, xmax + _eps
+            self._cached_region = ds[[self.variable]].sel(
+                latitude=slice(ymax + _eps, ymin - _eps),
+                longitude=slice(xmin_sel, xmax_sel),
+            )
             self._cached_bbox = bbox_tuple
-            self._cached_region = region
-            return region
+            return self._cached_region
+
+    def _apply_transforms(self, ds: xr.Dataset) -> xr.Dataset:
+        if self.variable == "t2m":
+            return kelvin_to_celsius(ds, {"variable": self.variable})
+        if self.variable == "tp":
+            return metres_to_mm(ds, {"variable": self.variable})
+        return ds
 
     def close(self) -> None:
         with self._cache_lock:
-            self._close_cached_region_locked()
+            self._close_cached_locked()
 
-    def _close_cached_region_locked(self) -> None:
+    def _close_cached_locked(self) -> None:
         if self._cached_region is not None:
             self._cached_region.close()
         self._cached_region = None
         self._cached_bbox = None
 
+    def _latest_available(self) -> str:
+        """Return the latest available timestamp from the EDH Zarr store."""
+        ds = _edh_open_zarr(self._edh_url, consolidated=self._edh_consolidated)
+        try:
+            return str(np.datetime64(ds.valid_time.isel(valid_time=-1).values, "h"))
+        finally:
+            ds.close()
 
-class ERA5LandPrecipitationPlugin(ERA5LandHourlySingleBandPlugin):
-    """ERA5-Land hourly precipitation plugin.
 
-    This currently preserves the legacy dataset semantics exactly:
-    - fetch direct `tp` values from the upstream ERA5-Land source
-    - rely on the template transform pipeline for metres -> millimetres
+class ERA5LandEDHDailyPlugin(_ERA5LandEDHBase):
+    """Streaming plugin for daily ERA5-Land from the Earth Data Hub Zarr store.
 
-    Deaccumulation and trailing-boundary handling belong to the dedicated
-    precipitation canonicalization work and should be added here later without
-    forcing another dataset-template contract change.
+    Unlike the CDS daily statistics dataset, the EDH daily store includes
+    ``total_precipitation`` (``tp``), enabling daily precipitation ingestion.
+
+    Requires a Standard API key configured in netrc for ``api.earthdatahub.destine.eu``
+    or the ``EDH_API_KEY`` environment variable.
     """
 
-    def __init__(self) -> None:
-        super().__init__(variable="tp")
+    _edh_url = _EDH_DAILY_URL
+    _edh_lon_360 = True  # longitude stored as 0–360
+    max_concurrency = 4
+    commit_batch_size = 30
+
+    def __init__(self, variable: str, **_: Any) -> None:
+        super().__init__(variable)
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        latest = await asyncio.to_thread(self._latest_available)
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), date.fromisoformat(latest[:10]))
+        if start_dt > end_dt:
+            return []
+        return _iter_days(start_dt, end_dt)
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        return await asyncio.to_thread(self._fetch_sync, period_id, bbox)
+
+    def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        region = self._region_for_bbox(bbox)
+        timestamp = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        ds = region.sel(valid_time=slice(timestamp, timestamp))[[self.variable]].load()
+        if self._edh_lon_360:
+            ds = _normalize_lon(ds)
+        ds = ds.rename({"longitude": "x", "latitude": "y", "valid_time": "t"})
+        return self._apply_transforms(ds)
 
 
-def _open_era5_land_region(variable: str, bbox: tuple[float, float, float, float]) -> xr.Dataset:
-    module = import_module("dhis2eo.data.destine.era5_land.hourly")
-    open_zarr = cast(Callable[[list[str]], xr.Dataset], getattr(module, "open_zarr"))
-    get_zarr_region = cast(
-        Callable[[xr.Dataset, tuple[float, float, float, float]], xr.Dataset],
-        getattr(module, "get_zarr_region"),
-    )
-    return get_zarr_region(open_zarr([variable]), bbox)
+class ERA5LandTempDailyPlugin(ERA5LandEDHDailyPlugin):
+    """Canonical daily temperature plugin: EDH daily store for history, CDS for the recent tail.
+
+    Uses pre-computed daily means from the EDH daily store.  Falls back to
+    the CDS ``derived-era5-land-daily-statistics`` dataset for the ~4-week
+    tail not yet published by EDH.  Only supports ``t2m``; precipitation is
+    not available from the CDS daily statistics product.
+    """
+
+    def __init__(self, variable: str, **_: Any) -> None:
+        super().__init__(variable=variable)
+        self._cds_plugin = ERA5LandDailyTemperaturePlugin() if variable == "t2m" else None
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        if self._cds_plugin is None:
+            # tp: EDH only
+            return await super().periods(start, end)
+        cds_cutoff = await asyncio.to_thread(_daily_availability_cutoff)
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), cds_cutoff)
+        if start_dt > end_dt:
+            return []
+        return _iter_days(start_dt, end_dt)
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        edh_latest = await asyncio.to_thread(self._latest_available)
+        if self._cds_plugin is None or period_id <= edh_latest:
+            return await super().fetch_period(period_id, bbox)
+        return await self._cds_plugin.fetch_period(period_id, bbox)
+
+
+class ERA5LandEDHPrecipitationDailyPlugin(_ERA5LandEDHBase):
+    """Daily total precipitation from the EDH hourly store with proper deaccumulation.
+
+    Fetches 25 consecutive hourly ``tp`` values (the target day plus the
+    preceding hour for deaccumulation context), deaccumulates by differencing
+    and clipping negatives (which arise at the 12 UTC forecast reset), then
+    sums the 24 target-day hours to produce a daily total in mm.
+
+    This avoids the EDH daily Zarr store, whose ``tp`` field is a daily mean
+    of accumulated values — a quantity with no physical interpretation.
+
+    Requires a Standard API key configured in netrc for ``api.earthdatahub.destine.eu``
+    or the ``EDH_API_KEY`` environment variable.
+    """
+
+    _edh_url = _EDH_HOURLY_URL
+    _edh_consolidated = True
+    _edh_lon_360 = True
+    max_concurrency = 4
+    commit_batch_size = 30
+
+    def __init__(self, **_: Any) -> None:
+        super().__init__("tp")
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        latest_str = await asyncio.to_thread(self._latest_available)
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), date.fromisoformat(latest_str[:10]))
+        if start_dt > end_dt:
+            return []
+        return _iter_days(start_dt, end_dt)
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        return await asyncio.to_thread(self._fetch_daily_sync, period_id, bbox)
+
+    def _fetch_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        from open_climate_service import config as api_config
+
+        region = self._region_for_bbox(bbox)
+        day = date.fromisoformat(period_id)
+        utc_offset = api_config.get_utc_offset()
+
+        if utc_offset == 0:
+            # ERA5-Land tp accumulates from 00:00 UTC each day. The full 24h daily
+            # total for day D is stored at 00:00 UTC of day D+1 (step 24). Using
+            # this avoids missing the 23:00–midnight precipitation hour.
+            next_midnight = np.datetime64(f"{day + timedelta(days=1)}T00", "h").astype("datetime64[ns]")
+            ds = region.sel(valid_time=next_midnight)[["tp"]].load()
+            if self._edh_lon_360:
+                ds = _normalize_lon(ds)
+            ds = metres_to_mm(ds, {"variable": "tp"})
+        else:
+            # For non-UTC instances: aggregate deaccumulated hourly values within
+            # the local-day window (e.g. UTC+3 → 21:00 UTC D-1 to 20:00 UTC D).
+            local_start = datetime(day.year, day.month, day.day) - utc_offset
+            local_end = local_start + timedelta(hours=23)
+            window_start = local_start - timedelta(hours=1)
+            start_np = np.datetime64(local_start, "h").astype("datetime64[ns]")
+            end_np = np.datetime64(local_end, "h").astype("datetime64[ns]")
+            window_np = np.datetime64(window_start, "h").astype("datetime64[ns]")
+
+            window = region.sel(valid_time=slice(window_np, end_np))[["tp"]].load()
+            if self._edh_lon_360:
+                window = _normalize_lon(window)
+            deacc = _deaccumulate_tp(window["tp"])
+            daily_total = deacc.sel(valid_time=slice(start_np, end_np)).sum("valid_time")
+            ds = metres_to_mm(xr.Dataset({"tp": daily_total}), {"variable": "tp"})
+
+        ts = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        return ds.expand_dims({"valid_time": [ts]}).rename({"longitude": "x", "latitude": "y", "valid_time": "t"})
+
+
+class ERA5LandPrecipDailyPlugin(ERA5LandEDHPrecipitationDailyPlugin):
+    """Canonical daily precipitation plugin: EDH hourly for history, CDS hourly for the recent tail.
+
+    Extends ``ERA5LandEDHPrecipitationDailyPlugin`` with a CDS fallback so
+    periods beyond EDH's ~4-week publishing lag are filled automatically.
+    Timezone-aware: the local-day window respects ``utc_offset_hours`` in
+    climate-service.yaml on both the EDH and CDS paths.  Serves both
+    ``era5land_precipitation_daily`` and ``era5land_precipitation_daily_from_hourly``.
+    """
+
+    max_concurrency = 1
+
+    def __init__(self, **_: Any) -> None:
+        super().__init__()
+        self._cds_hourly = ERA5LandPrecipitationPlugin()
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        cds_cutoff = await asyncio.to_thread(_hourly_availability_cutoff)
+        from open_climate_service import config as api_config
+
+        utc_offset = api_config.get_utc_offset()
+        # Subtract the UTC offset so we only include local days whose final
+        # UTC hour is already published (e.g. UTC+3 needs data until 20:00 UTC).
+        cutoff_local_dt = cds_cutoff - utc_offset if hasattr(cds_cutoff, "__sub__") else cds_cutoff
+        cutoff_local = cutoff_local_dt.date() if hasattr(cutoff_local_dt, "date") else cutoff_local_dt
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), cutoff_local)
+        return _iter_days(start_dt, end_dt) if start_dt <= end_dt else []
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        edh_latest = await asyncio.to_thread(self._latest_available)
+        if period_id <= edh_latest[:10]:
+            return await asyncio.to_thread(self._fetch_daily_sync, period_id, bbox)
+        return await asyncio.to_thread(self._fetch_cds_daily_sync, period_id, bbox)
+
+    def _fetch_cds_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        from open_climate_service import config as api_config
+
+        day = date.fromisoformat(period_id)
+        bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
+        utc_offset = api_config.get_utc_offset()
+
+        with self._cds_hourly._cache_lock:
+            if self._cds_hourly._cached_month != (day.year, day.month) or self._cds_hourly._cached_bbox != bbox_tuple:
+                self._cds_hourly._cached_ds = self._cds_hourly._fetch_month(day.year, day.month, bbox_tuple)
+                self._cds_hourly._cached_month = (day.year, day.month)
+                self._cds_hourly._cached_bbox = bbox_tuple
+            monthly_ds = self._cds_hourly._cached_ds
+
+        assert monthly_ds is not None
+
+        if utc_offset == 0:
+            # Sum T01..T00-next (24 deaccumulated hours) to match the EDH step-24 value
+            next_day = day + timedelta(days=1)
+            day_start = np.datetime64(f"{day}T01", "h").astype("datetime64[ns]")
+            day_end = np.datetime64(f"{next_day}T00", "h").astype("datetime64[ns]")
+        else:
+            local_start = datetime(day.year, day.month, day.day) - utc_offset
+            local_end = local_start + timedelta(hours=24)
+            day_start = np.datetime64(local_start, "h").astype("datetime64[ns]")
+            day_end = np.datetime64(local_end, "h").astype("datetime64[ns]")
+
+        daily_total = monthly_ds.sel(t=slice(day_start, day_end))["tp"].sum("t")
+        ds = xr.Dataset({"tp": daily_total})
+        ts = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        return ds.expand_dims({"valid_time": [ts]}).rename({"valid_time": "t"})
+
+
+class ERA5LandTempDailyFromHourlyPlugin(_ERA5LandEDHBase):
+    """Daily 2m temperature: EDH hourly for history, CDS hourly for the recent tail.
+
+    Computes the daily mean from 24 individual hourly values, respecting
+    ``utc_offset_hours`` from climate-service.yaml.  EDH covers history
+    efficiently via lazy Zarr access; the CDS ERA5-Land hourly dataset fills
+    the ~4-week recent tail not yet published by EDH.
+    """
+
+    _edh_url = _EDH_HOURLY_URL
+    _edh_consolidated = True
+    _edh_lon_360 = True
+    max_concurrency = 4
+    commit_batch_size = 30
+
+    def __init__(self, **_: Any) -> None:
+        super().__init__("t2m")
+        self._cds_hourly = ERA5LandCDSHourlyPlugin(variable="t2m")
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        cds_cutoff = await asyncio.to_thread(_hourly_availability_cutoff)
+        from open_climate_service import config as api_config
+
+        utc_offset = api_config.get_utc_offset()
+        # Subtract the UTC offset so we only include local days whose final
+        # UTC hour is already published (e.g. UTC+3 needs data until 20:00 UTC).
+        cutoff_local_dt = cds_cutoff - utc_offset if hasattr(cds_cutoff, "__sub__") else cds_cutoff
+        cutoff_local = cutoff_local_dt.date() if hasattr(cutoff_local_dt, "date") else cutoff_local_dt
+        start_dt = date.fromisoformat(start[:10])
+        end_dt = min(date.fromisoformat(end[:10]), cutoff_local)
+        return _iter_days(start_dt, end_dt) if start_dt <= end_dt else []
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        edh_latest = await asyncio.to_thread(self._latest_available)
+        if period_id <= edh_latest[:10]:
+            return await asyncio.to_thread(self._fetch_daily_sync, period_id, bbox)
+        return await asyncio.to_thread(self._fetch_cds_daily_sync, period_id, bbox)
+
+    def _fetch_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        from open_climate_service import config as api_config
+
+        region = self._region_for_bbox(bbox)
+        day = date.fromisoformat(period_id)
+        utc_offset = api_config.get_utc_offset()
+
+        local_start = datetime(day.year, day.month, day.day) - utc_offset
+        local_end = local_start + timedelta(hours=23)
+        start_np = np.datetime64(local_start, "h").astype("datetime64[ns]")
+        end_np = np.datetime64(local_end, "h").astype("datetime64[ns]")
+
+        window = region.sel(valid_time=slice(start_np, end_np))[["t2m"]].load()
+        if self._edh_lon_360:
+            window = _normalize_lon(window)
+
+        daily_mean = window["t2m"].mean("valid_time")
+        ds = kelvin_to_celsius(xr.Dataset({"t2m": daily_mean}), {"variable": "t2m"})
+        ts = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        return ds.expand_dims({"valid_time": [ts]}).rename({"longitude": "x", "latitude": "y", "valid_time": "t"})
+
+    def _fetch_cds_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
+        from open_climate_service import config as api_config
+
+        day = date.fromisoformat(period_id)
+        bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
+        utc_offset = api_config.get_utc_offset()
+
+        with self._cds_hourly._cache_lock:
+            if self._cds_hourly._cached_month != (day.year, day.month) or self._cds_hourly._cached_bbox != bbox_tuple:
+                self._cds_hourly._cached_ds = self._cds_hourly._fetch_month(day.year, day.month, bbox_tuple)
+                self._cds_hourly._cached_month = (day.year, day.month)
+                self._cds_hourly._cached_bbox = bbox_tuple
+            monthly_ds = self._cds_hourly._cached_ds
+
+        assert monthly_ds is not None
+        local_start = datetime(day.year, day.month, day.day) - utc_offset
+        local_end = local_start + timedelta(hours=23)
+        start_np = np.datetime64(local_start, "h").astype("datetime64[ns]")
+        end_np = np.datetime64(local_end, "h").astype("datetime64[ns]")
+
+        daily_mean = monthly_ds.sel(t=slice(start_np, end_np))["t2m"].mean("t")
+        ds = xr.Dataset({"t2m": daily_mean})
+        ts = np.datetime64(period_id, "D").astype("datetime64[ns]")
+        return ds.expand_dims({"valid_time": [ts]}).rename({"valid_time": "t"})

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -1,26 +1,124 @@
-- id: era5land_temperature_hourly
+- id: era5land_temperature_daily
   name: 2m temperature (ERA5-Land)
   short_name: 2m temperature
   variable: t2m
-  period_type: hourly
+  period_type: daily
   sync:
     kind: temporal
     execution: append
-    availability:
-      latest_available_function: open_climate_service.providers.availability.lagged_latest_available
-      lag_hours: 120
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
     temporal:
       begin: "1950-01-01"
-      resolution: PT1H
+      resolution: P1D
   ingestion:
-    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandHourlySingleBandPlugin
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandTempDailyPlugin
     params:
       variable: t2m
-  transforms:
-    - open_climate_service.transforms.kelvin_to_celsius
+  units: degC
+  resolution: 9 km x 9 km
+  source: ERA5-Land Reanalysis
+  source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
+  display:
+    colormap: rdbu_r
+    range: [-30.0, 30.0]
+
+- id: era5land_precipitation_daily
+  name: Total precipitation (ERA5-Land)
+  short_name: Total precipitation
+  variable: tp
+  period_type: daily
+  sync:
+    kind: temporal
+    execution: append
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+    temporal:
+      begin: "1950-01-01"
+      resolution: P1D
+  ingestion:
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
+    params: {}
+  units: mm
+  resolution: 9 km x 9 km
+  source: ERA5-Land Reanalysis
+  source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
+  display:
+    colormap: blues
+    range: [0.0, 20.0]
+    nodata: 0.0
+
+- id: era5land_temperature_monthly
+  name: 2m temperature (ERA5-Land)
+  short_name: 2m temperature
+  variable: t2m
+  period_type: monthly
+  sync:
+    kind: temporal
+    execution: append
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+    temporal:
+      begin: "1950-01"
+      resolution: P1M
+  ingestion:
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandMonthlyPlugin
+    params:
+      variable: t2m
+  units: degC
+  resolution: 9 km x 9 km
+  source: ERA5-Land Reanalysis
+  source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
+  display:
+    colormap: rdbu_r
+    range: [-30.0, 30.0]
+
+- id: era5land_precipitation_monthly
+  name: Total precipitation (ERA5-Land)
+  short_name: Total precipitation
+  variable: tp
+  period_type: monthly
+  sync:
+    kind: temporal
+    execution: append
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+    temporal:
+      begin: "1950-01"
+      resolution: P1M
+  ingestion:
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandMonthlyPrecipitationPlugin
+    params: {}
+  units: mm
+  resolution: 9 km x 9 km
+  source: ERA5-Land Reanalysis
+  source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
+  display:
+    colormap: blues
+    range: [0.0, 100.0]
+    nodata: 0.0
+
+- id: era5land_temperature_daily_from_hourly
+  name: 2m temperature (ERA5-Land, local time)
+  short_name: 2m temperature
+  variable: t2m
+  period_type: daily
+  sync:
+    kind: temporal
+    execution: append
+  extents:
+    spatial:
+      bbox: [-180, -90, 180, 90]
+    temporal:
+      begin: "1950-01-01"
+      resolution: P1D
+  ingestion:
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandTempDailyFromHourlyPlugin
+    params: {}
   units: degC
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
@@ -29,33 +127,28 @@
     colormap: rdbu_r
     range: [-30.0, 30.0]
 
-- id: era5land_precipitation_hourly
-  name: Total precipitation (ERA5-Land)
+- id: era5land_precipitation_daily_from_hourly
+  name: Total precipitation (ERA5-Land, local time)
   short_name: Total precipitation
   variable: tp
-  period_type: hourly
+  period_type: daily
   sync:
     kind: temporal
     execution: append
-    availability:
-      latest_available_function: open_climate_service.providers.availability.lagged_latest_available
-      lag_hours: 120
   extents:
     spatial:
       bbox: [-180, -90, 180, 90]
     temporal:
       begin: "1950-01-01"
-      resolution: PT1H
+      resolution: P1D
   ingestion:
-    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipitationPlugin
+    plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
     params: {}
-  transforms:
-    - open_climate_service.transforms.metres_to_mm
   units: mm
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
   display:
     colormap: blues
-    range: [0.0, 5.0]
+    range: [0.0, 20.0]
     nodata: 0.0

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -1,140 +1,392 @@
 import asyncio
-from typing import cast
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import xarray as xr
 
-from open_climate_service.plugins.datasets.era5_land import ERA5LandHourlySingleBandPlugin, ERA5LandPrecipitationPlugin
+from open_climate_service.plugins.datasets.era5_land import (
+    ERA5LandCDSHourlyPlugin,
+    ERA5LandDailyTemperaturePlugin,
+    ERA5LandEDHDailyPlugin,
+    ERA5LandMonthlyPlugin,
+    ERA5LandMonthlyPrecipitationPlugin,
+    ERA5LandPrecipitationPlugin,
+    _daily_availability_cutoff,
+    _edh_open_zarr,
+    _era5land_monthly_product_type,
+    _hourly_availability_cutoff,
+    _monthly_availability_cutoff,
+)
 
 
-def test_era5_land_periods_enumerate_hours() -> None:
-    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
-
-    periods = asyncio.run(plugin.periods("2026-01-01T00", "2026-01-01T02"))
-
-    assert periods == ["2026-01-01T00", "2026-01-01T01", "2026-01-01T02"]
+def test_era5_land_hourly_plugin_rejects_unknown_variable() -> None:
+    with pytest.raises(ValueError, match="unsupported variable"):
+        ERA5LandCDSHourlyPlugin(variable="unknown")
 
 
-def test_era5_land_probe_uses_region_shape(monkeypatch: pytest.MonkeyPatch) -> None:
-    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
-
-    def fake_region_for_bbox(bbox: list[float]) -> xr.Dataset:
-        _ = bbox
-        return xr.Dataset(
-            {"t2m": (("valid_time", "latitude", "longitude"), np.ones((1, 3, 4), dtype=np.float32))},
-            coords={
-                "valid_time": ["2026-01-01T00:00:00"],
-                "latitude": [3.0, 2.0, 1.0],
-                "longitude": [4.0, 5.0, 6.0, 7.0],
-            },
-        )
-
-    monkeypatch.setattr(plugin, "_region_for_bbox", fake_region_for_bbox)
-
-    spec = asyncio.run(plugin.probe([1.0, 2.0, 3.0, 4.0]))
-
-    assert spec.shape == (3, 4)
+def test_era5_land_hourly_probe_derives_shape_from_bbox() -> None:
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+    spec = asyncio.run(plugin.probe([-13.5, 6.9, -10.1, 10.0]))
+    assert spec.shape == (31, 34)
     assert spec.time_dim == "t"
     assert spec.x_dim == "x"
     assert spec.y_dim == "y"
 
 
-def test_era5_land_fetch_period_normalizes_coordinates(monkeypatch: pytest.MonkeyPatch) -> None:
-    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
+def test_era5_land_hourly_periods_enumerates_hours() -> None:
+    from datetime import timezone
 
-    def fake_region_for_bbox(bbox: list[float]) -> xr.Dataset:
-        _ = bbox
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+    cutoff = datetime(2026, 1, 1, 2, tzinfo=timezone.utc)
+    with patch(
+        "open_climate_service.plugins.datasets.era5_land._hourly_availability_cutoff",
+        return_value=cutoff,
+    ):
+        periods = asyncio.run(plugin.periods("2026-01-01T00", "2026-01-01T05"))
+    assert periods == ["2026-01-01T00", "2026-01-01T01", "2026-01-01T02"]
+
+
+def test_era5_land_hourly_fetch_uses_cached_monthly_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+    fetch_calls: list[tuple[int, int]] = []
+
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        fetch_calls.append((year, month))
         return xr.Dataset(
-            {"t2m": (("valid_time", "latitude", "longitude"), np.array([[[280.0]], [[281.0]]], dtype=np.float32))},
+            {"t2m": (("t", "y", "x"), np.array([[[20.0]], [[21.0]]], dtype=np.float32))},
             coords={
-                "valid_time": np.array(["2026-01-01T00:00:00", "2026-01-01T01:00:00"], dtype="datetime64[ns]"),
-                "latitude": [9.0],
-                "longitude": [30.0],
+                "t": np.array(["2026-01-01T00", "2026-01-01T01"], dtype="datetime64[h]").astype("datetime64[ns]"),
+                "y": [9.0],
+                "x": [30.0],
             },
         )
 
-    monkeypatch.setattr(plugin, "_region_for_bbox", fake_region_for_bbox)
+    monkeypatch.setattr(ERA5LandCDSHourlyPlugin, "_fetch_month", fake_fetch_month)
 
-    dataset = asyncio.run(plugin.fetch_period("2026-01-01T01", [1.0, 2.0, 3.0, 4.0]))
+    asyncio.run(plugin.fetch_period("2026-01-01T00", [-1.0, 8.0, 31.0, 10.0]))
+    asyncio.run(plugin.fetch_period("2026-01-01T01", [-1.0, 8.0, 31.0, 10.0]))
 
-    assert "t" in dataset.dims
-    assert "x" in dataset.dims
-    assert "y" in dataset.dims
-    assert "longitude" not in dataset.dims
-    assert "latitude" not in dataset.dims
-    assert dataset["t2m"].values.tolist() == [[[281.0]]]
+    assert fetch_calls == [(2026, 1)]
 
 
-def test_era5_land_precipitation_plugin_defaults_to_tp(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_era5_land_hourly_fetch_converts_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        ds = xr.Dataset(
+            {"t2m": (("t", "y", "x"), np.array([[[300.0]]], dtype=np.float32))},
+            coords={
+                "t": np.array(["2026-01-01T00"], dtype="datetime64[h]").astype("datetime64[ns]"),
+                "y": [9.0],
+                "x": [30.0],
+            },
+        )
+        from open_climate_service.transforms.unit_conversion import kelvin_to_celsius
+
+        return kelvin_to_celsius(ds, {"variable": "t2m"})
+
+    monkeypatch.setattr(ERA5LandCDSHourlyPlugin, "_fetch_month", fake_fetch_month)
+    ds = asyncio.run(plugin.fetch_period("2026-01-01T00", [-1.0, 8.0, 31.0, 10.0]))
+    np.testing.assert_allclose(ds["t2m"].values, [[300.0 - 273.15]], atol=1e-3)
+
+
+def test_era5_land_precipitation_plugin_uses_tp_and_converts_to_mm(monkeypatch: pytest.MonkeyPatch) -> None:
     plugin = ERA5LandPrecipitationPlugin()
 
-    def fake_region_for_bbox(bbox: list[float]) -> xr.Dataset:
-        _ = bbox
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
         return xr.Dataset(
-            {"tp": (("valid_time", "latitude", "longitude"), np.array([[[0.002]]], dtype=np.float32))},
+            {"tp": (("t", "y", "x"), np.array([[[0.002]]], dtype=np.float32))},
             coords={
-                "valid_time": np.array(["2026-01-01T00:00:00"], dtype="datetime64[ns]"),
-                "latitude": [9.0],
-                "longitude": [30.0],
+                "t": np.array(["2026-01-01T00"], dtype="datetime64[h]").astype("datetime64[ns]"),
+                "y": [9.0],
+                "x": [30.0],
             },
         )
 
-    monkeypatch.setattr(plugin, "_region_for_bbox", fake_region_for_bbox)
-
-    dataset = asyncio.run(plugin.fetch_period("2026-01-01T00", [1.0, 2.0, 3.0, 4.0]))
-
-    assert list(dataset.data_vars) == ["tp"]
-    np.testing.assert_allclose(dataset["tp"].values, [[[0.002]]])
+    monkeypatch.setattr(ERA5LandCDSHourlyPlugin, "_fetch_month", fake_fetch_month)
+    ds = asyncio.run(plugin.fetch_period("2026-01-01T00", [-1.0, 8.0, 31.0, 10.0]))
+    assert list(ds.data_vars) == ["tp"]
+    np.testing.assert_allclose(ds["tp"].values, [[2.0]], atol=1e-3)
 
 
-def test_era5_land_cached_region_closes_previous_dataset_when_bbox_changes(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
-    opened: list[object] = []
+def test_era5_land_hourly_availability_cutoff_uses_cds() -> None:
+    from datetime import timezone
 
-    class FakeRegion:
-        def __init__(self, label: str) -> None:
-            self.label = label
-            self.closed = False
+    fake_col = MagicMock()
+    fake_col.end_datetime = datetime(2026, 5, 29, 23, tzinfo=timezone.utc)
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_col
 
-        def close(self) -> None:
-            self.closed = True
+    with patch("open_climate_service.plugins.datasets.era5_land._CdsClient", return_value=fake_client):
+        cutoff = _hourly_availability_cutoff()
 
-    def fake_open_region(variable: str, bbox: tuple[float, float, float, float]) -> object:
-        region = FakeRegion(f"{variable}:{bbox}")
-        opened.append(region)
-        return region
-
-    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._open_era5_land_region", fake_open_region)
-
-    first = plugin._region_for_bbox([1.0, 2.0, 3.0, 4.0])
-    second = plugin._region_for_bbox([2.0, 3.0, 4.0, 5.0])
-
-    assert first is opened[0]
-    assert second is opened[1]
-    assert cast(FakeRegion, first).closed is True
-    assert cast(FakeRegion, second).closed is False
+    assert cutoff == datetime(2026, 5, 29, 23, tzinfo=timezone.utc)
 
 
-def test_era5_land_plugin_close_releases_cached_region(monkeypatch: pytest.MonkeyPatch) -> None:
-    plugin = ERA5LandHourlySingleBandPlugin(variable="t2m")
+def test_era5_land_daily_probe_derives_shape_from_bbox() -> None:
+    plugin = ERA5LandDailyTemperaturePlugin()
+    spec = asyncio.run(plugin.probe([-13.5, 6.9, -10.1, 10.0]))
+    assert spec.shape == (31, 34)
+    assert spec.crs == 4326
+    assert spec.time_dim == "t"
 
-    class FakeRegion:
-        def __init__(self) -> None:
-            self.closed = False
 
-        def close(self) -> None:
-            self.closed = True
+def test_era5_land_daily_periods_enumerates_days() -> None:
+    plugin = ERA5LandDailyTemperaturePlugin()
+    with patch(
+        "open_climate_service.plugins.datasets.era5_land._daily_availability_cutoff",
+        return_value=date(2024, 1, 3),
+    ):
+        periods = asyncio.run(plugin.periods("2024-01-01", "2024-01-10"))
+    assert periods == ["2024-01-01", "2024-01-02", "2024-01-03"]
 
-    region = FakeRegion()
-    monkeypatch.setattr(
-        "open_climate_service.plugins.datasets.era5_land._open_era5_land_region",
-        lambda variable, bbox: region,
+
+def test_era5_land_daily_fetch_uses_cached_monthly_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandDailyTemperaturePlugin()
+    fetch_calls: list[tuple[int, int]] = []
+
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        fetch_calls.append((year, month))
+        return xr.Dataset(
+            {"t2m": (("t", "y", "x"), np.zeros((3, 1, 1), dtype=np.float32))},
+            coords={
+                "t": np.array(["2024-01-01", "2024-01-02", "2024-01-03"], dtype="datetime64[D]").astype(
+                    "datetime64[ns]"
+                ),
+                "y": [9.0],
+                "x": [30.0],
+            },
+        )
+
+    monkeypatch.setattr(ERA5LandDailyTemperaturePlugin, "_fetch_month", fake_fetch_month)
+
+    asyncio.run(plugin.fetch_period("2024-01-01", [-1.0, 8.0, 31.0, 10.0]))
+    asyncio.run(plugin.fetch_period("2024-01-02", [-1.0, 8.0, 31.0, 10.0]))
+    asyncio.run(plugin.fetch_period("2024-01-03", [-1.0, 8.0, 31.0, 10.0]))
+
+    # Three days in the same month → only one CDS API call
+    assert fetch_calls == [(2024, 1)]
+
+
+def test_era5_land_daily_availability_cutoff_uses_cds() -> None:
+    fake_col = MagicMock()
+    fake_col.end_datetime = datetime(2026, 5, 29, tzinfo=None)
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_col
+
+    with patch("open_climate_service.plugins.datasets.era5_land._CdsClient", return_value=fake_client):
+        cutoff = _daily_availability_cutoff()
+
+    assert cutoff == date(2026, 5, 29)
+
+
+def test_era5_land_monthly_plugin_rejects_unknown_variable() -> None:
+    with pytest.raises(ValueError, match="unsupported variable"):
+        ERA5LandMonthlyPlugin(variable="unknown")
+
+
+def test_era5_land_monthly_probe_derives_shape_from_bbox() -> None:
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    spec = asyncio.run(plugin.probe([-13.5, 6.9, -10.1, 10.0]))
+    assert spec.shape == (31, 34)
+    assert spec.crs == 4326
+    assert spec.time_dim == "t"
+    assert spec.x_dim == "x"
+    assert spec.y_dim == "y"
+
+
+def test_era5_land_monthly_periods_enumerates_months() -> None:
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    with patch(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        return_value=date(2024, 3, 1),
+    ):
+        periods = asyncio.run(plugin.periods("2024-01", "2024-06"))
+    assert periods == ["2024-01", "2024-02", "2024-03"]
+
+
+def test_era5_land_monthly_periods_empty_when_start_after_cutoff() -> None:
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    with patch(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        return_value=date(2023, 12, 1),
+    ):
+        periods = asyncio.run(plugin.periods("2024-01", "2024-06"))
+    assert periods == []
+
+
+def _make_monthly_nc(variable: str, value: float, kelvin: bool = False) -> xr.Dataset:
+    data = np.array([[[[value]]]], dtype=np.float32)
+    return xr.Dataset(
+        {variable: (("valid_time", "latitude", "longitude"), data[0])},
+        coords={
+            "valid_time": np.array(["2024-01-01"], dtype="datetime64[ns]"),
+            "latitude": [9.0],
+            "longitude": [30.0],
+        },
     )
 
-    plugin._region_for_bbox([1.0, 2.0, 3.0, 4.0])
-    plugin.close()
 
-    assert region.closed is True
+def test_era5_land_monthly_fetch_renames_coords_and_converts_temperature(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+) -> None:
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    raw_ds = _make_monthly_nc("t2m", 300.0)
+
+    def fake_fetch_sync(period_id: str, bbox: list[float]) -> xr.Dataset:
+        ds = raw_ds[["t2m"]]
+        ds = ds.rename({"longitude": "x", "latitude": "y", "valid_time": "t"})
+        from open_climate_service.transforms.unit_conversion import kelvin_to_celsius
+
+        return kelvin_to_celsius(ds, {"variable": "t2m"})
+
+    monkeypatch.setattr(plugin, "_fetch_sync", fake_fetch_sync)
+    ds = asyncio.run(plugin.fetch_period("2024-01", [-1.0, 8.0, 31.0, 10.0]))
+
+    assert "t" in ds.dims
+    assert "x" in ds.dims
+    assert "y" in ds.dims
+    np.testing.assert_allclose(ds["t2m"].values, [[[300.0 - 273.15]]], atol=1e-3)
+
+
+def test_era5_land_monthly_precipitation_converts_metres_to_mm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ERA5LandMonthlyPrecipitationPlugin()
+    raw_ds = xr.Dataset(
+        {"tp": (("t", "y", "x"), np.array([[[0.05]]], dtype=np.float32))},
+        coords={"t": np.array(["2024-01-01"], dtype="datetime64[ns]"), "y": [9.0], "x": [30.0]},
+    )
+
+    def fake_parent_fetch(self: object, period_id: str, bbox: list[float]) -> xr.Dataset:
+        return raw_ds
+
+    monkeypatch.setattr(ERA5LandMonthlyPlugin, "_fetch_sync", fake_parent_fetch)
+    ds = asyncio.run(plugin.fetch_period("2024-01", [-1.0, 8.0, 31.0, 10.0]))
+
+    # 0.05 m/day × 1000 mm/m × 31 days (January 2024) = 1550 mm monthly total
+    np.testing.assert_allclose(ds["tp"].values, [[[1550.0]]], atol=1e-1)
+
+
+def test_monthly_availability_cutoff_uses_cds_end_datetime() -> None:
+    from datetime import timezone
+
+    fake_col = MagicMock()
+    fake_col.end_datetime = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_col
+
+    with patch("open_climate_service.plugins.datasets.era5_land._CdsClient", return_value=fake_client):
+        cutoff = _monthly_availability_cutoff()
+
+    assert cutoff == date(2026, 4, 1)
+
+
+def test_monthly_availability_cutoff_raises_when_cds_unavailable() -> None:
+    with (
+        patch("open_climate_service.plugins.datasets.era5_land._CdsClient", side_effect=Exception("network error")),
+        pytest.raises(Exception, match="network error"),
+    ):
+        _monthly_availability_cutoff()
+
+
+def test_era5_land_hourly_refetches_when_month_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+    fetch_calls: list[tuple[int, int]] = []
+
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        fetch_calls.append((year, month))
+        ts = f"{year:04d}-{month:02d}-01T00"
+        return xr.Dataset(
+            {"t2m": (("t", "y", "x"), np.zeros((1, 1, 1), dtype=np.float32))},
+            coords={
+                "t": np.array([ts], dtype="datetime64[h]").astype("datetime64[ns]"),
+                "y": [9.0],
+                "x": [30.0],
+            },
+        )
+
+    monkeypatch.setattr(ERA5LandCDSHourlyPlugin, "_fetch_month", fake_fetch_month)
+
+    asyncio.run(plugin.fetch_period("2026-01-01T00", [-1.0, 8.0, 31.0, 10.0]))
+    asyncio.run(plugin.fetch_period("2026-02-01T00", [-1.0, 8.0, 31.0, 10.0]))
+
+    assert fetch_calls == [(2026, 1), (2026, 2)]
+
+
+# ---------------------------------------------------------------------------
+# EDH plugin tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_edh_hourly_region() -> xr.Dataset:
+    return xr.Dataset(
+        {"t2m": (("valid_time", "latitude", "longitude"), np.array([[[280.0]], [[281.0]]], dtype=np.float32))},
+        coords={
+            "valid_time": np.array(["2026-01-01T00", "2026-01-01T01"], dtype="datetime64[h]").astype("datetime64[ns]"),
+            "latitude": [9.0],
+            "longitude": [30.0],
+        },
+    )
+
+
+def _fake_edh_daily_region() -> xr.Dataset:
+    return xr.Dataset(
+        {"t2m": (("valid_time", "latitude", "longitude"), np.array([[[285.0]], [[286.0]]], dtype=np.float32))},
+        coords={
+            "valid_time": np.array(["2026-01-01", "2026-01-02"], dtype="datetime64[D]").astype("datetime64[ns]"),
+            "latitude": [9.0],
+            "longitude": [30.0],
+        },
+    )
+
+
+def test_edh_daily_plugin_rejects_unknown_variable() -> None:
+    with pytest.raises(ValueError, match="unsupported variable"):
+        ERA5LandEDHDailyPlugin(variable="unknown")
+
+
+def test_edh_daily_fetch_renames_coords_and_converts_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandEDHDailyPlugin(variable="t2m")
+    monkeypatch.setattr(plugin, "_region_for_bbox", lambda bbox: _fake_edh_daily_region())
+    ds = asyncio.run(plugin.fetch_period("2026-01-01", [-1.0, 8.0, 31.0, 10.0]))
+    assert set(ds.dims) == {"t", "y", "x"}
+    np.testing.assert_allclose(ds["t2m"].values, [[[285.0 - 273.15]]], atol=1e-3)
+
+
+def test_edh_daily_periods_capped_to_latest_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ERA5LandEDHDailyPlugin(variable="t2m")
+    monkeypatch.setattr(plugin, "_latest_available", lambda: "2026-01-03")
+    periods = asyncio.run(plugin.periods("2026-01-01", "2026-01-10"))
+    assert periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
+def test_edh_open_zarr_injects_api_key_in_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[str] = []
+
+    def fake_open_zarr(url: str, **kwargs: object) -> xr.Dataset:
+        captured.append(url)
+        return MagicMock()
+
+    monkeypatch.setenv("EDH_API_KEY", "mytoken")
+    with patch("open_climate_service.plugins.datasets.era5_land.xr.open_zarr", fake_open_zarr):
+        _edh_open_zarr("https://api.earthdatahub.destine.eu/era5/test.zarr")
+
+    assert captured[0] == "https://edh:mytoken@api.earthdatahub.destine.eu/era5/test.zarr"
+
+
+def test_era5land_monthly_product_type_uses_workaround_for_affected_period() -> None:
+    # Workaround only applies to accumulated variables (tp), not instantaneous (t2m)
+    # Affected period: September 2022 – February 2024 (CDS data bug, forum.ecmwf.int/t/2370)
+    assert _era5land_monthly_product_type(2022, 9, "tp") == "monthly_averaged_reanalysis_by_hour_of_day"
+    assert _era5land_monthly_product_type(2023, 6, "tp") == "monthly_averaged_reanalysis_by_hour_of_day"
+    assert _era5land_monthly_product_type(2024, 2, "tp") == "monthly_averaged_reanalysis_by_hour_of_day"
+    # t2m always uses standard product (switching type would change from monthly mean to 00:00 mean)
+    assert _era5land_monthly_product_type(2022, 9, "t2m") == "monthly_averaged_reanalysis"
+    assert _era5land_monthly_product_type(2023, 6, "t2m") == "monthly_averaged_reanalysis"
+    # Outside affected period: standard product for all variables
+    assert _era5land_monthly_product_type(2022, 8, "tp") == "monthly_averaged_reanalysis"
+    assert _era5land_monthly_product_type(2024, 3, "tp") == "monthly_averaged_reanalysis"
+    assert _era5land_monthly_product_type(2026, 1, "tp") == "monthly_averaged_reanalysis"


### PR DESCRIPTION
## Summary

Adds a complete ERA5-Land dataset plugin suite covering temperature and precipitation at hourly, daily, and monthly resolution. Data comes from two sources: the DestinE **Earth Data Hub (EDH)** for history and the **Copernicus CDS** API for the recent tail and monthly means. All plugins automatically route requests to the right source.

Closes #218.

---

## 6 dataset templates

| Dataset ID | Variable | Period | Primary source | Recent tail |
|---|---|---|---|---|
| `era5land_temperature_daily` | t2m (°C) | Daily | EDH pre-computed daily means | CDS daily stats |
| `era5land_temperature_daily_from_hourly` | t2m (°C) | Daily | EDH hourly, timezone-aware | CDS hourly |
| `era5land_precipitation_daily` | tp (mm) | Daily | EDH hourly, step-24 | CDS hourly |
| `era5land_precipitation_daily_from_hourly` | tp (mm) | Daily | EDH hourly, timezone-aware | CDS hourly |
| `era5land_temperature_monthly` | t2m (°C) | Monthly | CDS monthly means | — |
| `era5land_precipitation_monthly` | tp (mm) | Monthly | CDS monthly means | — |

EDH covers up to ~4 weeks ago; CDS fills the gap to ~5 days.

---

## Key design decisions

### Bulk hourly fetch — O(days) not O(hours)

`periods()` returns one period per calendar day; `fetch_period()` loads all 24 hours in a single lazy Zarr read and returns a 24-step Dataset. Reduces orchestrator calls from 744 to 31 per month and Icechunk commits from 31 to 4.

**Benchmark — January 2026, Sierra Leone:**

| Dataset | Time |
|---|---|
| `era5land_temperature_daily` | 50.3s |
| `era5land_temperature_hourly` (744 steps) | 71.3s |
| `era5land_precipitation_daily` | 72.9s |

### Precipitation deaccumulation

ERA5-Land `tp` accumulates continuously from 00:00 UTC, resetting at 01:00 UTC each day. `diff.where(diff >= 0, tp_current)` at the reset boundary recovers the correct hourly rate with no hours lost. Daily totals use `tp[D+1 00:00]` (step 24 = full 24h), verified to match the sum of deaccumulated hourly rates to float32 precision.

### Grid alignment fix

EDH uses 0–360 longitude. Floating-point rounding can miss boundary grid points. Fixed by extending the bbox selection by 0.05° so EDH returns the same 32×35 grid as CDS for Sierra Leone.

### Monthly precipitation — CDS data bug workaround

The standard `monthly_averaged_reanalysis` product contains incorrect values for accumulated variables for **September 2022 – February 2024** ([ECMWF forum post](https://forum.ecmwf.int/t/2370)). For that range the plugin automatically switches to `monthly_averaged_reanalysis_by_hour_of_day` at `time=00:00`, which is unaffected.

**Verified — January 2024, Sierra Leone:**

| | Value |
|---|---|
| EDH daily / from hourly | 10.54 mm |
| CDS monthly (after fix) | **10.54 mm** ✓ |

### Monthly precipitation — calendar-month total

CDS monthly means return m/day. Multiplied by `days_in_month` so stored values are the **calendar-month total in mm** — directly comparable to summing daily datasets.

### Timezone support

`utc_offset_hours` in `climate-service.yaml` shifts local-day boundaries for the `_from_hourly` daily datasets.

---

## Bug fixes (code review)

- Four `periods()` methods blocked the asyncio event loop with synchronous CDS HTTP calls → wrapped in `asyncio.to_thread`
- Race condition in `ERA5LandDailyTemperaturePlugin._fetch_sync`: `_cached_ds` now captured inside the lock
- `ERA5LandTempDailyPlugin` CDS fallback dropped the `t` dimension (scalar `sel` → `sel(slice)`)
- `ERA5LandPrecipDailyPlugin` CDS fallback summed 23h instead of 24h → extended to match EDH step-24

---

## Tests

31 unit tests covering all plugin classes, deaccumulation, transforms, CDS bug workaround, availability cutoffs, EDH cache behaviour, grid shape.

```
31 passed in 0.10s
```