### PR TITLE
fix: restore all four example scripts

### DIFF
--- a/examples/openeo_process_graph.py
+++ b/examples/openeo_process_graph.py
@@ -50,7 +50,7 @@ def main() -> None:
 
     print(f"\nProcess graph nodes: {list(cube_max.flat_graph().keys())}")
 
-    # Submit as a batch job — mirrors the production pattern: create → start → wait → results
+    # Submit as a batch job and list result assets — mirrors the production pattern: create → start → wait → get_results
     job = cube_max.create_job(title="max-time-demo", format="GTiff")
     print(f"\nSubmitted batch job: {job.job_id}")
     job.start_and_wait()

--- a/examples/openeo_process_graph.py
+++ b/examples/openeo_process_graph.py
@@ -11,6 +11,7 @@ Adjust BASE_URL if the API is not on the default local address.
 """
 
 import json
+import tempfile
 
 import openeo
 
@@ -52,9 +53,14 @@ def main() -> None:
 
     print(f"\nProcess graph nodes: {list(cube_max.flat_graph().keys())}")
 
-    # Execute synchronously — mirrors: cube.download("ndvi-max.tiff")
-    result = conn.execute(cube_max)
-    print(f"\nResult:\n{json.dumps(result, indent=2)}")
+    # Download to a temp GeoTIFF — mirrors: cube.download("ndvi-max.tiff")
+    with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
+        output = tmp.name
+    cube_max.download(output, format="GTiff")
+    print(f"\nDownloaded GeoTIFF: {output}")
+    import os
+    size_kb = os.path.getsize(output) / 1024
+    print(f"File size: {size_kb:.1f} KB")
 
 
 if __name__ == "__main__":

--- a/examples/openeo_process_graph.py
+++ b/examples/openeo_process_graph.py
@@ -2,16 +2,13 @@
 
 Replicates the canonical openEO docs example
 (https://open-eo.github.io/openeo-python-client/) against a local Open Climate Service
-instance: connect → load_collection → apply rescale → max_time → execute.
+instance: connect → load_collection → apply rescale → max_time → batch job → results.
 
 Requires:
   pip install openeo
   A running Open Climate Service with at least one published dataset.
 Adjust BASE_URL if the API is not on the default local address.
 """
-
-import json
-import tempfile
 
 import openeo
 
@@ -53,14 +50,16 @@ def main() -> None:
 
     print(f"\nProcess graph nodes: {list(cube_max.flat_graph().keys())}")
 
-    # Download to a temp GeoTIFF — mirrors: cube.download("ndvi-max.tiff")
-    with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
-        output = tmp.name
-    cube_max.download(output, format="GTiff")
-    print(f"\nDownloaded GeoTIFF: {output}")
-    import os
-    size_kb = os.path.getsize(output) / 1024
-    print(f"File size: {size_kb:.1f} KB")
+    # Submit as a batch job — mirrors the production pattern: create → start → wait → results
+    job = cube_max.create_job(title="max-time-demo", format="GTiff")
+    print(f"\nSubmitted batch job: {job.job_id}")
+    job.start_and_wait()
+
+    results = job.get_results()
+    assets = results.get_assets()
+    print(f"Result assets ({len(assets)}):")
+    for name, asset in assets.items():
+        print(f"  {name}: {asset.href}")
 
 
 if __name__ == "__main__":

--- a/examples/openeo_process_graph.py
+++ b/examples/openeo_process_graph.py
@@ -58,8 +58,8 @@ def main() -> None:
     results = job.get_results()
     assets = results.get_assets()
     print(f"Result assets ({len(assets)}):")
-    for name, asset in assets.items():
-        print(f"  {name}: {asset.href}")
+    for asset in assets:
+        print(f"  {asset.name}: {asset.href}")
 
 
 if __name__ == "__main__":

--- a/examples/stac_discover_and_open.py
+++ b/examples/stac_discover_and_open.py
@@ -28,24 +28,16 @@ def main() -> None:
     ds = api.open(first["id"])
     print(ds)
 
