### PR TITLE
fix: exclude non-ingestable templates from the ingest dropdown

### DIFF
--- a/open_climate_service/startup.py
+++ b/open_climate_service/startup.py
@@ -5,6 +5,7 @@ environment variables and logging are configured before other imports.
 """
 
 import logging
+import os
 
 from dotenv import load_dotenv  # noqa: E402
 
@@ -19,3 +20,55 @@ if not eo_logger.handlers:
     handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s"))
     eo_logger.addHandler(handler)
 eo_logger.propagate = False
+
+
+def _ensure_proj_database() -> None:
+    """Make sure pyproj can resolve CRS codes, healing a polluted host PROJ env.
+
+    Common failure mode on developer machines: a conda/miniforge ``PROJ_DATA``
+    (or ``PROJ_LIB``) is inherited that points at a ``proj.db`` incompatible with
+    the installed pyproj, so even ``EPSG:4326`` fails to resolve — which then
+    breaks GeoZarr metadata generation during ingestion with a confusing
+    "proj:code 'EPSG:4326' does not resolve to a known CRS" error.
+
+    When CRS resolution already works (e.g. a clean Docker image) this is a no-op.
+    Otherwise it pins the PROJ database to the one bundled with pyproj.
+    """
+    try:
+        import pyproj
+        from pyproj import CRS, datadir
+    except ImportError:
+        return  # client-only install without pyproj
+
+    try:
+        CRS.from_authority("EPSG", "4326")
+        return  # resolution already works — leave the environment untouched
+    except Exception:
+        pass
+
+    bundled = os.path.join(os.path.dirname(pyproj.__file__), "proj_dir", "share", "proj")
+    if not os.path.exists(os.path.join(bundled, "proj.db")):
+        eo_logger.error(
+            "PROJ database self-check failed (EPSG:4326 does not resolve) and no bundled "
+            "pyproj database was found at %s. CRS operations (ingest/STAC) will fail; "
+            "check PROJ_DATA / PROJ_LIB.",
+            bundled,
+        )
+        return
+
+    os.environ["PROJ_DATA"] = bundled
+    os.environ.pop("PROJ_LIB", None)
+    try:
+        datadir.set_data_dir(bundled)
+        CRS.from_authority("EPSG", "4326")
+    except Exception:
+        eo_logger.exception("Could not establish a working PROJ database even from bundled pyproj data")
+        return
+    eo_logger.warning(
+        "Inherited PROJ environment could not resolve EPSG:4326; pinned the PROJ "
+        "database to pyproj's bundled data at %s",
+        bundled,
+    )
+
+
+_ensure_proj_database()

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -136,6 +136,17 @@ def _load_templates() -> list[dict[str, Any]]:
         return []
 
 
+def _ingestable_templates() -> list[dict[str, Any]]:
+    """Return only templates that can be ingested from a source.
+
+    Ingestable templates declare an ``ingestion.plugin``. Derived/static templates
+    (e.g. workflow outputs published via ``save_result``, which have ``sync.kind:
+    static`` and no upstream fetch path) are excluded so they don't appear in the
+    ingest form.
+    """
+    return [t for t in _load_templates() if (t.get("ingestion") or {}).get("plugin")]
+
+
 def _load_datasets() -> list[Any]:
     try:
         return list_datasets().items
@@ -165,7 +176,7 @@ def render_manage(version: str, base: str, message: str | None = None, error: st
         base=base,
         name=api_config.get_name(),
         extent=_load_extent(),
-        templates=_load_templates(),
+        templates=_ingestable_templates(),
         datasets=_load_datasets(),
         today=today,
         year_ago=year_ago,

--- a/tests/test_startup_proj.py
+++ b/tests/test_startup_proj.py
@@ -1,0 +1,60 @@
+"""Tests for the PROJ database self-heal in open_climate_service.startup."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pyproj = pytest.importorskip("pyproj")
+
+
+def _bundled_proj_dir() -> str:
+    return os.path.join(os.path.dirname(pyproj.__file__), "proj_dir", "share", "proj")
+
+
+def test_ensure_proj_database_pins_bundled_db_when_resolution_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the inherited PROJ env can't resolve EPSG:4326, pin the bundled pyproj db."""
+    from pyproj import CRS
+
+    from open_climate_service import startup
+
+    bundled = _bundled_proj_dir()
+    if not os.path.exists(os.path.join(bundled, "proj.db")):
+        pytest.skip("pyproj bundled proj.db not available in this environment")
+
+    real_from_authority = CRS.from_authority
+    state = {"first_call": True}
+
+    def flaky_from_authority(auth: str, code: str, *args: object, **kwargs: object):
+        # Simulate a broken inherited PROJ database on the first check, then recover
+        # once the bundled database has been pinned.
+        if state["first_call"]:
+            state["first_call"] = False
+            raise pyproj.exceptions.CRSError("simulated broken PROJ database")
+        return real_from_authority(auth, code)
+
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(pyproj.CRS, "from_authority", flaky_from_authority)
+    monkeypatch.setattr(pyproj.datadir, "set_data_dir", lambda d: captured.update(dir=d))
+    monkeypatch.setenv("PROJ_DATA", "/some/broken/conda/path")  # restored on teardown
+
+    startup._ensure_proj_database()
+
+    assert captured["dir"] == bundled  # pinned pyproj's bundled database
+    assert os.environ["PROJ_DATA"] == bundled  # and exported it for GDAL et al.
+
+
+def test_ensure_proj_database_is_noop_when_resolution_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When CRS resolution already works the env is left untouched."""
+    from pyproj import CRS
+
+    from open_climate_service import startup
+
+    touched: dict[str, str] = {}
+    monkeypatch.setattr(pyproj.datadir, "set_data_dir", lambda d: touched.update(dir=d))
+
+    startup._ensure_proj_database()
+
+    assert "dir" not in touched  # no fallback performed
+    assert CRS.from_authority("EPSG", "4326").to_authority() == ("EPSG", "4326")

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -329,6 +329,52 @@ def test_manage_page_shows_split_publication_and_sync_columns(
     assert "const message = err instanceof Error ? err.message : String(err);" in response.text
 
 
+def test_ingestable_templates_excludes_static_workflow_outputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Templates with no ingestion.plugin (e.g. workflow outputs) are not ingestable."""
+    monkeypatch.setattr(
+        system_templates,
+        "_load_templates",
+        lambda: [
+            {"id": "chirps3_precipitation_daily", "ingestion": {"plugin": "pkg.Plugin"}},
+            {"id": "worldpop_population_yearly", "ingestion": {"plugin": "pkg.Plugin"}},
+            {"id": "worldpop_population_change", "sync": {"kind": "static"}},  # derived, no plugin
+        ],
+    )
+
+    ingestable_ids = [t["id"] for t in system_templates._ingestable_templates()]
+
+    assert "worldpop_population_change" not in ingestable_ids
+    assert ingestable_ids == ["chirps3_precipitation_daily", "worldpop_population_yearly"]
+
+
+def test_manage_page_dropdown_excludes_static_templates(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The /manage ingest dropdown lists only ingestable templates."""
+    monkeypatch.setattr(
+        system_templates,
+        "_load_templates",
+        lambda: [
+            {
+                "id": "chirps3_precipitation_daily",
+                "name": "Total precipitation (CHIRPS3)",
+                "ingestion": {"plugin": "p"},
+            },
+            {
+                "id": "worldpop_population_change",
+                "name": "Population change (WorldPop Global2)",
+                "sync": {"kind": "static"},
+            },
+        ],
+    )
+    monkeypatch.setattr(system_templates, "_load_extent", lambda: {"id": "sle", "name": "Sierra Leone", "bbox": []})
+    monkeypatch.setattr(system_templates, "_load_datasets", lambda: [])
+
+    response = client.get("/manage")
+
+    assert response.status_code == 200
+    assert 'value="chirps3_precipitation_daily"' in response.text
+    assert 'value="worldpop_population_change"' not in response.text
+
+
 def test_map_viewer_initializes_at_latest_timestep(client: TestClient) -> None:
     response = client.get("/map")
 


### PR DESCRIPTION
The `/manage` ingest dropdown listed **Population change (WorldPop Global2)** (`worldpop_population_change`), but that template can't be ingested — it's a derived dataset produced by the `temporal_change` workflow via `save_result` (`sync.kind: static`, no `ingestion.plugin`). Selecting it failed.

### Fix
Add `_ingestable_templates()` (templates that declare an `ingestion.plugin`) and use it to populate the ingest form. Derived/static templates are excluded. This is general — any future workflow-output template is filtered automatically, not just WorldPop change.

Posting a static template still fails gracefully server-side (the plugin loader raises *'does not define ingestion.plugin'*), so this is purely a UX fix on the dropdown.

### Tests
- `_ingestable_templates()` filters out templates without a plugin.
- `/manage` page renders the ingestable template as an `<option>` and omits the static one.

`make lint` and the system-routes tests pass.