### PR TITLE
feat: CF-compliant GeoZarr stores + make xclim indices (SPI) work end-to-end

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -134,11 +134,20 @@ extents:
     resolution: P1D              # ISO 8601 duration: PT1H, P1D, P1M, P1Y
 ```
 
-**Units and display**
+**CF metadata** — stamped onto the stored variable (and backfilled at load) so the GeoZarr
+store is CF-compliant and CF-aware tools (xclim climate indices, cf-xarray, QGIS) work
+without per-process glue:
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |
-| `units` | No | Physical units of the stored data (e.g. `mm`, `degC`, `m`) |
+| `units` | No | Physical units, as a **CF/udunits** string (e.g. `mm`, `mm/d`, `degC`, `kg m-2 s-1`). Validated at registration — a non-udunits value (e.g. `people`) is logged as a warning. Use `""` for a dimensionless quantity (e.g. a standardized index). For unit-aware processes (e.g. SPI) the unit must be *dimensionally* correct — a precipitation **rate** is `mm/d`, not bare `mm`. |
+| `standard_name` | No | CF [standard name](https://cfconventions.org/standard-names.html) (e.g. `air_temperature`, `lwe_thickness_of_precipitation_amount`). |
+| `cell_methods` | No | CF cell methods describing the temporal aggregation (e.g. `time: mean`, `time: sum`). |
+
+**Display**
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
 | `resolution` | No | Human-readable spatial resolution (e.g. `5 km x 5 km`) |
 | `display.colormap` | No | Colormap name for map rendering (e.g. `blues`, `rdbu_r`) |
 | `display.range` | No | `[min, max]` display range for the colormap |

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -134,9 +134,10 @@ extents:
     resolution: P1D              # ISO 8601 duration: PT1H, P1D, P1M, P1Y
 ```
 
-**CF metadata** — stamped onto the stored variable (and backfilled at load) so the GeoZarr
-store is CF-compliant and CF-aware tools (xclim climate indices, cf-xarray, QGIS) work
-without per-process glue:
+**CF metadata** — stamped onto the stored variable at ingest so the GeoZarr store is
+CF-compliant on disk and CF-aware tools (xclim climate indices, cf-xarray, QGIS) work
+without per-process glue. These fields take effect when the store is written, so changing
+them requires re-ingesting the dataset:
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -159,3 +159,14 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
         has_plugin = isinstance(plugin, str) and bool(plugin)
         if not has_plugin:
             raise ValueError(f"Dataset template '{dataset_id}' in {source} must define ingestion.plugin")
+
+    # Surface non-CF/udunits units so unit-aware processes (xclim indices) don't fail
+    # cryptically later. Warn rather than reject — not every variable is a physical
+    # quantity (e.g. population counts) (#280).
+    units = dataset.get("units")
+    if isinstance(units, str):
+        from open_climate_service.shared.cf import validate_units
+
+        message = validate_units(units)
+        if message:
+            logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -19,6 +19,7 @@ from open_climate_service.data_accessor.services.accessor import open_icechunk_d
 from open_climate_service.data_manager.services.utils import get_time_dim
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat
+from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
 
 logger = logging.getLogger(__name__)
 
@@ -362,16 +363,33 @@ def _load_collection_impl(
                 ),
             )
 
+    # Backfill CF attributes (units / standard_name / cell_methods) from the dataset
+    # template so unit-aware processes (xclim's spi / climate indices) work even when the
+    # stored variable predates CF-stamping at ingest. Existing attributes win (#280).
+    cf_attrs = _template_cf_attrs(artifact, id)
+
     if len(available_vars) == 1:
-        return ds[available_vars[0]]
+        return apply_cf_metadata(ds[available_vars[0]], cf_attrs)
 
     # Multi-band: stack variables on a new "bands" dimension
     import pandas as pd
 
     return xr.concat(
-        [ds[b] for b in available_vars],
+        [apply_cf_metadata(ds[b], cf_attrs) for b in available_vars],
         dim=pd.Index(available_vars, name="bands"),
     )
+
+
+def _template_cf_attrs(artifact: Any, dataset_id: str) -> dict[str, str]:
+    """Resolve CF variable attributes for a loaded collection from its dataset template."""
+    from open_climate_service.data_registry.services import datasets as registry
+
+    template_id = getattr(artifact, "source_dataset_id", None) or dataset_id
+    try:
+        template = registry.get_dataset(template_id) or registry.get_dataset(dataset_id)
+    except Exception:
+        template = None
+    return cf_attrs_from_template(template)
 
 
 class SaveResultEnvelope:

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -19,7 +19,6 @@ from open_climate_service.data_accessor.services.accessor import open_icechunk_d
 from open_climate_service.data_manager.services.utils import get_time_dim
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat
-from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
 
 logger = logging.getLogger(__name__)
 
@@ -363,33 +362,16 @@ def _load_collection_impl(
                 ),
             )
 
-    # Backfill CF attributes (units / standard_name / cell_methods) from the dataset
-    # template so unit-aware processes (xclim's spi / climate indices) work even when the
-    # stored variable predates CF-stamping at ingest. Existing attributes win (#280).
-    cf_attrs = _template_cf_attrs(artifact, id)
-
     if len(available_vars) == 1:
-        return apply_cf_metadata(ds[available_vars[0]], cf_attrs)
+        return ds[available_vars[0]]
 
     # Multi-band: stack variables on a new "bands" dimension
     import pandas as pd
 
     return xr.concat(
-        [apply_cf_metadata(ds[b], cf_attrs) for b in available_vars],
+        [ds[b] for b in available_vars],
         dim=pd.Index(available_vars, name="bands"),
     )
-
-
-def _template_cf_attrs(artifact: Any, dataset_id: str) -> dict[str, str]:
-    """Resolve CF variable attributes for a loaded collection from its dataset template."""
-    from open_climate_service.data_registry.services import datasets as registry
-
-    template_id = getattr(artifact, "source_dataset_id", None) or dataset_id
-    try:
-        template = registry.get_dataset(template_id) or registry.get_dataset(dataset_id)
-    except Exception:
-        template = None
-    return cf_attrs_from_template(template)
 
 
 class SaveResultEnvelope:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -549,6 +549,12 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
         if current_name != desired_name:
             ds = ds.rename({current_name: desired_name})
 
+    # Stamp CF attributes (units / standard_name / cell_methods) from the template so the
+    # published store is CF-compliant on disk (#280).
+    from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
+
+    apply_cf_metadata(ds, cf_attrs_from_template(template))
+
     try:
         x_dim, y_dim = get_x_y_dims(ds)
     except ValueError as exc:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -550,10 +550,11 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
             ds = ds.rename({current_name: desired_name})
 
     # Stamp CF attributes (units / standard_name / cell_methods) from the template so the
-    # published store is CF-compliant on disk (#280).
+    # published store is CF-compliant on disk (#280). The template is authoritative for the
+    # fields it declares, so overwrite any placeholder/generic value left on the variable.
     from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
 
-    apply_cf_metadata(ds, cf_attrs_from_template(template))
+    apply_cf_metadata(ds, cf_attrs_from_template(template), overwrite=True)
 
     try:
         x_dim, y_dim = get_x_y_dims(ds)

--- a/open_climate_service/openeo/xclim_processes.py
+++ b/open_climate_service/openeo/xclim_processes.py
@@ -13,6 +13,34 @@ logger = logging.getLogger(__name__)
 _cache: list[Any] | None = None
 
 