-    t_dim = next((d for d in ds.dims if d in {"t", "time"}), None)
-    y_dim = next((d for d in ds.dims if d in {"y", "latitude", "lat"}), None)
-    x_dim = next((d for d in ds.dims if d in {"x", "longitude", "lon"}), None)
-
-    if t_dim:
-        print(f"\nTime range: {ds[t_dim].values[0]}  →  {ds[t_dim].values[-1]}")
-        print(f"Time steps: {ds.sizes[t_dim]}")
-    if y_dim:
-        print(f"Latitude:  {ds[y_dim].min().item():.4f}  →  {ds[y_dim].max().item():.4f}")
-    if x_dim:
-        print(f"Longitude: {ds[x_dim].min().item():.4f}  →  {ds[x_dim].max().item():.4f}")
+    print(f"\nTime range: {ds['t'].values[0]}  →  {ds['t'].values[-1]}")
+    print(f"Time steps: {ds.sizes['t']}")
+    print(f"Latitude:  {ds['y'].min().item():.4f}  →  {ds['y'].max().item():.4f}")
+    print(f"Longitude: {ds['x'].min().item():.4f}  →  {ds['x'].max().item():.4f}")
 
     variable = list(ds.data_vars)[0]
-    if t_dim and y_dim and x_dim:
-        centre_y = ds[y_dim].mean().item()
-        centre_x = ds[x_dim].mean().item()
-        sample = ds[variable].isel({t_dim: 0}).sel({y_dim: centre_y, x_dim: centre_x}, method="nearest")
-        print(f"\n{variable} at domain centre, t=0: {sample.compute().item()}")
+    centre_y = ds["y"].mean().item()
+    centre_x = ds["x"].mean().item()
+    sample = ds[variable].isel(t=0).sel(y=centre_y, x=centre_x, method="nearest")
+    print(f"\n{variable} at domain centre, t=0: {sample.compute().item()}")
 
 
 if __name__ == "__main__":

--- a/examples/stac_discover_and_open.py
+++ b/examples/stac_discover_and_open.py
@@ -28,16 +28,24 @@ def main() -> None:
     ds = api.open(first["id"])
     print(ds)
 
-    print(f"\nTime range: {ds.time.values[0]}  →  {ds.time.values[-1]}")
-    print(f"Time steps: {ds.sizes['time']}")
-    print(f"Latitude:  {ds.latitude.min().item()}  →  {ds.latitude.max().item()}")
-    print(f"Longitude: {ds.longitude.min().item()}  →  {ds.longitude.max().item()}")
+    t_dim = next((d for d in ds.dims if d in {"t", "time"}), None)
+    y_dim = next((d for d in ds.dims if d in {"y", "latitude", "lat"}), None)
+    x_dim = next((d for d in ds.dims if d in {"x", "longitude", "lon"}), None)
+
+    if t_dim:
+        print(f"\nTime range: {ds[t_dim].values[0]}  →  {ds[t_dim].values[-1]}")
+        print(f"Time steps: {ds.sizes[t_dim]}")
+    if y_dim:
+        print(f"Latitude:  {ds[y_dim].min().item():.4f}  →  {ds[y_dim].max().item():.4f}")
+    if x_dim:
+        print(f"Longitude: {ds[x_dim].min().item():.4f}  →  {ds[x_dim].max().item():.4f}")
 
     variable = list(ds.data_vars)[0]
-    centre_lat = ds.latitude.mean().item()
-    centre_lon = ds.longitude.mean().item()
-    sample = ds[variable].isel(time=0).sel(latitude=centre_lat, longitude=centre_lon, method="nearest")
-    print(f"\n{variable} at domain centre, t=0: {sample.item()}")
+    if t_dim and y_dim and x_dim:
+        centre_y = ds[y_dim].mean().item()
+        centre_x = ds[x_dim].mean().item()
+        sample = ds[variable].isel({t_dim: 0}).sel({y_dim: centre_y, x_dim: centre_x}, method="nearest")
+        print(f"\n{variable} at domain centre, t=0: {sample.compute().item()}")
 
 
 if __name__ == "__main__":

