### PR TITLE
fix(openeo): preserve merged cube names in CHAP CSV exports

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -86,6 +86,40 @@ def _make_sorted_atp(original_fn: Any) -> Any:
     return _sorted_atp
 
 
+def _make_named_merge_cubes(original_fn: Any) -> Any:
+    """Wrap merge_cubes to preserve DataArray names as dataset variables when possible.
+
+    The upstream implementation stacks two named DataArrays onto a synthetic
+    ``__cubes__`` dimension. That loses semantic variable names like ``tp`` and
+    ``t2m``, which then forces downstream CHAPCSV export to relabel ``cube1`` /
+    ``cube2`` manually. When both inputs are named DataArrays with distinct names,
+    we can preserve the richer structure by merging them into a Dataset directly.
+
+    Fall back to the upstream implementation for unnamed arrays, colliding names,
+    or any merge/alignment shape we cannot represent safely as a Dataset.
+    """
+
+    def _named_merge_cubes(cube1: Any, cube2: Any, **kwargs: Any) -> Any:
+        if (
+            isinstance(cube1, xr.DataArray)
+            and isinstance(cube2, xr.DataArray)
+            and cube1.name
+            and cube2.name
+            and cube1.name != cube2.name
+        ):
+            try:
+                return xr.merge(
+                    [cube1.to_dataset(name=str(cube1.name)), cube2.to_dataset(name=str(cube2.name))],
+                    join="exact",
+                    compat="override",
+                )
+            except Exception:
+                pass
+        return original_fn(cube1=cube1, cube2=cube2, **kwargs)
+
+    return _named_merge_cubes
+
+
 def _build_process_registry() -> Any:
     """Build the base process registry (lazy-initialised singleton).
 
@@ -115,6 +149,10 @@ def _build_process_registry() -> Any:
     registry["aggregate_temporal_period"] = Process(
         spec=getattr(specs_module, "aggregate_temporal_period", {}),
         implementation=_make_sorted_atp(impls_module.aggregate_temporal_period),
+    )
+    registry["merge_cubes"] = Process(
+        spec=getattr(specs_module, "merge_cubes", {}),
+        implementation=_make_named_merge_cubes(impls_module.merge_cubes),
     )
 
     # @process-decorated plugin functions — override standard processes with same id.

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -87,35 +87,31 @@ def _make_sorted_atp(original_fn: Any) -> Any:
 
 
 def _make_named_merge_cubes(original_fn: Any) -> Any:
-    """Wrap merge_cubes to preserve DataArray names as dataset variables when possible.
+    """Wrap merge_cubes to preserve DataArray names on the ``__cubes__`` axis.
 
-    The upstream implementation stacks two named DataArrays onto a synthetic
-    ``__cubes__`` dimension. That loses semantic variable names like ``tp`` and
-    ``t2m``, which then forces downstream CHAPCSV export to relabel ``cube1`` /
-    ``cube2`` manually. When both inputs are named DataArrays with distinct names,
-    we can preserve the richer structure by merging them into a Dataset directly.
-
-    Fall back to the upstream implementation for unnamed arrays, colliding names,
-    or any merge/alignment shape we cannot represent safely as a Dataset.
+    The upstream implementation returns a DataArray stacked on a synthetic
+    ``__cubes__`` dimension with labels like ``cube1`` / ``cube2``. That loses
+    semantic source names like ``tp`` and ``t2m``. Keep the upstream return type
+    unchanged, but relabel ``__cubes__`` to the original DataArray names when
+    both inputs are named and distinct.
     """
 
     def _named_merge_cubes(cube1: Any, cube2: Any, **kwargs: Any) -> Any:
+        merged = original_fn(cube1=cube1, cube2=cube2, **kwargs)
         if (
             isinstance(cube1, xr.DataArray)
             and isinstance(cube2, xr.DataArray)
             and cube1.name
             and cube2.name
             and cube1.name != cube2.name
+            and isinstance(merged, xr.DataArray)
+            and "__cubes__" in merged.dims
         ):
             try:
