### PR TITLE
chore(docker): drop sh -c from CMD so uvicorn runs as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ USER ocs
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:${PORT}/health || exit 1
 
-# exec form (JSON) so uvicorn receives signals directly; `exec` replaces the
-# shell that expands ${PORT} so no extra process sits between init and uvicorn.
-CMD ["sh", "-c", "exec uvicorn open_climate_service.main:app --host 0.0.0.0 --port ${PORT}"]
+# exec form (JSON) so uvicorn is PID 1 and receives signals directly, with no
+# shell process between init and uvicorn. Port is the fixed 8000 set above.
+CMD ["uvicorn", "open_climate_service.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## What

The container `CMD` wrapped uvicorn in `sh -c "exec uvicorn ... --port ${PORT}"` purely to expand `${PORT}`. Since `PORT` is fixed at `8000` via `ENV` in the same Dockerfile, this inlines the literal port and switches to a pure exec-form `CMD`.

```dockerfile
# before
CMD ["sh", "-c", "exec uvicorn open_climate_service.main:app --host 0.0.0.0 --port ${PORT}"]
# after
CMD ["uvicorn", "open_climate_service.main:app", "--host", "0.0.0.0", "--port", "8000"]
```

## Why

No shell process sits between init and uvicorn — uvicorn is PID 1 and receives signals directly. This matches the exec-form `CMD` already used in chap-core.

Note: this assumes the port stays fixed at 8000 (consistent with the rest of the Dockerfile). Making it runtime-overridable again would require the shell back to expand the var.