### PR TITLE
ci(docker): drop dead make openapi step from image workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,25 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create .env from example
-        run: cp .env.example .env
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --extra server
-
-      - name: Generate OpenAPI spec
-        run: make openapi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Problem

The **Build and push Docker image** workflow has failed on every push to `main` since `7efb216` ("ci: remove make openapi step — pygeoapi removed"). It aborts at:

```
make: *** No rule to make target 'openapi'.  Stop.
```

That commit removed the `openapi:` target from the `Makefile` and the matching step from `ci.yml`, but missed the identical `make openapi` step in `docker.yml`. As a result the GHCR image has not been published since then. (PR #299 was unrelated — just the next push to land.)

## Fix

Remove the dead `Generate OpenAPI spec` step, along with the host-side `Create .env` / `Install uv` / `Set up Python` / `Install dependencies` steps that only existed to feed it. The image builds in-container via `build-push-action` (`context: .`), so none of that host setup is needed.

Workflow now runs: checkout → buildx → GHCR login → metadata → build & push → attestation.