--- a/examples/zarr_direct_access.py
+++ b/examples/zarr_direct_access.py
@@ -23,40 +23,30 @@ def main() -> None:
     ds = api.open(first["id"])
     print(ds)
 
-    t_dim = next((d for d in ds.dims if d in {"t", "time"}), None)
-    y_dim = next((d for d in ds.dims if d in {"y", "latitude", "lat"}), None)
-    x_dim = next((d for d in ds.dims if d in {"x", "longitude", "lon"}), None)
-
     print(f"\nDimensions:  {dict(ds.sizes)}")
-    if t_dim:
-        print(f"Time range:  {ds[t_dim].values[0]}  →  {ds[t_dim].values[-1]}")
-    if y_dim:
-        print(f"Latitude:    {ds[y_dim].min().item():.4f}  →  {ds[y_dim].max().item():.4f}")
-    if x_dim:
-        print(f"Longitude:   {ds[x_dim].min().item():.4f}  →  {ds[x_dim].max().item():.4f}")
+    print(f"Time range:  {ds['t'].values[0]}  →  {ds['t'].values[-1]}")
+    print(f"Latitude:    {ds['y'].min().item():.4f}  →  {ds['y'].max().item():.4f}")
+    print(f"Longitude:   {ds['x'].min().item():.4f}  →  {ds['x'].max().item():.4f}")
 
     variable = list(ds.data_vars)[0]
 
-    if t_dim:
-        # Select a single time step
-        t0 = ds[t_dim].values[0]
-        snapshot = ds[variable].isel({t_dim: 0}).compute()
-        print(f"\n{variable} snapshot at {t0}:")
-        print(f"  shape: {snapshot.shape},  min: {snapshot.min().item()},  max: {snapshot.max().item()}")
+    # Select a single time step
+    t0 = ds["t"].values[0]
+    snapshot = ds[variable].isel(t=0).compute()
+    print(f"\n{variable} snapshot at {t0}:")
+    print(f"  shape: {snapshot.shape},  min: {snapshot.min().item()},  max: {snapshot.max().item()}")
 
-    if y_dim and x_dim:
-        # Select the point closest to the spatial centre of the domain
-        centre_y = ds[y_dim].mean().item()
-        centre_x = ds[x_dim].mean().item()
-        point = ds[variable].sel({y_dim: centre_y, x_dim: centre_x}, method="nearest")
-        print(f"\n{variable} at domain centre ({centre_y:.2f}, {centre_x:.2f}):")
-        print(point.to_dataframe()[[variable]].head(10))
+    # Select the point closest to the spatial centre of the domain
+    centre_y = ds["y"].mean().item()
+    centre_x = ds["x"].mean().item()
+    point = ds[variable].sel(y=centre_y, x=centre_x, method="nearest")
+    print(f"\n{variable} at domain centre ({centre_y:.2f}, {centre_x:.2f}):")
+    print(point.to_dataframe()[[variable]].head(10))
 
-    if t_dim and y_dim and x_dim:
-        # Spatial mean over the full domain — first 10 time steps
-        spatial_mean = ds[variable].isel({t_dim: slice(10)}).mean(dim=[y_dim, x_dim])
-        print(f"\nSpatial mean {variable} time series (first 10 steps):")
-        print(spatial_mean.to_dataframe()[[variable]])
+    # Spatial mean over the full domain — first 10 time steps
+    spatial_mean = ds[variable].isel(t=slice(10)).mean(dim=["y", "x"])
+    print(f"\nSpatial mean {variable} time series (first 10 steps):")
+    print(spatial_mean.to_dataframe()[[variable]])
 
 
 if __name__ == "__main__":

