### PR TITLE
chore: add CODEOWNERS for docker/compose infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS
+# Docker / Compose infrastructure is owned by the DevOps team.
+# Pattern syntax: https://docs.github.com/articles/about-code-owners
+
+# Docker build files (root only)
+/Dockerfile*            @dhis2/devops
+
+# Docker Compose stacks (compose.yml, compose.ghcr.yml)
+/compose.*              @dhis2/devops
+
+# Docker build context
+/.dockerignore          @dhis2/devops
+
+# Docker image CI workflow
+/.github/workflows/docker.yml   @dhis2/devops


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` so the DevOps team (`@dhis2/devops`) is automatically requested as a reviewer for changes to the container/deployment infrastructure.

Mirrors the approach taken in dhis2-chap/chap-core#477, using the `@dhis2/devops` team from the [dhis2/dhis2-core CODEOWNERS](https://github.com/dhis2/dhis2-core/blob/master/.github/CODEOWNERS).

## Scope (infra files only)

Ownership is anchored to the repo root via leading-slash patterns:

- `/Dockerfile*` — root Dockerfile
- `/compose.*` — Compose stacks (`compose.yml`, `compose.ghcr.yml`)
- `/.dockerignore`
- `/.github/workflows/docker.yml` — the Docker image build/push workflow

Python source and non-docker workflows (`ci.yml`, `docs.yml`, `publish.yml`) are intentionally not covered. This repo has no Helm charts, so no `/charts/` entry.

## Note

For GitHub to honor the entries, `@dhis2/devops` must have at least write access to this repo. If it doesn't, GitHub will flag a CODEOWNERS validity warning on the file — that's an org-level setting, not part of this change.