-                return xr.merge(
-                    [cube1.to_dataset(name=str(cube1.name)), cube2.to_dataset(name=str(cube2.name))],
-                    join="exact",
-                    compat="override",
-                )
-            except Exception:
-                pass
-        return original_fn(cube1=cube1, cube2=cube2, **kwargs)
+                return merged.assign_coords(__cubes__=[str(cube1.name), str(cube2.name)])
+            except Exception as exc:
+                logger.debug("Falling back to default __cubes__ labels after merge_cubes", exc_info=exc)
+        return merged
 
     return _named_merge_cubes
 

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -1004,9 +1004,9 @@ def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
             if not isinstance(cube_labels_raw, dict):
                 raise ValueError("CHAPCSV option 'cube_labels' must be an object mapping cube ids to output columns")
             rename_map: dict[str, str] = {}
-            for raw_key, raw_value in cube_labels_raw.items():
+            for raw_key, label_value in cube_labels_raw.items():
                 key = str(raw_key).strip()
-                value = str(raw_value).strip()
+                value = str(label_value).strip()
                 if not key or not value:
                     raise ValueError("CHAPCSV option 'cube_labels' must map non-empty cube ids to non-empty labels")
                 rename_map[key] = value
@@ -1027,8 +1027,8 @@ def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
             "location": str(location),
         }
         for value_field in value_fields:
-            value = record.get(value_field)
-            row[value_field] = "" if _is_nullish(value) else _to_dhis2_value_string(value)
+            raw_value: Any | None = record.get(value_field)
+            row[value_field] = "" if _is_nullish(raw_value) else _to_dhis2_value_string(raw_value)
         rows.append(row)
 
     return pd.DataFrame(rows, columns=["time_period", "location", *value_fields])

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -958,6 +958,7 @@ def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
     period_field = _optional_str_option(options, "period_field") or "t"
     location_field = _optional_str_option(options, "location_field") or "geometry"
     period_type = _optional_str_option(options, "period_type")
+    cube_labels_raw = options.get("cube_labels")
 
     frame = pd.DataFrame(df).copy()
     if location_field not in frame.columns:
@@ -969,6 +970,47 @@ def _build_chap_csv_frame(df: Any, options: dict[str, Any]) -> Any:
         raise ValueError(f"Missing location field '{location_field}' in aggregated result")
     if period_field not in frame.columns:
         raise ValueError(f"Missing period field '{period_field}' in aggregated result")
+
+    # merge_cubes produces a single value column plus a synthetic "__cubes__"
+    # label dimension. Pivot that long form to one CHAP value column per cube.
+    if "__cubes__" in frame.columns:
+        cube_field = "__cubes__"
+        non_value_fields = {
+            location_field,
+            period_field,
+            cube_field,
+            "geometry",
+            "spatial_ref",
+            "index",
+            "band",
+            "bands",
+        }
+        candidate_value_fields = [
+            str(c) for c in frame.columns if c not in non_value_fields and not str(c).startswith("level_")
+        ]
+        if len(candidate_value_fields) != 1:
+            raise ValueError(
+                "CHAPCSV export with merged cubes requires exactly one value column before pivoting; "
+                f"found {candidate_value_fields}"
+            )
+        value_field = candidate_value_fields[0]
+        frame = (
+            frame[[period_field, location_field, cube_field, value_field]]
+            .pivot(index=[period_field, location_field], columns=cube_field, values=value_field)
+            .reset_index()
+        )
+        frame.columns.name = None
+        if cube_labels_raw is not None:
+            if not isinstance(cube_labels_raw, dict):
+                raise ValueError("CHAPCSV option 'cube_labels' must be an object mapping cube ids to output columns")
+            rename_map: dict[str, str] = {}
+            for raw_key, raw_value in cube_labels_raw.items():
+                key = str(raw_key).strip()
+                value = str(raw_value).strip()
+                if not key or not value:
+                    raise ValueError("CHAPCSV option 'cube_labels' must map non-empty cube ids to non-empty labels")
+                rename_map[key] = value
+            frame = frame.rename(columns=rename_map)
 
     value_fields = _select_chap_value_fields(frame, location_field, period_field)
     rows: list[dict[str, str]] = []
