### PR TITLE
chore: make server port env-driven, default 9000 (CLIM-793)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,16 +25,20 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # COUNTRY_CODE=SLE
 
 # ── API deployment ────────────────────────────────────────────────────────────
+# Host and port the server binds to. Defaults to 0.0.0.0:9000.
+# HOST=0.0.0.0
+# PORT=9000
+
 # Set when running behind a reverse proxy so that STAC hrefs and native dataset
 # links use the public address instead of the internal request URL.
 # Note: pygeoapi's OGC self/root links are controlled separately via server.url
 # in config/pygeoapi/base.yml and are not affected by this variable.
-# CLIMATE_SERVICE_BASE_URL=http://localhost:8000
+# CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
 # Fallback used to derive the native API base URL when CLIMATE_SERVICE_BASE_URL is not set.
 # Only needed if CLIMATE_SERVICE_BASE_URL is unset and the OGC API path is known.
 # Note: pygeoapi's server.url is controlled separately in config/pygeoapi/base.yml.
-# OGCAPI_BASE_URL=http://localhost:8000/ogcapi
+# OGCAPI_BASE_URL=http://localhost:9000/ogcapi
 
 # Comma-separated list of origins used for extra browser/private-network headers
 # on Zarr responses (default: https://inspect.geozarr.org).

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /app/data/pygeoapi /app/data/artifacts && \
 
 ENV PYGEOAPI_CONFIG=/app/data/pygeoapi/pygeoapi-config.yml
 ENV PYGEOAPI_OPENAPI=/app/data/pygeoapi/pygeoapi-openapi.yml
-ENV PORT=8000
+ENV PORT=9000
 ENV PATH="/app/.venv/bin:$PATH"
 
 USER ocs
@@ -46,6 +46,7 @@ USER ocs
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:${PORT}/health || exit 1
 