+def call_with_ocs_time_dim(func: Any, *args: Any, **kwargs: Any) -> Any:
+    """Call an xclim function, mapping the OCS ``t`` dimension to/from ``time``.
+
+    Our GeoZarr stores name the temporal dimension ``t``, but xclim indicators and
+    indices require a dimension literally named ``time`` (they index ``da.time``
+    directly). This renames ``t`` -> ``time`` on every xarray argument on the way
+    in, and renames ``time`` -> ``t`` back on the result, so xclim works against our
+    cubes without the caller adding ``rename_dimension`` to every process graph.
+    """
+    import xarray as xr
+
+    renamed = False
+
+    def _to_time(value: Any) -> Any:
+        nonlocal renamed
+        if isinstance(value, (xr.DataArray, xr.Dataset)) and "t" in value.dims and "time" not in value.dims:
+            renamed = True
+            return value.rename({"t": "time"})
+        return value
+
+    args = tuple(_to_time(a) for a in args)
+    kwargs = {key: _to_time(value) for key, value in kwargs.items()}
+    result = func(*args, **kwargs)
+    if renamed and isinstance(result, (xr.DataArray, xr.Dataset)) and "time" in result.dims and "t" not in result.dims:
+        result = result.rename({"time": "t"})
+    return result
+
+
 def scan() -> list[Any]:
     """Return all xclim indicators as process callables (cached after first call)."""
     global _cache
@@ -96,7 +124,7 @@ def _make_callable(indicator: Any, meta: dict[str, Any]) -> Any:
     """Wrap an xclim indicator as a bare callable with process metadata attached."""
 
     def _call(**kwargs: Any) -> Any:
-        return indicator(**kwargs)
+        return call_with_ocs_time_dim(indicator, **kwargs)
 
     setattr(_call, _OCS_PROCESS_ATTR, meta)
     return _call

--- a/open_climate_service/openeo/xclim_processes.py
+++ b/open_climate_service/openeo/xclim_processes.py
@@ -36,9 +36,18 @@ def call_with_ocs_time_dim(func: Any, *args: Any, **kwargs: Any) -> Any:
     args = tuple(_to_time(a) for a in args)
     kwargs = {key: _to_time(value) for key, value in kwargs.items()}
     result = func(*args, **kwargs)
-    if renamed and isinstance(result, (xr.DataArray, xr.Dataset)) and "time" in result.dims and "t" not in result.dims:
-        result = result.rename({"time": "t"})
-    return result
+
+    def _to_t(value: Any) -> Any:
+        if isinstance(value, (xr.DataArray, xr.Dataset)) and "time" in value.dims and "t" not in value.dims:
+            return value.rename({"time": "t"})
+        return value
+
+    if not renamed:
+        return result
+    # Restore the OCS `t` name on the output(s). Some indicators return a tuple of arrays.
+    if isinstance(result, tuple):
+        return tuple(_to_t(item) for item in result)
+    return _to_t(result)
 
 
 def scan() -> list[Any]:

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -1,6 +1,7 @@
 - id: chirps3_precipitation_daily
-  name: Total precipitation (CHIRPS3)
-  short_name: Total precipitation
+  name: Precipitation rate (CHIRPS3)
+  short_name: Precipitation
+  standard_name: lwe_precipitation_rate
   variable: precip
   period_type: daily
   sync:
@@ -14,9 +15,11 @@
       resolution: P1D
   ingestion:
     plugin: open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin
-  units: mm
-  standard_name: lwe_thickness_of_precipitation_amount
-  cell_methods: "time: sum"
+  # Daily precipitation as a rate (mm/day): a daily total in mm equals the mean daily
+  # rate (the cell is one day), so this is a relabel, not a value change. Storing precip
+  # as a flux is what xclim drought indices (SPI/SPEI) consume directly.
+  units: mm/d
+  cell_methods: "time: mean"
   resolution: 5 km x 5 km
   source: CHIRPS v3
   source_url: https://www.chc.ucsb.edu/data/chirps3

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -15,6 +15,8 @@
   ingestion:
     plugin: open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin
   units: mm
+  standard_name: lwe_thickness_of_precipitation_amount
+  cell_methods: "time: sum"
   resolution: 5 km x 5 km
   source: CHIRPS v3
   source_url: https://www.chc.ucsb.edu/data/chirps3

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -295,23 +295,22 @@ class ERA5LandMonthlyPlugin:
 
 
 class ERA5LandMonthlyPrecipitationPlugin(ERA5LandMonthlyPlugin):
-    """ERA5-Land monthly total precipitation plugin.
+    """ERA5-Land monthly precipitation plugin (mean daily rate, mm/day).
 
-    CDS returns the monthly mean of daily totals (m/day). Multiplying by the
-    number of days in the month converts this to the calendar-month total in mm,
-    which is the natural unit for DHIS2 and climate-health reporting.
+    CDS returns the monthly mean of daily totals (m/day). We convert m -> mm to
+    store the mean daily precipitation *rate* (mm/day) — the dimensionally-correct
+    precipitation flux that xclim's indices (SPI/SPEI, …) consume directly. We
+    deliberately do not pre-multiply by days-in-month: the calendar-month total is
+    a trivial ``rate * days_in_month`` derivation, while keeping the rate lets xclim
+    integrate over the exact period length itself.
     """
 
     def __init__(self, **_: Any) -> None:
         super().__init__(variable="tp")
 
     def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
-        year = int(period_id[:4])
-        month = int(period_id[5:7])
-        _, days_in_month = calendar.monthrange(year, month)
         ds = super()._fetch_sync(period_id, bbox)
-        ds = metres_to_mm(ds, {"variable": self.variable})
-        return ds.assign(tp=ds["tp"] * days_in_month)
+        return metres_to_mm(ds, {"variable": self.variable})
 
 
 def _parse_monthly(period: str) -> datetime:

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -17,6 +17,8 @@
     params:
       variable: t2m
   units: degC
+  standard_name: air_temperature
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
@@ -42,6 +44,8 @@
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
     params: {}
   units: mm
+  standard_name: lwe_thickness_of_precipitation_amount
+  cell_methods: "time: sum"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
@@ -69,6 +73,8 @@
     params:
       variable: t2m
   units: degC
+  standard_name: air_temperature
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
@@ -94,6 +100,8 @@
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandMonthlyPrecipitationPlugin
     params: {}
   units: mm
+  standard_name: lwe_thickness_of_precipitation_amount
+  cell_methods: "time: sum"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
@@ -120,6 +128,8 @@
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandTempDailyFromHourlyPlugin
     params: {}
   units: degC
+  standard_name: air_temperature
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
@@ -145,6 +155,8 @@
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
     params: {}
   units: mm
+  standard_name: lwe_thickness_of_precipitation_amount
+  cell_methods: "time: sum"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -1,6 +1,7 @@
 - id: era5land_temperature_daily
   name: 2m temperature (ERA5-Land)
   short_name: 2m temperature
+  standard_name: air_temperature
   variable: t2m
   period_type: daily
   sync:
@@ -17,7 +18,6 @@
     params:
       variable: t2m
   units: degC
-  standard_name: air_temperature
   cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
@@ -27,8 +27,9 @@
     range: [-30.0, 30.0]
 
 - id: era5land_precipitation_daily
-  name: Total precipitation (ERA5-Land)
-  short_name: Total precipitation
+  name: Precipitation rate (ERA5-Land)
+  short_name: Precipitation
+  standard_name: lwe_precipitation_rate
   variable: tp
   period_type: daily
   sync:
@@ -43,9 +44,11 @@
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
     params: {}
-  units: mm
-  standard_name: lwe_thickness_of_precipitation_amount
-  cell_methods: "time: sum"
+  # Daily precipitation as a rate (mm/day): a daily total in mm equals the mean daily
+  # rate (the cell is one day), so this is a relabel, not a value change. Storing precip
+  # as a flux is what xclim drought indices (SPI/SPEI) consume directly.
+  units: mm/d
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
@@ -57,6 +60,7 @@
 - id: era5land_temperature_monthly
   name: 2m temperature (ERA5-Land)
   short_name: 2m temperature
+  standard_name: air_temperature
   variable: t2m
   period_type: monthly
   sync:
@@ -73,7 +77,6 @@
     params:
       variable: t2m
   units: degC
-  standard_name: air_temperature
   cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
@@ -85,6 +88,7 @@
 - id: era5land_precipitation_monthly
   name: Precipitation rate (ERA5-Land)
   short_name: Precipitation
+  standard_name: lwe_precipitation_rate
   variable: tp
   period_type: monthly
   sync:
@@ -103,7 +107,6 @@
   # dimensionally-correct input xclim drought indices (SPI/SPEI) consume directly.
   # Monthly total is a trivial rate * days_in_month derivation downstream.
   units: mm/d
-  standard_name: lwe_precipitation_rate
   cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
@@ -116,6 +119,7 @@
 - id: era5land_temperature_daily_from_hourly
   name: 2m temperature (ERA5-Land, local time)
   short_name: 2m temperature
+  standard_name: air_temperature
   variable: t2m
   period_type: daily
   sync:
@@ -131,7 +135,6 @@
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandTempDailyFromHourlyPlugin
     params: {}
   units: degC
-  standard_name: air_temperature
   cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
@@ -141,8 +144,9 @@
     range: [-30.0, 30.0]
 
 - id: era5land_precipitation_daily_from_hourly
-  name: Total precipitation (ERA5-Land, local time)
-  short_name: Total precipitation
+  name: Precipitation rate (ERA5-Land, local time)
+  short_name: Precipitation
+  standard_name: lwe_precipitation_rate
   variable: tp
   period_type: daily
   sync:
@@ -157,9 +161,9 @@
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandPrecipDailyPlugin
     params: {}
-  units: mm
-  standard_name: lwe_thickness_of_precipitation_amount
-  cell_methods: "time: sum"
+  # Daily precipitation rate (mm/day) — see era5land_precipitation_daily.
+  units: mm/d
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -83,8 +83,8 @@
     range: [-30.0, 30.0]
 
 - id: era5land_precipitation_monthly
-  name: Total precipitation (ERA5-Land)
-  short_name: Total precipitation
+  name: Precipitation rate (ERA5-Land)
+  short_name: Precipitation
   variable: tp
   period_type: monthly
   sync:
@@ -99,15 +99,18 @@
   ingestion:
     plugin: open_climate_service.plugins.datasets.era5_land.ERA5LandMonthlyPrecipitationPlugin
     params: {}
-  units: mm
-  standard_name: lwe_thickness_of_precipitation_amount
-  cell_methods: "time: sum"
+  # Mean daily precipitation rate (a flux), not the calendar-month total: this is the
+  # dimensionally-correct input xclim drought indices (SPI/SPEI) consume directly.
+  # Monthly total is a trivial rate * days_in_month derivation downstream.
+  units: mm/d
+  standard_name: lwe_precipitation_rate
+  cell_methods: "time: mean"
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
   display:
     colormap: blues
-    range: [0.0, 100.0]
+    range: [0.0, 20.0]
     nodata: 0.0
 
 - id: era5land_temperature_daily_from_hourly

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -12,6 +12,7 @@ import xclim.indicators.atmos as xclim_atmos
 import xclim.indices
 from xclim.core.indicator import InputKind
 
+from open_climate_service.openeo.xclim_processes import call_with_ocs_time_dim
 from open_climate_service.process import process
 
 _VARIABLE_SCHEMA: dict[str, Any] = {"type": "object", "subtype": "datacube"}
@@ -56,8 +57,12 @@ def spi(
     fitted to the calibration period. Values below -1 indicate drought conditions;
     values above +1 indicate wet conditions.
     """