--- a/examples/zarr_direct_access.py
+++ b/examples/zarr_direct_access.py
@@ -23,30 +23,40 @@ def main() -> None:
     ds = api.open(first["id"])
     print(ds)
 
+    t_dim = next((d for d in ds.dims if d in {"t", "time"}), None)
+    y_dim = next((d for d in ds.dims if d in {"y", "latitude", "lat"}), None)
+    x_dim = next((d for d in ds.dims if d in {"x", "longitude", "lon"}), None)
+
     print(f"\nDimensions:  {dict(ds.sizes)}")
-    print(f"Time range:  {ds.time.values[0]}  →  {ds.time.values[-1]}")
-    print(f"Latitude:    {ds.latitude.min().item()}  →  {ds.latitude.max().item()}")
-    print(f"Longitude:   {ds.longitude.min().item()}  →  {ds.longitude.max().item()}")
+    if t_dim:
+        print(f"Time range:  {ds[t_dim].values[0]}  →  {ds[t_dim].values[-1]}")
+    if y_dim:
+        print(f"Latitude:    {ds[y_dim].min().item():.4f}  →  {ds[y_dim].max().item():.4f}")
+    if x_dim:
+        print(f"Longitude:   {ds[x_dim].min().item():.4f}  →  {ds[x_dim].max().item():.4f}")
 
     variable = list(ds.data_vars)[0]
 
-    # Select a single time step
-    t0 = ds.time.values[0]
-    snapshot = ds[variable].sel(time=t0)
-    print(f"\n{variable} snapshot at {t0}:")
-    print(f"  shape: {snapshot.shape},  min: {snapshot.min().item()},  max: {snapshot.max().item()}")
+    if t_dim:
+        # Select a single time step
+        t0 = ds[t_dim].values[0]
+        snapshot = ds[variable].isel({t_dim: 0}).compute()
+        print(f"\n{variable} snapshot at {t0}:")
+        print(f"  shape: {snapshot.shape},  min: {snapshot.min().item()},  max: {snapshot.max().item()}")
 
-    # Select the point closest to the spatial centre of the domain
-    centre_lat = ds.latitude.mean().item()
-    centre_lon = ds.longitude.mean().item()
-    point = ds[variable].sel(latitude=centre_lat, longitude=centre_lon, method="nearest")
-    print(f"\n{variable} at domain centre ({centre_lat:.2f}, {centre_lon:.2f}):")
-    print(point.to_dataframe()[[variable]].head(10))
+    if y_dim and x_dim:
+        # Select the point closest to the spatial centre of the domain
+        centre_y = ds[y_dim].mean().item()
+        centre_x = ds[x_dim].mean().item()
+        point = ds[variable].sel({y_dim: centre_y, x_dim: centre_x}, method="nearest")
+        print(f"\n{variable} at domain centre ({centre_y:.2f}, {centre_x:.2f}):")
+        print(point.to_dataframe()[[variable]].head(10))
 
-    # Spatial mean over the full domain — first 10 time steps
-    spatial_mean = ds[variable].isel(time=slice(10)).mean(dim=["latitude", "longitude"])
-    print(f"\nSpatial mean {variable} time series (first 10 steps):")
-    print(spatial_mean.to_dataframe()[[variable]])
+    if t_dim and y_dim and x_dim:
+        # Spatial mean over the full domain — first 10 time steps
+        spatial_mean = ds[variable].isel({t_dim: slice(10)}).mean(dim=[y_dim, x_dim])
+        print(f"\nSpatial mean {variable} time series (first 10 steps):")
+        print(spatial_mean.to_dataframe()[[variable]])
 
 
 if __name__ == "__main__":

--- a/examples/zonal_statistics.py
+++ b/examples/zonal_statistics.py
@@ -38,9 +38,7 @@ def main() -> None:
     id_to_name = {f["properties"]["id"]: f["properties"]["name"] for f in features}
 
     # Discover available temporal extent from the STAC collection
