### PR TITLE
docs: note recommended server install paths (uv/Docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ pip install open-climate-service[xarray]    # + open published datasets as xarra
 pip install open-climate-service[server]    # full server stack — run your own instance
 ```
 
+> **Running a server?** The recommended ways to run an instance are **uv** or **Docker** — see [Run a server](#run-a-server) and the [setup guide](https://dhis2.github.io/open-climate-service/setup_guide/). The `[server]` extra installs with `pip` on Linux x86-64; on macOS or ARM, use uv or Docker. The client and `[xarray]` extras work on any platform.
+
 ## Quick start (client)
 
 ```python


### PR DESCRIPTION
Per the 0.1.0 release plan (option a — ship now), clarify the install paths in the README.

The base **client** and **`[xarray]`** extras install via `pip` on any platform. The **`[server]`** extra transitively pulls `rqadeforestation`, whose only wheel bundles a **Linux x86-64** `.so` — so `pip install …[server]` works on Linux x86-64 but fails to load on macOS/ARM. The recommended server paths (uv / Docker, per the setup guide) use the dhis2 `openeo-processes-dask-slim` fork, which drops that dependency and works everywhere.

Adds a short note under the install block pointing server users to uv/Docker, so the README is accurate the moment 0.1.0 is on PyPI. Docs-only.

See #246 for the underlying dependency item.