-    # DateStr is NewType(str) in xclim — cast to satisfy pyright without importing private types
-    return xclim.indices.standardized_precipitation_index(  # type: ignore[no-any-return]
+    # Delegate to xclim unchanged — the custom process exists only to give SPI a
+    # richer description. call_with_ocs_time_dim maps our ``t`` dimension to the
+    # ``time`` dimension xclim requires (and back), the one behaviour every xclim
+    # process needs. DateStr is NewType(str) in xclim — cast to satisfy pyright.
+    return call_with_ocs_time_dim(  # type: ignore[no-any-return]
+        xclim.indices.standardized_precipitation_index,
         pr,
         freq=freq,
         window=window,

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -77,6 +77,14 @@ def spi(
         cal_start=cast(Any, cal_start),
         cal_end=cast(Any, cal_end),
     )
+    # xclim attaches gamma-fit diagnostics (prob_of_zero, number_of_zeros,
+    # number_of_notnull) as non-dimension coordinates. They are fit internals, not
+    # publishable layers — drop them so the store and STAC cube:variables expose only
+    # the SPI field (georeferencing coords like spatial_ref are dimension/known coords
+    # and are left untouched).
+    diagnostics = [c for c in ("prob_of_zero", "number_of_zeros", "number_of_notnull") if c in result.coords]
+    if diagnostics:
+        result = result.drop_vars(diagnostics)
     # xclim returns float64; downcast to float32. SPI is a small standardized index
     # (~±3) so float32 is ample precision, and it keeps the published store renderable
     # by WebGL map clients (carbonplan ZarrLayer uploads to float32 textures).

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -66,7 +66,7 @@ def spi(
     # maximum-likelihood fit, does not raise FitError on real precipitation that has a
     # pronounced dry season (e.g. near-zero winter months), where ML optimization
     # diverges. DateStr is NewType(str) in xclim — cast to satisfy pyright.
-    return call_with_ocs_time_dim(  # type: ignore[no-any-return]
+    result = call_with_ocs_time_dim(
         xclim.indices.standardized_precipitation_index,
         pr,
         freq=freq,
@@ -77,3 +77,7 @@ def spi(
         cal_start=cast(Any, cal_start),
         cal_end=cast(Any, cal_end),
     )
+    # xclim returns float64; downcast to float32. SPI is a small standardized index
+    # (~±3) so float32 is ample precision, and it keeps the published store renderable
+    # by WebGL map clients (carbonplan ZarrLayer uploads to float32 textures).
+    return cast(xr.DataArray, result.astype("float32"))

--- a/open_climate_service/plugins/processes/climate_indices.py
+++ b/open_climate_service/plugins/processes/climate_indices.py
@@ -57,15 +57,23 @@ def spi(
     fitted to the calibration period. Values below -1 indicate drought conditions;
     values above +1 indicate wet conditions.
     """
-    # Delegate to xclim unchanged — the custom process exists only to give SPI a
-    # richer description. call_with_ocs_time_dim maps our ``t`` dimension to the
-    # ``time`` dimension xclim requires (and back), the one behaviour every xclim
-    # process needs. DateStr is NewType(str) in xclim — cast to satisfy pyright.
+    # Delegate to xclim — the custom process exists to give SPI a richer description,
+    # and to pin a robust fitting configuration. call_with_ocs_time_dim maps our ``t``
+    # dimension to the ``time`` dimension xclim requires (and back).
+    #
+    # We fit a two-parameter gamma (location fixed at 0 via fitkwargs) with the APP
+    # (L-moments) method. This is the standard SPI setup and, unlike xclim's default
+    # maximum-likelihood fit, does not raise FitError on real precipitation that has a
+    # pronounced dry season (e.g. near-zero winter months), where ML optimization
+    # diverges. DateStr is NewType(str) in xclim — cast to satisfy pyright.
     return call_with_ocs_time_dim(  # type: ignore[no-any-return]
         xclim.indices.standardized_precipitation_index,
         pr,
         freq=freq,
         window=window,
+        dist="gamma",
+        method="APP",
+        fitkwargs={"floc": 0},
         cal_start=cast(Any, cal_start),
         cal_end=cast(Any, cal_end),
     )

--- a/open_climate_service/shared/cf.py
+++ b/open_climate_service/shared/cf.py
@@ -4,9 +4,9 @@ Stamp CF attributes (``units``, ``standard_name``, ``cell_methods``) onto stored
 loaded variables from the dataset template, so CF-aware tools — xclim's climate indices,
 cf-xarray, QGIS, earthkit — work against our GeoZarr stores without per-process wrappers.
 
-The single source of truth is the dataset template; the same attributes are applied both
-when writing a store (so it is CF-compliant on disk) and as a backfill when loading
-already-ingested data.
+The single source of truth is the dataset template. Attributes are stamped only on the
+write paths (streaming ingest and managed publish) so the store is CF-compliant on disk;
+there is no read-time backfill — to make an existing store CF-compliant, re-ingest it.
 """
 
 from __future__ import annotations
@@ -97,7 +97,8 @@ def validate_units(units: str) -> str | None:
         return None
     try:
         from xclim.core.units import units2pint
-    except Exception:
+    except ImportError:
+        # xclim is an optional (server-only) dependency; skip validation when absent.
         return None
     try:
         units2pint(units)

--- a/open_climate_service/shared/cf.py
+++ b/open_climate_service/shared/cf.py
@@ -1,0 +1,106 @@
+"""CF Conventions metadata helpers (issue #280).
+
+Stamp CF attributes (``units``, ``standard_name``, ``cell_methods``) onto stored and
+loaded variables from the dataset template, so CF-aware tools — xclim's climate indices,
+cf-xarray, QGIS, earthkit — work against our GeoZarr stores without per-process wrappers.
+
+The single source of truth is the dataset template; the same attributes are applied both
+when writing a store (so it is CF-compliant on disk) and as a backfill when loading
+already-ingested data.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, overload
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# Variable-level CF attributes we propagate from the dataset template.
+CF_VARIABLE_FIELDS = ("units", "standard_name", "cell_methods")
+
+
+def cf_attrs_from_template(template: dict[str, Any] | None) -> dict[str, str]:
+    """Return the CF variable attributes declared on a dataset template.
+
+    ``units: ""`` is kept (an explicitly dimensionless quantity, e.g. a standardized index).
+    """
+    if not template:
+        return {}
+    out: dict[str, str] = {}
+    for key in CF_VARIABLE_FIELDS:
+        value = template.get(key)
+        if isinstance(value, str):
+            out[key] = value
+    return out
+
+
+@overload
+def apply_cf_metadata(
+    obj: "xr.Dataset", attrs: dict[str, str], *, variable: str | None = ..., overwrite: bool = ...
+) -> "xr.Dataset": ...
+
+
+@overload
+def apply_cf_metadata(
+    obj: "xr.DataArray", attrs: dict[str, str], *, variable: str | None = ..., overwrite: bool = ...
+) -> "xr.DataArray": ...
+
+
+def apply_cf_metadata(
+    obj: "xr.Dataset | xr.DataArray",
+    attrs: dict[str, str],
+    *,
+    variable: str | None = None,
+    overwrite: bool = False,
+) -> "xr.Dataset | xr.DataArray":
+    """Set CF attributes on the target variable(s) in place and return ``obj``.
+
+    Existing attributes are preserved unless ``overwrite=True`` (so metadata already on
+    the data — e.g. from the source — wins over the template). For a ``Dataset``, applies
+    to ``variable`` when given and present, otherwise to all data variables.
+    """
+    import xarray as xr
+
+    if not attrs:
+        return obj
+
+    def _set(da: xr.DataArray) -> None:
+        for key, value in attrs.items():
+            # An empty-string units means "dimensionless" and is intentional, so treat it
+            # as present; for the others, only fill when missing/blank.
+            present = key in da.attrs and (da.attrs[key] != "" or key == "units")
+            if overwrite or not present:
+                da.attrs[key] = value
+
+    if isinstance(obj, xr.DataArray):
+        _set(obj)
+        return obj
+
+    targets: list[Any] = [variable] if variable and variable in obj.data_vars else list(obj.data_vars)
+    for name in targets:
+        _set(obj[name])
+    return obj
+
+
+def validate_units(units: str) -> str | None:
+    """Return an error message if ``units`` is not a recognised CF/udunits unit, else None.
+
+    Uses xclim's unit registry (what the xclim indices parse against), so "valid here"
+    means "xclim can use it". ``""`` is allowed (dimensionless). Returns None — rather
+    than raising — when the validator is unavailable (client-only install).
+    """
+    if units == "":
+        return None
+    try:
+        from xclim.core.units import units2pint
+    except Exception:
+        return None
+    try:
+        units2pint(units)
+    except Exception as exc:  # noqa: BLE001 — any parse failure means invalid units
+        return f"units '{units}' is not a recognised CF/udunits unit ({exc})"
+    return None

--- a/open_climate_service/shared/cf.py
+++ b/open_climate_service/shared/cf.py
@@ -1,8 +1,8 @@
 """CF Conventions metadata helpers (issue #280).
 
-Stamp CF attributes (``units``, ``standard_name``, ``cell_methods``) onto stored and
-loaded variables from the dataset template, so CF-aware tools — xclim's climate indices,
-cf-xarray, QGIS, earthkit — work against our GeoZarr stores without per-process wrappers.
+Stamp CF attributes (``units``, ``standard_name``, ``cell_methods``) onto stored variables
+from the dataset template, so CF-aware tools — xclim's climate indices, cf-xarray, QGIS,
+earthkit — work against our GeoZarr stores without per-process wrappers.
 
 The single source of truth is the dataset template. Attributes are stamped only on the
 write paths (streaming ingest and managed publish) so the store is CF-compliant on disk;

--- a/open_climate_service/shared/cf.py
+++ b/open_climate_service/shared/cf.py
@@ -59,9 +59,13 @@ def apply_cf_metadata(
 ) -> "xr.Dataset | xr.DataArray":
     """Set CF attributes on the target variable(s) in place and return ``obj``.
 
-    Existing attributes are preserved unless ``overwrite=True`` (so metadata already on
-    the data — e.g. from the source — wins over the template). For a ``Dataset``, applies
-    to ``variable`` when given and present, otherwise to all data variables.
+    With ``overwrite=False`` existing attributes are preserved (the data wins). Ingest and
+    managed-publish stamp with ``overwrite=True`` because the dataset template is the
+    authoritative source for the CF fields it declares: an explicit template value replaces
+    any generic or placeholder value a source/transform left on the variable (e.g. GRIB's
+    ``standard_name="unknown"`` or a unit conversion's dimensionally-generic ``"mm"`` where
+    the template declares the rate ``"mm/d"``). Fields the template omits are untouched.
+    For a ``Dataset``, applies to ``variable`` when given and present, else all data vars.
     """
     import xarray as xr
 

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -15,7 +15,11 @@ _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?
 _PERIOD_TYPE_ISO_STEP = {
     "hourly": "PT1H",
     "daily": "P1D",
+    # A week is exactly 7 days; "P7D" (not "P1W") so the map viewer's duration parser,
+    # which handles H/D/M/Y but not W, can build the slider.
+    "weekly": "P7D",
     "monthly": "P1M",
+    "quarterly": "P3M",
     "yearly": "P1Y",
 }
 

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -12,6 +12,25 @@ logger = logging.getLogger(__name__)
 
 _ISO_DURATION_RE = re.compile(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
+_PERIOD_TYPE_ISO_STEP = {
+    "hourly": "PT1H",
+    "daily": "P1D",
+    "monthly": "P1M",
+    "yearly": "P1Y",
+}
+
+
+def period_type_to_iso_step(period_type: Any) -> str | None:
+    """Map a dataset ``period_type`` to its ISO 8601 step, or None if not a regular cadence.
+
+    Used as a fallback for the temporal cube dimension's ``step`` when a template does
+    not declare ``extents.temporal.resolution`` (e.g. openEO ``save_result`` outputs).
+    Without a step the map viewer cannot build a time slider.
+    """
+    if not isinstance(period_type, str):
+        return None
+    return _PERIOD_TYPE_ISO_STEP.get(period_type)
+
 
 def resolve_iso_period_step(dataset: dict[str, Any]) -> str | None:
     """Return the ISO 8601 duration step from ``extents.temporal.resolution``.

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -19,7 +19,11 @@ from open_climate_service.data_manager.services.utils import get_time_dim, get_x
 from open_climate_service.data_registry.services import datasets as registry_datasets
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
-from open_climate_service.shared.time import parse_period_string_to_datetime, resolve_iso_period_step
+from open_climate_service.shared.time import (
+    parse_period_string_to_datetime,
+    period_type_to_iso_step,
+    resolve_iso_period_step,
+)
 
 CATALOG_TITLE = "Open Climate Service"
 CATALOG_DESCRIPTION = "Published Open Climate Service GeoZarr datasets"
@@ -132,7 +136,13 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_payload["license"] = template.license
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
-    _override_time_step(collection_payload, resolve_iso_period_step(source_dataset))
+    # Prefer an explicit extents.temporal.resolution; fall back to the dataset's
+    # period_type so openEO save_result outputs (which omit the extents block) still
+    # get a temporal step — the map viewer needs it to build the time slider.
+    _override_time_step(
+        collection_payload,
+        resolve_iso_period_step(source_dataset) or period_type_to_iso_step(source_dataset.get("period_type")),
+    )
     _override_spatial_extent_from_artifact(collection_payload, artifact)
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -391,11 +391,18 @@ def _build_cube_variables(ds: xr.Dataset) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for name in ds.data_vars:
         var = ds[name]
-        result[str(name)] = {
+        entry: dict[str, Any] = {
             "type": "data",
             "dimensions": [str(d) for d in var.dims],
             "unit": var.attrs.get("units"),
         }
+        # Surface the CF semantics we stamp onto the store so catalog clients can
+        # identify the quantity, not just its unit (#283).
+        for cf_key in ("standard_name", "cell_methods"):
+            value = var.attrs.get(cf_key)
+            if isinstance(value, str):
+                entry[cf_key] = value
+        result[str(name)] = entry
     return result
 
 
@@ -452,6 +459,13 @@ def _sanitize_variable_attrs(collection: dict[str, Any]) -> None:
         if isinstance(units, str):
             kept_attrs["units"] = units
             variable["unit"] = units
+        # Surface the CF semantics we stamp onto the store as top-level cube:variable
+        # fields (and keep them in attrs) so catalog clients see the quantity (#283).
+        for cf_key in ("standard_name", "cell_methods"):
+            value = attrs.get(cf_key)
+            if isinstance(value, str):
+                kept_attrs[cf_key] = value
+                variable[cf_key] = value
         variable["attrs"] = kept_attrs
 
 

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -129,6 +129,10 @@ async def run_streaming_ingest(
     expected_spatial_shape: tuple[int, int] | None = None
     # CF attributes (units / standard_name / cell_methods) declared on the template,
     # stamped onto each written period so the store is CF-compliant on disk (#280).
+    # The template is authoritative for the fields it declares, so we overwrite any
+    # generic or placeholder value the source/transform left behind (e.g. GRIB's
+    # standard_name="unknown", or a unit conversion's dimensionally-generic "mm" for
+    # what the template declares as a rate "mm/d"). Fields the template omits are kept.
     cf_attrs = cf_attrs_from_template(dataset)
 
     async def _fetch(period_id: str) -> xr.Dataset:
@@ -150,7 +154,7 @@ async def run_streaming_ingest(
             period_id, task = in_flight.popleft()
             ds = await task
             _strip_cf_encoding(ds, period_type, time_dim=spec.time_dim)
-            apply_cf_metadata(ds, cf_attrs)
+            apply_cf_metadata(ds, cf_attrs, overwrite=True)
             try:
                 spatial_shape = (int(ds.sizes[spec.y_dim]), int(ds.sizes[spec.x_dim]))
             except KeyError as exc:

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -25,6 +25,7 @@ from typing import Any
 
 import xarray as xr
 
+from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
 from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
 from open_climate_service.streaming.store import (
     is_store_empty,
@@ -126,6 +127,9 @@ async def run_streaming_ingest(
     # Icechunk transaction batching.
     commit_batch_size = max(1, int(plugin.commit_batch_size))
     expected_spatial_shape: tuple[int, int] | None = None
+    # CF attributes (units / standard_name / cell_methods) declared on the template,
+    # stamped onto each written period so the store is CF-compliant on disk (#280).
+    cf_attrs = cf_attrs_from_template(dataset)
 
     async def _fetch(period_id: str) -> xr.Dataset:
         return await plugin.fetch_period(period_id, bbox, **params)
@@ -146,6 +150,7 @@ async def run_streaming_ingest(
             period_id, task = in_flight.popleft()
             ds = await task
             _strip_cf_encoding(ds, period_type, time_dim=spec.time_dim)
+            apply_cf_metadata(ds, cf_attrs)
             try:
                 spatial_shape = (int(ds.sizes[spec.y_dim]), int(ds.sizes[spec.x_dim]))
             except KeyError as exc:

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -278,12 +278,29 @@
       }
 
       function generateDateRange(start, end, step) {
-        const inc = parseDuration(step);
-        if (!inc) return [start];
-        const startMs = new Date(start).getTime();
-        const endMs = new Date(end).getTime();
-        if (isNaN(startMs) || isNaN(endMs)) return [start];
-        const count = Math.max(1, Math.floor((endMs - startMs) / inc) + 1);
+        const m = step.match(/^P(?:T(\d+)H|(\d+)D|(\d+)M|(\d+)Y)$/);
+        if (!m) return [start];
+        const sd = new Date(start);
+        const ed = new Date(end);
+        if (isNaN(sd.getTime()) || isNaN(ed.getTime())) return [start];
+        // Months and years must step by the calendar, not a fixed 30-/365-day
+        // approximation: the approximation drifts over multi-year ranges and
+        // overcounts steps, leaving the slider with more positions than the store
+        // has time slices (so the last position reads out of bounds and renders blank).
+        if (m[3]) {
+          const n = parseInt(m[3]);
+          const months =
+            (ed.getUTCFullYear() - sd.getUTCFullYear()) * 12 +
+            (ed.getUTCMonth() - sd.getUTCMonth());
+          return { lazy: true, start, calUnit: "M", n, count: Math.max(1, Math.floor(months / n) + 1) };
+        }
+        if (m[4]) {
+          const n = parseInt(m[4]);
+          const years = ed.getUTCFullYear() - sd.getUTCFullYear();
+          return { lazy: true, start, calUnit: "Y", n, count: Math.max(1, Math.floor(years / n) + 1) };
+        }
+        const inc = m[1] ? parseInt(m[1]) * 3_600_000 : parseInt(m[2]) * 86_400_000;
+        const count = Math.max(1, Math.floor((ed.getTime() - sd.getTime()) / inc) + 1);
         return { lazy: true, start, inc, count };
       }
 
@@ -297,20 +314,18 @@
 
       function timeStepAt(i) {
         if (Array.isArray(timeSteps)) return timeSteps[i];
-        return new Date(new Date(timeSteps.start).getTime() + i * timeSteps.inc)
-          .toISOString()
-          .slice(0, 10);
-      }
-
-      // Minimal ISO 8601 duration parser for common climate period types.
-      function parseDuration(iso) {
-        const m = iso.match(/^P(?:T(\d+)H|(\d+)D|(\d+)M|(\d+)Y)$/);
-        if (!m) return null;
-        if (m[1]) return parseInt(m[1]) * 3_600_000; // PT#H
-        if (m[2]) return parseInt(m[2]) * 86_400_000; // P#D
-        if (m[3]) return parseInt(m[3]) * 30 * 86_400_000; // P#M (approximation)
-        if (m[4]) return parseInt(m[4]) * 365 * 86_400_000; // P#Y (approximation)
-        return null;
+        const sd = new Date(timeSteps.start);
+        if (timeSteps.calUnit === "M") {
+          const d = new Date(sd);
+          d.setUTCMonth(d.getUTCMonth() + i * timeSteps.n);
+          return d.toISOString().slice(0, 10);
+        }
+        if (timeSteps.calUnit === "Y") {
+          const d = new Date(sd);
+          d.setUTCFullYear(d.getUTCFullYear() + i * timeSteps.n);
+          return d.toISOString().slice(0, 10);
+        }
+        return new Date(sd.getTime() + i * timeSteps.inc).toISOString().slice(0, 10);
       }
 
       const MAP_UNAVAILABLE_MESSAGE =

--- a/tests/test_cf_metadata.py
+++ b/tests/test_cf_metadata.py
@@ -1,15 +1,11 @@
-"""Tests for CF-metadata stamping/backfill and units validation (issue #280)."""
+"""Tests for CF-metadata stamping and units validation (issue #280)."""
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 
-import open_climate_service.openeo.execution as ex
 from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template, validate_units
 
 
@@ -58,33 +54,3 @@ def test_validate_units_accepts_valid(units: str) -> None:
 def test_validate_units_rejects_invalid(units: str) -> None:
     msg = validate_units(units)
     assert msg is not None and "not a recognised" in msg
-
-
-def test_load_collection_backfills_cf_from_template(monkeypatch: pytest.MonkeyPatch) -> None:
-    times = pd.date_range("2020-01-01", periods=2, freq="D")
-    ds = xr.Dataset(
-        {"precip": (("t", "y", "x"), np.ones((2, 1, 1), dtype="float32"))},
-        coords={"t": times, "y": [0.0], "x": [0.0]},
-    )
-    monkeypatch.setattr(
-        ex, "_get_published_artifact", lambda _id: SimpleNamespace(source_dataset_id="chirps3_precipitation_daily")
-    )
-    monkeypatch.setattr(ex, "_open_artifact", lambda _a: ds)
-    monkeypatch.setattr(ex, "_ensure_crs", lambda d: d)
-    from open_climate_service.data_registry.services import datasets as registry
-
-    monkeypatch.setattr(
-        registry,
-        "get_dataset",
-        lambda i: {
-            "units": "mm",
-            "standard_name": "lwe_thickness_of_precipitation_amount",
-            "cell_methods": "time: sum",
-        },
-    )
-
-    cube = ex._load_collection_impl("chirps3_precipitation_daily")
-
-    assert cube.attrs.get("units") == "mm"
-    assert cube.attrs.get("standard_name") == "lwe_thickness_of_precipitation_amount"
-    assert cube.attrs.get("cell_methods") == "time: sum"

--- a/tests/test_cf_metadata.py
+++ b/tests/test_cf_metadata.py
@@ -1,0 +1,90 @@
+"""Tests for CF-metadata stamping/backfill and units validation (issue #280)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import open_climate_service.openeo.execution as ex
+from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template, validate_units
+
+
+def test_cf_attrs_from_template_extracts_cf_fields() -> None:
+    template = {
+        "units": "mm",
+        "standard_name": "lwe_thickness_of_precipitation_amount",
+        "cell_methods": "time: sum",
+        "name": "x",
+    }
+    assert cf_attrs_from_template(template) == {
+        "units": "mm",
+        "standard_name": "lwe_thickness_of_precipitation_amount",
+        "cell_methods": "time: sum",
+    }
+    assert cf_attrs_from_template(None) == {}
+    assert cf_attrs_from_template({"units": ""}) == {"units": ""}  # dimensionless kept
+
+
+def test_apply_cf_metadata_sets_and_preserves() -> None:
+    da = xr.DataArray(np.zeros((2, 2), dtype="float32"), dims=("y", "x"))
+    apply_cf_metadata(da, {"units": "mm", "standard_name": "lwe_thickness_of_precipitation_amount"})
+    assert da.attrs["units"] == "mm"
+    assert da.attrs["standard_name"] == "lwe_thickness_of_precipitation_amount"
+
+    # existing attrs win unless overwrite=True
+    da2 = xr.DataArray(np.zeros(2), dims=("x",), attrs={"units": "kg m-2 s-1"})
+    apply_cf_metadata(da2, {"units": "mm"})
+    assert da2.attrs["units"] == "kg m-2 s-1"
+    apply_cf_metadata(da2, {"units": "mm"}, overwrite=True)
+    assert da2.attrs["units"] == "mm"
+
+
+def test_apply_cf_metadata_targets_dataset_variable() -> None:
+    ds = xr.Dataset({"precip": (("y", "x"), np.zeros((1, 1), dtype="float32"))}, coords={"y": [0.0], "x": [0.0]})
+    apply_cf_metadata(ds, {"units": "mm"}, variable="precip")
+    assert ds["precip"].attrs["units"] == "mm"
+
+
+@pytest.mark.parametrize("units", ["mm", "mm/d", "degC", "kg m-2 s-1", ""])
+def test_validate_units_accepts_valid(units: str) -> None:
+    assert validate_units(units) is None
+
+
+@pytest.mark.parametrize("units", ["people", "not-a-unit"])
+def test_validate_units_rejects_invalid(units: str) -> None:
+    msg = validate_units(units)
+    assert msg is not None and "not a recognised" in msg
+
+
+def test_load_collection_backfills_cf_from_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    times = pd.date_range("2020-01-01", periods=2, freq="D")
+    ds = xr.Dataset(
+        {"precip": (("t", "y", "x"), np.ones((2, 1, 1), dtype="float32"))},
+        coords={"t": times, "y": [0.0], "x": [0.0]},
+    )
+    monkeypatch.setattr(
+        ex, "_get_published_artifact", lambda _id: SimpleNamespace(source_dataset_id="chirps3_precipitation_daily")
+    )
+    monkeypatch.setattr(ex, "_open_artifact", lambda _a: ds)
+    monkeypatch.setattr(ex, "_ensure_crs", lambda d: d)
+    from open_climate_service.data_registry.services import datasets as registry
+
+    monkeypatch.setattr(
+        registry,
+        "get_dataset",
+        lambda i: {
+            "units": "mm",
+            "standard_name": "lwe_thickness_of_precipitation_amount",
+            "cell_methods": "time: sum",
+        },
+    )
+
+    cube = ex._load_collection_impl("chirps3_precipitation_daily")
+
+    assert cube.attrs.get("units") == "mm"
+    assert cube.attrs.get("standard_name") == "lwe_thickness_of_precipitation_amount"
+    assert cube.attrs.get("cell_methods") == "time: sum"

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -73,6 +73,17 @@ def test_spi1_output_length_matches_monthly_resampling(daily_precip: xr.DataArra
     assert result.sizes["time"] == 60
 
 
+def test_spi_drops_xclim_fit_diagnostic_coords(daily_precip: xr.DataArray) -> None:
+    """xclim attaches gamma-fit diagnostics as non-dim coords; we drop them so the
+    published store / STAC cube:variables expose only the SPI field, while keeping
+    georeferencing coords like spatial_ref."""
+    cube = daily_precip.assign_coords(spatial_ref=0)
+    result = spi(cube, window=3)
+    assert not {"prob_of_zero", "number_of_zeros", "number_of_notnull"} & set(result.coords)
+    assert "spatial_ref" in result.coords
+    assert result.dtype == "float32"
+
+
 def test_spi_accepts_ocs_t_dimension_and_returns_t(daily_precip: xr.DataArray) -> None:
     """OCS stores name the temporal dim 't'; xclim needs 'time'. The wrapper renames
     on-the-fly and restores 't' on the output, so graphs need no rename_dimension."""

--- a/tests/test_climate_indices.py
+++ b/tests/test_climate_indices.py
@@ -73,6 +73,16 @@ def test_spi1_output_length_matches_monthly_resampling(daily_precip: xr.DataArra
     assert result.sizes["time"] == 60
 
 
+def test_spi_accepts_ocs_t_dimension_and_returns_t(daily_precip: xr.DataArray) -> None:
+    """OCS stores name the temporal dim 't'; xclim needs 'time'. The wrapper renames
+    on-the-fly and restores 't' on the output, so graphs need no rename_dimension."""
+    cube_t = daily_precip.rename({"time": "t"})
+    result = spi(cube_t, window=1)
+    assert isinstance(result, xr.DataArray)
+    assert "t" in result.dims and "time" not in result.dims
+    assert result.sizes["t"] == 60
+
+
 def test_spi3_produces_different_values_than_spi1(daily_precip: xr.DataArray) -> None:
     r1 = spi(daily_precip, window=1)
     r3 = spi(daily_precip, window=3)

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -251,7 +251,7 @@ def test_era5_land_monthly_fetch_renames_coords_and_converts_temperature(
     np.testing.assert_allclose(ds["t2m"].values, [[[300.0 - 273.15]]], atol=1e-3)
 
 
-def test_era5_land_monthly_precipitation_converts_metres_to_mm(
+def test_era5_land_monthly_precipitation_converts_metres_to_mm_rate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     plugin = ERA5LandMonthlyPrecipitationPlugin()
@@ -266,8 +266,10 @@ def test_era5_land_monthly_precipitation_converts_metres_to_mm(
     monkeypatch.setattr(ERA5LandMonthlyPlugin, "_fetch_sync", fake_parent_fetch)
     ds = asyncio.run(plugin.fetch_period("2024-01", [-1.0, 8.0, 31.0, 10.0]))
 
-    # 0.05 m/day × 1000 mm/m × 31 days (January 2024) = 1550 mm monthly total
-    np.testing.assert_allclose(ds["tp"].values, [[[1550.0]]], atol=1e-1)
+    # CDS gives the mean daily total (m/day). We store the mean daily *rate* in mm/day,
+    # NOT the calendar-month total: 0.05 m/day × 1000 mm/m = 50 mm/day. (A flux is the
+    # dimensionally-correct input for xclim indices; the monthly total is rate × days.)
+    np.testing.assert_allclose(ds["tp"].values, [[[50.0]]], atol=1e-1)
 
 
 def test_monthly_availability_cutoff_uses_cds_end_datetime() -> None:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1114,6 +1114,40 @@ def test_persist_result_writes_icechunk_when_dataset_id_in_options(
     assert publish_flag is True  # publish defaults to True when key is absent
 
 
+def test_persist_result_stamps_cf_attrs_from_template(
+    job_service: OpenEOJobService, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CF attributes from the dataset template are persisted onto the managed store variable (#280)."""
+    from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
+
+    def _cf_template(dataset_id: str) -> dict[str, Any]:
+        return {
+            "id": dataset_id,
+            "units": "mm",
+            "standard_name": "lwe_thickness_of_precipitation_amount",
+            "cell_methods": "time: sum",
+        }
+
+    monkeypatch.setattr("open_climate_service.data_manager.services.downloader.DOWNLOAD_DIR", tmp_path)
+    monkeypatch.setattr("open_climate_service.data_registry.services.datasets.get_dataset", _cf_template)
+    monkeypatch.setattr(
+        "open_climate_service.ingestions.services.register_artifact_record",
+        lambda record, publish: record,
+    )
+
+    envelope = SaveResultEnvelope(_small_dataset(), "Zarr", {"dataset_id": "cf_aggregate", "publish": False})
+    job_service._persist_result("job-cf", envelope)
+
+    written = open_icechunk_dataset(str(tmp_path / "cf_aggregate.icechunk"))
+    try:
+        attrs = written["precip"].attrs
+        assert attrs.get("units") == "mm"
+        assert attrs.get("standard_name") == "lwe_thickness_of_precipitation_amount"
+        assert attrs.get("cell_methods") == "time: sum"
+    finally:
+        written.close()
+
+
 def test_persist_result_does_not_publish_when_publish_false(
     job_service: OpenEOJobService, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -4,7 +4,23 @@ from open_climate_service.shared.time import (
     datetime_to_period_string,
     normalize_period_string,
     parse_period_string_to_datetime,
+    period_type_to_iso_step,
 )
+
+
+@pytest.mark.parametrize(
+    ("period_type", "expected"),
+    [
+        ("hourly", "PT1H"),
+        ("daily", "P1D"),
+        ("monthly", "P1M"),
+        ("yearly", "P1Y"),
+        ("climatology", None),
+        (None, None),
+    ],
+)
+def test_period_type_to_iso_step(period_type: object, expected: str | None) -> None:
+    assert period_type_to_iso_step(period_type) == expected
 
 
 def test_normalize_period_string_raises_targeted_monthly_error() -> None:

--- a/tests/test_shared_time.py
+++ b/tests/test_shared_time.py
@@ -13,7 +13,9 @@ from open_climate_service.shared.time import (
     [
         ("hourly", "PT1H"),
         ("daily", "P1D"),
+        ("weekly", "P7D"),
         ("monthly", "P1M"),
+        ("quarterly", "P3M"),
         ("yearly", "P1Y"),
         ("climatology", None),
         (None, None),

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -197,6 +197,8 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
                     "attrs": {
                         "long_name": "Precipitation",
                         "units": "mm/day",
+                        "standard_name": "lwe_precipitation_rate",
+                        "cell_methods": "time: mean",
                         "TIFFTAG_SOFTWARE": "IDL 9.0.0",
                     },
                 },
@@ -225,9 +227,14 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     assert payload["cube:dimensions"]["t"]["extent"] == ["2026-01-01T00:00:00Z", "2026-01-10T00:00:00Z"]
     assert payload["cube:dimensions"]["t"]["step"] == "P1D"
     assert payload["cube:variables"]["precip"]["unit"] == "mm/day"
+    # CF semantics surfaced as top-level cube:variable fields (#283)
+    assert payload["cube:variables"]["precip"]["standard_name"] == "lwe_precipitation_rate"
+    assert payload["cube:variables"]["precip"]["cell_methods"] == "time: mean"
     assert payload["cube:variables"]["precip"]["attrs"] == {
         "long_name": "Precipitation",
         "units": "mm/day",
+        "standard_name": "lwe_precipitation_rate",
+        "cell_methods": "time: mean",
     }
     assert "https://stac-extensions.github.io/projection/v2.0.0/schema.json" in payload["stac_extensions"]
 

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -158,6 +158,44 @@ def test_orchestrator_uses_store_state_as_resume_truth(monkeypatch: pytest.Monke
     assert cursor_saves[-1] == {"last_committed": "2026-01-03"}
 
 
+def test_orchestrator_stamps_cf_attrs_from_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """CF attributes declared on the template are persisted onto the stored variable (#280)."""
+    store_path = tmp_path / "streaming-store.zarr"
+    repo = _FakeRepo(str(store_path))
+
+    monkeypatch.setattr(streaming_orchestrator, "open_or_create_repo", lambda path: repo)
+    monkeypatch.setattr(
+        streaming_orchestrator,
+        "read_committed_period_ids",
+        lambda path, period_type, time_dim="t": _read_committed_periods_from_zarr(path, period_type, time_dim=time_dim),
+    )
+    monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
+
+    run_streaming_ingest_sync(
+        plugin=_FakePlugin(),
+        params={},
+        dataset={
+            "units": "mm",
+            "standard_name": "lwe_thickness_of_precipitation_amount",
+            "cell_methods": "time: sum",
+        },
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        start="2026-01-01",
+        end="2026-01-03",
+        store_path=store_path,
+        period_type="daily",
+    )
+
+    written = xr.open_zarr(store_path, consolidated=None)
+    try:
+        attrs = written["precip"].attrs
+        assert attrs.get("units") == "mm"
+        assert attrs.get("standard_name") == "lwe_thickness_of_precipitation_amount"
+        assert attrs.get("cell_methods") == "time: sum"
+    finally:
+        written.close()
+
+
 def test_orchestrator_refuses_destructive_first_write_when_existing_store_is_not_empty(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -158,8 +158,22 @@ def test_orchestrator_uses_store_state_as_resume_truth(monkeypatch: pytest.Monke
     assert cursor_saves[-1] == {"last_committed": "2026-01-03"}
 
 
+class _PlaceholderAttrsPlugin(_FakePlugin):
+    """Emits the kind of generic/placeholder CF attrs GRIB & unit-conversions leave behind."""
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
+        ds = await super().fetch_period(period_id, bbox, **params)
+        ds["precip"].attrs.update({"units": "mm", "standard_name": "unknown"})
+        return ds
+
+
 def test_orchestrator_stamps_cf_attrs_from_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """CF attributes declared on the template are persisted onto the stored variable (#280)."""
+    """The template is authoritative: its CF fields overwrite placeholder source attrs (#280).
+
+    The source variable arrives with a dimensionally-generic ``units='mm'`` and a placeholder
+    ``standard_name='unknown'``; the template declares the rate ``mm/d`` and the real
+    standard name, which must win on disk so xclim-style unit checks pass.
+    """
     store_path = tmp_path / "streaming-store.zarr"
     repo = _FakeRepo(str(store_path))
 
@@ -172,12 +186,12 @@ def test_orchestrator_stamps_cf_attrs_from_template(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
 
     run_streaming_ingest_sync(
-        plugin=_FakePlugin(),
+        plugin=_PlaceholderAttrsPlugin(),
         params={},
         dataset={
-            "units": "mm",
-            "standard_name": "lwe_thickness_of_precipitation_amount",
-            "cell_methods": "time: sum",
+            "units": "mm/d",
+            "standard_name": "lwe_precipitation_rate",
+            "cell_methods": "time: mean",
         },
         bbox=[0.0, 0.0, 1.0, 1.0],
         start="2026-01-01",
@@ -189,9 +203,9 @@ def test_orchestrator_stamps_cf_attrs_from_template(monkeypatch: pytest.MonkeyPa
     written = xr.open_zarr(store_path, consolidated=None)
     try:
         attrs = written["precip"].attrs
-        assert attrs.get("units") == "mm"
-        assert attrs.get("standard_name") == "lwe_thickness_of_precipitation_amount"
-        assert attrs.get("cell_methods") == "time: sum"
+        assert attrs.get("units") == "mm/d"  # template rate overrides source 'mm'
+        assert attrs.get("standard_name") == "lwe_precipitation_rate"  # overrides 'unknown'
+        assert attrs.get("cell_methods") == "time: mean"
     finally:
         written.close()
 


### PR DESCRIPTION
Implements #280 and #283. Makes our generic GeoZarr stores **CF-compliant on disk** so xclim climate indices — and any CF-aware tool (cf-xarray, QGIS, earthkit) — work without per-process wrappers. While validating this end-to-end with SPI on a live instance, it grew to fix every gap on the path from "store has units" to "drought index renders on the map".

## 1. CF metadata on the store (the core, #280)
- **`shared/cf.py`**: `apply_cf_metadata()` stamps `units` / `standard_name` / `cell_methods`; `cf_attrs_from_template()`; `validate_units()` (xclim udunits registry).
- **Stamped at write time** — streaming ingest (orchestrator) and `save_result` managed publish (`jobs._write_managed_zarr`) → the store is CF-compliant **on disk**. **No read-time backfill** (supersedes the closed #279): to make an existing store CF-compliant, **re-ingest it**.
- **Template is authoritative** for the CF fields it declares (stamped with `overwrite=True`). GRIB/source data and unit-conversion transforms leave placeholder/generic attrs (`standard_name="unknown"`, a dimensionally-generic `"mm"` for what is really a rate) that previously won over the curated template and silently mislabeled stores. The template now wins for fields it declares; fields it omits are untouched.
- **Registration warns** on non-udunits `units` (e.g. `people`) — non-blocking.
- **Built-in templates** annotated (CHIRPS3, ERA5-Land); `standard_name` placed right after `short_name`.

## 2. All precipitation datasets stored as a rate (mm/day)
Precipitation is stored as a **flux** (`mm/d`, `lwe_precipitation_rate`, `cell_methods: time: mean`) — the dimensionally-correct input xclim drought indices require — across **every** precip dataset, so all are usable for SPI/SPEI:
- `era5land_precipitation_monthly`: ERA5 monthly-means is natively the mean of daily totals; we stop pre-multiplying by days-in-month and keep the rate.
- `era5land_precipitation_daily`, `era5land_precipitation_daily_from_hourly`, `chirps3_precipitation_daily`: a daily total in `mm` equals the mean daily rate (1-day cell), so these are template **relabels**, not value changes. **This unblocks SPI on CHIRPS3 — the original Uganda use case.**

Monthly/period totals remain a trivial `rate × days_in_month` derivation downstream.

## 3. xclim processes work against our cubes
- **`t` → `time` on the fly**: shared `call_with_ocs_time_dim` helper renames our temporal dim to the `time` dim xclim requires (and back to `t` on output, including tuple-returning indicators), used by both auto-registered xclim indicators and the custom `spi`. No `rename_dimension` needed in graphs. The custom `spi` stays a *description-only* override that delegates to xclim.
- **Robust SPI fit**: pin the standard two-parameter gamma (`floc=0`) with the `APP` (L-moments) method — xclim’s default ML fit raises `FitError` on real precip with a dry season. SPI output is downcast to **float32** (ample for a ±3 index, and keeps the published store renderable by WebGL map clients).

## 4. STAC `cube:variables` exposes CF semantics (#283)
`_build_cube_variables` and `_sanitize_variable_attrs` now surface `standard_name` and `cell_methods` (alongside `unit`) as top-level cube:variable fields, so the catalog identifies the quantity, not just its unit. The `spi` process also drops xclim’s gamma-fit diagnostic coordinates (`prob_of_zero`/`number_of_zeros`/`number_of_notnull`) so the store and catalog expose only the SPI field.

## 5. Map viewer fixes
- **Calendar-aware time slider**: `generateDateRange` approximated `P1M`/`P1Y` as fixed 30-/365-day spans, drifting over multi-year ranges and **overcounting** slider positions (a 6-year monthly dataset got 73 positions for 72 slices) — the default position read out of bounds and rendered blank. Now steps by the calendar.
- **Temporal step fallback**: openEO `save_result` outputs omit `extents.temporal.resolution`, leaving the STAC temporal dimension with no `step` → the viewer hid the slider and locked to `t=0` (all-NaN for SPI-3). The STAC builder now falls back to deriving the step from `period_type`.

## Validation (end-to-end on a live instance)
Re-ingested ERA5-Land monthly precip as `mm/d` → ran `load_collection → spi(window=3) → save_result(Zarr, publish)` as a batch openEO job → published `era5land_spi3_monthly` GeoZarr (STAC collection, ~97% finite, SPI range ±2.2), rendering on `/map` with a working time slider. The original Uganda `units` error is fully resolved.

## Tests / lint
New/updated tests: `test_cf_metadata`, `test_streaming_orchestrator` (placeholder source attrs → template wins), `test_openeo_execution` (managed-publish stamping), `test_climate_indices` (`t`→`time` round-trip), `test_shared_time` (period_type→step), `test_stac` (cube:variables CF fields), `test_era5_land_plugin` (mm/d rate). `make lint` clean; suites green except the unrelated pre-existing PROJ-env `test_openeo_execution` failures (pass in CI).

## Follow-ups (not blocking)
- A sync `save_result(NETCDF)` after `reduce_dimension` 500s on a dict attr — tracked in #285.

Closes #280, #283.