### PR TITLE
fix: load_collection carries the dataset's declared units onto the cube

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -362,14 +362,24 @@ def _load_collection_impl(
                 ),
             )
 
+    # Backfill the cube's `units` from the dataset's declared units so unit-aware
+    # processes (e.g. xclim's spi / climate indices) can find them. The stored Zarr
+    # variable does not retain a units attribute, so without this xclim raises a
+    # confusing KeyError 'units'. Only set it when the data doesn't already carry one.
+    def _with_units(da: xr.DataArray) -> xr.DataArray:
+        units = getattr(artifact, "units", None)
+        if units and not da.attrs.get("units"):
+            return da.assign_attrs(units=units)
+        return da
+
     if len(available_vars) == 1:
-        return ds[available_vars[0]]
+        return _with_units(ds[available_vars[0]])
 
     # Multi-band: stack variables on a new "bands" dimension
     import pandas as pd
 
     return xr.concat(
-        [ds[b] for b in available_vars],
+        [_with_units(ds[b]) for b in available_vars],
         dim=pd.Index(available_vars, name="bands"),
     )
 

--- a/tests/test_load_collection_units.py
+++ b/tests/test_load_collection_units.py
@@ -1,0 +1,45 @@
+"""load_collection backfills the cube's units from the dataset's declared units.
+
+Without this, unit-aware processes (e.g. xclim's spi / climate indices) fail with a
+confusing ``KeyError 'units'`` because the stored Zarr variable carries no units attr.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import open_climate_service.openeo.execution as ex
+
+
+def _dataset(units: str | None = None) -> xr.Dataset:
+    times = pd.date_range("2020-01-01", periods=3, freq="D")
+    attrs = {"units": units} if units else {}
+    return xr.Dataset(
+        {"precip": (("t", "y", "x"), np.ones((3, 2, 2), dtype="float32"), attrs)},
+        coords={"t": times, "y": [1.0, 2.0], "x": [1.0, 2.0]},
+    )
+
+
+def test_load_collection_backfills_units_from_artifact(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ex, "_get_published_artifact", lambda _id: SimpleNamespace(units="mm"))
+    monkeypatch.setattr(ex, "_open_artifact", lambda _a: _dataset())
+    monkeypatch.setattr(ex, "_ensure_crs", lambda ds: ds)
+
+    cube = ex._load_collection_impl("chirps3_precipitation_daily")
+
+    assert cube.attrs.get("units") == "mm"
+
+
+def test_load_collection_preserves_existing_units(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ex, "_get_published_artifact", lambda _id: SimpleNamespace(units="mm"))
+    monkeypatch.setattr(ex, "_open_artifact", lambda _a: _dataset(units="kg m-2 s-1"))
+    monkeypatch.setattr(ex, "_ensure_crs", lambda ds: ds)
+
+    cube = ex._load_collection_impl("some_dataset")
+
+    assert cube.attrs.get("units") == "kg m-2 s-1"  # data's own units win


### PR DESCRIPTION
### Problem
xclim-based openEO processes (e.g. `spi`, climate indices) are **unit-aware** and read `pr.attrs['units']`. The stored Zarr variable retains no `units` attribute, so running `spi` on a loaded CHIRPS collection fails with a confusing `KeyError: 'units'` — surfaced to clients as `400 Invalid process graph: 'units'`. (Reported from a Uganda-instance SPI workflow.)

### Fix
`_load_collection_impl` now backfills the cube's `units` from the artifact's declared units (populated from the dataset template's `units` field at ingest), unless the data already carries one. Applies to single-variable and multi-band cubes.

### Tests
`tests/test_load_collection_units.py` — units backfilled from the artifact; existing data units are preserved (not overridden).

`make lint` clean.

> Note for instances: the backfilled value is whatever the template declares, so for xclim's `spi` the precipitation template should declare a **rate** unit (`mm/d`), not a bare `mm` length, or xclim may still reject it on dimensionality grounds.