@@ -996,6 +1038,7 @@ def _select_chap_value_fields(frame: Any, location_field: str, period_field: str
     excluded = {
         location_field,
         period_field,
+        "__cubes__",
         "geometry",
         "spatial_ref",
         "index",

--- a/open_climate_service/plugins/processes/aggregate_spatial.py
+++ b/open_climate_service/plugins/processes/aggregate_spatial.py
@@ -70,7 +70,6 @@ def _dataset_reduce_spatial(
     reducer: Callable,
     y_dim: str,
     x_dim: str,
-    t_dim: str | None,
     context: Any = None,
 ) -> xr.Dataset:
     """Apply spatial mask and reducer to each variable in a Dataset.
@@ -139,7 +138,6 @@ def aggregate_spatial(
 
     x_dim = _find_dim(data, ["x", "longitude", "lon"])
     y_dim = _find_dim(data, ["y", "latitude", "lat"])
-    t_dim = _find_dim(data, ["t", "time"])
     if x_dim is None or y_dim is None:
         raise ValueError(f"aggregate_spatial: cannot identify x/y dimensions in {list(data.dims)}")
 
@@ -170,7 +168,7 @@ def aggregate_spatial(
         if height > 1 and float(y_coords[1]) > float(y_coords[0]):
             mask = mask[::-1]
 
-        geom_ds = _dataset_reduce_spatial(data, mask, reducer, y_dim, x_dim, t_dim, context)
+        geom_ds = _dataset_reduce_spatial(data, mask, reducer, y_dim, x_dim, context)
         results.append(geom_ds)
 
     combined = xr.concat(results, dim=geom_dim)

--- a/open_climate_service/plugins/processes/aggregate_spatial.py
+++ b/open_climate_service/plugins/processes/aggregate_spatial.py
@@ -75,8 +75,8 @@ def _dataset_reduce_spatial(
 ) -> xr.Dataset:
     """Apply spatial mask and reducer to each variable in a Dataset.
 
-    Iterates over time steps so the reducer receives a 1-D array of pixel values
-    (matching the OpenEO reducer contract: array-in, scalar-out).
+    Reduces only over the spatial dimensions while preserving any other dimensions
+    (e.g. time or ``merge_cubes``' synthetic ``__cubes__`` dimension).
 
     Pixels are selected by boolean-indexing the raw arrays with ``mask`` directly
     rather than materialising ``ds.where(mask)`` — the latter allocates a full
@@ -88,40 +88,22 @@ def _dataset_reduce_spatial(
         # Only floating arrays can carry NaN; np.isnan raises on integer dtypes.
         return pixels[~np.isnan(pixels)] if np.issubdtype(pixels.dtype, np.floating) else pixels
 
-    if t_dim is None or t_dim not in ds.dims:
-        # No temporal dimension — reduce directly
-        result_vars: dict[str, Any] = {}
-        for var in ds.data_vars:
-            vname = str(var)
-            pixels = _drop_nan(ds[vname].values[mask])
-            result_vars[vname] = xr.DataArray(reduce(pixels))
-        return xr.Dataset(result_vars)
-
-    t_vals = ds[t_dim].values
-    var_names = [str(v) for v in ds.data_vars]
-
-    # Pre-extract numpy arrays with the time axis first so each time step is a
-    # simple row index rather than an xarray label lookup (O(1) vs O(log N)).
     mask_flat = mask.ravel()
-    var_arrs: dict[str, np.ndarray] = {}
-    for vname in var_names:
-        arr = ds[vname].values
-        t_axis = list(ds[vname].dims).index(t_dim)
-        if t_axis != 0:
-            arr = np.moveaxis(arr, t_axis, 0)
-        var_arrs[vname] = arr.reshape(len(t_vals), -1)
-
-    rows: list[dict[str, float]] = []
-    for t_idx in range(len(t_vals)):
-        row: dict[str, float] = {}
-        for vname in var_names:
-            pixels = _drop_nan(var_arrs[vname][t_idx][mask_flat])
-            row[vname] = reduce(pixels)
-        rows.append(row)
-
-    return xr.Dataset(
-        {v: xr.DataArray([row[v] for row in rows], coords={t_dim: t_vals}, dims=[t_dim]) for v in var_names}
-    )
+    result_vars: dict[str, Any] = {}
+    for var in ds.data_vars:
+        vname = str(var)
+        da = ds[vname]
+        remaining_dims = [d for d in da.dims if d not in {y_dim, x_dim}]
+        arr = da.transpose(*remaining_dims, y_dim, x_dim).values
+        arr = arr.reshape((-1, mask_flat.size))
+        reduced = [reduce(_drop_nan(pixels[mask_flat])) for pixels in arr]
+        if remaining_dims:
+            coords = {d: da.coords[d].values for d in remaining_dims if d in da.coords}
+            shape = tuple(int(da.sizes[d]) for d in remaining_dims)
+            result_vars[vname] = xr.DataArray(np.array(reduced).reshape(shape), coords=coords, dims=remaining_dims)
+        else:
+            result_vars[vname] = xr.DataArray(reduced[0])
+    return xr.Dataset(result_vars)
 
 
 @process(

--- a/tests/test_aggregate_spatial.py
+++ b/tests/test_aggregate_spatial.py
@@ -108,6 +108,17 @@ def test_aggregate_spatial_with_time_dimension() -> None:
     np.testing.assert_allclose(out["v"].isel(geometry=0).values, [5.5, 105.5])
 
 
+def test_aggregate_spatial_preserves_non_spatial_dimensions() -> None:
+    cube1 = xr.concat([_grid(y_ascending=True), _grid(y_ascending=True) + 100], dim="t").assign_coords(t=[0, 1])
+    cube2 = cube1 + 1000
+    merged = xr.concat([cube1, cube2], dim="__cubes__").assign_coords(__cubes__=["cube1", "cube2"])
+    out = aggregate_spatial(merged, _box(-0.4, -0.4, 1.4, 1.4), _mean)
+    assert list(out["__cubes__"].values) == ["cube1", "cube2"]
+    assert list(out["t"].values) == [0, 1]
+    np.testing.assert_allclose(out["v"].sel(__cubes__="cube1", geometry="0").values, [5.5, 105.5])
+    np.testing.assert_allclose(out["v"].sel(__cubes__="cube2", geometry="0").values, [1005.5, 1105.5])
+
+
 def test_aggregate_spatial_multiple_geometries_labelled() -> None:
     da = _grid(y_ascending=True)
     fc = {

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -932,6 +932,59 @@ def test_build_chap_csv_frame_requires_at_least_one_value_column() -> None:
         )
 
 
+def test_build_chap_csv_frame_pivots_merged_cubes_wide() -> None:
+    frame = _build_chap_csv_frame(
+        [
+            {"t": "2024-01-01", "geometry": "OU_1", "__cubes__": "cube1", "tp": 1.5},
+            {"t": "2024-01-01", "geometry": "OU_1", "__cubes__": "cube2", "tp": 2.5},
+            {"t": "2024-02-01", "geometry": "OU_1", "__cubes__": "cube1", "tp": 3.5},
+            {"t": "2024-02-01", "geometry": "OU_1", "__cubes__": "cube2", "tp": 4.5},
+        ],
+        {"period_type": "monthly"},
+    )
+    assert list(frame.columns) == ["time_period", "location", "cube1", "cube2"]
+    assert frame.to_dict(orient="records") == [
+        {"time_period": "202401", "location": "OU_1", "cube1": "1.5", "cube2": "2.5"},
+        {"time_period": "202402", "location": "OU_1", "cube1": "3.5", "cube2": "4.5"},
+    ]
+
+
+def test_build_chap_csv_frame_renames_merged_cubes_with_explicit_labels() -> None:
+    frame = _build_chap_csv_frame(
+        [
+            {"t": "2024-01-01", "geometry": "OU_1", "__cubes__": "cube1", "tp": 1.5},
+            {"t": "2024-01-01", "geometry": "OU_1", "__cubes__": "cube2", "tp": 2.5},
+        ],
+        {"period_type": "monthly", "cube_labels": {"cube1": "tp", "cube2": "t2m"}},
+    )
+    assert list(frame.columns) == ["time_period", "location", "tp", "t2m"]
+    assert frame.to_dict(orient="records") == [
+        {"time_period": "202401", "location": "OU_1", "tp": "1.5", "t2m": "2.5"},
+    ]
+
+
+def test_merge_cubes_wrapper_preserves_named_dataarrays_as_dataset() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    reg = _build_process_registry()
+    merge = reg["merge_cubes"].implementation
+    cube1 = xr.DataArray(
+        np.ones((2, 2, 2), dtype=np.float32),
+        dims=("t", "y", "x"),
+        coords={"t": [0, 1], "y": [0, 1], "x": [0, 1]},
+        name="tp",
+    )
+    cube2 = xr.DataArray(
+        np.full((2, 2, 2), 2.0, dtype=np.float32),
+        dims=("t", "y", "x"),
+        coords={"t": [0, 1], "y": [0, 1], "x": [0, 1]},
+        name="t2m",
+    )
+    merged = merge(cube1=cube1, cube2=cube2)
+    assert isinstance(merged, xr.Dataset)
+    assert list(merged.data_vars) == ["tp", "t2m"]
+
+
 def test_dhis2_period_string_accepts_existing_monthly_string() -> None:
     assert _to_dhis2_period_string("202401") == "202401"
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -963,7 +963,7 @@ def test_build_chap_csv_frame_renames_merged_cubes_with_explicit_labels() -> Non
     ]
 
 
-def test_merge_cubes_wrapper_preserves_named_dataarrays_as_dataset() -> None:
+def test_merge_cubes_wrapper_preserves_named_dataarrays_on_cube_axis() -> None:
     from open_climate_service.openeo.execution import _build_process_registry
 
     reg = _build_process_registry()
@@ -981,8 +981,9 @@ def test_merge_cubes_wrapper_preserves_named_dataarrays_as_dataset() -> None:
         name="t2m",
     )
     merged = merge(cube1=cube1, cube2=cube2)
-    assert isinstance(merged, xr.Dataset)
-    assert list(merged.data_vars) == ["tp", "t2m"]
+    assert isinstance(merged, xr.DataArray)
+    assert "__cubes__" in merged.dims
+    assert list(merged["__cubes__"].values) == ["tp", "t2m"]
 
 
 def test_dhis2_period_string_accepts_existing_monthly_string() -> None:


### PR DESCRIPTION
## What

Fixes the multi-variable openEO `CHAPCSV` export path.

This patch:
- keeps `merge_cubes` on its normal upstream return type
- preserves source names on the synthetic `__cubes__` coordinate when possible
- updates `aggregate_spatial` to reduce only over spatial dimensions while preserving non-spatial ones
- keeps support for explicit CHAP-facing renaming via `cube_labels`

## Why

A graph like:

`load_collection -> merge_cubes -> aggregate_spatial -> save_result(format="CHAPCSV")`

was failing for aligned multi-variable datasets because `merge_cubes` introduced a synthetic `__cubes__` dimension and `aggregate_spatial` flattened that dimension into the spatial mask axis.

This change fixes that path without changing the broader cube contract used by standard downstream processes.

Naming behavior is now:
- preserve native source names when `merge_cubes` can keep aligned cubes on the `__cubes__` axis
- allow explicit semantic labels when needed via `cube_labels`

For cross-dataset cases where cubes do not align exactly, the fallback path still applies, so `cube_labels` remains the way to control output column names for CHAP.

## Validation

Manual validation on a running SLE-scoped local instance:
- single-dataset `DHIS2JSON`: passed
- single-dataset `CHAPCSV`: passed
- multi-dataset `CHAPCSV` with precipitation + temperature: passed after fix