### PR TITLE
feat: log an instance-plugin loading summary at startup

### DIFF
--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -53,6 +53,9 @@ def _append_vary_value(response: Response, value: str) -> None:
 @asynccontextmanager
 async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Run lightweight startup recovery hooks for the application lifecycle."""
+    from open_climate_service.plugins_diagnostics import log_plugin_loading
+
+    log_plugin_loading()
     job_service = get_job_service()
     job_service.recover_pending_jobs()
     openeo_service = get_openeo_job_service()

--- a/open_climate_service/plugins_diagnostics.py
+++ b/open_climate_service/plugins_diagnostics.py
@@ -41,11 +41,21 @@ def log_plugin_loading() -> None:
         )
         return
 
+    if not isinstance(plugins_dir, (str, Path)):
+        logger.warning(
+            "Instance plugins: plugins_dir has unexpected type %s — no instance plugins will load.",
+            type(plugins_dir).__name__,
+        )
+        return
+
     config_path = api_config.get_config_path()
     base = config_path.parent if config_path else Path()
     root = (base / str(plugins_dir)).resolve()
     if not root.is_dir():
-        logger.warning("Instance plugins: plugins_dir '%s' does not exist — no instance plugins will load.", root)
+        logger.warning(
+            "Instance plugins: plugins_dir '%s' does not exist or is not a directory — no instance plugins will load.",
+            root,
+        )
         return
 
     counts: list[str] = []
@@ -55,6 +65,9 @@ def log_plugin_loading() -> None:
             logger.warning("Instance plugins: '%s/' is missing under %s — those plugins will not load.", sub, root)
             counts.append(f"{sub}=0")
             continue
-        n = len([p for p in directory.glob(pattern) if not p.name.startswith("_")])
+        # Only skip _-prefixed files for Python process plugins; dataset YAML and
+        # workflow JSON loaders load all matching files without that convention.
+        skip_private = pattern.endswith(".py")
+        n = len([p for p in directory.glob(pattern) if not (skip_private and p.name.startswith("_"))])
         counts.append(f"{sub}={n}")
     logger.info("Instance plugins loaded from %s — %s.", root, ", ".join(counts))

--- a/open_climate_service/plugins_diagnostics.py
+++ b/open_climate_service/plugins_diagnostics.py
@@ -1,0 +1,60 @@
+"""Startup diagnostics for instance plugins (datasets, processes, workflows).
+
+A misconfigured or unset ``plugins_dir`` silently drops instance plugin workflows and
+processes — the loaders just return an empty list — which later surfaces as a cryptic
+"process not found in namespace predefined". Logging a one-line summary at startup (and a
+warning for a missing ``plugins_dir`` or sub-directory) makes that immediately obvious.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from open_climate_service import config as api_config
+
+logger = logging.getLogger("open_climate_service")
+
+# (subdirectory, glob) for each plugin kind under plugins_dir.
+_PLUGIN_SUBDIRS: tuple[tuple[str, str], ...] = (
+    ("datasets", "*.y*ml"),
+    ("processes", "*.py"),
+    ("workflows", "*.json"),
+)
+
+
+def log_plugin_loading() -> None:
+    """Log a summary of instance plugins discovered under ``plugins_dir``.
+
+    Best-effort and never raises — purely diagnostic.
+    """
+    try:
+        config = api_config.get_config()
+    except Exception:
+        logger.debug("Plugin loading summary skipped: configuration unavailable", exc_info=True)
+        return
+
+    plugins_dir = config.get("plugins_dir") if config else None
+    if not plugins_dir:
+        logger.info(
+            "Instance plugins: no plugins_dir configured — using built-in datasets, processes and workflows only."
+        )
+        return
+
+    config_path = api_config.get_config_path()
+    base = config_path.parent if config_path else Path()
+    root = (base / str(plugins_dir)).resolve()
+    if not root.is_dir():
+        logger.warning("Instance plugins: plugins_dir '%s' does not exist — no instance plugins will load.", root)
+        return
+
+    counts: list[str] = []
+    for sub, pattern in _PLUGIN_SUBDIRS:
+        directory = root / sub
+        if not directory.is_dir():
+            logger.warning("Instance plugins: '%s/' is missing under %s — those plugins will not load.", sub, root)
+            counts.append(f"{sub}=0")
+            continue
+        n = len([p for p in directory.glob(pattern) if not p.name.startswith("_")])
+        counts.append(f"{sub}={n}")
+    logger.info("Instance plugins loaded from %s — %s.", root, ", ".join(counts))

