### PR TITLE
feat(openeo): add chapcsv export format

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -920,7 +920,8 @@ def _write_dataset_tabular_export(ds: Any, results_dir: Any, fmt: str, options: 
 
     inferred_options = dict(options)
     period_field = _optional_str_option(inferred_options, "period_field") or "t"
-    if "period_type" not in inferred_options and period_field in getattr(ds, "coords", {}):
+    period_type = _optional_str_option(inferred_options, "period_type")
+    if period_type is None and period_field in getattr(ds, "coords", {}):
         inferred = _infer_period_type(ds, period_field)
         if inferred in {"daily", "weekly", "monthly", "quarterly", "yearly"}:
             inferred_options["period_type"] = inferred

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -8,6 +8,7 @@ import os
 import threading
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, TypeVar
 from uuid import uuid4
@@ -434,6 +435,8 @@ class OpenEOJobService:
                 # managed dataset via a marker that _result_assets expands into
                 # /datasets, /zarr (and /stac when published) result links.
                 return f"managed://{options['dataset_id']}"
+            if fmt in _TABULAR_EXPORT_FORMATS:
+                return _write_dataset_tabular_export(result, results_dir, fmt, options)
             return _write_raster(result, results_dir, fmt)
 
         # Tabular: resolve dask_geopandas → GeoDataFrame
@@ -449,6 +452,13 @@ class OpenEOJobService:
             import geopandas as gpd
 
             if isinstance(result, gpd.GeoDataFrame):
+                if fmt in _TABULAR_EXPORT_FORMATS:
+                    return _write_tabular_export(
+                        result.drop(columns="geometry", errors="ignore"),
+                        results_dir,
+                        fmt,
+                        options,
+                    )
                 return _write_vector(result, results_dir, fmt)
         except ImportError:
             pass
@@ -692,6 +702,8 @@ def _infer_period_type(ds: Any, t_dim: str) -> str | None:
         return "weekly"
     if median_seconds <= 32 * 86400:
         return "monthly"
+    if median_seconds <= 100 * 86400:
+        return "quarterly"
     return "yearly"
 
 
@@ -810,6 +822,10 @@ _VECTOR_FORMATS: dict[str, tuple[str, str]] = {
     "PARQUET": (".parquet", "application/vnd.apache.parquet"),
 }
 
+_TABULAR_EXPORT_FORMATS: dict[str, tuple[str, str]] = {
+    "CHAPCSV": (".csv", "text/csv"),
+}
+
 
 def _write_raster(ds: Any, results_dir: Any, fmt: str) -> str | None:
     """Write an xr.Dataset to disk in the requested format. Returns the output path."""
@@ -894,6 +910,190 @@ def _write_vector(gdf: Any, results_dir: Any, fmt: str) -> str | None:
     path = str(results_dir / "result.geojson")
     gdf.to_file(path, driver="GeoJSON")
     return path
+
+
+def _write_dataset_tabular_export(ds: Any, results_dir: Any, fmt: str, options: dict[str, Any]) -> str | None:
+    import pandas as pd
+
+    inferred_options = dict(options)
+    period_field = _optional_str_option(inferred_options, "period_field") or "t"
+    if "period_type" not in inferred_options and period_field in getattr(ds, "coords", {}):
+        inferred = _infer_period_type(ds, period_field)
+        if inferred in {"daily", "weekly", "monthly", "quarterly", "yearly"}:
+            inferred_options["period_type"] = inferred
+
+    if hasattr(ds, "to_dataframe"):
+        df = ds.to_dataframe().reset_index()
+    elif isinstance(ds, pd.DataFrame):
+        df = ds
+    else:
+        raise TypeError(f"Unsupported data type for tabular export: {type(ds).__name__}")
+    return _write_tabular_export(df, results_dir, fmt, inferred_options)
+
+
+def _write_tabular_export(df: Any, results_dir: Any, fmt: str, options: dict[str, Any]) -> str | None:
+    if fmt == "CHAPCSV":
+        return _write_chap_csv(df, results_dir, options)
+    known = ", ".join(sorted(_TABULAR_EXPORT_FORMATS))
+    raise ValueError(f"Unsupported tabular export format '{fmt}'. Known formats: {known}")
+
+
+def _write_chap_csv(df: Any, results_dir: Any, options: dict[str, Any]) -> str:
+    frame = _build_chap_csv_frame(df, options)
+    path = str(results_dir / "result.csv")
+    frame.to_csv(path, index=False)
+    return path
+
+
+def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
+    import pandas as pd
+
+    period_field = _optional_str_option(options, "period_field") or "t"
+    location_field = _optional_str_option(options, "location_field") or "geometry"
+    period_type = _optional_str_option(options, "period_type")
+
+    frame = pd.DataFrame(df).copy()
+    if location_field not in frame.columns:
+        raise ValueError(f"Missing location field '{location_field}' in aggregated result")
+    if period_field not in frame.columns:
+        raise ValueError(f"Missing period field '{period_field}' in aggregated result")
+
+    value_fields = _select_chap_value_fields(frame, location_field, period_field)
+    rows: list[dict[str, str]] = []
+    for row_index, record in enumerate(frame.to_dict(orient="records")):
+        period_value = record.get(period_field)
+        if _is_nullish(period_value):
+            raise ValueError(f"Null period value in field '{period_field}' at row {row_index}")
+        location = record.get(location_field)
+        if _is_nullish(location):
+            raise ValueError(f"Null location value in field '{location_field}' at row {row_index}")
+
+        row: dict[str, str] = {
+            "time_period": _to_dhis2_period_string(period_value, period_type),
+            "location": str(location),
+        }
+        for value_field in value_fields:
+            value = record.get(value_field)
+            row[value_field] = "" if _is_nullish(value) else _to_dhis2_value_string(value)
+        rows.append(row)
+
+    return pd.DataFrame(rows, columns=["time_period", "location", *value_fields])
+
+
+def _select_chap_value_fields(frame: Any, location_field: str, period_field: str) -> list[str]:
+    excluded = {
+        location_field,
+        period_field,
+        "geometry",
+        "spatial_ref",
+        "index",
+        "band",
+        "bands",
+    }
+    candidates = [str(c) for c in frame.columns if c not in excluded and not str(c).startswith("level_")]
+    if not candidates:
+        raise ValueError("CHAPCSV export requires at least one value column")
+    return candidates
+
+
+def _optional_str_option(options: dict[str, Any], key: str) -> str | None:
+    raw = options.get(key)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def _is_nullish(value: Any) -> bool:
+    import numpy as np
+    import pandas as pd
+
+    result = pd.isna(value)
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    if isinstance(result, np.ndarray):
+        if result.ndim == 0:
+            return bool(result.item())
+        raise ValueError("Array-like values are not supported in tabular export cells")
+    if hasattr(result, "shape") and getattr(result, "shape", ()) not in [(), None]:
+        raise ValueError("Array-like values are not supported in tabular export cells")
+    if hasattr(result, "item"):
+        return bool(result.item())
+    return bool(result)
+
+
+def _to_dhis2_value_string(value: Any) -> str:
+    import numpy as np
+
+    if isinstance(value, (bool, np.bool_)):
+        return "true" if bool(value) else "false"
+    if isinstance(value, (int, np.integer)) and not isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)):
+        as_float = float(value)
+        as_float32 = float(np.float32(as_float))
+        if as_float == as_float32:
+            return np.format_float_positional(np.float32(as_float), trim="-")
+        return np.format_float_positional(as_float, trim="-")
+    if isinstance(value, Decimal):
+        normalized = format(value, "f")
+        if "." in normalized:
+            normalized = normalized.rstrip("0").rstrip(".")
+        return normalized or "0"
+    return str(value)
+
+
+def _to_dhis2_period_string(value: Any, period_type: str | None = None) -> str:
+    import re
+
+    import pandas as pd
+
+    raw = str(value).strip()
+    if not raw:
+        raise ValueError("Empty period value is not allowed")
+
+    patterns = {
+        "daily": re.compile(r"^\d{8}$"),
+        "weekly": re.compile(r"^\d{4}W\d{2}$"),
+        "monthly": re.compile(r"^\d{6}$"),
+        "quarterly": re.compile(r"^\d{4}Q[1-4]$"),
+        "yearly": re.compile(r"^\d{4}$"),
+    }
+    if period_type is not None:
+        period_type = period_type.strip().lower()
+        if period_type not in patterns:
+            raise ValueError(f"Unsupported period_type '{period_type}'")
+        if patterns[period_type].match(raw):
+            return raw
+        for known_type, pattern in patterns.items():
+            if known_type != period_type and pattern.match(raw):
+                raise ValueError(f"Period value appears to be {known_type}, but period_type={period_type}")
+    else:
+        for pattern in patterns.values():
+            if pattern.match(raw):
+                return raw
+
+    if period_type is None:
+        raise ValueError(
+            "Ambiguous period value; provide period_type explicitly when the input is not already in DHIS2 format"
+        )
+
+    try:
+        ts = pd.Timestamp(value)
+    except Exception as exc:
+        raise ValueError(f"Could not parse period value {raw!r} for period_type={period_type}") from exc
+    if period_type == "daily":
+        return ts.strftime("%Y%m%d")
+    if period_type == "weekly":
+        iso = ts.isocalendar()
+        return f"{int(iso.year):04d}W{int(iso.week):02d}"
+    if period_type == "monthly":
+        return ts.strftime("%Y%m")
+    if period_type == "quarterly":
+        return f"{ts.year:04d}Q{((ts.month - 1) // 3) + 1}"
+    if period_type == "yearly":
+        return ts.strftime("%Y")
+    raise ValueError(f"Unsupported period_type '{period_type}'")
 
 
 def _write_png(ds: Any, results_dir: Any) -> str | None:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -703,9 +703,11 @@ def _infer_period_type(ds: Any, t_dim: str) -> str | None:
         return "weekly"
     if median_seconds <= 32 * 86400:
         return "monthly"
