### PR TITLE
feat: server-dependency guardrails (#288, #289, #290)

### DIFF
--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -196,23 +196,47 @@ See [Extensibility](extensibility.md) for the three plugin types, and [Adding cu
 
 ---
 
-## Keeping open-climate-service up to date
+## Upgrading and troubleshooting
 
-To pull the latest changes from the `main` branch:
+### Upgrading
+
+To move to a newer release, bump the pin in `pyproject.toml` (e.g. `open-climate-service[server]==0.2.0`), then:
 
 ```bash
 uv lock --upgrade-package open-climate-service
 uv sync
 ```
 
-Commit the updated `uv.lock`. Everyone working with this repository will get the same updated version after running `uv sync`.
+Commit the updated `uv.lock` so everyone gets the same versions.
 
-To pin to a specific commit for a more controlled upgrade:
+> **`uv sync` alone does not upgrade.** It only makes the environment match the lockfile. To actually move to a newer version you must re-lock first (`uv lock --upgrade-package open-climate-service`) — this is true both for a pinned release and for a git source.
+
+If you track the latest unreleased code via a `[tool.uv.sources]` git entry, `uv lock --upgrade-package open-climate-service` re-resolves to the current branch head. To pin to a specific commit instead:
 
 ```toml
 [tool.uv.sources]
 open-climate-service = { git = "https://github.com/dhis2/open-climate-service.git", rev = "abc1234" }
 ```
+
+Pinning to a released version (`==X.Y.Z`) is recommended over tracking `main`: a release is reproducible, whereas `main`'s dependency tree shifts over time and can change under you between syncs.
+
+### Troubleshooting
+
+- **Always run inside the synced environment** — use `make run` or `uv run uvicorn …`, never a bare `uvicorn`/`python`. If a stray virtual environment is activated (`echo $VIRTUAL_ENV`), deactivate it; uv warns when `VIRTUAL_ENV` doesn't match the project's `.venv`.
+
+- **Never `pip install` into the venv.** `uv sync` makes the environment *exactly* match the lockfile and removes anything else — so hand-installed packages disappear on the next sync, and a missing package "comes back" after every upgrade. If something is genuinely needed, add it to `[project] dependencies` (or the right extra/group) and re-lock.
+
+- **`ModuleNotFoundError` for `xvec`, `odc`, `dask_geopandas`, `planetary_computer`, `pystac_client`, `stac_validator`, … when running a job** means the `[server]` extra is not fully installed. `openeo-processes-dask` eagerly imports its whole implementation stack, so all of these must be present. Don't add them one by one — the `[server]` extra is the complete, maintained set. Ensure your dependency is `open-climate-service[server]` (with the extra), then:
+  ```bash
+  uv lock --upgrade-package open-climate-service
+  uv sync
+  ```
+  Verify the stack is complete:
+  ```bash
+  uv run python -c "import xvec, odc.geo, dask_geopandas, planetary_computer, pystac_client, stac_validator; print('ok')"
+  ```
+
+- **`pip install open-climate-service[server]` does not work** — the `[server]` extra needs dependency overrides (for upstream version caps) that `uv` applies but `pip` cannot. Install the server stack with **uv** (this guide) or **Docker**. The base client and `[xarray]` extras install fine with `pip`.
 
 ---
 

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -139,8 +139,9 @@ def _build_process_registry() -> Any:
         impls_module = importlib.import_module("openeo_processes_dask.process_implementations")
         specs_module = importlib.import_module("openeo_processes_dask.specs")
     except ModuleNotFoundError as exc:
+        missing = exc.name or "an openeo-processes-dask dependency"
         raise RuntimeError(
-            f"Could not build the openEO process registry: missing server dependency '{exc.name}'. "
+            f"Could not build the openEO process registry: missing server dependency '{missing}'. "
             "Your environment is missing part of the open-climate-service [server] extra "
             "(openeo-processes-dask eagerly imports its full implementation stack). "
             "Re-sync the environment with `uv sync` (run `uv lock --upgrade-package open-climate-service` "

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -128,10 +128,25 @@ def _build_process_registry() -> Any:
         return _registry
 
     from openeo_pg_parser_networkx.process_registry import Process, ProcessRegistry
-    from openeo_processes_dask.process_implementations.core import process as wrap_fn
 
-    impls_module = importlib.import_module("openeo_processes_dask.process_implementations")
-    specs_module = importlib.import_module("openeo_processes_dask.specs")
+    # openeo-processes-dask eagerly imports its whole implementation stack (xvec, odc,
+    # dask_geopandas, planetary_computer, …) at module load, so the open-climate-service
+    # [server] extra must provide all of it. If any piece is missing, surface one clear,
+    # actionable message instead of a deep ModuleNotFoundError mid-job (#289).
+    try:
+        from openeo_processes_dask.process_implementations.core import process as wrap_fn
+
+        impls_module = importlib.import_module("openeo_processes_dask.process_implementations")
+        specs_module = importlib.import_module("openeo_processes_dask.specs")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            f"Could not build the openEO process registry: missing server dependency '{exc.name}'. "
+            "Your environment is missing part of the open-climate-service [server] extra "
+            "(openeo-processes-dask eagerly imports its full implementation stack). "
+            "Re-sync the environment with `uv sync` (run `uv lock --upgrade-package open-climate-service` "
+            "first if you just upgraded). Don't `pip install` it by hand — uv sync prunes that. "
+            "See the instance guide's 'Upgrading and troubleshooting' section."
+        ) from exc
 
     registry = ProcessRegistry(wrap_funcs=[wrap_fn])
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -990,6 +990,50 @@ def test_build_chap_csv_frame_renames_merged_cubes_with_explicit_labels() -> Non
     ]
 
 
+def test_process_registry_builds_with_full_server_impl_stack() -> None:
+    """Guard against the [server] curated dep list drifting from upstream (#288).
+
+    openeo-processes-dask eagerly imports its whole implementation stack (xvec, odc,
+    dask_geopandas, planetary_computer, pystac_client, stac_validator, …) at module load.
+    Importing it here fails if any of those are missing from the [server] extra, and
+    building the registry confirms the standard + backend processes are all present.
+    A new openeo-processes-dask release that adds an eager import we don't declare would
+    fail this test in CI — before it reaches an instance as a mid-job ModuleNotFoundError.
+    """
+    import importlib
+
+    # Triggers the eager import of the full implementation stack.
+    importlib.import_module("openeo_processes_dask.process_implementations")
+
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    predefined = _build_process_registry()[("predefined", None)]
+    assert len(predefined) > 50  # the full standard process library loaded
+    expected = ("spi", "load_collection", "save_result", "ndvi", "reduce_dimension", "aggregate_temporal_period")
+    for process_id in expected:
+        assert process_id in predefined, f"expected process '{process_id}' missing from the registry"
+
+
+def test_registry_build_missing_server_dep_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing [server] impl dep yields one clear, actionable message, not a deep
+    ModuleNotFoundError mid-job (#289)."""
+    import importlib
+
+    import open_climate_service.openeo.execution as ex
+
+    monkeypatch.setattr(ex, "_registry", None)  # bypass the singleton so the import runs
+    real_import = importlib.import_module
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "openeo_processes_dask.process_implementations":
+            raise ModuleNotFoundError("No module named 'xvec'", name="xvec")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(ex.importlib, "import_module", fake_import)
+    with pytest.raises(RuntimeError, match=r"missing server dependency 'xvec'"):
+        ex._build_process_registry()
+
+
 def test_merge_cubes_wrapper_preserves_named_dataarrays_on_cube_axis() -> None:
     from open_climate_service.openeo.execution import _build_process_registry
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1008,7 +1008,7 @@ def test_process_registry_builds_with_full_server_impl_stack() -> None:
     from open_climate_service.openeo.execution import _build_process_registry
 
     predefined = _build_process_registry()[("predefined", None)]
-    assert len(predefined) > 50  # the full standard process library loaded
+    assert predefined  # registry built and non-empty
     expected = ("spi", "load_collection", "save_result", "ndvi", "reduce_dimension", "aggregate_temporal_period")
     for process_id in expected:
         assert process_id in predefined, f"expected process '{process_id}' missing from the registry"


### PR DESCRIPTION
Implements #288, #289 and #290 together — defense-in-depth against an incomplete `[server]` install, the class of failure a maintainer hit (`No module named 'xvec'` mid-job, then the next missing package after each manual fix). Each becomes unnecessary once #287 makes `[server]` pip-installable and lets us drop the hand-curated impl list.

Background: `openeo-processes-dask.process_implementations` **eagerly imports its whole implementation stack** (`xvec`, `odc`, `dask_geopandas`, `planetary_computer`, …) at module load, so OCS `[server]` must declare all of it. Resolution stays clean; a gap only surfaces at runtime as a deep `ModuleNotFoundError` when the process registry is built.

### #289 — actionable error instead of a deep traceback
`_build_process_registry()` now wraps the `openeo-processes-dask` import and, on `ModuleNotFoundError`, raises one clear message naming the missing dependency and the fix:
> Could not build the openEO process registry: missing server dependency 'xvec'. … Re-sync the environment with `uv sync` (run `uv lock --upgrade-package open-climate-service` first if you just upgraded). Don't `pip install` it by hand — uv sync prunes that. See the instance guide's 'Upgrading and troubleshooting' section.

### #288 — CI guard against curated-list drift
New test imports `openeo_processes_dask.process_implementations` and builds the registry, asserting the standard + backend processes are present (`spi`, `load_collection`, `save_result`, `ndvi`, `reduce_dimension`, `aggregate_temporal_period`). A future `openeo-processes-dask` release that adds an eager import we don't declare in `[server]` now fails CI — before it reaches an instance. Plus a test that the missing-dep path raises the actionable error.

### #290 — instance guide: Upgrading and troubleshooting
Reworks "Keeping up to date" into an **Upgrading and troubleshooting** section: the `uv lock --upgrade-package … && uv sync` flow (and why `uv sync` alone doesn't upgrade), never `pip install` into the venv (sync prunes it), prefer a pinned release over git `main`, the `xvec`/`odc`/… symptom→fix with a one-line verification command, and why `pip install [server]` isn't supported (→ uv/Docker).

### Tests / lint
`make lint` clean; the two new tests pass; suites otherwise green except the unrelated pre-existing PROJ-env `test_ensure_crs_*` / `test_load_collection_returns_georegistered_cube` failures.

Relates to #287 (root fix).