### PR TITLE
feat: support a non-temporal (ordinal) stepping dimension (viewer + STAC + ingest)

### DIFF
--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -265,6 +265,12 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
             # so the map viewer can resolve the variable name and spatial axes.
             payload.setdefault("cube:dimensions", _build_static_cube_dimensions(ds, x_dimension, y_dimension))
             payload.setdefault("cube:variables", _build_cube_variables(ds))
+        # Declare ordinal (non-spatial, non-temporal) axes — e.g. a day-of-year
+        # climatology — that xstac/the static path would otherwise drop, so the map
+        # viewer can offer a slider over them.
+        ordinal_dims = _build_ordinal_dimensions(ds, x_dimension, y_dimension, time_dimension)
+        if ordinal_dims:
+            payload.setdefault("cube:dimensions", {}).update(ordinal_dims)
         _cache_xstac_collection_payload(artifact.artifact_id, payload)
         return deepcopy(payload)
     except HTTPException:
@@ -384,6 +390,37 @@ def _build_static_cube_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str) -> dic
             "reference_system": crs,
         },
     }
+
+
+def _build_ordinal_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str, time_dim: str | None) -> dict[str, Any]:
+    """cube:dimensions entries for non-spatial, non-temporal axes (e.g. ``dayofyear``).
+
+    The datacube/STAC machinery only declares spatial and temporal axes, so an ordinal
+    coordinate like a day-of-year climatology axis would otherwise be dropped — and the
+    map viewer could not slider it. Declared here with explicit ``values`` (and a ``step``
+    for evenly spaced integer axes) so the viewer can step over them.
+    """
+    import numpy as np
+
+    dims = getattr(ds, "dims", None)
+    if not dims:
+        return {}
+    skip = {x_dim, y_dim} | ({time_dim} if time_dim else set())
+    out: dict[str, Any] = {}
+    for name in dims:
+        if name in skip or name not in ds.coords:
+            continue
+        coord = ds[name]
+        if np.issubdtype(coord.dtype, np.datetime64):
+            continue  # a temporal axis — handled by xstac
+        values = coord.values.tolist()
+        entry: dict[str, Any] = {"type": "other", "values": values}
+        if len(values) > 1 and all(isinstance(v, int) for v in values):
+            step = values[1] - values[0]
+            if step:
+                entry["step"] = step
+        out[str(name)] = entry
+    return out
 
 
 def _build_cube_variables(ds: xr.Dataset) -> dict[str, Any]:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -416,9 +416,14 @@ def _build_ordinal_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str, time_dim: 
         values = coord.values.tolist()
         entry: dict[str, Any] = {"type": "other", "values": values}
         if len(values) > 1 and all(isinstance(v, int) for v in values):
-            step = values[1] - values[0]
-            if step:
-                entry["step"] = step
+            # Only publish a step for a genuinely evenly spaced axis: every
+            # consecutive delta must match. Deriving it from the first delta
+            # alone would emit a wrong step for irregular integer coordinates.
+            deltas = {b - a for a, b in zip(values, values[1:])}
+            if len(deltas) == 1:
+                (step,) = deltas
+                if step:
+                    entry["step"] = step
         out[str(name)] = entry
     return out
 

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -63,7 +63,9 @@ def _strip_cf_encoding(ds: xr.Dataset, period_type: str, *, time_dim: str) -> No
     for name in list(ds.data_vars) + list(ds.coords):
         ds[name].encoding.clear()
         ds[name].attrs = {key: value for key, value in ds[name].attrs.items() if key not in cf_keys}
-    if time_dim in ds.coords:
+    # Only force datetime CF encoding for an actual datetime axis. An ordinal step
+    # dimension (e.g. an integer day-of-year climatology) is left as-is.
+    if time_dim in ds.coords and ds[time_dim].dtype.kind == "M":
         units = "hours since 1970-01-01" if period_type == "hourly" else "days since 1970-01-01"
         ds[time_dim].encoding.update({"units": units, "dtype": "int32"})
 

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -56,9 +56,19 @@ def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: s
         try:
             if time_dim not in ds.coords:
                 return set()
+            coord = ds[time_dim]
+            if coord.dtype.kind != "M":
+                # Non-datetime (ordinal) step dimension — e.g. an integer
+                # ``dayofyear`` axis. Period ids are the coord values as plain
+                # strings, matching what ``plugin.periods()`` emits; parsing them
+                # as datetimes would mangle every value and leave ``committed``
+                # empty, causing duplicate appends on resume.
+                if coord.dtype.kind in "iu":
+                    return {str(int(item)) for item in coord.values}
+                return {str(item.item()) for item in coord.values}
             return {
                 datetime_to_period_string(pd.Timestamp(item.item()).to_pydatetime(), period_type)
-                for item in ds[time_dim].values
+                for item in coord.values
             }
         finally:
             ds.close()

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -207,7 +207,7 @@
 
           <div id="time-section" class="panel-section hidden">
             <div class="time-header">
