### PR TITLE
fix: fail clearly when load_collection temporal_extent selects no data

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -278,11 +278,26 @@ def _load_collection_impl(
         end = t_extent[1] if len(t_extent) > 1 else None
         try:
             t_dim = get_time_dim(ds)
+            available = ds[t_dim].values
             ds = ds.sel({t_dim: slice(start, end)})
         except (ValueError, KeyError):
             # ValueError: no recognisable time dimension
             # KeyError: coordinate exists but is not an indexable dimension
             pass
+        else:
+            # An empty temporal selection would otherwise flow into downstream
+            # reducers (reduce_dimension, aggregate_*) as a zero-length cube and
+            # surface as a cryptic "ndim=0" / "zero-size array" / broadcast error.
+            # Fail early here, where we can name the dataset and its coverage.
+            if ds.sizes.get(t_dim, 0) == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"load_collection: dataset '{id}' has no data in the requested "
+                        f"temporal_extent [{start}, {end}]. Available time coverage: "
+                        f"{_format_time_coverage(available)}."
+                    ),
+                )
 
     if bbox is not None:
         x_dim = next((d for d in ("x", "longitude") if d in ds.dims), None)
@@ -338,6 +353,27 @@ def _save_result_impl(data: Any, format: str = "Zarr", options: dict[str, Any] |
 # ---------------------------------------------------------------------------
 # Internal helpers shared with _load_collection_impl
 # ---------------------------------------------------------------------------
+
+
+def _format_time_coverage(values: Any) -> str:
+    """Human-readable summary of a time coordinate's coverage for error messages."""
+    import numpy as np
+
+    vals = np.asarray(values).ravel()
+    n = int(vals.size)
+    if n == 0:
+        return "no timesteps"
+
+    def _fmt(v: Any) -> str:
+        try:
+            return str(np.datetime_as_string(v, unit="D"))
+        except (TypeError, ValueError):
+            return str(v)
+
+    step_word = "step" if n == 1 else "steps"
+    if n == 1:
+        return f"{_fmt(vals[0])} ({n} {step_word})"
+    return f"{_fmt(vals.min())} to {_fmt(vals.max())} ({n} {step_word})"
 
 
 def _get_published_artifact(collection_id: str) -> Any:

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -278,7 +278,10 @@ def _load_collection_impl(
         end = t_extent[1] if len(t_extent) > 1 else None
         try:
             t_dim = get_time_dim(ds)
-            available = ds[t_dim].values
+            # Keep a lazy handle to the original time coordinate; only materialise
+            # it (in the empty-selection branch below) so valid requests don't pay
+            # to load the full coordinate on every call.
+            available_coord = ds[t_dim]
             ds = ds.sel({t_dim: slice(start, end)})
         except (ValueError, KeyError):
             # ValueError: no recognisable time dimension
@@ -295,7 +298,7 @@ def _load_collection_impl(
                     detail=(
                         f"load_collection: dataset '{id}' has no data in the requested "
                         f"temporal_extent [{start}, {end}]. Available time coverage: "
-                        f"{_format_time_coverage(available)}."
+                        f"{_format_time_coverage(available_coord.values)}."
                     ),
                 )
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import xarray as xr
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from open_climate_service.ingestions.schemas import ArtifactFormat
@@ -179,6 +180,32 @@ def test_load_collection_returns_georegistered_cube(monkeypatch: pytest.MonkeyPa
     # (resample_cube_spatial) can georegister it.
     assert cube.rio.crs is not None
     assert cube.rio.crs.to_epsg() == 4326
+
+
+def test_load_collection_empty_temporal_extent_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The mock cube only covers 2021; a 2030 extent selects zero timesteps.
+    monkeypatch.setattr("open_climate_service.openeo.execution._get_published_artifact", lambda _id: object())
+    monkeypatch.setattr("open_climate_service.openeo.execution._open_artifact", lambda _a: _streaming_style_cube())
+
+    with pytest.raises(HTTPException) as excinfo:
+        _load_collection_impl("pop_collection", temporal_extent=["2030-01-01", "2030-12-31"])
+
+    # Fails early with an actionable message instead of letting an empty cube
+    # reach reduce_dimension (which would raise a cryptic ndim=0 / broadcast error).
+    assert excinfo.value.status_code == 400
+    detail = str(excinfo.value.detail)
+    assert "pop_collection" in detail
+    assert "2030" in detail
+    assert "2021" in detail  # reports the available coverage
+
+
+def test_load_collection_overlapping_temporal_extent_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("open_climate_service.openeo.execution._get_published_artifact", lambda _id: object())
+    monkeypatch.setattr("open_climate_service.openeo.execution._open_artifact", lambda _a: _streaming_style_cube())
+
+    cube = _load_collection_impl("pop_collection", temporal_extent=["2021-01-01", "2021-12-31"])
+
+    assert cube.sizes["t"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a `temporal_extent` doesn't overlap a dataset's ingested timesteps, `load_collection` returns an **empty (zero-length time) cube**. That empty cube then flows into downstream reducers and surfaces as a cryptic error with no hint of the real cause:

- `first`/`last` reducers → `ValueError: dimensions ('y','x') must have the same length as the number of data dimensions, ndim=0`
- `mean`/`min`/`max` → `zero-size array to reduction operation minimum which has no identity`
- (and, with a stray length-N time axis, `could not broadcast (N,H,W) into (H,W)`)

This was hit on the malaria-hotspots workflow (HISP-MALAWI/MWI-Climate-Service#3, reported on the Rwanda instance): WorldPop is yearly, so a `temporal_extent` that doesn't cover an ingested WorldPop year produces an empty cube and the workflow dies in `reduce_dimension`.

## Fix

Guard the temporal selection in `load_collection`: if it yields **zero timesteps**, raise a `400` that names the dataset, the requested extent, and the dataset's **available time coverage** — e.g.

```
load_collection: dataset 'worldpop_population_yearly' has no data in the requested
temporal_extent [2030-01-01, 2030-12-31]. Available time coverage: 2018-01-01 (1 step).
```

This is general — every workflow that loads data (malaria hotspots, `temporal_change`, the aggregation UDPs) now gets an actionable message instead of a numpy traceback. It's a guard only; valid selections are unaffected.

## Changes
- `open_climate_service/openeo/execution.py` — empty-selection guard in `_load_collection_impl` + a `_format_time_coverage` helper for the message.
- `tests/test_openeo_execution.py` — non-overlapping extent raises the clear 400 (names dataset + extent + coverage); overlapping extent still returns data.

## Notes
- This addresses the *empty-selection* failure mode. The `≥2 timesteps` broadcast variant reduces correctly on current `main` (verified: `first`/`last`/`mean` collapse a `(t,y,x)` cube to `(y,x)`), so instances still seeing it should confirm they're deployed on current `main`.
- 3 pre-existing `rioxarray`/`.rio.crs` tests fail in my local env (PROJ/proj.db version mismatch) independently of this change; they pass in CI.