### PR TITLE
feat: UI — manage form cleanup and home page reorder

### DIFF
--- a/open_climate_service/templates/landing_page.html
+++ b/open_climate_service/templates/landing_page.html
@@ -213,6 +213,57 @@
         {% endif %}
       </div>
 
+      <!-- Links -->
+      <div class="card">
+        <h2>Explore</h2>
+        <ul class="links-list">
+          <li>
+            <span class="link-label"
+              ><a href="{{ base }}/manage">Manage</a></span
+            >
+            <span class="link-desc"
+              >Ingest and sync datasets without using the API directly</span
+            >
+          </li>
+          <li>
+            <span class="link-label"
+              ><a href="{{ base }}/docs">API documentation</a></span
+            >
+            <span class="link-desc"
+              >Interactive Swagger UI for all endpoints</span
+            >
+          </li>
+          <li>
+            <span class="link-label"
+              ><a href="{{ base }}/map">Map viewer</a></span
+            >
+            <span class="link-desc"
+              >Browse published datasets on an interactive map</span
+            >
+          </li>
+          <li>
+            <span class="link-label"
+              ><a href="{{ base }}/openeo" target="_blank" rel="noopener">openEO Editor</a></span
+            >
+            <span class="link-desc"
+              >Build and run openEO process graphs in the browser</span
+            >
+          </li>
+          <li>
+            <span class="link-label"
+              ><a href="{{ base }}/stac/catalog.json">STAC Catalog</a></span
+            >
+            <span class="link-desc"
+              >SpatioTemporal Asset Catalog of published datasets</span
+            >
+          </li>
+          <li>
+            <span class="link-label"><a href="{{ base }}/?f=json">Root (JSON)</a></span>
+            <span class="link-desc">This page as a JSON navigation object</span>
+          </li>
+        </ul>
+      </div>
+
       <!-- Datasets -->
       <div class="card">
         <h2>Datasets <span class="badge">{{ datasets | length }}</span></h2>
@@ -297,57 +348,6 @@
         {% else %}
         <p class="note">No dataset templates found.</p>
         {% endif %}
-      </div>
-
-      <!-- Links -->
-      <div class="card">
-        <h2>Explore</h2>
-        <ul class="links-list">
-          <li>
-            <span class="link-label"
-              ><a href="{{ base }}/manage">Manage</a></span
-            >
-            <span class="link-desc"
-              >Ingest and sync datasets without using the API directly</span
-            >
-          </li>
-          <li>
-            <span class="link-label"
-              ><a href="{{ base }}/docs">API documentation</a></span
-            >
-            <span class="link-desc"
-              >Interactive Swagger UI for all endpoints</span
-            >
-          </li>
-          <li>
-            <span class="link-label"
-              ><a href="{{ base }}/map">Map viewer</a></span
-            >
-            <span class="link-desc"
-              >Browse published datasets on an interactive map</span
-            >
-          </li>
-          <li>
-            <span class="link-label"
-              ><a href="{{ base }}/openeo" target="_blank" rel="noopener">openEO Editor</a></span
-            >
-            <span class="link-desc"
-              >Build and run openEO process graphs in the browser</span
-            >
-          </li>
-          <li>
-            <span class="link-label"
-              ><a href="{{ base }}/stac/catalog.json">STAC Catalog</a></span
-            >
-            <span class="link-desc"
-              >SpatioTemporal Asset Catalog of published datasets</span
-            >
-          </li>
-          <li>
-            <span class="link-label"><a href="{{ base }}/?f=json">Root (JSON)</a></span>
-            <span class="link-desc">This page as a JSON navigation object</span>
-          </li>
-        </ul>
       </div>
     </main>
 

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -427,15 +427,6 @@
               />
             </div>
 
-            <div class="field">
-              <label>Extent</label>
-              <input
-                type="text"
-                value="{{ extent.name or extent.id }} ({{ extent.id }})"
-                disabled
-              />
-            </div>
-
             <div class="field" style="justify-content:flex-end;padding-bottom:0.1rem">
               <div class="checkbox-row">
                 <input type="checkbox" id="publish" name="publish" checked />


### PR DESCRIPTION
## Summary

- **`/manage`**: remove the disabled Extent input from the ingest form — it showed a read-only value users couldn't change, adding visual noise with no utility. The extent warning (shown when no extent is configured) and the temporal extent column in the dataset table are unaffected.
- **`/`**: move the Explore card from last position to second so navigation links (Manage, API docs, Map, openEO, STAC) are immediately visible without scrolling past the full dataset table. New order: Instance → Explore → Datasets → Available templates.

## Test plan

- [ ] Visit `/` — confirm section order is Instance, Explore, Datasets, Available templates
- [ ] Visit `/manage` — confirm ingest form shows Dataset template / Start / End fields with no Extent row
- [ ] Verify the no-extent config warning still appears when `extent:` is not set
- [ ] Verify temporal extent still shows in the dataset table on `/`