-# exec form (JSON) so uvicorn is PID 1 and receives signals directly, with no
-# shell process between init and uvicorn. Port is the fixed 8000 set above.
-CMD ["uvicorn", "open_climate_service.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# exec form (JSON) so the server is PID 1 and receives signals directly, with no
+# shell process between init and uvicorn. The climate-service entry point reads
+# HOST and PORT from the environment (PORT defaults to 9000, set above).
+CMD ["climate-service"]

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ sync-gdal: ## Pin gdal override to the installed system libgdal version, then sy
 		rm -f pyproject.toml.bak && \
 		uv sync --all-extras
 
-run: ## Start the app with uvicorn
-	uv run uvicorn open_climate_service.main:app --reload --reload-include "*.html" --reload-include "*.yaml" --reload-include "*.yml"
+run: ## Start the app with uvicorn (honors PORT, default 9000)
+	uv run uvicorn open_climate_service.main:app --port $${PORT:-9000} --reload --reload-include "*.html" --reload-include "*.yaml" --reload-include "*.yml"
 
 lint: ## Check linting, formatting, and types (no autofix)
 	uv run ruff check .

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/dhis2/open-climate-service:latest
     env_file: .env
     ports:
-      - "${PORT:-8000}:${PORT:-8000}"
+      - "${PORT:-9000}:${PORT:-9000}"
     init: true
     restart: unless-stopped
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     env_file: .env
     ports:
-      - "${PORT:-8000}:${PORT:-8000}"
+      - "${PORT:-9000}:${PORT:-9000}"
     init: true
     restart: unless-stopped
     volumes:

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -235,7 +235,7 @@ Since `plugins_dir` is added to `sys.path`, the plugin class at `datasets.enacts
 Once the API is running with `CLIMATE_SERVICE_CONFIG` pointing to your updated config:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8000/ingestions \
+curl -s -X POST http://127.0.0.1:9000/ingestions \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "enacts_rainfall_daily",
@@ -248,5 +248,5 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
 Verify it appears in the STAC catalog:
 
 ```bash
-curl -s http://127.0.0.1:8000/stac/catalog.json | jq '.links[] | select(.rel == "child")'
+curl -s http://127.0.0.1:9000/stac/catalog.json | jq '.links[] | select(.rel == "child")'
 ```

--- a/docs/climate_indices.md
+++ b/docs/climate_indices.md
@@ -19,7 +19,7 @@ Browse the full list from any connected client:
 ```python
 import openeo
 
-conn = openeo.connect("http://your-instance:8000")
+conn = openeo.connect("http://your-instance:9000")
 processes = conn.list_processes()
 print([p.id for p in processes])
 ```
@@ -44,7 +44,7 @@ SPI is the primary drought monitoring index. The `window` parameter selects the 
 ```python
 import openeo
 
-conn = openeo.connect("http://your-instance:8000")
+conn = openeo.connect("http://your-instance:9000")
 
 precip = conn.load_collection(
     "chirps_rainfall_daily",

--- a/docs/era5_land_datasets.md
+++ b/docs/era5_land_datasets.md
@@ -38,7 +38,7 @@ key: <your-cds-api-key>
 Once authenticated, ingest ERA5-Land daily temperature:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8000/ingestions \
+curl -s -X POST http://127.0.0.1:9000/ingestions \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "era5land_temperature_daily",

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -122,7 +122,7 @@ Calling the workflow from any openEO client:
 ```python
 import openeo
 
-conn = openeo.connect("http://your-instance:8000")
+conn = openeo.connect("http://your-instance:9000")
 job = conn.execute_batch_job({
     "process_graph": {
         "result": {

--- a/docs/importing_to_dhis2.md
+++ b/docs/importing_to_dhis2.md
@@ -48,7 +48,7 @@ Run the `aggregate_to_dhis2_json` workflow with `ClimateService.execute()`. It l
 ```python
 from open_climate_service import ClimateService
 
-service = ClimateService("http://127.0.0.1:8000")
+service = ClimateService("http://127.0.0.1:9000")
 
 data_value_set = service.execute(
     {

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -109,7 +109,7 @@ install: ## Install dependencies with uv
 
 run: ## Start the API with uvicorn
 	set -a && . ./.env && set +a && \
-		uv run uvicorn open_climate_service.main:app --reload --reload-include "*.yaml" --reload-include "*.yml" --port 8000
+		uv run uvicorn open_climate_service.main:app --reload --reload-include "*.yaml" --reload-include "*.yml" --port 9000
 ```
 
 ## Step 4: Configure the instance
@@ -171,7 +171,7 @@ make install
 make run
 ```
 
-Visit `http://127.0.0.1:8000` to confirm the service is running. From there, open
+Visit `http://127.0.0.1:9000` to confirm the service is running. From there, open
 `/manage` to ingest data and `/map` to view it — see [Using the web interface](web_interface.md).
 The `/extent` endpoint should return your configured bounding box.
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -43,7 +43,7 @@ The configured extent is setup-time Open Climate Service configuration. It is re
 Example:
 
 ```bash
-curl -s http://127.0.0.1:8000/extent | jq
+curl -s http://127.0.0.1:9000/extent | jq
 ```
 
 Example response:
@@ -76,7 +76,7 @@ Raw `bbox` and `country_code` are not part of the public ingestion payload — t
 ### Example: CHIRPS3
 
 ```bash
-curl -s -X POST http://127.0.0.1:8000/ingestions \
+curl -s -X POST http://127.0.0.1:9000/ingestions \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "chirps3_precipitation_daily",
@@ -90,7 +90,7 @@ curl -s -X POST http://127.0.0.1:8000/ingestions \
 ### Example: WorldPop
 
 ```bash
-curl -s -X POST http://127.0.0.1:8000/ingestions \
+curl -s -X POST http://127.0.0.1:9000/ingestions \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "worldpop_population_global2_R2025A_100m",
@@ -172,7 +172,7 @@ What this means:
 Example:
 
 ```bash
-curl -s http://127.0.0.1:8000/ingestions | jq
+curl -s http://127.0.0.1:9000/ingestions | jq
 ```
 
 What this means:
@@ -210,7 +210,7 @@ Example error response:
 Example:
 
 ```bash
-curl -s http://127.0.0.1:8000/datasets | jq
+curl -s http://127.0.0.1:9000/datasets | jq
 ```
 
 Example response:
@@ -278,7 +278,7 @@ What this means:
 Example:
 
 ```bash
-curl -s http://127.0.0.1:8000/datasets/chirps3_precipitation_daily | jq
+curl -s http://127.0.0.1:9000/datasets/chirps3_precipitation_daily | jq
 ```
 
 What this adds beyond the list response:
@@ -296,7 +296,7 @@ The detailed dataset response is where version history belongs. The ingestion re
 Examples:
 
 ```bash
-curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily/zarr.json | jq
+curl -s http://127.0.0.1:9000/zarr/chirps3_precipitation_daily/zarr.json | jq
 ```
 
 `/zarr/{dataset_id}` is the store prefix; the root metadata is at `/zarr/{dataset_id}/zarr.json`.
@@ -309,7 +309,7 @@ curl -s http://127.0.0.1:8000/zarr/chirps3_precipitation_daily/zarr.json | jq
 import icechunk, xarray as xr
 
 repo = icechunk.Repository.open(
-    icechunk.http_storage("http://127.0.0.1:8000/icechunk/chirps3_precipitation_daily")
+    icechunk.http_storage("http://127.0.0.1:9000/icechunk/chirps3_precipitation_daily")
 )
 ds = xr.open_zarr(repo.readonly_session("main").store, zarr_format=3, consolidated=False)
 ```
@@ -338,8 +338,8 @@ Published Zarr-backed datasets are exposed through `/stac` for discovery.
 STAC examples:
 
 ```bash
-curl -s "http://127.0.0.1:8000/stac/catalog.json" | jq
-curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:9000/stac/catalog.json" | jq
+curl -s "http://127.0.0.1:9000/stac/collections/chirps3_precipitation_daily" | jq
 ```
 
 What this means:
@@ -383,32 +383,32 @@ Configured availability policies:
 Example dry-run plan:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
+curl -s "http://127.0.0.1:9000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
 ```
 
 Example execution:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
+curl -s -X POST "http://127.0.0.1:9000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{"end":"2024-02-10","publish":true}' | jq
 ```
 
 ## Manual Test Sequence
 
-These commands assume the API is running on `http://127.0.0.1:8000` and that
+These commands assume the API is running on `http://127.0.0.1:9000` and that
 `jq` is available.
 
 ### 1. Confirm configured extent
 
 ```bash
-curl -s "http://127.0.0.1:8000/extent" | jq
+curl -s "http://127.0.0.1:9000/extent" | jq
 ```
 
 ### 2. Create an initial CHIRPS3 managed dataset
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/ingestions" \
+curl -s -X POST "http://127.0.0.1:9000/ingestions" \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "chirps3_precipitation_daily",
@@ -427,15 +427,15 @@ Expected:
 ### 3. Inspect the managed dataset and publication
 
 ```bash
-curl -s "http://127.0.0.1:8000/datasets/chirps3_precipitation_daily" | jq
-curl -s "http://127.0.0.1:8000/stac/collections/chirps3_precipitation_daily" | jq
-curl -s "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:9000/stac/collections/chirps3_precipitation_daily" | jq
+curl -s "http://127.0.0.1:9000/zarr/chirps3_precipitation_daily" | jq
 ```
 
 ### 4. Dry-run a CHIRPS3 append sync
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
+curl -s "http://127.0.0.1:9000/sync/chirps3_precipitation_daily/plan?end=2024-02-10" | jq
 ```
 
 Expected planning response:
@@ -479,7 +479,7 @@ If CHIRPS3 currently has complete released data through `2026-03-31` and you ask
 for:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2026-04-21" | jq
+curl -s "http://127.0.0.1:9000/sync/chirps3_precipitation_daily/plan?end=2026-04-21" | jq
 ```
 
 Expected:
@@ -491,7 +491,7 @@ Expected:
 ### 5. Execute the CHIRPS3 sync
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
+curl -s -X POST "http://127.0.0.1:9000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2024-02-10",
@@ -514,7 +514,7 @@ Expected:
 You can then extend the same managed dataset again:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/chirps3_precipitation_daily" \
+curl -s -X POST "http://127.0.0.1:9000/sync/chirps3_precipitation_daily" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2024-02-20",
@@ -535,7 +535,7 @@ Expected:
 Run the same plan again with the current end:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/chirps3_precipitation_daily/plan?end=2024-02-20" | jq
+curl -s "http://127.0.0.1:9000/sync/chirps3_precipitation_daily/plan?end=2024-02-20" | jq
 ```
 
 Expected:
@@ -549,7 +549,7 @@ Expected:
 Create an initial WorldPop managed dataset:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/ingestions" \
+curl -s -X POST "http://127.0.0.1:9000/ingestions" \
   -H "Content-Type: application/json" \
   -d '{
     "dataset_id": "worldpop_population_global2_R2025A_100m",
@@ -562,7 +562,7 @@ curl -s -X POST "http://127.0.0.1:8000/ingestions" \
 Plan a later release:
 
 ```bash
-curl -s "http://127.0.0.1:8000/sync/worldpop_population_global2_R2025A_100m/plan?end=2021" | jq
+curl -s "http://127.0.0.1:9000/sync/worldpop_population_global2_R2025A_100m/plan?end=2021" | jq
 ```
 
 Expected:
@@ -575,7 +575,7 @@ Expected:
 Execute the release sync:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8000/sync/worldpop_population_global2_R2025A_100m" \
+curl -s -X POST "http://127.0.0.1:9000/sync/worldpop_population_global2_R2025A_100m" \
   -H "Content-Type: application/json" \
   -d '{
     "end": "2021",

--- a/docs/openeo.md
+++ b/docs/openeo.md
@@ -39,7 +39,7 @@ Concretely it means:
 ```python
 import openeo
 
-conn = openeo.connect("http://127.0.0.1:8000")
+conn = openeo.connect("http://127.0.0.1:9000")
 print(conn.capabilities().api_version())  # 1.2.0
 ```
 
@@ -96,7 +96,7 @@ print(type(result))
 Equivalent with curl:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8000/result \
+curl -s -X POST http://127.0.0.1:9000/result \
   -H "Content-Type: application/json" \
   -d '{
     "process": {
@@ -143,18 +143,18 @@ REST equivalent:
 
 ```bash
 # 1 — create
-curl -s -X POST http://127.0.0.1:8000/jobs \
+curl -s -X POST http://127.0.0.1:9000/jobs \
   -H "Content-Type: application/json" \
   -d '{"process": {"process_graph": {...}}, "title": "my-job"}'
 
 # 2 — start
-curl -s -X POST http://127.0.0.1:8000/jobs/{job_id}/results
+curl -s -X POST http://127.0.0.1:9000/jobs/{job_id}/results
 
 # 3 — poll
-curl -s http://127.0.0.1:8000/jobs/{job_id}
+curl -s http://127.0.0.1:9000/jobs/{job_id}
 
 # 4 — download result
-curl -s http://127.0.0.1:8000/jobs/{job_id}/results
+curl -s http://127.0.0.1:9000/jobs/{job_id}/results
 ```
 
 Completed batch jobs write their output to disk and expose it as an asset link at `GET /jobs/{id}/results/{filename}`. The output format is controlled by the `format` argument of `save_result` — see [Export formats](#export-formats) below.
@@ -203,7 +203,7 @@ For aggregating a dataset to DHIS2 org units and producing `DHIS2JSON` or `CHAPC
 
 ```bash
 # Monthly precipitation totals as NetCDF
-curl -X POST http://127.0.0.1:8000/result \
+curl -X POST http://127.0.0.1:9000/result \
   -H "Content-Type: application/json" \
   -d '{
     "process": {
@@ -224,7 +224,7 @@ UDPs are named, parameterized process graphs stored server-side. They let you de
 
 ```bash
 # Store a UDP
-curl -s -X PUT http://127.0.0.1:8000/process_graphs/pop_millions \
+curl -s -X PUT http://127.0.0.1:9000/process_graphs/pop_millions \
   -H "Content-Type: application/json" \
   -d '{
     "summary": "Load WorldPop population in millions",
@@ -263,7 +263,7 @@ curl -s -X PUT http://127.0.0.1:8000/process_graphs/pop_millions \
   }'
 
 # Invoke it from another process graph
-curl -s -X POST http://127.0.0.1:8000/result \
+curl -s -X POST http://127.0.0.1:9000/result \
   -H "Content-Type: application/json" \
   -d '{
     "process": {

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -72,17 +72,17 @@ see [ERA5-Land datasets](era5_land_datasets.md).
 make run
 ```
 
-The service starts on `http://127.0.0.1:8000`. Open it in a browser — the landing page
+The service starts on `http://127.0.0.1:9000`. Open it in a browser — the landing page
 links to the management and map-viewer interfaces.
 
 ## Step 5: Ingest and view data
 
-Open **`http://127.0.0.1:8000/manage`** and ingest your first dataset through the form.
+Open **`http://127.0.0.1:9000/manage`** and ingest your first dataset through the form.
 CHIRPS3 (daily precipitation) requires no API key and is a good one to start with — pick
 it from the dropdown, enter a start date, and ingest (leave **Publish** checked). Progress
 streams live, and the dataset appears in the status table when it finishes.
 
-Then open **`http://127.0.0.1:8000/map`** to view it on the map, stepping through time with
+Then open **`http://127.0.0.1:9000/map`** to view it on the map, stepping through time with
 the slider.
 
 See [Using the web interface](web_interface.md) for a full walkthrough of the management

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,6 +1,6 @@
 # User Guide
 
-This guide shows how to discover and access data from a running Open Climate Service instance. It assumes the API is running locally at `http://127.0.0.1:8000` and that at least one dataset has been ingested and published.
+This guide shows how to discover and access data from a running Open Climate Service instance. It assumes the API is running locally at `http://127.0.0.1:9000` and that at least one dataset has been ingested and published.
 
 For configuring a new instance for your country, see the [instance guide](instance_guide.md). To browse datasets visually instead of through code, use the built-in [map viewer](web_interface.md#the-map-viewer-map). For the full ingestion and sync API reference, see [managed_data_api_guide.md](managed_data_api_guide.md).
 
@@ -9,14 +9,14 @@ For configuring a new instance for your country, see the [instance guide](instan
 The STAC catalog is the starting point for data discovery. It lists all published GeoZarr datasets as STAC Collections.
 
 ```bash
-curl -s http://127.0.0.1:8000/stac/catalog.json | jq
+curl -s http://127.0.0.1:9000/stac/catalog.json | jq
 ```
 
 Each entry in `links` with `"rel": "child"` points to one dataset collection. Use the `href` from the catalog to fetch it:
 
 ```bash
 # Replace {dataset_id} with any id from the catalog above, e.g. chirps3_precipitation_daily
-curl -s http://127.0.0.1:8000/stac/collections/{dataset_id} | jq
+curl -s http://127.0.0.1:9000/stac/collections/{dataset_id} | jq
 ```
 
 The `assets.zarr` field contains everything needed to open the dataset:
@@ -25,7 +25,7 @@ The `assets.zarr` field contains everything needed to open the dataset:
 {
   "assets": {
     "zarr": {
-      "href": "http://127.0.0.1:8000/zarr/chirps3_precipitation_daily",
+      "href": "http://127.0.0.1:9000/zarr/chirps3_precipitation_daily",
       "xarray:open_kwargs": { "consolidated": true }
     }
   }
@@ -45,7 +45,7 @@ pip install open-climate-service[xarray]    # + open published datasets as xarra
 ```python
 from open_climate_service import ClimateService
 
-service = ClimateService("http://127.0.0.1:8000")
+service = ClimateService("http://127.0.0.1:9000")
 
 # Discover published datasets (STAC catalog)
 for link in service.datasets():
@@ -81,14 +81,14 @@ data_value_set = service.execute(
 ```python
 from open_climate_service import ClimateService
 
-service = ClimateService("http://127.0.0.1:8000")
+service = ClimateService("http://127.0.0.1:9000")
 
 datasets = service.datasets()
 ds = service.open_dataset(datasets[0]["id"])  # open whichever dataset is published first
 print(ds)
 ```
 
-The `base_url` defaults to the `CLIMATE_SERVICE_BASE_URL` environment variable (falling back to `http://127.0.0.1:8000`), so module-level functions work without any argument when the env var is set:
+The `base_url` defaults to the `CLIMATE_SERVICE_BASE_URL` environment variable (falling back to `http://127.0.0.1:9000`), so module-level functions work without any argument when the env var is set:
 
 ```python
 from open_climate_service.client import list_datasets, open_dataset  # reads CLIMATE_SERVICE_BASE_URL

--- a/docs/web_interface.md
+++ b/docs/web_interface.md
@@ -2,7 +2,7 @@
 
 Every Open Climate Service instance ships with a small built-in web interface — no
 separate application to install. Once the instance is running, open its root URL
-(`http://127.0.0.1:8000` by default) and the landing page links to everything below.
+(`http://127.0.0.1:9000` by default) and the landing page links to everything below.
 
 | Page           | URL       | What it does                                                                         |
 | -------------- | --------- | ------------------------------------------------------------------------------------ |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -214,7 +214,7 @@ The workflow appears in `GET /process_graphs` immediately on the next request â€
 ### Via API
 
 ```bash
-curl -X PUT http://127.0.0.1:8000/process_graphs/monthly_precipitation \
+curl -X PUT http://127.0.0.1:9000/process_graphs/monthly_precipitation \
   -H "Content-Type: application/json" \
   -d @monthly_precipitation.json
 ```
@@ -228,7 +228,7 @@ curl -X PUT http://127.0.0.1:8000/process_graphs/monthly_precipitation \
 ```python
 from openeo import connect
 
-conn = connect("http://127.0.0.1:8000")
+conn = connect("http://127.0.0.1:9000")
 
 result = conn.execute({
     "process_graph": {
@@ -246,7 +246,7 @@ result = conn.execute({
 ```javascript
 import { OpenEO } from "@openeo/js-client";
 
-const conn = await OpenEO.connect("http://127.0.0.1:8000");
+const conn = await OpenEO.connect("http://127.0.0.1:9000");
 
 const process = await conn.buildProcess((builder) =>
   builder.monthly_precipitation("chirps3_precipitation_daily")

--- a/examples/aggregate_and_import_to_dhis2.py
+++ b/examples/aggregate_and_import_to_dhis2.py
@@ -30,7 +30,7 @@ from dhis2_client.settings import ClientSettings
 from open_climate_service import ClimateService
 
 # --- Open Climate Service ---------------------------------------------------
-OCS_BASE_URL = "http://127.0.0.1:8000"
+OCS_BASE_URL = "http://127.0.0.1:9000"
 DATASET_ID = "era5land_temperature_monthly"  # a published collection (see /datasets)
 TEMPORAL_EXTENT = ["2025-01-01", "2025-12-31"]
 METHOD = "mean"  # mean (default), min, max, or sum

--- a/examples/openeo_process_graph.py
+++ b/examples/openeo_process_graph.py
@@ -12,7 +12,7 @@ Adjust BASE_URL if the API is not on the default local address.
 
 import openeo
 
-BASE_URL = "http://127.0.0.1:8000"
+BASE_URL = "http://127.0.0.1:9000"
 
 
 def main() -> None:

--- a/examples/stac_discover_and_open.py
+++ b/examples/stac_discover_and_open.py
@@ -8,7 +8,7 @@ import json
 
 from open_climate_service import ClimateService
 
-BASE_URL = "http://127.0.0.1:8000"
+BASE_URL = "http://127.0.0.1:9000"
 
 
 def main() -> None:

--- a/examples/zarr_direct_access.py
+++ b/examples/zarr_direct_access.py
@@ -6,7 +6,7 @@ Adjust BASE_URL if the API is not running on the default local address.
 
 from open_climate_service import ClimateService
 
-BASE_URL = "http://127.0.0.1:8000"
+BASE_URL = "http://127.0.0.1:9000"
 
 
 def main() -> None:

--- a/open_climate_service/cli.py
+++ b/open_climate_service/cli.py
@@ -1,8 +1,19 @@
 """Command-line entry point for running the Open Climate Service with uvicorn."""
 
+import os
+
 import uvicorn
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 9000
 
 
 def main() -> None:
-    """Start the Open Climate Service server."""
-    uvicorn.run("open_climate_service.main:app", host="0.0.0.0", port=8000)
+    """Start the Open Climate Service server.
+
+    Host and port are read from the HOST and PORT environment variables,
+    defaulting to 0.0.0.0:9000.
+    """
+    host = os.environ.get("HOST", DEFAULT_HOST)
+    port = int(os.environ.get("PORT", DEFAULT_PORT))
+    uvicorn.run("open_climate_service.main:app", host=host, port=port)

--- a/open_climate_service/client.py
+++ b/open_climate_service/client.py
@@ -42,7 +42,7 @@ import httpx
 if TYPE_CHECKING:
     import xarray as xr
 
-_FALLBACK_BASE_URL = "http://127.0.0.1:8000"
+_FALLBACK_BASE_URL = "http://127.0.0.1:9000"
 _DEFAULT_TIMEOUT = 30.0
 # Synchronous process graphs (POST /result) can run for minutes — allow more headroom.
 _RESULT_TIMEOUT = 300.0
@@ -124,11 +124,11 @@ class ClimateService:
     Maintains a persistent HTTP connection for efficient repeated calls. Use as a
     context manager to ensure the connection is closed::
 
-        with ClimateService("http://localhost:8000") as service:
+        with ClimateService("http://localhost:9000") as service:
             datasets = service.datasets()
 
     Args:
-        base_url: Base URL of the running Open Climate Service (e.g. ``http://localhost:8000``).
+        base_url: Base URL of the running Open Climate Service (e.g. ``http://localhost:9000``).
         timeout: Default HTTP request timeout in seconds (default: 30).
     """
 
@@ -216,7 +216,7 @@ def list_datasets(base_url: str | None = None) -> list[dict]:
 
     Each entry is a STAC child link dict with at least ``id``, ``title``, and ``href``.
     ``base_url`` defaults to the ``CLIMATE_SERVICE_BASE_URL`` environment variable,
-    falling back to ``http://127.0.0.1:8000``.
+    falling back to ``http://127.0.0.1:9000``.
     """
     url = (base_url or _default_base_url()).rstrip("/")
     response = httpx.get(f"{url}/stac/catalog.json", timeout=_DEFAULT_TIMEOUT)
@@ -230,7 +230,7 @@ def open_dataset(dataset_id: str, *, base_url: str | None = None) -> xr.Dataset:
     Fetches the STAC collection for ``dataset_id``, reads the Zarr asset metadata, and
     returns the opened dataset. Requires the ``xarray`` extra. ``base_url`` defaults to
     the ``CLIMATE_SERVICE_BASE_URL`` environment variable, falling back to
-    ``http://127.0.0.1:8000``.
+    ``http://127.0.0.1:9000``.
     """
     url = (base_url or _default_base_url()).rstrip("/")
     response = httpx.get(f"{url}/stac/collections/{dataset_id}", timeout=_DEFAULT_TIMEOUT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ server = [
     "geozarr-toolkit==0.1.*",
     "topozarr>=0.0.91,<0.1",
     "rioxarray>=0.17",
+    # Directly imported (shared/time.py, streaming, openeo). Capped to 2.x; pandas
+    # 3.0 is a breaking major and not yet validated against this stack.
+    "pandas>=2.3,<3",
     "portalocker>=3.2.0",
     "openeo-pg-parser-networkx>=2026.3.3",
     # We depend on the base package and hand-pick the implementation deps rather than

--- a/tests/integration/test_stac_interop.py
+++ b/tests/integration/test_stac_interop.py
@@ -16,7 +16,7 @@ Manual setup example:
 3. ``pip install pytest httpx openeo``
 4. start the Open Climate Service separately, e.g. ``make run``
 5. run:
-   ``RUN_STAC_INTEROP=1 STAC_BASE_URL=http://127.0.0.1:8000 pytest --noconftest tests/integration/test_stac_interop.py``
+   ``RUN_STAC_INTEROP=1 STAC_BASE_URL=http://127.0.0.1:9000 pytest --noconftest tests/integration/test_stac_interop.py``
 """
 
 import os
@@ -31,7 +31,7 @@ def test_openeo_can_load_stac_collection() -> None:
         pytest.skip("Set RUN_STAC_INTEROP=1 to enable live STAC interoperability checks")
 
     openeo = pytest.importorskip("openeo")
-    base_url = os.getenv("STAC_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+    base_url = os.getenv("STAC_BASE_URL", "http://127.0.0.1:9000").rstrip("/")
     dataset_id = os.getenv("STAC_DATASET_ID")
 
     catalog_url = f"{base_url}/stac/catalog.json"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ import xarray as xr
 
 from open_climate_service.client import (
     ClimateService,
+    _FALLBACK_BASE_URL,
     _id_from_href,
     list_datasets,
     open_dataset,
@@ -138,17 +139,19 @@ def test_open_dataset_uses_default_base_url() -> None:
         with patch("xarray.open_zarr", return_value=MagicMock()):
             open_dataset("any_dataset")
 
-    mock_get.assert_called_once_with("http://127.0.0.1:9000/stac/collections/any_dataset", timeout=30)
+    mock_get.assert_called_once_with(f"{_FALLBACK_BASE_URL}/stac/collections/any_dataset", timeout=30)
 
 
 def test_open_dataset_uses_env_var_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CLIMATE_SERVICE_BASE_URL", "http://env-host:9000")
+    # Arbitrary host:port — the point is that the env var is honored verbatim,
+    # independent of the default base URL or port.
+    monkeypatch.setenv("CLIMATE_SERVICE_BASE_URL", "http://env-host:4321")
     collection = _make_collection("/dev/null")
     with patch("open_climate_service.client.httpx.get", return_value=_make_response(collection)) as mock_get:
         with patch("xarray.open_zarr", return_value=MagicMock()):
             open_dataset("any_dataset")
 
-    mock_get.assert_called_once_with("http://env-host:9000/stac/collections/any_dataset", timeout=30)
+    mock_get.assert_called_once_with("http://env-host:4321/stac/collections/any_dataset", timeout=30)
 
 
 # ── lazy xarray import ─────────────────────────────────────────────────────────

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -138,7 +138,7 @@ def test_open_dataset_uses_default_base_url() -> None:
         with patch("xarray.open_zarr", return_value=MagicMock()):
             open_dataset("any_dataset")
 
-    mock_get.assert_called_once_with("http://127.0.0.1:8000/stac/collections/any_dataset", timeout=30)
+    mock_get.assert_called_once_with("http://127.0.0.1:9000/stac/collections/any_dataset", timeout=30)
 
 
 def test_open_dataset_uses_env_var_base_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,8 +8,8 @@ import pytest
 import xarray as xr
 
 from open_climate_service.client import (
-    ClimateService,
     _FALLBACK_BASE_URL,
+    ClimateService,
     _id_from_href,
     list_datasets,
     open_dataset,

--- a/uv.lock
+++ b/uv.lock
@@ -1974,6 +1974,7 @@ server = [
     { name = "odc-stac" },
     { name = "openeo-pg-parser-networkx" },
     { name = "openeo-processes-dask" },
+    { name = "pandas" },
     { name = "planetary-computer" },
     { name = "portalocker" },
     { name = "pystac-client" },
@@ -2028,6 +2029,7 @@ requires-dist = [
     { name = "odc-stac", marker = "extra == 'server'", specifier = ">=0.3.9" },
     { name = "openeo-pg-parser-networkx", marker = "extra == 'server'", specifier = ">=2026.3.3" },
     { name = "openeo-processes-dask", marker = "extra == 'server'", specifier = ">=2026.6.3" },
+    { name = "pandas", marker = "extra == 'server'", specifier = ">=2.3,<3" },
     { name = "planetary-computer", marker = "extra == 'server'", specifier = ">=0.5.1" },
     { name = "portalocker", marker = "extra == 'server'", specifier = ">=3.2.0" },
     { name = "pystac", specifier = ">=1.10,<2" },
@@ -2125,7 +2127,7 @@ name = "oschmod"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/64/6e522f0a1b500470ae14dcd1a4bb8f8751f5cf441e85e9fee7dfc712cb7b/oschmod-0.3.12.tar.gz", hash = "sha256:bec99216f31615ee653b2a5c87cacfb4e4b6184c0e9f71da186300dacae974f3", size = 20064, upload-time = "2020-10-30T00:38:42.409Z" }
 wheels = [


### PR DESCRIPTION
## Summary

The server port is now driven by the `PORT` environment variable with a default of `9000` (was a hardcoded `8000`), so there's a single source of truth for the mechanism.

**Mechanism (commit 1):**
- `open_climate_service/cli.py` — the `climate-service` entry point reads `HOST`/`PORT` from the environment, defaulting to `0.0.0.0:9000`
- `Dockerfile` — `CMD` runs the `climate-service` console script (still PID 1 / signal-safe via exec form) so it honors `PORT`; `ENV PORT=9000`
- `compose.yml` / `compose.ghcr.yml` — default to `${PORT:-9000}`
- `open_climate_service/client.py` — fallback base URL → `127.0.0.1:9000` so the Python client's default target matches the server default
- `.env.example` — documents `HOST`/`PORT`
- `tests/` — assertions updated for the new fallback

**Docs consistency (commit 2):**
- Illustrative `127.0.0.1:8000` / `localhost:8000` URLs across `docs/` and `examples/` updated to `9000`

There are no `8000` references left in the repo. Override the port at runtime with `PORT=8080` (env var or compose).

## Test plan

- `make lint` — ruff, ruff format, mypy, pyright all pass
- `uv run pytest tests/test_client.py` — 22 passed