### PR TITLE
fix: migrate managed-store pyramid write to topozarr Pyramid.write API

### DIFF
--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -171,27 +171,22 @@ def write_to_icechunk_store(
         # topozarr.create_pyramid requires fully materialised numpy arrays.
         ds = ds.load()
         pyramid = create_pyramid(ds, levels=levels, x_dim=x_dim, y_dim=y_dim, method="mean")
-        pyramid.dt.attrs.update(geozarr_attrs)
+        # Pyramid.write() writes the root group attributes from ``pyramid.attrs``,
+        # so merge the GeoZarr conventions (multiscales / proj / spatial) in here.
+        pyramid.attrs.update(geozarr_attrs)
 
         # Keep the no-data sentinel consistent across pyramid levels so the map
         # renders the same pixels transparent at every zoom. topozarr mean-coarsens
         # an integer-coded mask (e.g. a 0/1 hotspot raster, where 0 is the no-data
-        # background and zarr's default integer fill) into float levels that default
-        # to fill_value=NaN. The background cells stay 0.0, so they no longer match
-        # the level's own NaN fill and render opaque at overview zooms while the
-        # full-resolution level (fill_value=0) stays transparent. Pin the coarse
-        # levels' fill_value back to 0 for integer-coded variables; float variables
-        # already use NaN as both data and fill, so leave them untouched.
-        data_var_names = [str(v) for v in ds.data_vars]
-        for level_path, level_enc in pyramid.encoding.items():
-            if str(level_path).rsplit("/", 1)[-1] == "0":
-                continue  # full-resolution level already carries the correct fill
-            for var_name in data_var_names:
-                if var_name in level_enc and ds[var_name].dtype.kind != "f":
-                    level_enc[var_name]["fill_value"] = 0
+        # background) into float levels that would otherwise default to a NaN fill,
+        # leaving the 0.0 background opaque at overview zooms. Pin the fill_value to
+        # 0 for integer-coded variables (Pyramid.write applies it across all levels);
+        # float variables already use NaN as both data and fill, so leave them be.
+        for var_name, var_da in ds.data_vars.items():
+            if var_da.dtype.kind != "f" and pyramid.fill_values.get(str(var_name)) is None:
+                pyramid.fill_values[str(var_name)] = 0
 
-        pyramid.dt.to_zarr(session.store, mode="w", encoding=pyramid.encoding, zarr_format=3)
-        pyramid.dt.close()
+        pyramid.write(session.store, mode="w")
 
         # topozarr demotes spatial_ref from coordinate to data variable in the pyramid.
         # Patch the root and each level group: add CRS to multiscales datasets entries so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ server = [
     "zarr>=3.1.6,<4",
     "icechunk>=2.0,<3",
     "geozarr-toolkit==0.1.*",
-    "topozarr==0.0.*",
+    "topozarr>=0.0.91,<0.1",
     "rioxarray>=0.17",
     "portalocker>=3.2.0",
     "dhis2eo>=1.2.1",

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -1,0 +1,63 @@
+"""Regression test for the managed-store multiscale pyramid write.
+
+Guards against the topozarr API drift that broke publishing of large workflow
+outputs (`'Pyramid' object has no attribute 'dt'`): exercises the full
+`write_to_icechunk_store` pyramid path against the current `topozarr` API.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+pytest.importorskip("icechunk")
+pytest.importorskip("topozarr")
+pytest.importorskip("rioxarray")
+zarr = pytest.importorskip("zarr")
+
+from open_climate_service.data_manager.services.downloader import (  # noqa: E402
+    needs_pyramid,
+    write_to_icechunk_store,
+)
+
+
+def _pyramid_sized_cube() -> xr.Dataset:
+    # Larger than the 2048x2048 pyramid threshold; integer var exercises the
+    # no-data fill_value handling that used to be pinned via pyramid.encoding.
+    ny = nx = 2100
+    data = np.ones((1, ny, nx), dtype="uint8")
+    return xr.Dataset(
+        {"hotspot": (("t", "y", "x"), data)},
+        coords={
+            "t": np.array(["2020-01-01"], dtype="datetime64[ns]"),
+            "y": np.linspace(-2.9, -1.0, ny),
+            "x": np.linspace(28.8, 30.9, nx),
+        },
+    )
+
+
+def test_write_to_icechunk_store_builds_pyramid(tmp_path: Path) -> None:
+    import icechunk
+
+    ds = _pyramid_sized_cube()
+    assert needs_pyramid(ds)
+
+    store_path = tmp_path / "pyramid.icechunk"
+    # Must not raise (regression: topozarr Pyramid.write API, not pyramid.dt.*).
+    write_to_icechunk_store(ds, store_path, crs="EPSG:4326")
+
+    store = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path))).readonly_session("main").store
+    root = zarr.open_group(store, mode="r")
+
+    # Root carries the multiscales metadata, and the level groups exist.
+    assert "multiscales" in dict(root.attrs)
+    level_groups = {k for k, _ in root.groups()}
+    assert {"0", "1"} <= level_groups
+
+    # Full-resolution level reads back at the original size with the variable intact.
+    lvl0 = xr.open_zarr(store, group="0", consolidated=False, zarr_format=3)
+    assert "hotspot" in lvl0.data_vars
+    assert lvl0.sizes["y"] == 2100 and lvl0.sizes["x"] == 2100

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -24,7 +24,7 @@ from open_climate_service.data_manager.services.downloader import (  # noqa: E40
 )
 
 
-def _pyramid_sized_cube() -> xr.Dataset:
+def _pyramid_sized_cube():
     # Larger than the 2048x2048 pyramid threshold; integer var exercises the
     # no-data fill_value handling that used to be pinned via pyramid.encoding.
     ny = nx = 2100

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -49,7 +49,8 @@ def test_write_to_icechunk_store_builds_pyramid(tmp_path: Path) -> None:
     # Must not raise (regression: topozarr Pyramid.write API, not pyramid.dt.*).
     write_to_icechunk_store(ds, store_path, crs="EPSG:4326")
 
-    store = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path))).readonly_session("main").store
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path)))
+    store = repo.readonly_session("main").store
     root = zarr.open_group(store, mode="r")
 
     # Root carries the multiscales metadata, and the level groups exist.
@@ -58,6 +59,6 @@ def test_write_to_icechunk_store_builds_pyramid(tmp_path: Path) -> None:
     assert {"0", "1"} <= level_groups
 
     # Full-resolution level reads back at the original size with the variable intact.
-    lvl0 = xr.open_zarr(store, group="0", consolidated=False, zarr_format=3)
-    assert "hotspot" in lvl0.data_vars
-    assert lvl0.sizes["y"] == 2100 and lvl0.sizes["x"] == 2100
+    with xr.open_zarr(store, group="0", consolidated=False, zarr_format=3) as lvl0:
+        assert "hotspot" in lvl0.data_vars
+        assert lvl0.sizes["y"] == 2100 and lvl0.sizes["x"] == 2100

--- a/uv.lock
+++ b/uv.lock
@@ -890,23 +890,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flox"
-version = "0.11.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "numpy-groupies" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "scipy" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/fd/94b6e6dba647c062434f21b40efe800ca3fed2292856f82c816a8a626b97/flox-0.11.2.tar.gz", hash = "sha256:ca48d391e4a06cdf1c24368bf73114191851149611a5b318d82436fa713efdf0", size = 956626, upload-time = "2026-02-26T05:41:53.575Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/7b/4ce04d96cb4538ab3eab6bbcc06e624bbbc3661011bfab0b536f4fb026ab/flox-0.11.2-py3-none-any.whl", hash = "sha256:d3932bfe9e26729dd7e471c4d448abeaee7a62272621f584de0e704b3c0665cb", size = 89143, upload-time = "2026-02-26T05:41:54.725Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1982,18 +1965,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy-groupies"
-version = "0.11.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ff/0559b586423d9a59feac52c2261501106dcd61e45214862de5fbb03b78cb/numpy_groupies-0.11.3.tar.gz", hash = "sha256:aed4afdad55e856b9e737fe4b4673c77e47c2f887c3663a18baaa200407c23e0", size = 159159, upload-time = "2025-05-22T11:47:58.364Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/e0/760e73c111193db5ca37712a148e4807d1b0c60302ab31e4ada6528ca34d/numpy_groupies-0.11.3-py3-none-any.whl", hash = "sha256:d4065dd5d56fda941ad5a7c80a7f80b49f671ed148aaa3e243a0e4caa71adcb3", size = 40784, upload-time = "2025-05-22T11:47:56.997Z" },
-]
-
-[[package]]
 name = "odc-geo"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2120,7 +2091,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.29" },
     { name = "rioxarray", marker = "extra == 'server'", specifier = ">=0.17" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.27.0" },
-    { name = "topozarr", marker = "extra == 'server'", specifier = "==0.0.*" },
+    { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.0.91,<0.1" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.41.0" },
     { name = "xarray", marker = "extra == 'server'", specifier = ">=2025.12.0" },
     { name = "xarray", marker = "extra == 'xarray'", specifier = ">=2025.12.0" },
@@ -2604,6 +2575,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -3466,17 +3465,35 @@ wheels = [
 
 [[package]]
 name = "topozarr"
-version = "0.0.6"
+version = "0.0.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dask" },
-    { name = "flox" },
+    { name = "numpy" },
+    { name = "psutil" },
+    { name = "pyproj" },
+    { name = "topozarr-core" },
     { name = "xarray" },
     { name = "xproj" },
+    { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/ca/583de433bc37128e431aba336a09642a9f6834988cd2021ca81216b3d63a/topozarr-0.0.6.tar.gz", hash = "sha256:8fc6728c7796da9c71a68f6026a78743dcedd6296e400206264487b5abf37dfe", size = 6349, upload-time = "2026-04-02T19:33:51.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/fe/d0c1187dadf2f4bc47f82ebf6215add47242fc9f6ae4197191846ef0dc74/topozarr-0.0.91.tar.gz", hash = "sha256:4eab2046abe868232320f2d113a8b0e5ea8a92e0c89199dd7a143fb691feada5", size = 14017, upload-time = "2026-06-11T04:19:15.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/b5/628461bf9f08944dd4f5f8204de4cb798e34c4affc6bd05c2c3d0e0f0ff0/topozarr-0.0.6-py3-none-any.whl", hash = "sha256:76c58b784d1272ecaf0b73a649f186c62799e8176b7a6d5a3d5fb834d333ad15", size = 7994, upload-time = "2026-04-02T19:33:52.404Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/43/95e8171ddafa2058531bb6093d12ba42b9051f69b1e0514b508252cdb72c/topozarr-0.0.91-py3-none-any.whl", hash = "sha256:c1c1107541d6c432ee82c22f9fe9262f4c2d1223c0427415665af43a2709bbc9", size = 17013, upload-time = "2026-06-11T04:19:15.92Z" },
+]
+
+[[package]]
+name = "topozarr-core"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/1a/20ab04138a05d452ccfbffda1473c89649335ecfb6674bd91e202fc121cf/topozarr_core-0.1.0.tar.gz", hash = "sha256:a6ecf677ad8e466be4af65655523049e9cd25c2b0435a80d0408ec3bb798abf7", size = 5292, upload-time = "2026-06-10T21:21:27.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/e1/5befadd853f2fcf2e1709274ddd12182c00ca35b16a084fd800227509e85/topozarr_core-0.1.0-cp312-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f1cf23ca24d69a0e14c3dc5814cbdfcbdf8ed4dad122c5927e08c99a8171049f", size = 611901, upload-time = "2026-06-10T21:21:30.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/53/755f1b8fc242e1f605462fae7f8c8fba5adb675abf38baba2c6d9cd73a31/topozarr_core-0.1.0-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fb73cbace9866d9a5a2c21ba956cda82619c96375e65af338664ba834286940", size = 332258, upload-time = "2026-06-10T21:21:28.756Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/6a5771596ba0c6baa1ad8f3e91df44b51241b58cb109aa12b5014b707513/topozarr_core-0.1.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7b5e3cc694fecf04e4f0d00f3ecef3c15beda55cef097f3aeefe582f24af6e7", size = 338095, upload-time = "2026-06-10T21:21:32.088Z" },
+    { url = "https://files.pythonhosted.org/packages/26/8f/51752ed5ea272422759c8a366ce624a10f51b7d770109d3ea481900b5881/topozarr_core-0.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:8aaddccf62bd762244080ea7f4cda856f07e6ae546242952295a5f8fcced5a21", size = 223939, upload-time = "2026-06-10T21:21:29.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #271.

## Problem
`topozarr 0.0.91` changed `create_pyramid` to return a **write-plan `Pyramid`** (`.attrs`, `.fill_values`, `.write(store)`) instead of a DataTree exposed as `.dt`. `downloader.write_to_icechunk_store` still used the old API:

```python
pyramid.dt.attrs.update(geozarr_attrs)
pyramid.dt.to_zarr(session.store, mode="w", encoding=pyramid.encoding, zarr_format=3)
pyramid.dt.close()
```

So publishing any managed `save_result` output large enough to need a pyramid (e.g. the Rwanda 30 m mosquito-hotspots raster) failed with `'Pyramid' object has no attribute 'dt'`. The pin was an unbounded `topozarr==0.0.*`, so a newer 0.0.x silently broke it. Small/flat outputs were unaffected, which is why it only surfaced now.

## Fix
- Use the current API: `pyramid.write(session.store, mode="w")`.
- Merge GeoZarr root attrs (multiscales conventions / proj / spatial) via `pyramid.attrs` — `write()` applies them with `root.attrs.update(self.attrs)`.
- Preserve the integer no-data behaviour (consistent transparent background across zoom levels) via `pyramid.fill_values` instead of mutating per-level `pyramid.encoding`.
- Pin `topozarr>=0.0.91,<0.1` so the new API is guaranteed (and the old `.dt` build can't be re-resolved).
- The post-write root/level attr fixups and root time-coordinate write are unchanged.

## Test
New `tests/test_downloader_pyramid.py` publishes a 2100×2100 (pyramid-triggering) cube and asserts the write succeeds, the root carries `multiscales`, level groups `0`/`1` exist, and the full-res level reads back — guarding against future topozarr drift. Passes locally (`uv run --extra server pytest tests/test_downloader_pyramid.py`).

## Validation context
Found while running the Rwanda `mosquito_hotspot_raster` workflow on current `main`: the graph now computes through fully (the #268 / reduce fixes work) and failed only here, at the pyramid publish step.