### PR TITLE
ci: switch docs deployment to GitHub Actions Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,4 +35,18 @@ jobs:
 
       - run: pip install -r docs/requirements.txt
 
-      - run: mkdocs gh-deploy --force --no-history
+      - run: mkdocs build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Problem

\`mkdocs gh-deploy\` fails with two rule violations on the \`gh-pages\` branch:
- \`Cannot force-push to this branch\`
- \`Commits must have verified signatures\` — \`ghp-import\` creates unsigned commits

## Fix

Switch to the standard GitHub Actions Pages deployment:
1. \`mkdocs build\` produces the \`site/\` directory
2. \`actions/upload-pages-artifact\` uploads it via the Actions API
3. \`actions/deploy-pages\` deploys — no push to \`gh-pages\` at all

## One manual step required

After merging, go to **Settings → Pages → Source** and change from:
> *Deploy from a branch: gh-pages*

to:
> *GitHub Actions*

This only needs to be done once.