--- a/tests/test_plugins_diagnostics.py
+++ b/tests/test_plugins_diagnostics.py
@@ -1,0 +1,63 @@
+"""Tests for the startup instance-plugin loading summary."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from open_climate_service import config as api_config
+from open_climate_service import plugins_diagnostics as pd
+
+
+@pytest.fixture
+def capture(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
+    # The "open_climate_service" logger has propagate=False, so attach caplog's
+    # handler directly to capture its records.
+    pd.logger.addHandler(caplog.handler)
+    pd.logger.setLevel(logging.INFO)
+    try:
+        yield caplog
+    finally:
+        pd.logger.removeHandler(caplog.handler)
+
+
+def test_logs_when_plugins_dir_unset(monkeypatch: pytest.MonkeyPatch, capture: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(api_config, "get_config", lambda: {})
+    pd.log_plugin_loading()
+    assert "no plugins_dir configured" in capture.text
+
+
+def test_warns_on_missing_subdir_and_counts_files(
+    monkeypatch: pytest.MonkeyPatch, capture: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    plugins = tmp_path / "plugins"
+    (plugins / "datasets").mkdir(parents=True)
+    (plugins / "processes").mkdir()
+    (plugins / "datasets" / "x.yaml").write_text("- id: x\n")
+    # workflows/ intentionally absent
+    config_path = tmp_path / "climate-service.yaml"
+    config_path.write_text("plugins_dir: ./plugins/\n")
+    monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": "./plugins/"})
+    monkeypatch.setattr(api_config, "get_config_path", lambda: config_path)
+
+    pd.log_plugin_loading()
+
+    text = capture.text
+    assert "datasets=1" in text  # counted the one template file
+    assert "workflows" in text and "missing" in text  # warned that workflows/ won't load
+
+
+def test_warns_when_plugins_dir_missing(
+    monkeypatch: pytest.MonkeyPatch, capture: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "climate-service.yaml"
+    config_path.write_text("plugins_dir: ./plugins/\n")
+    monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": "./does-not-exist/"})
+    monkeypatch.setattr(api_config, "get_config_path", lambda: config_path)
+
+    pd.log_plugin_loading()
+
+    assert "does not exist" in capture.text

--- a/tests/test_plugins_diagnostics.py
+++ b/tests/test_plugins_diagnostics.py
@@ -16,12 +16,14 @@ from open_climate_service import plugins_diagnostics as pd
 def capture(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
     # The "open_climate_service" logger has propagate=False, so attach caplog's
     # handler directly to capture its records.
+    original_level = pd.logger.level
     pd.logger.addHandler(caplog.handler)
     pd.logger.setLevel(logging.INFO)
     try:
         yield caplog
     finally:
         pd.logger.removeHandler(caplog.handler)
+        pd.logger.setLevel(original_level)
 
 
 def test_logs_when_plugins_dir_unset(monkeypatch: pytest.MonkeyPatch, capture: pytest.LogCaptureFixture) -> None:
@@ -60,4 +62,4 @@ def test_warns_when_plugins_dir_missing(
 
     pd.log_plugin_loading()
 
-    assert "does not exist" in capture.text
+    assert "does not exist or is not a directory" in capture.text


### PR DESCRIPTION
### Investigation
A Uganda-instance SPI workflow failed with `400 Invalid process graph: 'Process spi_from_precipitation not found in namespace predefined!'`. I reproduced the full loading + resolution path with a minimal instance config:

- the workflow JSON is valid, correctly placed, and its inner `spi` process **is** registered;
- with `plugins_dir` set, the UDP **loads** (`list_workflows()` includes it) and **resolves** at execution (the overlay works).

So there is **no core bug** — the failure means the instance's `plugins_dir` isn't loading the workflow (unset, wrong path, or the `workflows/` sub-dir absent on the running instance).

### The actual gap (fixed here)
The dataset registry *raises* on a bad `plugins_dir`, but `_load_plugin_workflows` / `_scan_instance_processes` **silently return `[]`** when `plugins_dir` is unset or the sub-dir is missing — so instance UDPs/processes vanish with zero feedback, surfacing only as a cryptic "process not found".

Add a startup **instance-plugin loading summary** (`plugins_diagnostics.log_plugin_loading`, called from the app lifespan):
- logs the resolved `plugins_dir` and per-kind file counts (`datasets=… processes=… workflows=…`);
- warns when `plugins_dir` is unset, doesn't exist, or a `datasets/`/`processes/`/`workflows/` sub-dir is missing.

Now "my custom workflow/template isn't loaded" is self-evident in the logs.

### Tests
`tests/test_plugins_diagnostics.py` — unset plugins_dir, missing sub-directory (with file counts), and non-existent plugins_dir.

`make lint` clean; app builds.

### For the Uganda instance
Set `plugins_dir: ./plugins/` in `climate-service.yaml` and run the server from that directory; `GET /process_graphs` should then list `spi_from_precipitation`. (Relates to the SPI workflow in HISP-Uganda/uganda-climate-service-tools#6 and the units fix #279.)