### PR TITLE
chore(docker): pin ocs uid/gid and use nologin shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         build-essential cython3 \
         libgeos-dev libproj-dev libeccodes-dev
 
-RUN groupadd --system ocs && useradd --system --gid ocs --create-home ocs
+RUN groupadd --gid 999 ocs && \
+    useradd --create-home --shell /usr/sbin/nologin --uid 999 --gid 999 ocs
 
 WORKDIR /app
 


### PR DESCRIPTION
Pin the `ocs` account to uid/gid 999 and give it a nologin shell.

- **Pinned uid/gid 999** — bind-mounted volumes (e.g. `/app/data`) get deterministic ownership across rebuilds instead of a uid auto-assigned from the system range. Uses the two-step `groupadd`/`useradd` form because `--user-group` can't pin the gid.
- **nologin shell** — the account only runs the server via the exec-form CMD and is never logged into. Matches the account style in chap-core.
- **Dropped `--system`** — redundant once uid/gid are pinned explicitly; chap-core doesn't use it either.
- **Kept `--create-home`** — load-bearing: with no `DATA_DIR` set, the jobs store falls back to `$HOME/.local/share/climate-service/jobs`, so `/home/ocs` must exist. This is why OCS keeps a home dir where chap-core uses `--no-create-home`.

## Verification

Built and ran the image:

- `getent passwd ocs` → `ocs:x:999:999::/home/ocs:/usr/sbin/nologin`
- PID 1 runs as `Uid: 999`, `Gid: 999`
- `/health` returns `{"status":"healthy"}`

## Follow-up (out of scope)

In the container the jobs store lands in the ephemeral `$HOME`, not the `/app/data` volume that gets chowned and is meant to persist. Setting `DATA_DIR` (or `XDG_DATA_HOME`) under `/app/data` would make jobs survive restarts — worth a separate change.