### PR TITLE
feat: split into client/server extras; rename Client to ClimateService (closes #181)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --all-extras
 
       - name: Run linting
         run: make lint

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra server
 
       - name: Generate OpenAPI spec
         run: make openapi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY pyproject.toml uv.lock .python-version ./
 COPY open_climate_service/ open_climate_service/
 COPY README.md .
 
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --extra server
 
 RUN mkdir -p /app/data/pygeoapi /app/data/artifacts && \
     printf '[]\n' > /app/data/artifacts/records.json && \

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
 
-sync: ## Install dependencies with uv
-	uv sync
+sync: ## Install all dependencies with uv (client + server + xarray extras)
+	uv sync --all-extras
 
 sync-gdal: ## Pin gdal override to the installed system libgdal version, then sync
 	@GDAL_VERSION=$$(gdal-config --version 2>/dev/null) && \
@@ -12,7 +12,7 @@ sync-gdal: ## Pin gdal override to the installed system libgdal version, then sy
 		echo "System GDAL: $$GDAL_VERSION" && \
 		sed -i.bak "s/\"gdal==[^\"]*\"/\"gdal==$$GDAL_VERSION\"/" pyproject.toml && \
 		rm -f pyproject.toml.bak && \
-		uv sync
+		uv sync --all-extras
 
 run: ## Start the app with uvicorn
 	uv run uvicorn open_climate_service.main:app --reload --reload-include "*.html" --reload-include "*.yaml" --reload-include "*.yml"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,37 @@ The platform is designed to operate independently of DHIS2 and can be deployed o
 
 > **Status: active development.** Current focus is on dataset ingestion, sync workflows, and GeoZarr storage. APIs and data models may change without notice.
 
-## Setup
+## Install
+
+The package ships a lightweight **client** by default and a full **server** stack as an optional extra:
+
+```bash
+pip install open-climate-service            # client only — talk to an instance over HTTP
+pip install open-climate-service[xarray]    # + open published datasets as xarray
+pip install open-climate-service[server]    # full server stack — run your own instance
+```
+
+The base client needs only `httpx` and `pystac`. See the [Python client](#python-client) section below and [docs/user_guide.md](docs/user_guide.md).
+
+### Python client
+
+```python
+from open_climate_service import ClimateService
+
+service = ClimateService("https://my-instance.example.org")
+datasets = service.datasets()                       # discover published collections
+ds = service.open_dataset(datasets[0]["id"])        # open as xarray (needs the [xarray] extra)
+workflows = service.workflows()                      # list reusable workflows (UDPs)
+```
+
+## Setup (server)
 
 ### Using uv (recommended)
 
 Install dependencies (requires [uv](https://docs.astral.sh/uv/)):
 
 ```
-uv sync
+uv sync --extra server
 ```
 
 Copy `.env.example` to `.env` and adjust values as needed. Environment variables are loaded automatically from `.env` at runtime. See `.env.example` for the full list of available options.
@@ -33,7 +56,7 @@ If you cannot use uv (e.g. mixed conda/forge environments):
 ```
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install -e ".[server]"
 python -m uvicorn open_climate_service.main:app --reload
 ```
 
@@ -42,7 +65,7 @@ python -m uvicorn open_climate_service.main:app --reload
 ```
 conda create -n dhis2-climate-service python=3.13
 conda activate dhis2-climate-service
-pip install -e .
+pip install -e ".[server]"
 python -m uvicorn open_climate_service.main:app --reload
 ```
 
@@ -52,7 +75,7 @@ Common Makefile targets:
 
 | Target         | Description                                      |
 | -------------- | ------------------------------------------------ |
-| `make sync`    | Install dependencies with uv                     |
+| `make sync`    | Install all dependencies with uv (client + server + xarray) |
 | `make run`     | Start the app with uvicorn (hot reload)          |
 | `make lint`    | Check linting, formatting, and types             |
 | `make fix`     | Autofix ruff lint and format issues              |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -74,9 +74,6 @@ data_value_set = service.execute(
 )
 ```
 
-> The `ClimateService` class was previously named `Client`; the old name remains as an
-> alias, as do `catalog()`/`open()` for `datasets()`/`open_dataset()`.
-
 ## Opening a dataset with xarray
 
 `open_dataset` reads the Zarr asset advertised in the dataset's STAC collection and returns a lazy `xarray.Dataset` (requires the `xarray` extra):

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,20 +32,62 @@ The `assets.zarr` field contains everything needed to open the dataset:
 }
 ```
 
-## Opening a dataset with xarray
+## The Python client
 
-The `open_climate_service.client` module provides a `Client` class for discovering and opening datasets:
+`open_climate_service` ships a lightweight `ClimateService` client. The base install
+needs only `httpx` and `pystac`; opening datasets as xarray adds the `xarray` extra:
+
+```bash
+pip install open-climate-service            # client only — talk to an instance over HTTP
+pip install open-climate-service[xarray]    # + open published datasets as xarray
+```
 
 ```python
-from open_climate_service.client import Client
+from open_climate_service import ClimateService
 
-api = Client("http://127.0.0.1:8000")
+service = ClimateService("http://127.0.0.1:8000")
 
-datasets = api.catalog()
-for link in datasets:
+# Discover published datasets (STAC catalog)
+for link in service.datasets():
     print(link["id"], "—", link["title"])
 
-ds = api.open(datasets[0]["id"])  # open whichever dataset is published first
+# List the processes and reusable workflows the instance exposes
+service.processes()    # standard openEO processes
+service.workflows()    # stored workflows / UDPs (e.g. aggregate_to_dhis2_org_units)
+
+# Run a process graph synchronously. JSON results (e.g. a DHIS2 dataValueSet) come
+# back as a dict; file results (CSV, GeoJSON, GeoTIFF) come back as bytes.
+data_value_set = service.execute(
+    {
+        "agg": {
+            "process_id": "aggregate_to_dhis2_org_units",
+            "arguments": {
+                "dataset_id": "era5land_temperature_monthly",
+                "temporal_extent": ["2025-01-01", "2025-12-31"],
+                "geometries": {"type": "FeatureCollection", "features": []},
+                "data_element_id": "fbfJHSPpUQD",
+                "method": "mean",
+            },
+            "result": True,
+        }
+    }
+)
+```
+
+> The `ClimateService` class was previously named `Client`; the old name remains as an
+> alias, as do `catalog()`/`open()` for `datasets()`/`open_dataset()`.
+
+## Opening a dataset with xarray
+
+`open_dataset` reads the Zarr asset advertised in the dataset's STAC collection and returns a lazy `xarray.Dataset` (requires the `xarray` extra):
+
+```python
+from open_climate_service import ClimateService
+
+service = ClimateService("http://127.0.0.1:8000")
+
+datasets = service.datasets()
+ds = service.open_dataset(datasets[0]["id"])  # open whichever dataset is published first
 print(ds)
 ```
 

--- a/examples/stac_discover_and_open.py
+++ b/examples/stac_discover_and_open.py
@@ -6,15 +6,15 @@ Adjust BASE_URL if the API is not running on the default local address.
 
 import json
 
-from open_climate_service.client import Client
+from open_climate_service import ClimateService
 
 BASE_URL = "http://127.0.0.1:8000"
 
 
 def main() -> None:
     """Discover and open the first published dataset."""
-    api = Client(BASE_URL)
-    datasets = api.catalog()
+    service = ClimateService(BASE_URL)
+    datasets = service.datasets()
 
     if not datasets:
         print("No published datasets found. Run an ingestion first.")
@@ -25,7 +25,7 @@ def main() -> None:
     first = datasets[0]
     print(f"\nOpening: {first['title']}")
 
-    ds = api.open(first["id"])
+    ds = service.open_dataset(first["id"])
     print(ds)
 
     print(f"\nTime range: {ds['t'].values[0]}  →  {ds['t'].values[-1]}")

--- a/examples/zarr_direct_access.py
+++ b/examples/zarr_direct_access.py
@@ -4,15 +4,15 @@ Requires a running Open Climate Service instance with at least one published dat
 Adjust BASE_URL if the API is not running on the default local address.
 """
 
-from open_climate_service.client import Client
+from open_climate_service import ClimateService
 
 BASE_URL = "http://127.0.0.1:8000"
 
 
 def main() -> None:
     """Open a Zarr store directly and demonstrate spatial and temporal subsetting."""
-    api = Client(BASE_URL)
-    datasets = api.catalog()
+    service = ClimateService(BASE_URL)
+    datasets = service.datasets()
     if not datasets:
         print("No published datasets found. Run an ingestion first.")
         return
@@ -20,7 +20,7 @@ def main() -> None:
     first = datasets[0]
     print(f"Opening: {first['title']}\n")
 
-    ds = api.open(first["id"])
+    ds = service.open_dataset(first["id"])
     print(ds)
 
     print(f"\nDimensions:  {dict(ds.sizes)}")

--- a/open_climate_service/__init__.py
+++ b/open_climate_service/__init__.py
@@ -1,3 +1,7 @@
+# The lightweight client is import-safe with only the base deps (httpx, pystac),
+# so it can be re-exported at the top level without pulling in the server stack.
+from open_climate_service.client import ClimateService
+
 try:
     from importlib.metadata import version as _get_version
 
@@ -5,8 +9,4 @@ try:
 except Exception:
     __version__ = "unknown"
 
-# The lightweight client is import-safe with only the base deps (httpx, pystac),
-# so it can be re-exported at the top level without pulling in the server stack.
-from open_climate_service.client import Client, ClimateService
-
-__all__ = ["Client", "ClimateService", "__version__"]
+__all__ = ["ClimateService", "__version__"]

--- a/open_climate_service/__init__.py
+++ b/open_climate_service/__init__.py
@@ -4,3 +4,9 @@ try:
     __version__ = _get_version("open-climate-service")
 except Exception:
     __version__ = "unknown"
+
+# The lightweight client is import-safe with only the base deps (httpx, pystac),
+# so it can be re-exported at the top level without pulling in the server stack.
+from open_climate_service.client import Client, ClimateService
+
+__all__ = ["Client", "ClimateService", "__version__"]

--- a/open_climate_service/client.py
+++ b/open_climate_service/client.py
@@ -210,14 +210,6 @@ class ClimateService:
             return Path(path)
         return response.content
 
-    # Backwards-compatible method aliases (pre-rename names).
-    catalog = datasets
-    open = open_dataset
-
-
-# Backwards-compatible class alias for the pre-rename name.
-Client = ClimateService
-
 
 def list_datasets(base_url: str | None = None) -> list[dict]:
     """Return all published datasets from the STAC catalog (one-shot, no persistent connection).

--- a/open_climate_service/client.py
+++ b/open_climate_service/client.py
@@ -1,13 +1,56 @@
-"""Lightweight client for discovering and opening published Open Climate Service datasets."""
+"""Lightweight client for a running Open Climate Service instance.
 
+The base install needs only ``httpx`` and ``pystac``. With it you can discover
+published datasets, list the available processes and workflows, and run process
+graphs over HTTP — everything that talks to a remote instance via REST::
+
+    pip install open-climate-service             # talk to an instance (REST only)
+    pip install open-climate-service[xarray]     # + open datasets as xarray
+    pip install open-climate-service[server]     # run your own instance
+
+Opening a published dataset as an in-memory :class:`xarray.Dataset` additionally
+requires the optional ``xarray`` extra; :meth:`ClimateService.open_dataset` raises a
+clear error pointing to it when the dependency is missing.
+
+Example:
+    >>> from open_climate_service import ClimateService
+    >>> service = ClimateService("https://my-instance.example.org")
+    >>> service.datasets()  # discover published collections
+    >>> ds = service.open_dataset("chirps3_precipitation_daily")  # needs [xarray]
+    >>> service.workflows()  # list reusable workflows (UDPs)
+    >>> service.execute(
+    ...     {  # run a process graph synchronously
+    ...         "agg": {
+    ...             "process_id": "aggregate_to_dhis2_org_units",
+    ...             "arguments": {...},
+    ...             "result": True,
+    ...         }
+    ...     }
+    ... )
+"""
+
+from __future__ import annotations
+
+import importlib.util
 import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import httpx
-import xarray as xr
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 _FALLBACK_BASE_URL = "http://127.0.0.1:8000"
 _DEFAULT_TIMEOUT = 30.0
+# Synchronous process graphs (POST /result) can run for minutes — allow more headroom.
+_RESULT_TIMEOUT = 300.0
+
+_XARRAY_INSTALL_HINT = (
+    "Opening datasets as xarray needs extra dependencies that are not part of the "
+    "base client. Install them with: pip install 'open-climate-service[xarray]'"
+)
 
 
 def _default_base_url() -> str:
@@ -19,18 +62,74 @@ def _id_from_href(href: str) -> str:
     return urlparse(href).path.rstrip("/").rsplit("/", 1)[-1]
 
 
-class Client:
-    """Client for a Open Climate Service instance.
+def _child_links(catalog: Any, source: str) -> list[dict]:
+    """Extract STAC child links (one per published dataset) from a catalog response."""
+    raw_links = catalog.get("links") if isinstance(catalog, dict) else None
+    if not isinstance(raw_links, list):
+        raise ValueError(f"Invalid STAC catalog response from {source}: missing or non-list 'links' field")
+    links = []
+    for link in raw_links:
+        if isinstance(link, dict) and link.get("rel") == "child":
+            href = link.get("href")
+            if not isinstance(href, str) or not href:
+                raise ValueError(f"STAC child link from {source} has a missing or invalid href")
+            links.append({**link, "id": _id_from_href(href)})
+    return links
 
-    Maintains a persistent HTTP connection for efficient repeated calls.
-    Use as a context manager to ensure the connection is closed:
 
-        with Client("http://localhost:8000") as client:
-            datasets = client.catalog()
+def _zarr_asset(collection: Any, dataset_id: str, source: str) -> tuple[str, dict]:
+    """Return the Zarr asset ``(href, open_kwargs)`` from a STAC collection response."""
+    assets = collection.get("assets") if isinstance(collection, dict) else None
+    if not isinstance(assets, dict):
+        raise ValueError(f"STAC collection for '{dataset_id}' from {source} has a missing or invalid 'assets' field")
+    asset = assets.get("zarr")
+    if not isinstance(asset, dict):
+        raise ValueError(f"Dataset '{dataset_id}' has no Zarr asset in the STAC collection")
+    href = asset.get("href")
+    if not isinstance(href, str) or not href:
+        raise ValueError(f"Zarr asset for '{dataset_id}' has a missing or invalid href")
+    open_kwargs = asset.get("xarray:open_kwargs", {})
+    if not isinstance(open_kwargs, dict):
+        raise ValueError(f"Zarr asset for '{dataset_id}' has a malformed xarray:open_kwargs field")
+    return href, open_kwargs
+
+
+def _open_zarr(href: str, open_kwargs: dict) -> xr.Dataset:
+    """Open a (possibly remote) Zarr store as an xarray Dataset, lazy-importing xarray."""
+    if importlib.util.find_spec("xarray") is None:
+        raise ModuleNotFoundError(_XARRAY_INSTALL_HINT)
+    import xarray as xr
+
+    ds: xr.Dataset = xr.open_zarr(href, **open_kwargs)
+    # Pyramided (multiscale) stores expose data under the highest-resolution group "0".
+    if not ds.data_vars:
+        ds.close()
+        ds = xr.open_zarr(href, group="0", **open_kwargs)
+    return ds
+
+
+def _process_graph_body(process_graph: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a process-graph nodes mapping into the POST /result request body.
+
+    Accepts a bare nodes mapping (``{node_id: {...}}``, e.g. an openEO client's
+    ``flat_graph()``) or a ``{"process_graph": {...}}`` wrapper.
+    """
+    pg = process_graph["process_graph"] if set(process_graph) == {"process_graph"} else process_graph
+    return {"process": {"process_graph": pg}}
+
+
+class ClimateService:
+    """Client for an Open Climate Service instance.
+
+    Maintains a persistent HTTP connection for efficient repeated calls. Use as a
+    context manager to ensure the connection is closed::
+
+        with ClimateService("http://localhost:8000") as service:
+            datasets = service.datasets()
 
     Args:
         base_url: Base URL of the running Open Climate Service (e.g. ``http://localhost:8000``).
-        timeout: HTTP request timeout in seconds (default: 30).
+        timeout: Default HTTP request timeout in seconds (default: 30).
     """
 
     def __init__(self, base_url: str, *, timeout: float = _DEFAULT_TIMEOUT) -> None:
@@ -41,65 +140,87 @@ class Client:
         """Close the underlying HTTP connection."""
         self._http.close()
 
-    def __enter__(self) -> "Client":
+    def __enter__(self) -> ClimateService:
         return self
 
     def __exit__(self, *args: object) -> None:
         self.close()
 
-    def catalog(self) -> list[dict]:
+    def datasets(self) -> list[dict]:
         """Return all published datasets from the STAC catalog.
 
         Each entry is a STAC child link dict with at least ``id``, ``title``, and ``href``.
         """
         response = self._http.get(f"{self.base_url}/stac/catalog.json")
         response.raise_for_status()
-        catalog = response.json()
-        raw_links = catalog.get("links")
-        if not isinstance(raw_links, list):
-            raise ValueError(f"Invalid STAC catalog response from {self.base_url}: missing or non-list 'links' field")
-        links = []
-        for link in raw_links:
-            if isinstance(link, dict) and link.get("rel") == "child":
-                href = link.get("href")
-                if not isinstance(href, str) or not href:
-                    raise ValueError(f"STAC child link from {self.base_url} has a missing or invalid href")
-                links.append({**link, "id": _id_from_href(href)})
-        return links
+        return _child_links(response.json(), self.base_url)
 
-    def open(self, dataset_id: str) -> xr.Dataset:
+    def open_dataset(self, dataset_id: str) -> xr.Dataset:
         """Open a published dataset as an xarray Dataset.
 
-        Fetches the STAC collection for ``dataset_id``, reads the Zarr asset
-        metadata, and returns the opened dataset. Coordinates are always
-        ``time``, ``latitude``, and ``longitude``.
+        Fetches the STAC collection for ``dataset_id``, reads the Zarr asset metadata,
+        and returns the opened (lazy) dataset. Requires the ``xarray`` extra.
         """
         response = self._http.get(f"{self.base_url}/stac/collections/{dataset_id}")
         response.raise_for_status()
-        collection = response.json()
-        assets = collection.get("assets")
-        if not isinstance(assets, dict):
-            raise ValueError(
-                f"STAC collection for '{dataset_id}' from {self.base_url} has a missing or invalid 'assets' field"
-            )
-        asset = assets.get("zarr")
-        if not isinstance(asset, dict):
-            raise ValueError(f"Dataset '{dataset_id}' has no Zarr asset in the STAC collection")
-        href = asset.get("href")
-        if not isinstance(href, str) or not href:
-            raise ValueError(f"Zarr asset for '{dataset_id}' has a missing or invalid href")
-        open_kwargs = asset.get("xarray:open_kwargs", {})
-        if not isinstance(open_kwargs, dict):
-            raise ValueError(f"Zarr asset for '{dataset_id}' has a malformed xarray:open_kwargs field")
-        ds: xr.Dataset = xr.open_zarr(href, **open_kwargs)
-        if not ds.data_vars:
-            ds.close()
-            ds = xr.open_zarr(href, group="0", **open_kwargs)
-        return ds
+        href, open_kwargs = _zarr_asset(response.json(), dataset_id, self.base_url)
+        return _open_zarr(href, open_kwargs)
+
+    def processes(self) -> list[dict]:
+        """Return all openEO processes available on the instance (``GET /processes``)."""
+        response = self._http.get(f"{self.base_url}/processes")
+        response.raise_for_status()
+        processes: list[dict] = response.json().get("processes", [])
+        return processes
+
+    def workflows(self) -> list[dict]:
+        """Return the reusable workflows (stored process graphs / UDPs) (``GET /process_graphs``)."""
+        response = self._http.get(f"{self.base_url}/process_graphs")
+        response.raise_for_status()
+        workflows: list[dict] = response.json().get("processes", [])
+        return workflows
+
+    def execute(
+        self,
+        process_graph: dict[str, Any],
+        *,
+        timeout: float | None = _RESULT_TIMEOUT,
+        path: str | Path | None = None,
+    ) -> Any:
+        """Run a process graph synchronously and return its result (``POST /result``).
+
+        ``process_graph`` is a process-graph nodes mapping (e.g. an openEO client's
+        ``flat_graph()``); one node must carry ``"result": true``.
+
+        Returns a parsed object for JSON results (e.g. a DHIS2 ``dataValueSet`` from
+        ``save_result`` ``format: "DHIS2JSON"``). For file results (CSV, GeoJSON,
+        GeoTIFF, …) it returns the raw ``bytes``, or — when ``path`` is given — writes
+        them there and returns the :class:`~pathlib.Path`.
+        """
+        response = self._http.post(
+            f"{self.base_url}/result",
+            json=_process_graph_body(process_graph),
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        if "application/json" in response.headers.get("content-type", ""):
+            return response.json()
+        if path is not None:
+            Path(path).write_bytes(response.content)
+            return Path(path)
+        return response.content
+
+    # Backwards-compatible method aliases (pre-rename names).
+    catalog = datasets
+    open = open_dataset
+
+
+# Backwards-compatible class alias for the pre-rename name.
+Client = ClimateService
 
 
 def list_datasets(base_url: str | None = None) -> list[dict]:
-    """Return all published datasets from the STAC catalog.
+    """Return all published datasets from the STAC catalog (one-shot, no persistent connection).
 
     Each entry is a STAC child link dict with at least ``id``, ``title``, and ``href``.
     ``base_url`` defaults to the ``CLIMATE_SERVICE_BASE_URL`` environment variable,
@@ -108,47 +229,19 @@ def list_datasets(base_url: str | None = None) -> list[dict]:
     url = (base_url or _default_base_url()).rstrip("/")
     response = httpx.get(f"{url}/stac/catalog.json", timeout=_DEFAULT_TIMEOUT)
     response.raise_for_status()
-    catalog = response.json()
-    raw_links = catalog.get("links")
-    if not isinstance(raw_links, list):
-        raise ValueError(f"Invalid STAC catalog response from {url}: missing or non-list 'links' field")
-    links = []
-    for link in raw_links:
-        if isinstance(link, dict) and link.get("rel") == "child":
-            href = link.get("href")
-            if not isinstance(href, str) or not href:
-                raise ValueError(f"STAC child link from {url} has a missing or invalid href")
-            links.append({**link, "id": _id_from_href(href)})
-    return links
+    return _child_links(response.json(), url)
 
 
 def open_dataset(dataset_id: str, *, base_url: str | None = None) -> xr.Dataset:
-    """Open a published dataset as an xarray Dataset.
+    """Open a published dataset as an xarray Dataset (one-shot, no persistent connection).
 
-    Fetches the STAC collection for ``dataset_id``, reads the Zarr asset
-    metadata, and returns the opened dataset. Coordinates are always
-    ``time``, ``latitude``, and ``longitude``.
-    ``base_url`` defaults to the ``CLIMATE_SERVICE_BASE_URL`` environment variable,
-    falling back to ``http://127.0.0.1:8000``.
+    Fetches the STAC collection for ``dataset_id``, reads the Zarr asset metadata, and
+    returns the opened dataset. Requires the ``xarray`` extra. ``base_url`` defaults to
+    the ``CLIMATE_SERVICE_BASE_URL`` environment variable, falling back to
+    ``http://127.0.0.1:8000``.
     """
     url = (base_url or _default_base_url()).rstrip("/")
     response = httpx.get(f"{url}/stac/collections/{dataset_id}", timeout=_DEFAULT_TIMEOUT)
     response.raise_for_status()
-    collection = response.json()
-    assets = collection.get("assets")
-    if not isinstance(assets, dict):
-        raise ValueError(f"STAC collection for '{dataset_id}' from {url} has a missing or invalid 'assets' field")
-    asset = assets.get("zarr")
-    if not isinstance(asset, dict):
-        raise ValueError(f"Dataset '{dataset_id}' has no Zarr asset in the STAC collection")
-    href = asset.get("href")
-    if not isinstance(href, str) or not href:
-        raise ValueError(f"Zarr asset for '{dataset_id}' has a missing or invalid href")
-    open_kwargs = asset.get("xarray:open_kwargs", {})
-    if not isinstance(open_kwargs, dict):
-        raise ValueError(f"Zarr asset for '{dataset_id}' has a malformed xarray:open_kwargs field")
-    ds: xr.Dataset = xr.open_zarr(href, **open_kwargs)
-    if not ds.data_vars:
-        ds.close()
-        ds = xr.open_zarr(href, group="0", **open_kwargs)
-    return ds
+    href, open_kwargs = _zarr_asset(response.json(), dataset_id, url)
+    return _open_zarr(href, open_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,17 +41,33 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: GIS",
 ]
+# Base install = the lightweight client. It only talks to a running instance over
+# HTTP (discover datasets, list processes/workflows, run process graphs).
 dependencies = [
+    "httpx>=0.28.1",
+    "pystac>=1.10,<2",
+]
+
+[project.optional-dependencies]
+# Open published datasets as in-memory xarray.Dataset objects from the client
+# (reads the remote Zarr store advertised in the STAC collection).
+xarray = [
+    "xarray>=2025.12.0",
+    "zarr>=3.1.6,<4",
+    "fsspec>=2024.6.0",
+    "aiohttp>=3.10",
+]
+# Full server stack — required to run your own Open Climate Service instance.
+server = [
     "fastapi>=0.100.0",
     "jinja2>=3.1",
     "starlette>=0.27.0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.0.1",
-    "pystac>=1.10,<2",
     "geojson-pydantic>=2.1.0",
-    "httpx>=0.28.1",
     "metpy>=1.7,<2",
     "xstac>=1.0,<2",
+    "xarray>=2025.12.0",
     "zarr>=3.1.6,<4",
     "icechunk>=2.0,<3",
     "geozarr-toolkit==0.1.*",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,13 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from open_climate_service.client import Client, _id_from_href, list_datasets, open_dataset
+from open_climate_service.client import (
+    Client,
+    ClimateService,
+    _id_from_href,
+    list_datasets,
+    open_dataset,
+)
 
 
 def _make_catalog(hrefs: list[str]) -> dict:
@@ -28,10 +34,18 @@ def _make_collection(zarr_href: str) -> dict:
     }
 
 
-def _make_response(json_body: dict, status_code: int = 200) -> MagicMock:
+def _make_response(
+    json_body: dict | list | None = None,
+    *,
+    status_code: int = 200,
+    content: bytes | None = None,
+    content_type: str = "application/json",
+) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status_code
     resp.json.return_value = json_body
+    resp.content = content if content is not None else b""
+    resp.headers = {"content-type": content_type}
     resp.raise_for_status.return_value = None
     return resp
 
@@ -122,7 +136,7 @@ def test_open_dataset_raises_on_http_error() -> None:
 def test_open_dataset_uses_default_base_url() -> None:
     collection = _make_collection("/dev/null")
     with patch("open_climate_service.client.httpx.get", return_value=_make_response(collection)) as mock_get:
-        with patch("open_climate_service.client.xr.open_zarr", return_value=MagicMock()):
+        with patch("xarray.open_zarr", return_value=MagicMock()):
             open_dataset("any_dataset")
 
     mock_get.assert_called_once_with("http://127.0.0.1:8000/stac/collections/any_dataset", timeout=30)
@@ -132,29 +146,53 @@ def test_open_dataset_uses_env_var_base_url(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("CLIMATE_SERVICE_BASE_URL", "http://env-host:9000")
     collection = _make_collection("/dev/null")
     with patch("open_climate_service.client.httpx.get", return_value=_make_response(collection)) as mock_get:
-        with patch("open_climate_service.client.xr.open_zarr", return_value=MagicMock()):
+        with patch("xarray.open_zarr", return_value=MagicMock()):
             open_dataset("any_dataset")
 
     mock_get.assert_called_once_with("http://env-host:9000/stac/collections/any_dataset", timeout=30)
 
 
-# ── Client class ───────────────────────────────────────────────────────────────
+# ── lazy xarray import ─────────────────────────────────────────────────────────
 
 
-def _make_client(base_url: str = "http://localhost") -> tuple[Client, MagicMock]:
-    """Return a Client with a mocked internal httpx.Client."""
-    client = Client(base_url)
+def test_open_zarr_without_xarray_raises_helpful_error() -> None:
+    from open_climate_service.client import _open_zarr
+
+    # Simulate xarray not being installed (the base client has no xarray).
+    with patch("open_climate_service.client.importlib.util.find_spec", return_value=None):
+        with pytest.raises(ModuleNotFoundError, match=r"open-climate-service\[xarray\]"):
+            _open_zarr("s3://bucket/x.zarr", {})
+
+
+# ── ClimateService class ───────────────────────────────────────────────────────
+
+
+def _make_service(base_url: str = "http://localhost") -> tuple[ClimateService, MagicMock]:
+    """Return a ClimateService with a mocked internal httpx.Client."""
+    service = ClimateService(base_url)
     mock_http = MagicMock()
-    client._http = mock_http
-    return client, mock_http
+    service._http = mock_http
+    return service, mock_http
 
 
-def test_client_catalog_uses_persistent_http_session() -> None:
+def test_client_is_backwards_compatible_alias() -> None:
+    assert Client is ClimateService
+
+
+def test_catalog_is_alias_of_datasets() -> None:
+    assert ClimateService.catalog is ClimateService.datasets
+
+
+def test_open_is_alias_of_open_dataset() -> None:
+    assert ClimateService.open is ClimateService.open_dataset
+
+
+def test_datasets_uses_persistent_http_session() -> None:
     catalog = _make_catalog(["http://localhost/stac/collections/chirps3_precipitation_daily_rwa"])
-    client, mock_http = _make_client()
+    service, mock_http = _make_service()
     mock_http.get.return_value = _make_response(catalog)
 
-    result = client.catalog()
+    result = service.datasets()
 
     mock_http.get.assert_called_once_with("http://localhost/stac/catalog.json")
     assert len(result) == 1
@@ -162,7 +200,7 @@ def test_client_catalog_uses_persistent_http_session() -> None:
     assert result[0]["id"] == "chirps3_precipitation_daily_rwa"
 
 
-def test_client_open_uses_persistent_http_session(tmp_path: Path) -> None:
+def test_open_dataset_uses_persistent_http_session(tmp_path: Path) -> None:
     zarr_path = tmp_path / "test.zarr"
     ds = xr.Dataset(
         {"precip": (["time", "latitude", "longitude"], np.ones((2, 3, 3), dtype="float32"))},
@@ -174,10 +212,10 @@ def test_client_open_uses_persistent_http_session(tmp_path: Path) -> None:
     )
     ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
 
-    client, mock_http = _make_client()
+    service, mock_http = _make_service()
     mock_http.get.return_value = _make_response(_make_collection(str(zarr_path)))
 
-    result = client.open("chirps3_precipitation_daily_rwa")
+    result = service.open_dataset("chirps3_precipitation_daily_rwa")
     try:
         assert "precip" in result.data_vars
         assert result.sizes["time"] == 2
@@ -187,22 +225,88 @@ def test_client_open_uses_persistent_http_session(tmp_path: Path) -> None:
     mock_http.get.assert_called_once_with("http://localhost/stac/collections/chirps3_precipitation_daily_rwa")
 
 
-def test_client_context_manager_closes_http_session() -> None:
-    with Client("http://localhost") as client:
+def test_processes_returns_process_list() -> None:
+    service, mock_http = _make_service()
+    mock_http.get.return_value = _make_response({"processes": [{"id": "mean"}, {"id": "sum"}], "links": []})
+
+    result = service.processes()
+
+    mock_http.get.assert_called_once_with("http://localhost/processes")
+    assert [p["id"] for p in result] == ["mean", "sum"]
+
+
+def test_workflows_returns_workflow_list() -> None:
+    service, mock_http = _make_service()
+    mock_http.get.return_value = _make_response({"processes": [{"id": "aggregate_to_dhis2_org_units"}], "links": []})
+
+    result = service.workflows()
+
+    mock_http.get.assert_called_once_with("http://localhost/process_graphs")
+    assert result[0]["id"] == "aggregate_to_dhis2_org_units"
+
+
+def test_execute_returns_json_for_json_result() -> None:
+    service, mock_http = _make_service()
+    payload = {"dataValues": [{"orgUnit": "OU_A", "period": "202501", "value": "1.0"}]}
+    mock_http.post.return_value = _make_response(payload, content_type="application/json")
+
+    graph = {"agg": {"process_id": "aggregate_to_dhis2_org_units", "arguments": {}, "result": True}}
+    result = service.execute(graph)
+
+    args, kwargs = mock_http.post.call_args
+    assert args[0] == "http://localhost/result"
+    assert kwargs["json"] == {"process": {"process_graph": graph}}
+    assert result == payload
+
+
+def test_execute_unwraps_process_graph_key() -> None:
+    service, mock_http = _make_service()
+    mock_http.post.return_value = _make_response({"ok": True})
+
+    nodes = {"agg": {"process_id": "x", "arguments": {}, "result": True}}
+    service.execute({"process_graph": nodes})
+
+    _, kwargs = mock_http.post.call_args
+    assert kwargs["json"] == {"process": {"process_graph": nodes}}
+
+
+def test_execute_returns_bytes_for_file_result() -> None:
+    service, mock_http = _make_service()
+    csv = b"time_period,location,hotspot\n202501,OU_A,0.1\n"
+    mock_http.post.return_value = _make_response(content=csv, content_type="text/csv")
+
+    result = service.execute({"r": {"process_id": "x", "result": True}})
+    assert result == csv
+
+
+def test_execute_writes_file_result_to_path(tmp_path: Path) -> None:
+    service, mock_http = _make_service()
+    csv = b"a,b\n1,2\n"
+    mock_http.post.return_value = _make_response(content=csv, content_type="text/csv")
+
+    out = tmp_path / "result.csv"
+    result = service.execute({"r": {"process_id": "x", "result": True}}, path=out)
+
+    assert result == out
+    assert out.read_bytes() == csv
+
+
+def test_context_manager_closes_http_session() -> None:
+    with ClimateService("http://localhost") as service:
         mock_http = MagicMock()
-        client._http = mock_http
+        service._http = mock_http
 
     mock_http.close.assert_called_once()
 
 
-def test_client_accepts_custom_timeout() -> None:
+def test_accepts_custom_timeout() -> None:
     with patch("open_climate_service.client.httpx.Client") as mock_cls:
-        Client("http://localhost", timeout=60)
+        ClimateService("http://localhost", timeout=60)
     mock_cls.assert_called_once_with(timeout=60)
 
 
-def test_client_strips_trailing_slash() -> None:
-    client, mock_http = _make_client("http://localhost/")
+def test_strips_trailing_slash() -> None:
+    service, mock_http = _make_service("http://localhost/")
     mock_http.get.return_value = _make_response(_make_catalog(["http://localhost/stac/collections/ds"]))
-    client.catalog()
+    service.datasets()
     mock_http.get.assert_called_once_with("http://localhost/stac/catalog.json")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,6 @@ import pytest
 import xarray as xr
 
 from open_climate_service.client import (
-    Client,
     ClimateService,
     _id_from_href,
     list_datasets,
@@ -173,18 +172,6 @@ def _make_service(base_url: str = "http://localhost") -> tuple[ClimateService, M
     mock_http = MagicMock()
     service._http = mock_http
     return service, mock_http
-
-
-def test_client_is_backwards_compatible_alias() -> None:
-    assert Client is ClimateService
-
-
-def test_catalog_is_alias_of_datasets() -> None:
-    assert ClimateService.catalog is ClimateService.datasets
-
-
-def test_open_is_alias_of_open_dataset() -> None:
-    assert ClimateService.open is ClimateService.open_dataset
 
 
 def test_datasets_uses_persistent_http_session() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1831,26 +1831,37 @@ name = "open-climate-service"
 version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
+    { name = "pystac" },
+]
+
+[package.optional-dependencies]
+server = [
     { name = "dhis2eo" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
     { name = "geozarr-toolkit" },
-    { name = "httpx" },
     { name = "icechunk" },
     { name = "jinja2" },
     { name = "metpy" },
     { name = "openeo-pg-parser-networkx" },
     { name = "openeo-processes-dask-slim", extra = ["implementations"] },
     { name = "portalocker" },
-    { name = "pystac" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rioxarray" },
     { name = "starlette" },
     { name = "topozarr" },
     { name = "uvicorn" },
+    { name = "xarray" },
     { name = "xclim" },
     { name = "xstac" },
+    { name = "zarr" },
+]
+xarray = [
+    { name = "aiohttp" },
+    { name = "fsspec" },
+    { name = "xarray" },
     { name = "zarr" },
 ]
 
@@ -1868,28 +1879,34 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dhis2eo", specifier = ">=1.2.1" },
-    { name = "fastapi", specifier = ">=0.100.0" },
-    { name = "geojson-pydantic", specifier = ">=2.1.0" },
-    { name = "geozarr-toolkit", specifier = "==0.1.*" },
+    { name = "aiohttp", marker = "extra == 'xarray'", specifier = ">=3.10" },
+    { name = "dhis2eo", marker = "extra == 'server'", specifier = ">=1.2.1" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0" },
+    { name = "fsspec", marker = "extra == 'xarray'", specifier = ">=2024.6.0" },
+    { name = "geojson-pydantic", marker = "extra == 'server'", specifier = ">=2.1.0" },
+    { name = "geozarr-toolkit", marker = "extra == 'server'", specifier = "==0.1.*" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "icechunk", specifier = ">=2.0,<3" },
-    { name = "jinja2", specifier = ">=3.1" },
-    { name = "metpy", specifier = ">=1.7,<2" },
-    { name = "openeo-pg-parser-networkx", specifier = ">=2026.3.3" },
-    { name = "openeo-processes-dask-slim", extras = ["implementations"], git = "https://github.com/dhis2/openeo-processes-dask-slim?branch=main" },
-    { name = "portalocker", specifier = ">=3.2.0" },
+    { name = "icechunk", marker = "extra == 'server'", specifier = ">=2.0,<3" },
+    { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1" },
+    { name = "metpy", marker = "extra == 'server'", specifier = ">=1.7,<2" },
+    { name = "openeo-pg-parser-networkx", marker = "extra == 'server'", specifier = ">=2026.3.3" },
+    { name = "openeo-processes-dask-slim", extras = ["implementations"], marker = "extra == 'server'", git = "https://github.com/dhis2/openeo-processes-dask-slim?branch=main" },
+    { name = "portalocker", marker = "extra == 'server'", specifier = ">=3.2.0" },
     { name = "pystac", specifier = ">=1.10,<2" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "python-multipart", specifier = ">=0.0.29" },
-    { name = "rioxarray", specifier = ">=0.17" },
-    { name = "starlette", specifier = ">=0.27.0" },
-    { name = "topozarr", specifier = "==0.0.*" },
-    { name = "uvicorn", specifier = ">=0.41.0" },
-    { name = "xclim", specifier = ">=0.61.1" },
-    { name = "xstac", specifier = ">=1.0,<2" },
-    { name = "zarr", specifier = ">=3.1.6,<4" },
+    { name = "python-dotenv", marker = "extra == 'server'", specifier = ">=1.0.1" },
+    { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.29" },
+    { name = "rioxarray", marker = "extra == 'server'", specifier = ">=0.17" },
+    { name = "starlette", marker = "extra == 'server'", specifier = ">=0.27.0" },
+    { name = "topozarr", marker = "extra == 'server'", specifier = "==0.0.*" },
+    { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.41.0" },
+    { name = "xarray", marker = "extra == 'server'", specifier = ">=2025.12.0" },
+    { name = "xarray", marker = "extra == 'xarray'", specifier = ">=2025.12.0" },
+    { name = "xclim", marker = "extra == 'server'", specifier = ">=0.61.1" },
+    { name = "xstac", marker = "extra == 'server'", specifier = ">=1.0,<2" },
+    { name = "zarr", marker = "extra == 'server'", specifier = ">=3.1.6,<4" },
+    { name = "zarr", marker = "extra == 'xarray'", specifier = ">=3.1.6,<4" },
 ]
+provides-extras = ["xarray", "server"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #181.

## What changed

Installing `open-climate-service` no longer pulls in the full server stack. The base install is a **lightweight client** (`httpx` + `pystac` only); the server stack and the xarray data-opening path are **optional extras**:

```bash
pip install open-climate-service            # client only — talk to an instance over HTTP
pip install open-climate-service[xarray]    # + open published datasets as xarray
pip install open-climate-service[server]    # full server stack — run your own instance
```

### Dependencies (`pyproject.toml`)
- Base `dependencies` → just `httpx` + `pystac`.
- New `[xarray]` extra → `xarray`, `zarr`, `fsspec`, `aiohttp` (open the remote Zarr advertised in a dataset's STAC collection).
- New `[server]` extra → everything previously in `dependencies` (FastAPI, uvicorn, rioxarray, icechunk, openeo-*, xclim, …).

### Client (`client.py`)
- Renamed `Client` → **`ClimateService`** (the issue's `ClimateClient` was the pre-existing `Client`). `Client` is kept as a back-compat alias, and `catalog()`/`open()` remain as aliases of `datasets()`/`open_dataset()`.
- **No server-only or xarray imports at module top level.** `open_dataset` lazily checks for xarray via `importlib.util.find_spec` and raises a clear, actionable error pointing to the `[xarray]` extra when it's missing.
- Re-exported from the package root: `from open_climate_service import ClimateService`.

### Thinking ahead to the DHIS2 Climate Tools notebooks
The issue is a refactor, but since the client is meant to be the entry point for the planned [Climate Tools](https://climate-tools.dhis2.org/) notebooks (load GeoZarr, run workflows, push to DHIS2, integrate with Chap), I built it into a small but complete REST surface — all `httpx`-only, so it works in the base install:

| Method | Endpoint | Notebook use |
|---|---|---|
| `datasets()` | `GET /stac/catalog.json` | discover published collections |
| `open_dataset(id)` | STAC + remote Zarr | load GeoZarr as xarray (`[xarray]` extra) |
| `processes()` | `GET /processes` | discover standard openEO processes |
| `workflows()` | `GET /process_graphs` | discover reusable workflows (e.g. `aggregate_to_dhis2_org_units`) |
| `execute(process_graph, *, path=None)` | `POST /result` | run a workflow synchronously |

`execute()` returns a **dict** for JSON results (e.g. a DHIS2 `dataValueSet` from `format: "DHIS2JSON"` — ready to POST to DHIS2) and **bytes** (or a written file) for CSV/GeoJSON/GeoTIFF. So a notebook cell can go dataset → aggregate → DHIS2 JSON → push, or → CHAP CSV → Chap, with just the base client.

```python
from open_climate_service import ClimateService

service = ClimateService("https://rwanda.climate.dhis2.org")
service.workflows()                          # what can I run?
data_value_set = service.execute({           # run it; get DHIS2 JSON back
    "agg": {"process_id": "aggregate_to_dhis2_org_units",
            "arguments": {...}, "result": True}
})
```

(DHIS2-push / Chap helpers are intentionally left to the notebooks — they target a DHIS2/Chap instance, not OCS, and need credentials. The client gives them the exact payloads they need.)

### Dev / CI / Docker
Because server deps moved to an extra, the dev and build environments now request them explicitly:
- `make sync` and `ci.yml` → `uv sync --all-extras`
- `docker.yml` and `Dockerfile` → `uv sync --extra server`

### Docs / examples
README, `docs/user_guide.md`, and both client examples updated to `ClimateService` and the install paths.

## Verification
- **Minimal-install acceptance test**: a fresh venv with *only* `httpx` + `pystac` imports `ClimateService`, uses it, and pulls in **no** xarray/server modules (asserted against `sys.modules`); `open_dataset` raises the `[xarray]`-extra hint.
- `make lint` clean (ruff + mypy + pyright); full suite **388 passed, 1 skipped**.
- 25 client tests cover the rename, aliases, lazy-xarray error, and the new `processes()`/`workflows()`/`execute()` (JSON, bytes, and file-to-path) paths.

## Note
`fsspec`/`aiohttp` are included in the `[xarray]` extra so `xr.open_zarr` can read a remote store over HTTP; opening remote stores isn't exercised by unit tests (they use local Zarr), so that combination is best validated against a live instance in the upcoming notebooks.
