### PR TITLE
fix: make aggregate_* workflows openEO-spec-compliant (literal process_id)

### DIFF
--- a/open_climate_service/plugins/processes/aggregate_spatial.py
+++ b/open_climate_service/plugins/processes/aggregate_spatial.py
@@ -174,3 +174,36 @@ def aggregate_spatial(
     combined = xr.concat(results, dim=geom_dim)
     combined[geom_dim] = geom_labels
     return combined
+
+
+_REDUCE_METHODS: dict[str, Callable[..., Any]] = {
+    "mean": np.mean,
+    "sum": np.sum,
+    "min": np.min,
+    "max": np.max,
+    "median": np.median,
+}
+
+
+@process(
+    summary="Reduce pixel values by a named method",
+    parameters={
+        "data": {"description": "The array of values to reduce."},
+        "method": {"description": "Reduction method: mean (default), sum, min, max or median."},
+    },
+)
+def reduce_by_method(data: Any, method: str = "mean") -> float:
+    """Reduce an array of values by a named method.
+
+    A spec-compliant alternative to parameterising a reducer's ``process_id``: workflows
+    pass ``method`` as an ordinary string argument (mean/sum/min/max/median) while
+    ``process_id`` stays the literal ``"reduce_by_method"``, so standard openEO tooling
+    can validate the graph. Used as the reducer in the ``aggregate_*`` workflows, where
+    it receives the (already NaN-dropped, 1-D) pixel values within each geometry.
+    """
+    if method not in _REDUCE_METHODS:
+        raise ValueError(f"Unknown reduce method '{method}'; expected one of {sorted(_REDUCE_METHODS)}")
+    arr = np.asarray(data, dtype="float64").ravel()
+    if arr.size == 0:
+        return float("nan")
+    return float(_REDUCE_METHODS[method](arr))

--- a/open_climate_service/plugins/workflows/aggregate_to_chap_csv.json
+++ b/open_climate_service/plugins/workflows/aggregate_to_chap_csv.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "method",
-      "description": "Spatial aggregation method applied to the pixels within each org unit: mean (default), min, max, or sum.",
+      "description": "Spatial aggregation method applied to the pixels within each org unit: mean (default), min, max, sum, or median.",
       "schema": { "type": "string" },
       "default": "mean"
     },

