### PR TITLE
chore: depend on upstream openeo-processes-dask, drop the fork

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -29,14 +29,14 @@ _registry: Any = None  # lazy singleton
 class _DatasetOpenEOAccessor:  # pyright: ignore[reportUnusedClass]
     """Mirrors the DataArray openeo accessor for xr.Dataset.
 
-    openeo-processes-dask-slim only registers the accessor for DataArray.
+    openeo-processes-dask only registers the accessor for DataArray.
     Several standard processes (e.g. rename_labels) call data.openeo.temporal_dims
     on the result of aggregate_spatial which returns a Dataset, so we register a
     minimal compatible accessor here.
     """
 
     def __init__(self, ds: xr.Dataset) -> None:
-        from openeo_processes_dask_slim.process_implementations.cubes._xr_interop import (
+        from openeo_processes_dask.process_implementations.cubes._xr_interop import (
             BANDS_GUESSES,
             TEMPORAL_GUESSES,
             X_GUESSES,
@@ -128,10 +128,10 @@ def _build_process_registry() -> Any:
         return _registry
 
     from openeo_pg_parser_networkx.process_registry import Process, ProcessRegistry
-    from openeo_processes_dask_slim.process_implementations.core import process as wrap_fn
+    from openeo_processes_dask.process_implementations.core import process as wrap_fn
 
-    impls_module = importlib.import_module("openeo_processes_dask_slim.process_implementations")
-    specs_module = importlib.import_module("openeo_processes_dask_slim.specs")
+    impls_module = importlib.import_module("openeo_processes_dask.process_implementations")
+    specs_module = importlib.import_module("openeo_processes_dask.specs")
 
     registry = ProcessRegistry(wrap_funcs=[wrap_fn])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ module-name = "open_climate_service"
 override-dependencies = [
     # openeo-pg-parser-networkx requires geojson-pydantic<2.0.0; our project uses >=2.1.0 which is compatible at runtime
     "geojson-pydantic>=2.1.0",
-    # openeo-processes-dask-slim has stale constraints; all safe to override (library doesn't use these directly)
+    # openeo-processes-dask pins zarr<=2.18.7 as an unconditional core dep
+    # (Open-EO/openeo-processes-dask#376). The cap is vestigial — zarr is only reached
+    # through xarray/odc — so we override it to run on a zarr v3 / icechunk backend.
+    # The remaining overrides relax other stale upstream lower bounds; safe at runtime.
     "zarr>=3.1.6",
     "pyarrow>=19.0",
     "xarray>=2025.12.0",
@@ -22,12 +25,6 @@ override-dependencies = [
     "rioxarray>=0.17",
     "pystac>=1.10",
 ]
-
-[tool.uv.sources]
-# The dhis2 fork relaxes the upstream <3.13 requires-python cap and drops the
-# rqadeforestation dependency (no working ARM64/macOS native binary). Dev and CI
-# resolve to it; the published wheel still depends on the plain PyPI package.
-openeo-processes-dask-slim = { git = "https://github.com/dhis2/openeo-processes-dask-slim", branch = "main" }
 
 [project]
 name = "open-climate-service"
@@ -82,7 +79,22 @@ server = [
     "portalocker>=3.2.0",
     "dhis2eo>=1.2.1",
     "openeo-pg-parser-networkx>=2026.3.3",
-    "openeo-processes-dask-slim[implementations]",
+    # We depend on the base package and hand-pick the implementation deps rather than
+    # using the [implementations] extra. The extra pulls the `gdal` Python bindings,
+    # which are never imported by the library yet fail to build unless the system
+    # libgdal exactly matches (the macOS/ARM64 dependency hell the old fork avoided).
+    # This list mirrors the [implementations] extra minus gdal and the try/except-guarded
+    # ml (xgboost) and experimental (rqadeforestation) process groups, which we don't use.
+    # If a future release adds a new core import, the registry will fail fast at startup —
+    # add the dep here. See Open-EO/openeo-processes-dask CI cap on gdal<3.13.1.
+    "openeo-processes-dask>=2026.6.3",
+    "dask-geopandas>=0.4",
+    "odc-geo>=0.4.1",
+    "odc-stac>=0.3.9",
+    "planetary-computer>=0.5.1",
+    "pystac-client>=0.6.1",
+    "stac-validator>=3.3.1",
+    "xvec>=0.3",
     "python-multipart>=0.0.29",
     "xclim>=0.61.1",
 ]
@@ -138,7 +150,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask_slim", "openeo_processes_dask_slim.*", "dask_geopandas", "dask_geopandas.*", "xclim", "xclim.*"]
+module = ["rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask", "openeo_processes_dask.*", "dask_geopandas", "dask_geopandas.*", "xclim", "xclim.*"]
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -2031,6 +2031,7 @@ dependencies = [
 
 [package.optional-dependencies]
 server = [
+    { name = "dask-geopandas" },
     { name = "dhis2eo" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
@@ -2038,18 +2039,24 @@ server = [
     { name = "icechunk" },
     { name = "jinja2" },
     { name = "metpy" },
+    { name = "odc-geo" },
+    { name = "odc-stac" },
     { name = "openeo-pg-parser-networkx" },
-    { name = "openeo-processes-dask-slim", extra = ["implementations"] },
+    { name = "openeo-processes-dask" },
+    { name = "planetary-computer" },
     { name = "portalocker" },
+    { name = "pystac-client" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rioxarray" },
+    { name = "stac-validator" },
     { name = "starlette" },
     { name = "topozarr" },
     { name = "uvicorn" },
     { name = "xarray" },
     { name = "xclim" },
     { name = "xstac" },
+    { name = "xvec" },
     { name = "zarr" },
 ]
 xarray = [
@@ -2074,6 +2081,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'xarray'", specifier = ">=3.10" },
+    { name = "dask-geopandas", marker = "extra == 'server'", specifier = ">=0.4" },
     { name = "dhis2eo", marker = "extra == 'server'", specifier = ">=1.2.1" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0" },
     { name = "fsspec", marker = "extra == 'xarray'", specifier = ">=2024.6.0" },
@@ -2083,13 +2091,18 @@ requires-dist = [
     { name = "icechunk", marker = "extra == 'server'", specifier = ">=2.0,<3" },
     { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1" },
     { name = "metpy", marker = "extra == 'server'", specifier = ">=1.7,<2" },
+    { name = "odc-geo", marker = "extra == 'server'", specifier = ">=0.4.1" },
+    { name = "odc-stac", marker = "extra == 'server'", specifier = ">=0.3.9" },
     { name = "openeo-pg-parser-networkx", marker = "extra == 'server'", specifier = ">=2026.3.3" },
-    { name = "openeo-processes-dask-slim", extras = ["implementations"], marker = "extra == 'server'", git = "https://github.com/dhis2/openeo-processes-dask-slim?branch=main" },
+    { name = "openeo-processes-dask", marker = "extra == 'server'", specifier = ">=2026.6.3" },
+    { name = "planetary-computer", marker = "extra == 'server'", specifier = ">=0.5.1" },
     { name = "portalocker", marker = "extra == 'server'", specifier = ">=3.2.0" },
     { name = "pystac", specifier = ">=1.10,<2" },
+    { name = "pystac-client", marker = "extra == 'server'", specifier = ">=0.6.1" },
     { name = "python-dotenv", marker = "extra == 'server'", specifier = ">=1.0.1" },
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.29" },
     { name = "rioxarray", marker = "extra == 'server'", specifier = ">=0.17" },
+    { name = "stac-validator", marker = "extra == 'server'", specifier = ">=3.3.1" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.27.0" },
     { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.0.91,<0.1" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.41.0" },
@@ -2097,6 +2110,7 @@ requires-dist = [
     { name = "xarray", marker = "extra == 'xarray'", specifier = ">=2025.12.0" },
     { name = "xclim", marker = "extra == 'server'", specifier = ">=0.61.1" },
     { name = "xstac", marker = "extra == 'server'", specifier = ">=1.0,<2" },
+    { name = "xvec", marker = "extra == 'server'", specifier = ">=0.3" },
     { name = "zarr", marker = "extra == 'server'", specifier = ">=3.1.6,<4" },
     { name = "zarr", marker = "extra == 'xarray'", specifier = ">=3.1.6,<4" },
 ]
@@ -2156,9 +2170,9 @@ wheels = [
 ]
 
 [[package]]
-name = "openeo-processes-dask-slim"
-version = "2026.4.4"
-source = { git = "https://github.com/dhis2/openeo-processes-dask-slim?branch=main#2e3a9aed79e621f7d2f203b4c363eb42036a506e" }
+name = "openeo-processes-dask"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "geoparquet" },
     { name = "numpy" },
@@ -2168,21 +2182,9 @@ dependencies = [
     { name = "scipy" },
     { name = "zarr" },
 ]
-
-[package.optional-dependencies]
-implementations = [
-    { name = "dask" },
-    { name = "dask-geopandas" },
-    { name = "geopandas" },
-    { name = "joblib" },
-    { name = "odc-geo" },
-    { name = "odc-stac" },
-    { name = "openeo-pg-parser-networkx" },
-    { name = "planetary-computer" },
-    { name = "pystac-client" },
-    { name = "stac-validator" },
-    { name = "xarray" },
-    { name = "xvec" },
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1b/d1c61bc91cef67cd97ecf66e68ad6e45adf2c1481f35770a6f510d6efbe8/openeo_processes_dask-2026.6.3.tar.gz", hash = "sha256:d5d29ab4c6c96f5f158554c85bbdf529d53592e6c5395cc2c4ac2165cb0e4972", size = 164000, upload-time = "2026-06-12T07:41:46.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/b4/20769799e50a5cc61f0f93517cae7a89274220ba99395b0d26027fe7a184/openeo_processes_dask-2026.6.3-py3-none-any.whl", hash = "sha256:f80e9b3b28ba1744c85e3d95ee0de777fa14f9dc23722cbae973a3e8d2ba8426", size = 291294, upload-time = "2026-06-12T07:41:47.577Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Drops the `dhis2/openeo-processes-dask-slim` git fork and depends on the **upstream** `openeo-processes-dask` PyPI package (`>=2026.6.3`).

### Why this is now possible
The fork existed to relax upstream's `requires-python <3.13` cap and drop the `rqadeforestation` native dep (no ARM64/macOS wheel). The [2026.6.3 release](https://github.com/Open-EO/openeo-processes-dask/releases/tag/2026.6.3) resolves both: `requires-python` is now `>=3.10,<3.14`, NumPy 2 compatibility is fixed, and `rqadeforestation` is optional. Installing the **released PyPI wheel** also sidesteps the SSH/submodule spec problem ([#383](https://github.com/Open-EO/openeo-processes-dask/issues/383)) — the wheel bundles the specs at build time.

### Why we hand-pick deps instead of the `[implementations]` extra
The `[implementations]` extra pulls the `gdal` Python bindings, which **the library never imports** (verified: zero `osgeo`/`gdal` import sites in the package) yet fail to build unless the system `libgdal` matches the binding version exactly — the dependency hell the slim fork was built to avoid (it hit `gdal==3.13.1` bindings vs system `libgdal 3.12.2` here).

So we depend on the **base** package plus the implementation deps the core `cubes` modules actually import at registry-build time:
`dask-geopandas`, `odc-geo`, `odc-stac`, `planetary-computer`, `pystac-client`, `stac-validator`, `xvec` (rioxarray/rasterio already present). This mirrors the extra **minus gdal** and the `try/except`-guarded `ml` (xgboost) and `experimental` (rqadeforestation) groups, which we don't use. A pyproject comment documents that a future new core import will fail fast at startup → add it to the list.

### Still open upstream
[#376](https://github.com/Open-EO/openeo-processes-dask/issues/376) — `zarr<=2.18.7` is still an unconditional core cap. We keep the existing `zarr>=3.1.6` resolver override (the cap is vestigial — zarr is only reached via xarray/odc), now documented with the issue link. Drop the override once upstream relaxes it.

### Changes
- `pyproject.toml`: remove `[tool.uv.sources]` git pin; base package + curated impl deps; update override + mypy module list.
- Rename imports `openeo_processes_dask_slim` → `openeo_processes_dask` (4 sites in `execution.py`).

### Verification
- `uv sync --all-extras` clean on macOS/ARM64 — **no gdal**, no fork.
- Process registry builds **303** processes; `spi`, `load_collection`, `save_result`, `ndvi` all resolve.
- `make lint` clean; `391 passed`, only the 3 pre-existing PROJ-env `test_ensure_crs_*` / `test_load_collection_returns_georegistered_cube` failures (local `proj.db` mismatch, identical on main).