### PR TITLE
fix: GeoZarr pyramid support for high-resolution streaming datasets

### DIFF
--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -351,6 +351,63 @@ def get_icechunk_path(dataset: dict[str, Any]) -> Path:
     return DOWNLOAD_DIR / f"{prefix}.icechunk"
 
 
+def get_zarr_path_unconditional(dataset: dict[str, Any]) -> Path:
+    """Return the pyramid Zarr path for a dataset, regardless of whether it exists."""
+    prefix = _get_cache_prefix(dataset)
+    return DOWNLOAD_DIR / f"{prefix}.zarr"
+
+
+def needs_pyramid(ds: xr.Dataset) -> bool:
+    """Return True when the dataset is large enough to need a multiscale pyramid."""
+    return _needs_pyramid(ds, "x", "y")
+
+
+def build_pyramid_zarr(ds: xr.Dataset, zarr_path: Path) -> None:
+    """Write a multiscale pyramid zarr from an already-loaded xr.Dataset.
+
+    The dataset must have canonical ``x``, ``y``, and ``t`` dimension names.
+    Any existing file at *zarr_path* is overwritten.
+    """
+    import shutil
+
+    crs = api_config.get_crs()
+    x_dim, y_dim = "x", "y"
+    dims = [x_dim, y_dim]
+
+    xmin = ds[x_dim].min().item()
+    xmax = ds[x_dim].max().item()
+    ymin = ds[y_dim].min().item()
+    ymax = ds[y_dim].max().item()
+    bbox = [xmin, ymin, xmax, ymax]
+    shape = (ds.sizes[x_dim], ds.sizes[y_dim])
+
+    geozarr_attrs = create_geozarr_attrs(dimensions=dims, crs=crs, bbox=bbox, shape=shape)
+    zarr_conventions = geozarr_attrs.get("zarr_conventions", [])
+    zarr_conventions.append(MultiscalesConventionMetadata().model_dump())
+    geozarr_attrs["zarr_conventions"] = zarr_conventions
+
+    levels = _pyramid_levels(ds, x_dim, y_dim)
+    logger.info(
+        "Building %d-level pyramid zarr (max dim %d px) → %s",
+        levels,
+        max(ds.sizes[x_dim], ds.sizes[y_dim]),
+        zarr_path,
+    )
+
+    if zarr_path.exists():
+        shutil.rmtree(zarr_path)
+
+    ds.load()
+    ds = ds.proj.assign_crs(spatial_ref=crs)
+
+    # https://github.com/carbonplan/topozarr/issues/13
+    pyramid = create_pyramid(ds, levels=levels, x_dim=x_dim, y_dim=y_dim, method="mean")
+    pyramid.dt.attrs.update(geozarr_attrs)
+    pyramid.dt.to_zarr(zarr_path, mode="w", encoding=pyramid.encoding, zarr_format=3)
+    _write_root_time_coordinate(zarr_path, ds, time_dim="t")
+    pyramid.dt.close()
+
+
 def _validate_spatial_coverage(dataset: dict[str, Any], bbox: list[float] | None) -> None:
     """Raise HTTP 400 if the request bbox falls outside the dataset's declared extents."""
     extents = dataset.get("extents")

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -355,15 +355,17 @@ def _create_streaming_artifact(
 
         request_scope = request_scope.model_copy(update={"end": coverage.temporal.end})
 
+        artifact_format, artifact_path, asset_paths = _maybe_build_pyramid(store_path, dataset)
+
         record = ArtifactRecord(
             artifact_id=str(uuid4()),
             dataset_id=str(dataset["id"]),
             dataset_name=str(dataset["name"]),
             variable=str(dataset["variable"]),
             period_type=str(dataset.get("period_type")) if dataset.get("period_type") is not None else None,
-            format=ArtifactFormat.ICECHUNK,
-            path=str(store_path.resolve()),
-            asset_paths=[str(store_path.resolve())],
+            format=artifact_format,
+            path=str(artifact_path.resolve()),
+            asset_paths=[str(p.resolve()) for p in asset_paths],
             variables=[str(dataset["variable"])],
             request_scope=request_scope,
             coverage=coverage,
@@ -380,6 +382,35 @@ def _create_streaming_artifact(
         return stored_record
     finally:
         lock.release()
+
+
+def _maybe_build_pyramid(
+    store_path: Path,
+    dataset: dict[str, object],
+) -> tuple[ArtifactFormat, Path, list[Path]]:
+    """Check whether the committed IceChunk store is large enough to need a pyramid.
+
+    If yes, builds a companion pyramid zarr and returns ZARR format with both paths.
+    The IceChunk path is kept as the first asset so the sync engine can still reach it.
+    If no, returns ICECHUNK format with the store path unchanged.
+    """
+    from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
+
+    try:
+        ds = open_icechunk_dataset(store_path)
+    except Exception:
+        logger.warning("Could not open IceChunk store for pyramid check; skipping", exc_info=True)
+        return ArtifactFormat.ICECHUNK, store_path, [store_path]
+
+    try:
+        if not downloader.needs_pyramid(ds):
+            return ArtifactFormat.ICECHUNK, store_path, [store_path]
+
+        zarr_path = downloader.get_zarr_path_unconditional(dataset)
+        downloader.build_pyramid_zarr(ds, zarr_path)
+        return ArtifactFormat.ZARR, zarr_path, [store_path, zarr_path]
+    finally:
+        ds.close()
 
 
 def _load_streaming_plugin(plugin_path: str, *, params: dict[str, object]) -> IngestionPlugin:

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -407,7 +407,11 @@ def _maybe_build_pyramid(
             return ArtifactFormat.ICECHUNK, store_path, [store_path]
 
         zarr_path = downloader.get_zarr_path_unconditional(dataset)
-        downloader.build_pyramid_zarr(ds, zarr_path)
+        try:
+            downloader.build_pyramid_zarr(ds, zarr_path)
+        except Exception:
+            logger.warning("Pyramid build failed; storing as flat IceChunk artifact", exc_info=True)
+            return ArtifactFormat.ICECHUNK, store_path, [store_path]
         return ArtifactFormat.ZARR, zarr_path, [store_path, zarr_path]
     finally:
         ds.close()

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -406,11 +406,28 @@ def _default_target_end(*, period_type: str) -> str:
     raise ValueError(f"Unsupported period_type '{period_type}' for sync")
 
 
+def _icechunk_path_for(artifact: ArtifactRecord) -> str | None:
+    """Return the IceChunk store path for a plugin-backed artifact.
+
+    For plain IceChunk artifacts this is simply ``artifact.path``.
+    For pyramid-upgraded ZARR artifacts the IceChunk companion is stored
+    as the first entry in ``asset_paths`` (convention set by the ingestion
+    service when it promotes the artifact to ZARR format).
+    """
+    if artifact.format == ArtifactFormat.ICECHUNK:
+        return artifact.path or (artifact.asset_paths[0] if artifact.asset_paths else None)
+    if artifact.format == ArtifactFormat.ZARR:
+        for ap in artifact.asset_paths or []:
+            if ".icechunk" in ap:
+                return ap
+    return None
+
+
 def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRecord) -> bool:
     """Return whether this template opts into store-based append sync execution."""
     if source_dataset.get("sync", {}).get("execution") != SyncAction.APPEND.value:
         return False
-    if latest_artifact.format != ArtifactFormat.ICECHUNK:
+    if _icechunk_path_for(latest_artifact) is None:
         logger.info(
             "Sync append execution for dataset '%s' requires an existing Icechunk artifact; "
             "falling back to rematerialize",
@@ -482,11 +499,9 @@ def _sync_current_end(*, source_dataset: dict[str, Any], latest_artifact: Artifa
     datasets, but keeps planning aligned with execution on the committed store
     state rather than a cached metadata snapshot.
     """
-    if not _is_plugin_backed(source_dataset) or latest_artifact.format != ArtifactFormat.ICECHUNK:
+    if not _is_plugin_backed(source_dataset):
         return latest_artifact.coverage.temporal.end
-    raw_artifact_path = latest_artifact.path or (
-        latest_artifact.asset_paths[0] if latest_artifact.asset_paths else None
-    )
+    raw_artifact_path = _icechunk_path_for(latest_artifact)
     if raw_artifact_path is None:
         return latest_artifact.coverage.temporal.end
     local_artifact_path, path_reason = _resolve_local_artifact_path(raw_artifact_path)

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -418,7 +418,7 @@ def _icechunk_path_for(artifact: ArtifactRecord) -> str | None:
         return artifact.path or (artifact.asset_paths[0] if artifact.asset_paths else None)
     if artifact.format == ArtifactFormat.ZARR:
         for ap in artifact.asset_paths or []:
-            if ".icechunk" in ap:
+            if ap.endswith(".icechunk"):
                 return ap
     return None
 
@@ -434,8 +434,7 @@ def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRe
     if latest_artifact.format == ArtifactFormat.ZARR and _icechunk_path_for(latest_artifact) is not None:
         return True
     logger.info(
-        "Sync append execution for dataset '%s' requires an existing Icechunk artifact; "
-        "falling back to rematerialize",
+        "Sync append execution for dataset '%s' requires an existing Icechunk artifact; falling back to rematerialize",
         source_dataset.get("id", "<unknown>"),
     )
     return False

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -427,14 +427,18 @@ def _supports_append(source_dataset: dict[str, Any], latest_artifact: ArtifactRe
     """Return whether this template opts into store-based append sync execution."""
     if source_dataset.get("sync", {}).get("execution") != SyncAction.APPEND.value:
         return False
-    if _icechunk_path_for(latest_artifact) is None:
-        logger.info(
-            "Sync append execution for dataset '%s' requires an existing Icechunk artifact; "
-            "falling back to rematerialize",
-            source_dataset.get("id", "<unknown>"),
-        )
-        return False
-    return True
+    # Plain IceChunk artifact — path may not yet be set on first sync plan.
+    if latest_artifact.format == ArtifactFormat.ICECHUNK:
+        return True
+    # Pyramid-upgraded ZARR artifact — IceChunk companion must be present in asset_paths.
+    if latest_artifact.format == ArtifactFormat.ZARR and _icechunk_path_for(latest_artifact) is not None:
+        return True
+    logger.info(
+        "Sync append execution for dataset '%s' requires an existing Icechunk artifact; "
+        "falling back to rematerialize",
+        source_dataset.get("id", "<unknown>"),
+    )
+    return False
 
 
 def _is_plugin_backed(source_dataset: dict[str, Any]) -> bool:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -305,19 +305,7 @@ def _public_zarr_asset_href(
     artifact: ArtifactRecord,
     source_dataset: dict[str, Any],
 ) -> str:
-    artifact_path = _artifact_store_path(artifact)
-    if artifact.format == ArtifactFormat.ICECHUNK:
-        return _abs_url(request, f"/zarr/{dataset_id}")
-    if _is_pyramid_zarr(artifact_path):
-        return _abs_url(request, f"/zarr/{dataset_id}")
     return _abs_url(request, f"/zarr/{dataset_id}")
-
-
-def _is_pyramid_zarr(artifact_path: str) -> bool:
-    """Return True if artifact_path is a multiscale pyramid zarr store."""
-    if "://" in artifact_path:
-        return False
-    return (Path(artifact_path) / "0").is_dir()
 
 
 def _abs_url(request: Request, path: str) -> str:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -309,7 +309,7 @@ def _public_zarr_asset_href(
     if artifact.format == ArtifactFormat.ICECHUNK:
         return _abs_url(request, f"/zarr/{dataset_id}")
     if _is_pyramid_zarr(artifact_path):
-        return _abs_url(request, f"/zarr/{dataset_id}/0")
+        return _abs_url(request, f"/zarr/{dataset_id}")
     return _abs_url(request, f"/zarr/{dataset_id}")
 
 

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1088,3 +1088,98 @@ def test_sync_dataset_forwards_country_code_from_extent(monkeypatch: pytest.Monk
     services.sync_dataset(dataset_id=dataset_id, end="2021", publish=True)
 
     assert captured["country_code"] == "SLE"
+
+
+# ---------------------------------------------------------------------------
+# Pyramid promotion tests
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_build_pyramid_promotes_to_zarr_when_large(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.data_manager.services import downloader
+    from open_climate_service.ingestions.services import _maybe_build_pyramid
+
+    icechunk_path = tmp_path / "dataset.icechunk"
+    icechunk_path.mkdir()
+    zarr_path = tmp_path / "dataset.zarr"
+
+    import numpy as np
+    import xarray as xr
+
+    big = np.zeros((3000, 3000), dtype="float32")
+    ds = xr.Dataset({"precip": xr.DataArray(big, dims=["y", "x"])})
+
+    monkeypatch.setattr(
+        "open_climate_service.data_accessor.services.accessor.open_icechunk_dataset",
+        lambda _: ds,
+    )
+    monkeypatch.setattr(downloader, "needs_pyramid", lambda _: True)
+
+    built: list[tuple] = []
+
+    def fake_build(ds_arg: xr.Dataset, path: Path) -> None:
+        built.append((ds_arg, path))
+
+    monkeypatch.setattr(downloader, "build_pyramid_zarr", fake_build)
+    monkeypatch.setattr(downloader, "get_zarr_path_unconditional", lambda _: zarr_path)
+
+    dataset: dict = {"id": "ds1", "variable": "precip"}
+    fmt, path, asset_paths = _maybe_build_pyramid(icechunk_path, dataset)
+
+    assert fmt == ArtifactFormat.ZARR
+    assert path == zarr_path
+    assert str(icechunk_path.resolve()) in [str(p.resolve()) for p in asset_paths]
+    assert len(built) == 1
+
+
+def test_maybe_build_pyramid_falls_back_on_build_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.data_manager.services import downloader
+    from open_climate_service.ingestions.services import _maybe_build_pyramid
+
+    icechunk_path = tmp_path / "dataset.icechunk"
+    icechunk_path.mkdir()
+
+    import xarray as xr
+
+    ds = xr.Dataset()
+    monkeypatch.setattr(
+        "open_climate_service.data_accessor.services.accessor.open_icechunk_dataset",
+        lambda _: ds,
+    )
+    monkeypatch.setattr(downloader, "needs_pyramid", lambda _: True)
+    monkeypatch.setattr(downloader, "build_pyramid_zarr", lambda *_: (_ for _ in ()).throw(RuntimeError("fail")))
+    monkeypatch.setattr(downloader, "get_zarr_path_unconditional", lambda _: tmp_path / "dataset.zarr")
+
+    fmt, path, _ = _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "v"})
+
+    assert fmt == ArtifactFormat.ICECHUNK
+    assert path == icechunk_path
+
+
+def test_plan_sync_append_for_pyramid_zarr_artifact_with_icechunk_companion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    icechunk_path = tmp_path / "dataset.icechunk"
+    icechunk_path.mkdir()
+    zarr_path = tmp_path / "dataset.zarr"
+
+    latest = _artifact(artifact_id="a1", managed_dataset_id="chirps3_precipitation_daily_sle", end="2026-01-15")
+    latest.format = ArtifactFormat.ZARR
+    latest.path = str(zarr_path)
+    latest.asset_paths = [str(icechunk_path), str(zarr_path)]
+
+    monkeypatch.setattr(sync_engine, "read_committed_period_ids", lambda *_a, **_k: {"2026-01-15"})
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-31",
+    )
+
+    assert result.action == SyncAction.APPEND

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -354,7 +354,7 @@ def test_collection_sets_hourly_step_to_pt1h(client: TestClient, monkeypatch: py
     assert payload["cube:dimensions"]["t"]["step"] == "PT1H"
 
 
-def test_collection_uses_level0_href_for_pyramid_zarr_store(
+def test_collection_uses_root_href_for_pyramid_zarr_store(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     zarr_path = tmp_path / "chirps3_precipitation_daily.zarr"
@@ -389,7 +389,7 @@ def test_collection_uses_level0_href_for_pyramid_zarr_store(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily/0")
+    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily")
 
 
 def test_collection_uses_root_href_for_icechunk_store(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -426,7 +426,7 @@ def test_collection_uses_root_href_for_icechunk_store(client: TestClient, monkey
     assert payload["assets"]["zarr"]["zarr:zarr_format"] == 3
 
 
-def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
+def test_collection_uses_root_href_for_remote_pyramid_zarr_store(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     artifact = _artifact(artifact_id="a1", path="s3://example-bucket/chirps3_precipitation_daily.zarr")
@@ -460,7 +460,7 @@ def test_collection_uses_level0_href_for_remote_pyramid_zarr_store(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily/0")
+    assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily")
 
 
 def test_collection_returns_404_for_unknown_dataset(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -454,7 +454,6 @@ def test_collection_uses_root_href_for_remote_pyramid_zarr_store(
     )
     monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {"zarr:consolidated": True})
     monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": None})
-    monkeypatch.setattr(stac_services, "_is_pyramid_zarr", lambda _: True)
 
     response = client.get("/collections/chirps3_precipitation_daily")
 


### PR DESCRIPTION
## Problem

Two related issues prevented high-resolution plugin-backed datasets (e.g. ESA WorldCover at 10 m) from rendering efficiently in the map viewer.

**1 — No pyramid created for streaming datasets**

Plugin-backed datasets always route through `_create_streaming_artifact`, which writes an IceChunk store. The `create_pyramid` code in `downloader.py` was only reachable from the legacy download path, so large datasets like WorldCover (~22 000 × 21 000 px for Rwanda) were stored flat with no overview levels.

Confirmed via `GET /zarr/esa_worldcover_2021`: store only contained `landcover`, `t`, `x`, `y` — no `0/`, `1/`, `2/` zoom levels.

**2 — STAC asset pointed to level 0 instead of the pyramid root**

Even with a pyramid zarr, `_public_zarr_asset_href` returned `/zarr/{id}/0`. ZarrLayer needs the root URL to read the `multiscales` metadata and pick zoom levels dynamically; pointing at `/0` bypassed that discovery entirely and always rendered full resolution.

Closes #209.

## Fix

**`downloader.py`** — extracted reusable public helpers:
- `needs_pyramid(ds)` — checks spatial extent against the 2048×2048 threshold
- `build_pyramid_zarr(ds, zarr_path)` — builds and writes the multiscale pyramid zarr
- `get_zarr_path_unconditional(dataset)` — companion zarr path regardless of whether it exists yet

**`services.py`** — added `_maybe_build_pyramid()` post-step in `_create_streaming_artifact`:
- Opens the committed IceChunk store after a successful write
- If `needs_pyramid`: builds a companion pyramid zarr; artifact promoted to `ZARR` format with IceChunk kept in `asset_paths[0]`
- Pyramid build failures fall back gracefully to the plain `ICECHUNK` artifact so ingestion still succeeds
- Otherwise: no change, artifact stays `ICECHUNK`

**`sync_engine.py`** — added `_icechunk_path_for()` helper:
- Uses `endswith('.icechunk')` to locate the IceChunk companion in `asset_paths` when the artifact format is `ZARR`
- `_supports_append`: plain `ICECHUNK` artifacts still allowed regardless of whether path is set; pyramid-upgraded `ZARR` artifacts allowed when IceChunk companion is present
- `_sync_current_end`: reads committed periods from IceChunk regardless of outer artifact format

**`stac/services.py`** — simplified `_public_zarr_asset_href` to a single return of the store root URL. Removed the now-dead `_is_pyramid_zarr` filesystem check.

## Tests added

- `test_maybe_build_pyramid_promotes_to_zarr_when_large` — verifies promotion to ZARR and IceChunk path in `asset_paths`
- `test_maybe_build_pyramid_falls_back_on_build_error` — verifies graceful fallback to ICECHUNK on pyramid build failure
- `test_plan_sync_append_for_pyramid_zarr_artifact_with_icechunk_companion` — verifies APPEND action is selected for pyramid-upgraded artifacts

## Verification

Re-ingest `esa_worldcover_2021` with `overwrite=true`. Expected:

```
GET /zarr/esa_worldcover_2021             → entries include 0/, 1/, 2/, ...
GET /stac/collections/esa_worldcover_2021 → assets.zarr.href ends with /zarr/esa_worldcover_2021 (no /0 suffix)
http://localhost:8000/map                 → WorldCover renders at correct zoom level
```