-    if median_seconds <= 100 * 86400:
+    if 80 * 86400 <= median_seconds <= 100 * 86400:
         return "quarterly"
-    return "yearly"
+    if 330 * 86400 <= median_seconds <= 370 * 86400:
+        return "yearly"
+    return None
 
 
 def _derive_variable(ds: Any, options: dict[str, Any]) -> str:
@@ -959,6 +961,11 @@ def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
 
     frame = pd.DataFrame(df).copy()
     if location_field not in frame.columns:
+        if location_field == "geometry":
+            raise ValueError(
+                "Missing location field 'geometry' in aggregated result; "
+                "for GeoDataFrame inputs set save_result option 'location_field' explicitly"
+            )
         raise ValueError(f"Missing location field '{location_field}' in aggregated result")
     if period_field not in frame.columns:
         raise ValueError(f"Missing period field '{period_field}' in aggregated result")

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -123,7 +123,7 @@ def file_formats() -> dict[str, Any]:
             "description": (
                 "Wide-format CSV for CHAP imports with one row per location-period and one column per variable."
             ),
-            "gis_data_types": ["table", "vector"],
+            "gis_data_types": ["table"],
             "parameters": {
                 "period_field": {"type": "string", "default": "t"},
                 "location_field": {"type": "string", "default": "geometry"},

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Callable
 
 from fastapi import APIRouter, Body, HTTPException, Request, Response
 from fastapi.responses import FileResponse, JSONResponse
@@ -117,6 +117,19 @@ def file_formats() -> dict[str, Any]:
             "gis_data_types": ["vector"],
             "parameters": {},
             "links": [{"rel": "about", "href": "https://geoparquet.org"}],
+        },
+        "CHAPCSV": {
+            "title": "CHAP CSV",
+            "description": (
+                "Wide-format CSV for CHAP imports with one row per location-period and one column per variable."
+            ),
+            "gis_data_types": ["table", "vector"],
+            "parameters": {
+                "period_field": {"type": "string", "default": "t"},
+                "location_field": {"type": "string", "default": "geometry"},
+                "period_type": {"type": "string"},
+            },
+            "links": [],
         },
     }
     return {
@@ -302,6 +315,27 @@ def download_result_file(job_id: str, filename: str) -> FileResponse:
     return FileResponse(str(path), media_type=media_type, filename=filename)
 
 
+def _sync_export_response(
+    write_output: Callable[[Any], str | None],
+    fmt: str,
+    media_type: str | None = None,
+) -> Response:
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            output = write_output(Path(tmp))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if output is None:
+            raise HTTPException(status_code=500, detail=f"Format '{fmt}' produced no output")
+        path = Path(output)
+        data = path.read_bytes()
+        resolved_media_type = media_type or _RESULT_MEDIA_TYPES.get(path.suffix.lower(), "application/octet-stream")
+        return Response(content=data, media_type=resolved_media_type)
+
+
 # ---------------------------------------------------------------------------
 # Synchronous result  POST /result
 # ---------------------------------------------------------------------------
@@ -336,12 +370,20 @@ def execute_synchronous(
     import xarray as xr
 
     from open_climate_service.openeo.execution import SaveResultEnvelope
-    from open_climate_service.openeo.jobs import _VECTOR_FORMATS, _write_raster, _write_vector
+    from open_climate_service.openeo.jobs import (
+        _VECTOR_FORMATS,
+        _write_dataset_tabular_export,
+        _write_raster,
+        _write_tabular_export,
+        _write_vector,
+    )
 
     # Unwrap save_result envelope to get requested format
     fmt = "ZARR"
+    options: dict[str, Any] = {}
     if isinstance(result, SaveResultEnvelope):
         fmt = result.format
+        options = result.options
         result = result.data
 
     if isinstance(result, xr.DataArray):
@@ -356,19 +398,16 @@ def execute_synchronous(
                     "use a non-ZARR format or submit a batch job"
                 ),
             )
-        with tempfile.TemporaryDirectory() as tmp:
-            from pathlib import Path
-
-            output = _write_raster(result, Path(tmp), fmt)
-            if output is None:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Format '{fmt}' produced no output",
-                )
-            data = Path(output).read_bytes()
-            suffix = Path(output).suffix.lower()
-            media_type = _RESULT_MEDIA_TYPES.get(suffix, "application/octet-stream")
-            return Response(content=data, media_type=media_type)
+        if fmt == "CHAPCSV":
+            return _sync_export_response(
+                lambda tmp_dir: _write_dataset_tabular_export(result, tmp_dir, fmt, options),
+                fmt,
+                "text/csv",
+            )
+        return _sync_export_response(
+            lambda tmp_dir: _write_raster(result, tmp_dir, fmt),
+            fmt,
+        )
 
     # Try vector
     try:
@@ -383,6 +422,17 @@ def execute_synchronous(
         import geopandas as gpd
 
         if isinstance(result, gpd.GeoDataFrame):
+            if fmt == "CHAPCSV":
+                return _sync_export_response(
+                    lambda tmp_dir: _write_tabular_export(
+                        result.drop(columns="geometry", errors="ignore"),
+                        tmp_dir,
+                        fmt,
+                        options,
+                    ),
+                    fmt,
+                    "text/csv",
+                )
             if fmt == "GEOJSON":
                 if result.crs is not None and result.crs.to_epsg() != 4326:
                     result = result.to_crs("EPSG:4326")

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -843,6 +843,14 @@ def test_build_chap_csv_frame_requires_location_field() -> None:
         )
 
 
+def test_build_chap_csv_frame_missing_default_geometry_field_guides_geodataframe_inputs() -> None:
+    with pytest.raises(ValueError, match="set save_result option 'location_field' explicitly"):
+        _build_chap_csv_frame(
+            [{"t": "2024-01-01", "temperature": 1.5}],
+            {"period_type": "daily"},
+        )
+
+
 def test_build_chap_csv_frame_requires_period_field() -> None:
     with pytest.raises(ValueError, match="Missing period field 't' in aggregated result"):
         _build_chap_csv_frame(
@@ -1139,6 +1147,12 @@ def test_infer_period_type(timedelta_days: int, expected: str) -> None:
 
 def test_infer_period_type_returns_none_for_single_timestep() -> None:
     ds = xr.Dataset({"v": ("t", [1.0])}, coords={"t": np.array(["2025-01-01"], dtype="datetime64[D]")})
+    assert _infer_period_type(ds, "t") is None
+
+
+def test_infer_period_type_returns_none_for_bimonthly_spacing() -> None:
+    t = np.arange(3).astype("timedelta64[D]") * 60 + np.datetime64("2025-01-01", "D")
+    ds = xr.Dataset({"v": ("t", [1.0, 2.0, 3.0])}, coords={"t": t})
     assert _infer_period_type(ds, "t") is None
 
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+from io import StringIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -22,11 +24,14 @@ from open_climate_service.openeo.execution import (
 )
 from open_climate_service.openeo.jobs import (
     OpenEOJobService,
+    _build_chap_csv_frame,
     _derive_coverage,
     _derive_variable,
     _infer_period_type,
     _recover_temporal_from_attrs,
     _result_assets,
+    _to_dhis2_period_string,
+    _write_dataset_tabular_export,
 )
 from open_climate_service.openeo.schemas import OpenEOJobCreate, OpenEOJobRecord, OpenEOJobStatus
 from open_climate_service.shared.time import utc_now
@@ -204,6 +209,41 @@ def test_persist_result_geodataframe_writes_geojson(job_service: OpenEOJobServic
     assert output_path.endswith(".geojson")
 
 
+def test_persist_result_dataset_writes_chap_csv(job_service: OpenEOJobService) -> None:
+    ds = xr.Dataset(
+        {
+            "temperature": xr.DataArray(
+                np.array([[28.4, 24.1], [29.0, 25.5]], dtype=np.float32),
+                dims=["t", "geometry"],
+                coords={
+                    "t": np.array(["2024-01-01", "2024-02-01"], dtype="datetime64[ns]"),
+                    "geometry": ["OU_1", "OU_2"],
+                },
+            ),
+            "precipitation": xr.DataArray(
+                np.array([[12.1, 8.3], [np.nan, 9.4]], dtype=np.float32),
+                dims=["t", "geometry"],
+                coords={
+                    "t": np.array(["2024-01-01", "2024-02-01"], dtype="datetime64[ns]"),
+                    "geometry": ["OU_1", "OU_2"],
+                },
+            ),
+        }
+    )
+
+    output_path = job_service._persist_result("job-chap", SaveResultEnvelope(ds, "CHAPCSV"))
+
+    assert output_path is not None
+    assert output_path.endswith("result.csv")
+    rows = list(csv.DictReader(StringIO(Path(output_path).read_text())))
+    assert rows == [
+        {"time_period": "202401", "location": "OU_1", "temperature": "28.4", "precipitation": "12.1"},
+        {"time_period": "202401", "location": "OU_2", "temperature": "24.1", "precipitation": "8.3"},
+        {"time_period": "202402", "location": "OU_1", "temperature": "29", "precipitation": ""},
+        {"time_period": "202402", "location": "OU_2", "temperature": "25.5", "precipitation": "9.4"},
+    ]
+
+
 def test_openeo_job_service_create_execute_and_get_results(
     job_service: OpenEOJobService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -255,6 +295,12 @@ def test_result_assets_geojson() -> None:
     assets = _result_assets(_record("/some/path/result.geojson"))
     assert assets["result"]["type"] == "application/geo+json"
     assert assets["result"]["href"].endswith("result.geojson")
+
+
+def test_result_assets_csv() -> None:
+    assets = _result_assets(_record("/some/path/result.csv"))
+    assert assets["result"]["type"] == "text/csv"
+    assert assets["result"]["href"].endswith("result.csv")
 
 
 def test_result_assets_none_output_returns_empty() -> None:
@@ -484,6 +530,118 @@ def test_result_route_reprojects_geojson_payload_to_wgs84(client: TestClient, mo
     assert coords[1] == pytest.approx(1.0, rel=0, abs=1e-6)
 
 
+def test_result_route_returns_chap_csv_payload(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    ds = xr.Dataset(
+        {
+            "temperature": xr.DataArray(
+                np.array([[28.4, 24.1]], dtype=np.float32),
+                dims=["t", "geometry"],
+                coords={
+                    "t": np.array(["2024-01-01"], dtype="datetime64[ns]"),
+                    "geometry": ["OU_1", "OU_2"],
+                },
+            ),
+            "precipitation": xr.DataArray(
+                np.array([[12.1, 8.3]], dtype=np.float32),
+                dims=["t", "geometry"],
+                coords={
+                    "t": np.array(["2024-01-01"], dtype="datetime64[ns]"),
+                    "geometry": ["OU_1", "OU_2"],
+                },
+            ),
+        }
+    )
+
+    def return_chap_result(*args: object, **kwargs: object) -> SaveResultEnvelope:
+        del args, kwargs
+        return SaveResultEnvelope(ds, "CHAPCSV", {"period_type": "monthly"})
+
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        return_chap_result,
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert rows == [
+        {"time_period": "202401", "location": "OU_1", "temperature": "28.4", "precipitation": "12.1"},
+        {"time_period": "202401", "location": "OU_2", "temperature": "24.1", "precipitation": "8.3"},
+    ]
+
+
+def test_build_chap_csv_frame_requires_location_field() -> None:
+    with pytest.raises(ValueError, match="Missing location field 'geometry' in aggregated result"):
+        _build_chap_csv_frame(
+            [{"t": "2024-01-01", "temperature": 1.5}],
+            {"period_type": "daily"},
+        )
+
+
+def test_build_chap_csv_frame_requires_period_field() -> None:
+    with pytest.raises(ValueError, match="Missing period field 't' in aggregated result"):
+        _build_chap_csv_frame(
+            [{"geometry": "OU_1", "temperature": 1.5}],
+            {"period_type": "daily"},
+        )
+
+
+def test_build_chap_csv_frame_includes_row_context_for_null_location() -> None:
+    with pytest.raises(ValueError, match=r"Null location value in field 'geometry' at row 0"):
+        _build_chap_csv_frame(
+            [{"t": "2024-01-01", "geometry": None, "temperature": 1.5}],
+            {"period_type": "daily"},
+        )
+
+
+def test_build_chap_csv_frame_requires_at_least_one_value_column() -> None:
+    with pytest.raises(ValueError, match="requires at least one value column"):
+        _build_chap_csv_frame(
+            [{"t": "2024-01-01", "geometry": "OU_1"}],
+            {"period_type": "daily"},
+        )
+
+
+def test_dhis2_period_string_accepts_existing_monthly_string() -> None:
+    assert _to_dhis2_period_string("202401") == "202401"
+
+
+def test_build_chap_csv_frame_rejects_ambiguous_period_without_period_type() -> None:
+    with pytest.raises(ValueError, match="Ambiguous period value"):
+        _build_chap_csv_frame(
+            [{"t": "2024-01-01", "geometry": "OU_1", "temperature": 1.5}],
+            {},
+        )
+
+
+def test_dhis2_period_string_rejects_mismatched_existing_period_type() -> None:
+    with pytest.raises(ValueError, match="appears to be monthly, but period_type=daily"):
+        _to_dhis2_period_string("202401", "daily")
+
+
+def test_dhis2_period_string_wraps_parse_failure_with_context() -> None:
+    with pytest.raises(ValueError, match=r"Could not parse period value 'not-a-date' for period_type=daily"):
+        _to_dhis2_period_string("not-a-date", "daily")
+
+
+def test_write_dataset_tabular_export_does_not_infer_unsupported_hourly_period_type(tmp_path: Path) -> None:
+    ds = xr.Dataset(
+        {"temperature": (("t", "geometry"), np.array([[1.0], [2.0]], dtype=np.float32))},
+        coords={
+            "t": np.array(["2024-01-01T00:00:00", "2024-01-01T01:00:00"], dtype="datetime64[ns]"),
+            "geometry": ["OU_1"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="Ambiguous period value"):
+        _write_dataset_tabular_export(ds, tmp_path, "CHAPCSV", {})
+
+
 # ---------------------------------------------------------------------------
 # _write_managed_zarr — managed Icechunk / pyramid store via save_result
 # ---------------------------------------------------------------------------
@@ -687,6 +845,7 @@ def test_derive_variable_raises_for_multiple_vars_without_option() -> None:
         (1, "daily"),
         (7, "weekly"),
         (30, "monthly"),
+        (90, "quarterly"),
         (365, "yearly"),
     ],
 )

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -902,6 +902,28 @@ def test_write_dataset_tabular_export_does_not_infer_unsupported_hourly_period_t
         _write_dataset_tabular_export(ds, tmp_path, "CHAPCSV", {})
 
 
+@pytest.mark.parametrize("period_type", [None, ""])
+def test_write_dataset_tabular_export_treats_blank_period_type_as_missing(
+    tmp_path: Path, period_type: str | None
+) -> None:
+    ds = xr.Dataset(
+        {"temperature": (("t", "geometry"), np.array([[1.0], [2.0]], dtype=np.float32))},
+        coords={
+            "t": np.array(["2024-01-01", "2024-02-01"], dtype="datetime64[ns]"),
+            "geometry": ["OU_1"],
+        },
+    )
+
+    output_path = _write_dataset_tabular_export(ds, tmp_path, "CHAPCSV", {"period_type": period_type})
+
+    assert output_path is not None
+    rows = list(csv.DictReader(StringIO(Path(output_path).read_text())))
+    assert rows == [
+        {"time_period": "202401", "location": "OU_1", "temperature": "1"},
+        {"time_period": "202402", "location": "OU_1", "temperature": "2"},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _write_managed_zarr — managed Icechunk / pyramid store via save_result
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds `CHAPCSV` as an openEO export format for CHAP-ready aggregated org-unit results.

## Changes

- add `CHAPCSV` to the openEO `file_formats` output registry
- add batch export support for `CHAPCSV` in the openEO job/export layer
- return synchronous `CHAPCSV` results directly as CSV payloads from `POST /result`
- add a wide tabular CSV builder with:
  - `time_period`
  - `location`
  - one column per variable
- infer supported period types where possible and convert them to DHIS2-style period strings
- preserve null values as empty CSV cells
- return clear validation errors for:
  - missing location field
  - missing period field
  - missing value columns
  - ambiguous or mismatched period values
  - unsupported non-scalar tabular cells

## Behavior

`CHAPCSV` is intended for workflows of the form:

```text
load_collection -> aggregate_spatial -> save_result(format="CHAPCSV", options=...)