### PR TITLE
fix(docker): repair image build, harden Dockerfile, fix data + config mounts [CLIM-779]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,51 @@
 FROM ghcr.io/astral-sh/uv:0.10-python3.12-trixie-slim
 
-RUN apt-get update && \
+# Compile Python bytecode for faster startup (.venv only)
+ENV UV_COMPILE_BYTECODE=1
+# Use copy mode to avoid hardlink issues across the uv cache mount
+ENV UV_LINK_MODE=copy
+# Prevent Python from writing .pyc files at runtime
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV MPLCONFIGDIR=/tmp
+
+# build-essential + cython3 + libgeos/libproj headers: cartopy ships no aarch64
+#   wheel, so it builds from source when the image targets ARM64.
+# libeccodes: the `eccodes` wheel is pure-Python and dlopens the system library
+#   at runtime (it bundles nothing) on every architecture.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         git curl \
         build-essential cython3 \
-        libgeos-dev libproj-dev libeccodes-dev && \
-    rm -rf /var/lib/apt/lists/*
+        libgeos-dev libproj-dev libeccodes-dev
 
-RUN groupadd --system eo && useradd --system --gid eo --create-home eo
+RUN groupadd --system ocs && useradd --system --gid ocs --create-home ocs
 
 WORKDIR /app
 
 COPY pyproject.toml uv.lock .python-version ./
 COPY open_climate_service/ open_climate_service/
-COPY README.md .
+COPY README.md LICENSE ./
 
-RUN uv sync --frozen --no-dev --extra server
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra server && \
+    python -m compileall -q open_climate_service/
 
 RUN mkdir -p /app/data/pygeoapi /app/data/artifacts && \
     printf '[]\n' > /app/data/artifacts/records.json && \
-    chown -R eo:eo /app/data
+    chown -R ocs:ocs /app/data
 
-ENV CACHE_OVERRIDE=/app/data
 ENV PYGEOAPI_CONFIG=/app/data/pygeoapi/pygeoapi-config.yml
 ENV PYGEOAPI_OPENAPI=/app/data/pygeoapi/pygeoapi-openapi.yml
 ENV PORT=8000
+ENV PATH="/app/.venv/bin:$PATH"
 
-USER eo
+USER ocs
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:${PORT}/health || exit 1
 
-CMD /app/.venv/bin/uvicorn open_climate_service.main:app --host 0.0.0.0 --port ${PORT}
+# exec form (JSON) so uvicorn receives signals directly; `exec` replaces the
+# shell that expands ${PORT} so no extra process sits between init and uvicorn.
+CMD ["sh", "-c", "exec uvicorn open_climate_service.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,15 @@ fix: ## Autofix ruff lint and format issues
 test: ## Run tests with pytest
 	uv run pytest tests/
 
-start: ## Start the Docker stack (builds images first)
-	docker compose up --build
+# Compose bind-mounts this into the container; a missing file would make Docker
+# create a directory at the mount point, so fail early with guidance instead.
+climate-service.yaml:
+	@echo "ERROR: climate-service.yaml is missing. Create it from the example:" >&2
+	@echo "  cp climate-service.yaml.example climate-service.yaml" >&2
+	@exit 1
 
-restart: ## Tear down, rebuild, and start the Docker stack from scratch
-	docker compose down -v && docker compose build --no-cache && docker compose up
+start: climate-service.yaml ## Start the Docker stack (builds images first)
+	docker compose up --build --remove-orphans
+
+restart: climate-service.yaml ## Tear down, rebuild, and start the Docker stack from scratch
+	docker compose down -v && docker compose build --no-cache && docker compose up --remove-orphans

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -7,7 +7,11 @@ services:
     init: true
     restart: unless-stopped
     volumes:
-      - data:/tmp/data
+      # Operator-provided instance config (extent, data_dir). .env points
+      # CLIMATE_SERVICE_CONFIG at ./climate-service.yaml, i.e. /app inside the
+      # container. Create it first: cp climate-service.yaml.example climate-service.yaml
+      - ./climate-service.yaml:/app/climate-service.yaml:ro
+      - data:/app/data
 
 volumes:
   data:

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,11 @@ services:
     init: true
     restart: unless-stopped
     volumes:
-      - data:/tmp/data
+      # Operator-provided instance config (extent, data_dir). .env points
+      # CLIMATE_SERVICE_CONFIG at ./climate-service.yaml, i.e. /app inside the
+      # container. Create it first: cp climate-service.yaml.example climate-service.yaml
+      - ./climate-service.yaml:/app/climate-service.yaml:ro
+      - data:/app/data
 
 volumes:
   data:


### PR DESCRIPTION
## Problem

`make restart` (and any `docker compose build`) failed at the `uv sync` step:

```
× Failed to build `open-climate-service @ file:///app`
  ╰─▶ Invalid project metadata
  ╰─▶ `project.license-files` glob `LICENSE` did not match any files
```

`pyproject.toml` declares `license-files = ["LICENSE"]`, but the Dockerfile never copied `LICENSE` into the build context, so the whole stack failed to build. Fixing that surfaced two further problems in the Compose setup (data + config never reaching the container).

## Changes

**Dockerfile**
- `COPY README.md LICENSE ./` — fixes the build failure above (the core fix).
- Adopt `chap-core`'s conventions: uv and apt **cache mounts**, `apt-get upgrade -y` for base-image security patches, `UV_COMPILE_BYTECODE` / `UV_LINK_MODE=copy` / `PYTHONDONTWRITEBYTECODE` / `MPLCONFIGDIR=/tmp` (matplotlib is used in `openeo/jobs.py` and needs a writable cache dir under the non-root user), venv on `PATH`, and `compileall` of the app package.
- Rename the runtime user/group `eo` → `ocs`; `eo` was too broad.
- Remove the dead `CACHE_OVERRIDE` env (read by nothing).
- Document why the build deps stay: **cartopy ships no aarch64 wheel**, so it builds from source on ARM64 (`cython3` + `build-essential` + `libgeos`/`libproj`), and the `eccodes` wheel `dlopen`s system `libeccodes` at runtime.
- **Exec-form `CMD`** (`["sh","-c","exec uvicorn ... --port ${PORT}"]`) so uvicorn runs as a direct child of init and receives `SIGTERM` directly while still expanding `${PORT}`. The previous shell form left uvicorn behind `/bin/sh`, which didn't forward signals (unclean shutdown). Also clears the `JSONArgsRecommended` lint.

**compose.yml / compose.ghcr.yml**
- Mount the named `data` volume at **`/app/data`** (the app's real data dir) instead of `/tmp/data`, which the app never touches.
- **Bind-mount the operator's `climate-service.yaml` into `/app`.** `.env` sets `CLIMATE_SERVICE_CONFIG=./climate-service.yaml`, which resolves to `/app/climate-service.yaml` in the container. Without the file, config-backed endpoints like `/extent` raised `FileNotFoundError`, and `get_data_dir()` returned `None` so downloads/artifacts fell back to `~/.local/share/...` outside the volume. With it present, `data_dir: ./data` resolves to `/app/data` and persists.

**Makefile**
- Make `climate-service.yaml` a prerequisite of `start`/`restart` — a missing config now fails fast with guidance instead of letting Docker create a directory at the bind-mount point.
- Add `--remove-orphans` to the `docker compose up` invocations.

## Investigated but *not* changed
- The geo build deps look removable on x86_64 (wheels exist) but are **required** on ARM64 — an empirical slim build proved cartopy compiles from source there. Kept, with a comment.
- gdal is intentionally absent (the `server` extra hand-picks deps *minus* gdal); no change.

## Verification
- `docker compose build --no-cache` succeeds (incl. cartopy's ARM64 source build).
- Container comes up **healthy** as non-root `ocs` (uid 999); data volume mounted **writable** at `/app/data`.
- uvicorn runs as a **direct child of `docker-init` (PID 1)** — no intervening `sh` — and stops cleanly on `SIGTERM` in <0.5s.
- `/health` → `{"status":"healthy"}`; **`/extent` → `200`** `{"name":"Sierra Leone","bbox":[-13.5,6.9,-10.1,10.0]}` (previously a 500).
- Inside the container: `config.get_data_dir()` → `/app/data`, `config.get_id()` → `sierra-leone-climate-service`.
- Makefile guard: with `climate-service.yaml` absent, `make restart` aborts with the copy-the-example hint before running any docker command.
- `make lint` clean; `make test` → 418 passed, 1 skipped.