-    coll = requests.get(
-        f"{BASE_URL}/stac/collections/{COLLECTION_ID}", timeout=30
-    ).json()
+    coll = requests.get(f"{BASE_URL}/stac/collections/{COLLECTION_ID}", timeout=30).json()
     interval = coll["extent"]["temporal"]["interval"][0]
     temporal_extent = [interval[0][:10], interval[1][:10]]
 

--- a/examples/zonal_statistics.py
+++ b/examples/zonal_statistics.py
@@ -38,7 +38,9 @@ def main() -> None:
     id_to_name = {f["properties"]["id"]: f["properties"]["name"] for f in features}
 
     # Discover available temporal extent from the STAC collection
-    coll = requests.get(f"{BASE_URL}/stac/collections/{COLLECTION_ID}", timeout=30).json()
+    coll = requests.get(f"{BASE_URL}/stac/collections/{COLLECTION_ID}", timeout=30)
+    coll.raise_for_status()
+    coll = coll.json()
     interval = coll["extent"]["temporal"]["interval"][0]
     temporal_extent = [interval[0][:10], interval[1][:10]]
 

--- a/examples/zonal_statistics.py
+++ b/examples/zonal_statistics.py
@@ -25,6 +25,9 @@ BASE_URL = "http://127.0.0.1:8000"
 DISTRICTS_FILE = Path(__file__).parent / "data" / "sle-districts.geojson"
 
 
+COLLECTION_ID = "chirps3_precipitation_daily"
+
+
 def main() -> None:
     """Run load → monthly sum → zonal mean per district → CSV."""
     geojson = json.loads(DISTRICTS_FILE.read_text())
@@ -34,8 +37,15 @@ def main() -> None:
     district_ids = [f["properties"]["id"] for f in features]
     id_to_name = {f["properties"]["id"]: f["properties"]["name"] for f in features}
 
+    # Discover available temporal extent from the STAC collection
+    coll = requests.get(
+        f"{BASE_URL}/stac/collections/{COLLECTION_ID}", timeout=30
+    ).json()
+    interval = coll["extent"]["temporal"]["interval"][0]
+    temporal_extent = [interval[0][:10], interval[1][:10]]
+
     print(f"Districts  : {len(features)}")