-              <label style="margin-bottom:0">Time step</label>
+              <label id="time-label" style="margin-bottom:0">Time step</label>
               <span id="time-count" class="time-count"></span>
             </div>
             <div style="margin-bottom:0.4rem">
@@ -255,23 +255,29 @@
         }
       }
 
-      // Resolve the temporal dimension key and step list from cube:dimensions.
-      function getTimeDimKey(dimensions) {
-        for (const [key, val] of Object.entries(dimensions ?? {})) {
+      // Resolve the primary "stepping" dimension key from cube:dimensions. Prefer a
+      // non-temporal, non-spatial dimension (e.g. dayofyear, bands) so the slider can
+      // drive an ordinal axis; otherwise fall back to the temporal dimension.
+      function getStepDimKey(dimensions) {
+        const entries = Object.entries(dimensions ?? {});
+        for (const [key, val] of entries) {
+          if (val.type === "spatial" || val.type === "temporal") continue;
+          if (Array.isArray(val.values) || val.extent) return key;
+        }
+        for (const [key, val] of entries) {
           if (val.type === "temporal") return key;
         }
         return "time";
       }
 
-      function buildTimeSteps(dimensions) {
-        if (!dimensions) return [];
-        const timeDim = Object.values(dimensions).find(
-          (d) => d.type === "temporal"
-        );
-        if (!timeDim) return [];
-        if (Array.isArray(timeDim.values)) return timeDim.values;
-        const [start, end] = timeDim.extent ?? [];
-        const step = timeDim.step;
+      // Build the step list for a dimension: explicit `values` (temporal or ordinal),
+      // else a temporal extent + ISO duration step.
+      function buildSteps(dimensions, dimKey) {
+        const dim = (dimensions ?? {})[dimKey];
+        if (!dim) return [];
+        if (Array.isArray(dim.values)) return dim.values;
+        const [start, end] = dim.extent ?? [];
+        const step = dim.step;
         if (!start) return [];
         if (!step || !end) return [start];
         return generateDateRange(start, end, step);
@@ -339,6 +345,7 @@
 
       const selectEl = document.getElementById("dataset-select");
       const timeSection = document.getElementById("time-section");
+      const timeLabelEl = document.getElementById("time-label");
       const timeSlider = document.getElementById("time-slider");
       const timeValueEl = document.getElementById("time-value");
       const timeCountEl = document.getElementById("time-count");
@@ -484,8 +491,8 @@
           "data";
 
         const dimensions = collection["cube:dimensions"] ?? {};
-        timeDimKey = getTimeDimKey(dimensions);
-        timeSteps = buildTimeSteps(dimensions);
+        timeDimKey = getStepDimKey(dimensions);
+        timeSteps = buildSteps(dimensions, timeDimKey);
 
         // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
         // reprojects natively instead of treating coordinates as WGS84 degrees.
@@ -540,9 +547,16 @@
         }
 
 
-        // Time slider.
+        // Dimension slider (temporal, or an ordinal axis such as day-of-year).
         if (timeStepCount() > 1) {
           const initialIndex = initialTimeIndex();
+          const stepDim = dimensions[timeDimKey] ?? {};
+          timeLabelEl.textContent =
+            stepDim.type === "temporal"
+              ? "Time step"
+              : timeDimKey === "dayofyear"
+                ? "Day of year"
+                : timeDimKey;
           timeSlider.max = timeStepCount() - 1;
           timeSlider.value = initialIndex;
           timeValueEl.textContent = timeStepAt(initialIndex);

--- a/tests/test_ordinal_dimensions.py
+++ b/tests/test_ordinal_dimensions.py
@@ -6,12 +6,15 @@ handling for an integer day-of-year axis (vs a datetime time axis).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from open_climate_service.stac.services import _build_ordinal_dimensions
 from open_climate_service.streaming.orchestrator import _strip_cf_encoding
+from open_climate_service.streaming.store import open_or_create_repo, read_committed_period_ids
 
 
 def _dayofyear_cube() -> xr.Dataset:
@@ -42,6 +45,34 @@ def test_build_ordinal_dimensions_declares_dayofyear() -> None:
 def test_build_ordinal_dimensions_excludes_spatial_and_temporal() -> None:
     # Only x/y (spatial) and t (temporal) present — nothing ordinal to declare.
     assert _build_ordinal_dimensions(_daily_cube(), "x", "y", "t") == {}
+
+
+def test_build_ordinal_dimensions_omits_step_for_irregular_axis() -> None:
+    # Unevenly spaced integer axis: a step derived from the first delta alone
+    # would be wrong, so no step should be published.
+    ds = xr.Dataset(
+        {"v": (("band", "y", "x"), np.zeros((4, 2, 2), dtype="float32"))},
+        coords={"band": [1, 2, 5, 8], "y": [1.0, 2.0], "x": [1.0, 2.0]},
+    )
+    dims = _build_ordinal_dimensions(ds, "x", "y", None)
+
+    assert dims["band"]["values"] == [1, 2, 5, 8]
+    assert "step" not in dims["band"]
+
+
+def test_read_committed_period_ids_ordinal_coord(tmp_path: Path) -> None:
+    # Round-trip an integer day-of-year axis through the store and confirm
+    # committed ids come back as plain strings ("1".."366"), not datetime-parsed
+    # garbage — otherwise resume would re-append everything.
+    store_path = tmp_path / "ordinal.icechunk"
+    repo = open_or_create_repo(store_path)
+    session = repo.writable_session("main")
+    _dayofyear_cube().to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("ingest: ordinal")
+
+    committed = read_committed_period_ids(store_path, "daily", time_dim="dayofyear")
+
+    assert committed == {str(i) for i in range(1, 367)}
 
 
 def test_strip_cf_encoding_skips_datetime_for_ordinal_coord() -> None:

--- a/tests/test_ordinal_dimensions.py
+++ b/tests/test_ordinal_dimensions.py
@@ -1,0 +1,57 @@
+"""Tests for non-temporal (ordinal) stepping-dimension support.
+
+Covers the STAC ``cube:dimensions`` declaration and the ingest orchestrator's CF-encoding
+handling for an integer day-of-year axis (vs a datetime time axis).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from open_climate_service.stac.services import _build_ordinal_dimensions
+from open_climate_service.streaming.orchestrator import _strip_cf_encoding
+
+
+def _dayofyear_cube() -> xr.Dataset:
+    return xr.Dataset(
+        {"t2m": (("dayofyear", "y", "x"), np.zeros((366, 2, 2), dtype="float32"))},
+        coords={"dayofyear": list(range(1, 367)), "y": [1.0, 2.0], "x": [1.0, 2.0]},
+    )
+
+
+def _daily_cube() -> xr.Dataset:
+    times = pd.date_range("2020-01-01", periods=3, freq="D")
+    return xr.Dataset(
+        {"v": (("t", "y", "x"), np.zeros((3, 2, 2), dtype="float32"))},
+        coords={"t": times, "y": [1.0, 2.0], "x": [1.0, 2.0]},
+    )
+
+
+def test_build_ordinal_dimensions_declares_dayofyear() -> None:
+    dims = _build_ordinal_dimensions(_dayofyear_cube(), "x", "y", None)
+
+    assert "dayofyear" in dims
+    doy = dims["dayofyear"]
+    assert doy["type"] == "other"
+    assert doy["values"][0] == 1 and doy["values"][-1] == 366
+    assert doy["step"] == 1
+
+
+def test_build_ordinal_dimensions_excludes_spatial_and_temporal() -> None:
+    # Only x/y (spatial) and t (temporal) present — nothing ordinal to declare.
+    assert _build_ordinal_dimensions(_daily_cube(), "x", "y", "t") == {}
+
+
+def test_strip_cf_encoding_skips_datetime_for_ordinal_coord() -> None:
+    ds = _dayofyear_cube()
+    _strip_cf_encoding(ds, "daily", time_dim="dayofyear")
+    # An integer day-of-year axis must not get datetime CF encoding.
+    assert "units" not in ds["dayofyear"].encoding
+
+
+def test_strip_cf_encoding_applies_datetime_for_time_coord() -> None:
+    ds = _daily_cube()
+    _strip_cf_encoding(ds, "daily", time_dim="t")
+    assert ds["t"].encoding.get("units") == "days since 1970-01-01"


### PR DESCRIPTION
Foundation for day-of-year climate normals (#244) and other non-temporal axes (e.g. WorldPop age/sex bands). Teaches three layers about a **non-temporal stepping dimension** so such datasets render, publish, and ingest without being forced onto a datetime time axis.

### Map viewer (`templates/map-viewer.html`)
- Generalise the slider: pick the primary *stepping* dimension — prefer a non-temporal, non-spatial `cube:dimensions` entry (with explicit `values`, e.g. `dayofyear`/`bands`) over the temporal one; fall back to temporal. Label it accordingly ("Day of year" / dim name vs "Time step") and drive the existing `setSelector({ [dim]: index })`. **Temporal-only datasets behave exactly as before.**

### STAC (`stac/services.py`)
- `_build_ordinal_dimensions`: declare ordinal axes in `cube:dimensions` (`type: other`, `values`, `step`) in **both** the xstac and the static paths — otherwise xstac/the static builder drops them and the viewer can't slider them.

### Ingest orchestrator (`streaming/orchestrator.py`)
- `_strip_cf_encoding` only forces datetime CF encoding for an actual datetime axis (`dtype.kind == 'M'`); an integer step coordinate (day-of-year) is left as-is so it stores as an ordinal dimension.

### Tests
- `tests/test_ordinal_dimensions.py`: STAC declares `dayofyear` (values 1..366, step 1) and excludes spatial/temporal; orchestrator skips datetime encoding for an ordinal coord but applies it for a datetime coord.

`make lint` clean; STAC/streaming/dataset suites green (only the unrelated pre-existing PROJ-env `test_openeo_execution` failure remains).

This is the dependency for the day-of-year rework of #244 and the openEO from-store normals.