### PR TITLE
fix(openeo): georegister all collections in load_collection (fixes #243)

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -382,8 +382,8 @@ def _ensure_crs(ds: xr.Dataset) -> xr.Dataset:
         crs = ds.attrs.get("proj:code") or ds.attrs.get("proj:epsg") or api_config.get_crs()
         tagged: xr.Dataset = ds.rio.write_crs(crs)
         return tagged
-    except Exception as exc:  # pragma: no cover - defensive; resampling will surface a clearer error
-        logger.warning("Could not attach CRS to collection: %s", exc)
+    except Exception:  # pragma: no cover - defensive; resampling will surface a clearer error
+        logger.warning("Could not attach CRS to collection; leaving untagged", exc_info=True)
         return ds
 
 

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -380,7 +380,8 @@ def _ensure_crs(ds: xr.Dataset) -> xr.Dataset:
         if ds.rio.crs is not None:
             return ds
         crs = ds.attrs.get("proj:code") or ds.attrs.get("proj:epsg") or api_config.get_crs()
-        return ds.rio.write_crs(crs)
+        tagged: xr.Dataset = ds.rio.write_crs(crs)
+        return tagged
     except Exception as exc:  # pragma: no cover - defensive; resampling will surface a clearer error
         logger.warning("Could not attach CRS to collection: %s", exc)
         return ds

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -14,6 +14,7 @@ from typing import Any
 import xarray as xr
 from fastapi import HTTPException, Request
 
+from open_climate_service import config as api_config
 from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset, open_zarr_dataset
 from open_climate_service.data_manager.services.utils import get_time_dim
 from open_climate_service.ingestions import services as ingestion_services
@@ -267,7 +268,7 @@ def _load_collection_impl(
 ) -> xr.DataArray:
     """Load a published dataset as an openEO data cube (xr.DataArray)."""
     artifact = _get_published_artifact(id)
-    ds = _open_artifact(artifact)
+    ds = _ensure_crs(_open_artifact(artifact))
 
     bbox = _bbox_to_dict(spatial_extent)
     t_extent = _temporal_to_list(temporal_extent)
@@ -356,6 +357,33 @@ def _open_artifact(artifact: Any) -> xr.Dataset:
     if artifact.format == ArtifactFormat.ICECHUNK:
         return open_icechunk_dataset(path)
     return open_zarr_dataset(path)
+
+
+def _ensure_crs(ds: xr.Dataset) -> xr.Dataset:
+    """Ensure the cube carries a CF ``spatial_ref`` coordinate that odc.geo can read.
+
+    Streaming-ingested IceChunk stores record their CRS only as GeoZarr root-group
+    attributes (``proj:code``), which odc.geo does not interpret. odc-based processes
+    such as ``resample_cube_spatial`` then fail with "Can not reproject non-georegistered
+    array". Writing the CRS here as a proper CF grid_mapping makes every collection
+    consistently georegistered regardless of storage format. Stores written by the
+    downloader/pyramid path already carry ``spatial_ref``; ``write_crs`` is a no-op for
+    them, so this is safe and idempotent.
+
+    The CRS is taken from the store's declared ``proj:code`` when present, falling back
+    to the instance CRS. Tagging failures are logged and the dataset returned untouched
+    rather than failing the load.
+    """
+    import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio accessor
+
+    try:
+        if ds.rio.crs is not None:
+            return ds
+        crs = ds.attrs.get("proj:code") or ds.attrs.get("proj:epsg") or api_config.get_crs()
+        return ds.rio.write_crs(crs)
+    except Exception as exc:  # pragma: no cover - defensive; resampling will surface a clearer error
+        logger.warning("Could not attach CRS to collection: %s", exc)
+        return ds
 
 
 def _artifact_store_path(artifact: Any) -> str:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -19,6 +19,8 @@ from open_climate_service.openeo.execution import (
     SaveResultEnvelope,
     _augment_with_workflows,
     _bbox_to_dict,
+    _ensure_crs,
+    _load_collection_impl,
     _RegistryOverlay,
     _temporal_to_list,
     run_process_graph,
@@ -122,6 +124,61 @@ def test_registry_overlay_tuple_key_uses_name() -> None:
     base: dict[Any, Any] = {}
     overlay = _RegistryOverlay(base, {"bar": proc})
     assert overlay[("predefined", "bar")] is proc
+
+
+# ---------------------------------------------------------------------------
+# _ensure_crs / load_collection CRS tagging (regression for #243)
+# ---------------------------------------------------------------------------
+
+
+def _streaming_style_cube() -> xr.Dataset:
+    """A cube as written by the streaming engine: x/y coords, CRS only in GeoZarr attrs."""
+    ds = xr.Dataset(
+        {"pop": (("t", "y", "x"), np.arange(20, dtype="float32").reshape(1, 4, 5))},
+        coords={
+            "t": np.array(["2021-01-01"], dtype="datetime64[ns]"),
+            "y": np.linspace(10, 7, 4),
+            "x": np.linspace(-13, -10, 5),
+        },
+    )
+    ds.attrs["proj:code"] = "EPSG:4326"  # GeoZarr root attr only — no spatial_ref coord
+    return ds
+
+
+def test_ensure_crs_tags_untagged_streaming_cube() -> None:
+    ds = _streaming_style_cube()
+    import rioxarray  # noqa: F401  # activate .rio  # pyright: ignore[reportUnusedImport]
+
+    assert ds.rio.crs is None  # odc.geo would see a non-georegistered array
+
+    tagged = _ensure_crs(ds)
+
+    assert "spatial_ref" in tagged.coords
+    assert tagged.rio.crs is not None
+    assert tagged.rio.crs.to_epsg() == 4326
+
+
+def test_ensure_crs_is_idempotent_and_preserves_existing_crs() -> None:
+    import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    ds = _streaming_style_cube().rio.write_crs("EPSG:32633")  # downloader-path style
+    # proj:code says 4326, but an already-written CRS must win (no override).
+    result = _ensure_crs(ds)
+    assert result.rio.crs.to_epsg() == 32633
+
+
+def test_load_collection_returns_georegistered_cube(monkeypatch: pytest.MonkeyPatch) -> None:
+    import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    monkeypatch.setattr("open_climate_service.openeo.execution._get_published_artifact", lambda _id: object())
+    monkeypatch.setattr("open_climate_service.openeo.execution._open_artifact", lambda _a: _streaming_style_cube())
+
+    cube = _load_collection_impl("pop_collection")
+
+    # The returned DataArray must carry a CRS so odc-based processes
+    # (resample_cube_spatial) can georegister it.
+    assert cube.rio.crs is not None
+    assert cube.rio.crs.to_epsg() == 4326
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`resample_cube_spatial` (and any odc.geo-based process) failed on collections backed by streaming-ingested **IceChunk** stores:

```
ValueError: Can not reproject non-georegistered array.   # odc: assert self._crs is not None
```

The streaming engine records a collection's CRS **only as GeoZarr root-group attributes** (`proj:code`), which `odc.geo` does not interpret. So `.odc.geobox` resolves `crs → None` and reprojection refuses the array. Stores written by the **downloader/pyramid** path worked because `downloader.py` calls `ds.rio.write_crs(...)`, which writes the CF `spatial_ref` coordinate odc.geo needs.

Fixes #243.

## Fix

`_load_collection_impl` now passes the opened dataset through a new `_ensure_crs` helper before returning it. `_ensure_crs`:

- returns the dataset unchanged if it already carries a CRS (`ds.rio.crs is not None`) — so downloader/pyramid stores and any already-tagged cube are untouched (idempotent);
- otherwise writes a CF `spatial_ref` coordinate via `ds.rio.write_crs(...)`, using the store's declared `proj:code`/`proj:epsg` and falling back to the instance CRS (`config.get_crs()`);
- on any failure, logs a warning and returns the dataset untouched rather than failing the load.

Tagging on **read** (rather than only fixing the streaming write path) means the fix is uniform across storage formats **and** covers stores that were already ingested, without re-ingestion.

## Verification

A streaming-style cube (`x`/`y` coords, CRS only in `proj:code`) before vs after:

| Input cube | `resample_cube_spatial` |
|---|---|
| before — CRS-less streaming store | ❌ `Can not reproject non-georegistered array.` |
| after — via `_load_collection_impl` → `_ensure_crs` | ✅ resamples, output CRS `EPSG:4326` |

## Tests

`tests/test_openeo_execution.py`:
- `_ensure_crs` tags an untagged streaming-style cube (adds `spatial_ref`, `rio.crs == EPSG:4326`)
- `_ensure_crs` is idempotent and does **not** override an already-written CRS (32633 wins over the `proj:code` 4326 attr)
- `_load_collection_impl` returns a georegistered DataArray

`make lint` clean; full suite **378 passed, 1 skipped**.

## Scope

Covers the `from_parameter`-of-CRS root cause for all collections. Does not change the streaming write path itself (stores still carry only GeoZarr attrs on disk); the CRS is applied consistently at load time instead.