--- a/open_climate_service/plugins/workflows/aggregate_to_chap_csv.json
+++ b/open_climate_service/plugins/workflows/aggregate_to_chap_csv.json
@@ -47,8 +47,8 @@
         "reducer": {
           "process_graph": {
             "reduce": {
-              "process_id": { "from_parameter": "method" },
-              "arguments": { "data": { "from_parameter": "data" } },
+              "process_id": "reduce_by_method",
+              "arguments": { "data": { "from_parameter": "data" }, "method": { "from_parameter": "method" } },
               "result": true
             }
           }

--- a/open_climate_service/plugins/workflows/aggregate_to_dhis2_json.json
+++ b/open_climate_service/plugins/workflows/aggregate_to_dhis2_json.json
@@ -52,8 +52,8 @@
         "reducer": {
           "process_graph": {
             "reduce": {
-              "process_id": { "from_parameter": "method" },
-              "arguments": { "data": { "from_parameter": "data" } },
+              "process_id": "reduce_by_method",
+              "arguments": { "data": { "from_parameter": "data" }, "method": { "from_parameter": "method" } },
               "result": true
             }
           }

--- a/open_climate_service/plugins/workflows/aggregate_to_dhis2_json.json
+++ b/open_climate_service/plugins/workflows/aggregate_to_dhis2_json.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "method",
-      "description": "Spatial aggregation method applied to the pixels within each org unit: mean (default), min, max, or sum.",
+      "description": "Spatial aggregation method applied to the pixels within each org unit: mean (default), min, max, sum, or median.",
       "schema": { "type": "string" },
       "default": "mean"
     },

--- a/tests/test_org_unit_workflows.py
+++ b/tests/test_org_unit_workflows.py
@@ -143,6 +143,7 @@ def test_reduce_by_method_dispatches() -> None:
     assert reduce_by_method(data, "sum") == 12.0
     assert reduce_by_method(data, "min") == 0.0
     assert reduce_by_method(data, "max") == 6.0
+    assert reduce_by_method(data, "median") == 3.0
     assert np.isnan(reduce_by_method(np.array([]), "mean"))  # empty geometry → NaN, not a crash
     with pytest.raises(ValueError, match="Unknown reduce method"):
         reduce_by_method(data, "bogus")

--- a/tests/test_org_unit_workflows.py
+++ b/tests/test_org_unit_workflows.py
@@ -133,3 +133,48 @@ def test_method_selects_reducer(method: str, expected: str) -> None:
     dv = jobs._build_dhis2_json_payload(envelope.data.to_dataframe().reset_index(), envelope.options)["dataValues"]
     ou_a_jan = next(d["value"] for d in dv if d["orgUnit"] == "OU_A" and d["period"] == "202501")
     assert ou_a_jan == expected
+
+
+def test_reduce_by_method_dispatches() -> None:
+    from open_climate_service.plugins.processes.aggregate_spatial import reduce_by_method
+
+    data = np.array([0.0, 1.0, 5.0, 6.0])
+    assert reduce_by_method(data, "mean") == 3.0
+    assert reduce_by_method(data, "sum") == 12.0
+    assert reduce_by_method(data, "min") == 0.0
+    assert reduce_by_method(data, "max") == 6.0
+    assert np.isnan(reduce_by_method(np.array([]), "mean"))  # empty geometry → NaN, not a crash
+    with pytest.raises(ValueError, match="Unknown reduce method"):
+        reduce_by_method(data, "bogus")
+
+
+def test_builtin_workflows_use_literal_process_ids() -> None:
+    """openEO requires `process_id` to be a literal string; a `{from_parameter}` process_id
+    is non-portable (standard validators reject it) even though OCS resolves it at runtime.
+    Guard against reintroducing the pattern in any built-in workflow — use a process that
+    takes the choice as an argument (e.g. reduce_by_method) instead."""
+    import importlib.resources
+    import json
+
+    def _non_literal_process_ids(node: Any, path: str = "") -> list[str]:
+        found: list[str] = []
+        if isinstance(node, dict):
+            if isinstance(node.get("process_id"), dict):
+                found.append(path or "<root>")
+            for key, value in node.items():
+                found += _non_literal_process_ids(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for i, value in enumerate(node):
+                found += _non_literal_process_ids(value, f"{path}[{i}]")
+        return found
+
+    pkg = importlib.resources.files("open_climate_service") / "plugins" / "workflows"
+    checked = 0
+    for resource in pkg.iterdir():
+        if not resource.name.endswith(".json"):
+            continue
+        checked += 1
+        workflow = json.loads(resource.read_text(encoding="utf-8"))
+        offenders = _non_literal_process_ids(workflow)
+        assert not offenders, f"{resource.name} has non-literal process_id(s) at: {offenders}"
+    assert checked > 0  # ensure we actually scanned the packaged workflows


### PR DESCRIPTION
Pasting `aggregate_to_dhis2_json` into the openEO Web Editor fails with **"Process node reduce doesnt contain a process id."**

## Cause
The `aggregate_to_dhis2_json` and `aggregate_to_chap_csv` workflows parameterise the reducers **`process_id`** so `method` can pick mean/sum/min/max:
```json
"reduce": { "process_id": { "from_parameter": "method" }, ... }
```
openEO requires `process_id` to be a **literal string**. OCS resolves the `{from_parameter}` at runtime (so it *runs* via the API), but standard openEO tooling validates statically and correctly rejects it — the workflow isnt portable.

## Fix
Move the choice out of `process_id` into a small **`reduce_by_method`** process; the reducer calls it with `method` as an ordinary argument:
```json
"reduce": {
  "process_id": "reduce_by_method",
  "arguments": { "data": { "from_parameter": "data" }, "method": { "from_parameter": "method" } },
  "result": true
}
```
`process_id` is now a literal → the editor validates it, and the friendly `method` string parameter is **unchanged** for callers.

- **`aggregate_spatial.py`** — add `reduce_by_method(data, method)` (mean/sum/min/max/median; numpy reduction over the already-NaN-dropped 1-D pixel array each geometry yields — the exact contract `aggregate_spatial` calls reducers with; raises on unknown method, returns NaN for an empty geometry).
- **both workflows** — reducer `process_id` → `"reduce_by_method"`, `method` passed as an argument.
- **tests** — `reduce_by_method` dispatch + empty/bad-method cases, and a regression guard that **no built-in workflow uses a non-literal `process_id`**. The existing `test_method_selects_reducer` (mean/sum/min/max) still passes end-to-end.

## Verified
`make lint` clean; 11 org-unit-workflow tests pass; `reduce_by_method` is registered (so the editor knows it via `/processes`); all three built-in workflows now have literal `process_id`s.

Reported via HISP-Uganda when pasting the workflow into the editor.