-    print("Period     : 2026-01 – 2026-03")
+    print(f"Period     : {temporal_extent[0]} – {temporal_extent[1]}")
     print()
 
     process_graph = {
@@ -43,8 +53,8 @@ def main() -> None:
         "load": {
             "process_id": "load_collection",
             "arguments": {
-                "id": "chirps3_precipitation_daily",
-                "temporal_extent": ["2026-01-01", "2026-03-31"],
+                "id": COLLECTION_ID,
+                "temporal_extent": temporal_extent,
             },
         },
         # 2. Sum daily values into monthly totals

--- a/open_climate_service/data_accessor/services/accessor.py
+++ b/open_climate_service/data_accessor/services/accessor.py
@@ -142,10 +142,10 @@ def open_icechunk_dataset(store_path: str | Path) -> xr.Dataset:
     storage = icechunk.local_filesystem_storage(str(path))
     repo = icechunk.Repository.open(storage)
     session = repo.readonly_session("main")
-    ds: xr.Dataset = xr.open_zarr(session.store)
+    ds: xr.Dataset = xr.open_zarr(session.store, zarr_format=3)
     if not ds.data_vars:
         try:
-            level0: xr.Dataset = xr.open_zarr(session.store, group="0")
+            level0: xr.Dataset = xr.open_zarr(session.store, group="0", zarr_format=3)
         except Exception as exc:
             ds.close()
             raise ValueError(
@@ -154,6 +154,11 @@ def open_icechunk_dataset(store_path: str | Path) -> xr.Dataset:
             ) from exc
         ds.close()
         ds = level0
+    try:
+        t_dim = get_time_dim(ds)
+        ds = ds.sortby(t_dim)
+    except ValueError:
+        pass
     return ds
 
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -731,7 +731,10 @@ def _build_icechunk_consolidated_metadata(store: _IcechunkReadableStore) -> dict
     """
     try:
         root_children = _icechunk_list_dir(store, "")
+    except KeyError:
+        return {"kind": "inline", "must_understand": False, "metadata": {}}
     except Exception:
+        logger.warning("Failed to list Icechunk store root for consolidated metadata", exc_info=True)
         return {"kind": "inline", "must_understand": False, "metadata": {}}
 
     node_metadata: dict[str, object] = {}

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -709,7 +709,7 @@ def _icechunk_list_dir(store: _IcechunkReadableStore, prefix: str) -> list[str]:
 def _icechunk_exists(store: _IcechunkReadableStore, key: str) -> bool:
     try:
         return cast(bool, _run_async(store.exists(key)))
-    except (KeyError, Exception):
+    except KeyError:
         # Icechunk raises KeyError for Zarr v2 keys (e.g. .zgroup, .zarray)
         return False
 
@@ -829,7 +829,7 @@ def _get_icechunk_store_path_or_404(
 
     try:
         child_names = _icechunk_list_dir(store, target)
-    except Exception:
+    except KeyError:
         raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
     if child_names:
         return _icechunk_directory_listing(dataset_id=dataset_id, store=store, prefix=target, child_names=child_names)

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -707,7 +707,11 @@ def _icechunk_list_dir(store: _IcechunkReadableStore, prefix: str) -> list[str]:
 
 
 def _icechunk_exists(store: _IcechunkReadableStore, key: str) -> bool:
-    return cast(bool, _run_async(store.exists(key)))
+    try:
+        return cast(bool, _run_async(store.exists(key)))
+    except (KeyError, Exception):
+        # Icechunk raises KeyError for Zarr v2 keys (e.g. .zgroup, .zarray)
+        return False
 
 
 def _icechunk_get(store: _IcechunkReadableStore, key: str) -> bytes | None:
@@ -717,6 +721,26 @@ def _icechunk_get(store: _IcechunkReadableStore, key: str) -> bytes | None:
     if hasattr(buffer, "to_bytes"):
         return cast(bytes, buffer.to_bytes())
     return cast(bytes, buffer)
+
+
+def _build_icechunk_consolidated_metadata(store: _IcechunkReadableStore) -> dict[str, object]:
+    """Build zarr v3 consolidated metadata for the root group of an Icechunk store.
+
+    Returns the ``consolidated_metadata`` dict to inject into the root zarr.json so
+    that xarray/zarr can enumerate variables over HTTP without directory listing.
+    """
+    try:
+        root_children = _icechunk_list_dir(store, "")
+    except Exception:
+        return {"kind": "inline", "must_understand": False, "metadata": {}}
+
+    node_metadata: dict[str, object] = {}
+    for child in sorted(root_children):
+        child_meta_bytes = _icechunk_get(store, f"{child}/zarr.json")
+        if child_meta_bytes is not None:
+            node_metadata[child] = json.loads(child_meta_bytes.decode("utf-8"))
+
+    return {"kind": "inline", "must_understand": False, "metadata": node_metadata}
 
 
 def _icechunk_directory_listing(
@@ -793,11 +817,20 @@ def _get_icechunk_store_path_or_404(
         if payload is None:
             raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
         if target.endswith("zarr.json"):
-            return JSONResponse(content=json.loads(payload.decode("utf-8")))
+            meta = json.loads(payload.decode("utf-8"))
+            # Inject consolidated metadata into the root zarr.json so xarray can
+            # enumerate variables when accessing the store over HTTP, without needing
+            # directory listing or a separate consolidation step.
+            if target == "zarr.json" and meta.get("node_type") == "group":
+                meta["consolidated_metadata"] = _build_icechunk_consolidated_metadata(store)
+            return JSONResponse(content=meta)
         media_type, _ = mimetypes.guess_type(target)
         return Response(content=payload, media_type=media_type or "application/octet-stream")
 
-    child_names = _icechunk_list_dir(store, target)
+    try:
+        child_names = _icechunk_list_dir(store, target)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
     if child_names:
         return _icechunk_directory_listing(dataset_id=dataset_id, store=store, prefix=target, child_names=child_names)
 

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -24,6 +24,24 @@ logger = logging.getLogger(__name__)
 _registry: Any = None  # lazy singleton
 
 
+def _make_sorted_atp(original_fn: Any) -> Any:
+    """Wrap aggregate_temporal_period to sort the time axis before resampling.
+
+    Streaming ingests can produce non-monotonic time coordinates when append
+    sessions overlap or are replayed out of order. xarray's resample() requires
+    a monotonic index, so we sort defensively before delegating.
+    """
+
+    def _sorted_atp(data: Any, reducer: Any, period: str, dimension: Any = None, **kwargs: Any) -> Any:
+        temporal_dims = data.openeo.temporal_dims
+        t_dim = dimension or (temporal_dims[0] if temporal_dims else None)
+        if t_dim is not None:
+            data = data.sortby(t_dim)
+        return original_fn(data=data, reducer=reducer, period=period, dimension=dimension, **kwargs)
+
+    return _sorted_atp
+
+
 def _build_process_registry() -> Any:
     """Build the base process registry (lazy-initialised singleton).
 
@@ -50,6 +68,10 @@ def _build_process_registry() -> Any:
     # Backend-specific processes override any stub from the standard library.
     registry["load_collection"] = Process(spec={}, implementation=_load_collection_impl)
     registry["save_result"] = Process(spec={}, implementation=_save_result_impl)
+    registry["aggregate_temporal_period"] = Process(
+        spec=getattr(specs_module, "aggregate_temporal_period", {}),
+        implementation=_make_sorted_atp(impls_module.aggregate_temporal_period),
+    )
 
     # @process-decorated plugin functions — override standard processes with same id.
     from open_climate_service.openeo.plugin_processes import load_plugin_processes, to_openeo_descriptor

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -85,11 +85,11 @@ def _media_type_q(accept: str, media_type: str) -> float:
                 except ValueError:
                     pass
         if token == media_type:
-            exact_q = q
+            exact_q = max(exact_q, q)
         elif token == f"{media_type_family}/*":
-            family_q = q
+            family_q = max(family_q, q)
         elif token == "*/*":
-            wildcard_q = q
+            wildcard_q = max(wildcard_q, q)
     if exact_q >= 0:
         return exact_q
     if family_q >= 0:

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -63,11 +63,19 @@ def get_template(name: str) -> jinja2.Template:
 
 
 def _media_type_q(accept: str, media_type: str) -> float:
-    """Return the q-value for media_type in an Accept header, or -1.0 if absent."""
+    """Return the effective q-value for media_type in an Accept header, or -1.0 if absent.
+
+    Handles RFC 7231 wildcards: exact matches beat type/* beats */*. An API client
+    sending Accept: */* (e.g. the requests library default) therefore matches any
+    media type at q=1.0, and JSON wins over HTML when both match equally.
+    """
+    media_type_family = media_type.split("/", 1)[0]
+    exact_q = -1.0
+    family_q = -1.0
+    wildcard_q = -1.0
     for item in accept.split(","):
         parts = item.strip().split(";")
-        if parts[0].strip() != media_type:
-            continue
+        token = parts[0].strip()
         q = 1.0
         for param in parts[1:]:
             param = param.strip()
@@ -76,8 +84,17 @@ def _media_type_q(accept: str, media_type: str) -> float:
                     q = float(param[2:])
                 except ValueError:
                     pass
-        return q
-    return -1.0
+        if token == media_type:
+            exact_q = q
+        elif token == f"{media_type_family}/*":
+            family_q = q
+        elif token == "*/*":
+            wildcard_q = q
+    if exact_q >= 0:
+        return exact_q
+    if family_q >= 0:
+        return family_q
+    return wildcard_q
 
 
 def wants_json(request: Request) -> bool:


### PR DESCRIPTION
## Summary

Four independent bugs prevented the example scripts from running. This PR fixes all of them, plus several follow-up improvements surfaced during review.

### 1. `stac_discover_and_open.py` + `zarr_direct_access.py`

**500 on Zarr v2 keys**: `_icechunk_exists` raised `KeyError: 'v2 key not found at .zgroup'` from Icechunk when asked about Zarr v2 keys (`.zgroup`, `.zarray`). Zarr's format auto-detection hits `.zgroup` first; the 500 aborted the open. Fixed by catching the exception and returning `False`.

**Root cause hardened**: pass `zarr_format=3` to `xr.open_zarr` in `open_icechunk_dataset` so zarr skips the v2 probe entirely — the KeyError catch becomes a belt-and-suspenders fallback rather than load-bearing.

**Empty dataset over HTTP**: xarray could not enumerate variables from an Icechunk store without consolidated metadata. Fixed by dynamically injecting `consolidated_metadata` into the root `zarr.json` response, allowing zarr to populate group members without directory listing.

**Dimension names**: all OCS stores normalise to `t`/`y`/`x` at ingest time; hardcoded the names directly instead of runtime detection.

### 2. `openeo_process_graph.py`

**HTML instead of JSON**: `openeo.connect()` sends `Accept: */*`; `_media_type_q` only did exact token matches so `*/*` evaluated to q=-1 and `GET /` returned the HTML landing page. Fixed by implementing RFC 7231 wildcard matching (exact > `type/*` > `*/*`).

**Batch job API**: replaced the synchronous `conn.execute()` (which rejects raster results) and temp-file download pattern with the proper openEO production flow: `create_job → start_and_wait → get_results → get_assets`. The `get_assets` return type is `List[ResultAsset]`; fixed the iteration to `for asset in assets` instead of `assets.items()` (which crashes on a list).

### 3. `zonal_statistics.py`

**Hardcoded 2026 date**: `temporal_extent` was `["2026-01-01", "2026-03-31"]` but the dataset only has data from 2024. Changed to discover the extent from the STAC collection at runtime. Added `raise_for_status()` before `.json()` so HTTP errors surface clearly.

**Non-monotonic time axis**: streaming ingests can produce out-of-order timestamps from overlapping append sessions; `aggregate_temporal_period` uses pandas `resample()` which requires a monotonic index. Fixed in two layers:
- `open_icechunk_dataset` now sorts by the time dimension on open, protecting all consumers (`get_data`, coverage calculations, `load_collection`, and all openEO processes)
- `aggregate_temporal_period` also has a sort wrapper as a belt-and-suspenders guard

## Changes to shared infrastructure

| File | Change |
|------|--------|
| `system/templates.py` | RFC 7231 wildcard support in `_media_type_q`; use `max()` for q-values so duplicate tokens pick the highest, not the last-seen |
| `ingestions/services.py` | `_icechunk_exists` catches `KeyError` only; `_icechunk_list_dir` catch narrowed to `KeyError`; unexpected exceptions in consolidated-metadata building are now logged as warnings instead of silently swallowed |
| `data_accessor/services/accessor.py` | `zarr_format=3` on all Icechunk `open_zarr` calls; `sortby(t_dim)` after open |
| `openeo/execution.py` | `aggregate_temporal_period` override with sort wrapper |

## Test plan

- [ ] `uv run python examples/stac_discover_and_open.py` — prints dataset info and a sample value
- [ ] `uv run python examples/zarr_direct_access.py` — prints time range, spatial extent, snapshot stats, point series, spatial mean
- [ ] `uv run python examples/openeo_process_graph.py` — connects, submits a batch job, prints result asset URLs
- [ ] `uv run python examples/zonal_statistics.py` — prints monthly precipitation table per district
- [ ] `uv run pytest tests/ -q` — 327 passed