### PR TITLE
docs: install from the PyPI release, not git

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Each instance is configured for a specific country or region: it scopes all data
 ```bash
 pip install open-climate-service            # client only — talk to an instance over HTTP
 pip install open-climate-service[xarray]    # + open published datasets as xarray
-pip install open-climate-service[server]    # full server stack — run your own instance
 ```
 
-> **Running a server?** The recommended ways to run an instance are **uv** or **Docker** — see [Run a server](#run-a-server), the [quick start](https://dhis2.github.io/open-climate-service/setup_guide/) (try it locally), and the [instance guide](https://dhis2.github.io/open-climate-service/instance_guide/) (operational deployments). The `[server]` extra installs with `pip` on Linux x86-64; on macOS or ARM, use uv or Docker. The client and `[xarray]` extras work on any platform.
+The client and `[xarray]` extras install with `pip` on any platform.
+
+> **Running a server?** Don't `pip install` the `[server]` extra — it depends on packages with upstream version pins (e.g. `geojson-pydantic`, `zarr`) that need dependency **overrides** to resolve, which `uv` applies but `pip` cannot. Run an instance with **uv** or **Docker** instead — see [Run a server](#run-a-server), the [quick start](https://dhis2.github.io/open-climate-service/setup_guide/) (try it locally), and the [instance guide](https://dhis2.github.io/open-climate-service/instance_guide/) (operational deployments), which give you a ready-to-use `pyproject.toml` with the required overrides.
 
 ## Quick start (client)
 

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -61,17 +61,32 @@ version = "0.1.0"
 requires-python = ">=3.12"
 description = "Open Climate Service instance for [context]"
 dependencies = [
-    "open-climate-service @ git+https://github.com/dhis2/open-climate-service.git",
+    "open-climate-service[server]==0.1.0",
 ]
 
 [tool.uv]
 package = false
 
-[tool.uv.sources]
-open-climate-service = { git = "https://github.com/dhis2/open-climate-service.git", branch = "main" }
+# Required for the [server] extra to resolve: these relax upstream transitive pins
+# that uv applies but pip cannot — openeo-pg-parser-networkx pins geojson-pydantic<2
+# (we need >=2.1.0), and openeo-processes-dask pins an older zarr
+# (Open-EO/openeo-processes-dask#376). Drop entries as upstream releases catch up.
+override-dependencies = [
+    "geojson-pydantic>=2.1.0",
+    "zarr>=3.1.6",
+    "pyarrow>=19.0",
+    "xarray>=2025.12.0",
+    "numpy>=2.2",
+    "dask>=2024.1.0",
+    "dask-geopandas>=0.4",
+    "geopandas>=1.1",
+    "xvec>=0.3",
+    "rioxarray>=0.17",
+    "pystac>=1.10",
+]
 ```
 
-The `package = false` setting tells uv that this repository is not itself a Python package — it only declares dependencies. The `[tool.uv.sources]` block pins open-climate-service to the `main` branch on GitHub. To pin to a specific release tag or commit instead, use `rev` (e.g. `rev = "<git tag or commit SHA>"`). Installing from git gives you the latest code; once a release is available on PyPI you can instead depend on `open-climate-service` from PyPI and drop the `[tool.uv.sources]` entry.
+The `package = false` setting tells uv that this repository is not itself a Python package — it only declares dependencies. It depends on the released `open-climate-service[server]` from PyPI, pinned here to `0.1.0`; bump the version to upgrade. The `override-dependencies` block is required for `uv` to resolve the `[server]` extra (see the comment above) — this is also why `pip install` is not a supported install path for `[server]`. To track the latest unreleased code instead of a release, add a `[tool.uv.sources]` entry pinning open-climate-service to git (`open-climate-service = { git = "https://github.com/dhis2/open-climate-service.git", branch = "main" }`) and change the dependency to `open-climate-service[server]`.
 
 Install dependencies:
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -12,12 +12,17 @@ from the web interface.
 
 ## Prerequisites
 
-- Python 3.13 or higher
+- Python 3.12 or higher
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - Git
 - Make (`make` — available by default on macOS and most Linux distributions; on Windows use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) or run the commands in the Makefile directly)
 
 ## Step 1: Clone and install
+
+This quick start runs from a clone of the core repository, which is best for evaluating
+the service or developing against it. To run an instance from the released PyPI package
+instead — in its own repository, without cloning this one — follow the
+[instance guide](instance_guide.md).
 
 ```bash
 git clone https://github.com/dhis2/open-climate-service.git


### PR DESCRIPTION
Now that `open-climate-service` 0.1.0 is on PyPI, update the install docs to use the released package instead of the git source.

## Changes
- **README** — `client` + `[xarray]` install with `pip` on any platform. Replaced the stale `[server]` caveat: the old *"pip works on Linux x86-64, use uv/Docker on macOS/ARM"* (rqadeforestation) limitation is gone after the switch to upstream `openeo-processes-dask`. The real reason `pip install [server]` doesn't work is now that the extra needs dependency **overrides** (upstream pins on `geojson-pydantic` and `zarr`) that uv applies but pip can't — so it points to **uv/Docker**.
- **`instance_guide.md`** — the example `pyproject.toml` now depends on `open-climate-service[server]==0.1.0` from PyPI (no `[tool.uv.sources]` git pin) and includes the `override-dependencies` block that is **required** for uv to resolve `[server]`. Documents how to track git `main` for the latest unreleased code.
- **`setup_guide.md`** — clarified that the clone path is for evaluating/developing the core repo, and pointed to the instance guide for installing the released package without cloning; aligned the Python prerequisite to 3.12 (matches `requires-python`).

## Why the override block is needed (and pip can't)
A bare `open-climate-service[server]==0.1.0` does **not** resolve without overrides:
- `openeo-pg-parser-networkx` pins `geojson-pydantic<2.0.0`; OCS needs `>=2.1.0`.
- `openeo-processes-dask` pins `zarr<=2.18.7` ([Open-EO/openeo-processes-dask#376](https://github.com/Open-EO/openeo-processes-dask/issues/376)); OCS needs `zarr>=3.1.6`.

uv applies `[tool.uv] override-dependencies`; pip has no equivalent. Hence `[server]` is a uv/Docker path.

## Verified
- The exact instance `pyproject.toml` in the guide resolves cleanly with `uv lock` (149 packages, no conflict).
- Validated against a real instance: a live deployment switched from the git source to `open-climate-service[server]==0.1.0` and runs correctly (305 processes, datasets served).