### PR TITLE
map-viewer: pin CDN deps + MapLibre 6, and publish CRS render hints in STAC

### DIFF
--- a/open_climate_service/shared/crs.py
+++ b/open_climate_service/shared/crs.py
@@ -28,9 +28,13 @@ def canonical_crs_code(code: str | int) -> str:
     URI) is geographic WGS84, but map reprojectors resolve only ``EPSG:4326`` /
     ``EPSG:3857`` from a code — so mapping the alias to ``EPSG:4326`` lets every consumer
     work with one canonical code. Separators are stripped before matching so ``CRS:84`` is
-    caught too; any non-CRS84 input is returned unchanged (as a string).
+    caught too. A bare EPSG number (the int ``4326`` or the string ``"4326"``) is prefixed
+    to ``EPSG:4326`` so downstream checks like :func:`is_builtin_crs` see a full code; any
+    other input is returned unchanged (as a string).
     """
-    s = str(code)
+    s = str(code).strip()
+    if s.isdigit():
+        return f"EPSG:{s}"
     return "EPSG:4326" if re.sub(r"[^A-Z0-9]", "", s.upper()).endswith("CRS84") else s
 
 
@@ -50,6 +54,11 @@ def crs_to_proj4(crs_input: object) -> str | None:
     it is only a client render hint; ``proj:code`` / WKT stay the canonical CRS.
     """
     import warnings
+
+    # A CRS84 alias passed as a code/int is built-in even though pyproj's to_epsg()
+    # may return None for it, so short-circuit on is_builtin_crs before parsing.
+    if isinstance(crs_input, (str, int)) and is_builtin_crs(crs_input):
+        return None
 
     try:
         from pyproj import CRS

--- a/open_climate_service/shared/crs.py
+++ b/open_climate_service/shared/crs.py
@@ -8,10 +8,61 @@ without ever consulting ``api_config.get_crs()``.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import xarray as xr
+
+
+# CRSes that map clients (proj4js, GDAL) resolve from the authority code alone; any
+# other CRS needs a full definition (proj4 / WKT) surfaced to the client. CRS84 aliases
+# are normalized to EPSG:4326 before this check (see canonical_crs_code).
+_BUILTIN_CRS_CODES = frozenset({"EPSG:4326", "EPSG:3857"})
+
+
+def canonical_crs_code(code: str | int) -> str:
+    """Collapse CRS84 geographic aliases to the canonical ``EPSG:4326``.
+
+    A CRS84 alias (``CRS84``, ``OGC:CRS84``, the short OGC form ``CRS:84``, or a CRS84
+    URI) is geographic WGS84, but map reprojectors resolve only ``EPSG:4326`` /
+    ``EPSG:3857`` from a code — so mapping the alias to ``EPSG:4326`` lets every consumer
+    work with one canonical code. Separators are stripped before matching so ``CRS:84`` is
+    caught too; any non-CRS84 input is returned unchanged (as a string).
+    """
+    s = str(code)
+    return "EPSG:4326" if re.sub(r"[^A-Z0-9]", "", s.upper()).endswith("CRS84") else s
+
+
+def is_builtin_crs(code: str | int) -> bool:
+    """True for a CRS a client resolves from the code alone (EPSG:4326 / EPSG:3857).
+
+    CRS84 aliases are normalized to EPSG:4326 first.
+    """
+    return canonical_crs_code(code).upper() in _BUILTIN_CRS_CODES
+
+
+def crs_to_proj4(crs_input: object) -> str | None:
+    """Derive a proj4 string from a CRS code, WKT, or proj4 input.
+
+    Returns ``None`` for built-in CRSes (EPSG:4326 / EPSG:3857 — clients resolve those
+    from the code) and for anything pyproj cannot parse. proj4 is lossy (PROJ warns), so
+    it is only a client render hint; ``proj:code`` / WKT stay the canonical CRS.
+    """
+    import warnings
+
+    try:
+        from pyproj import CRS
+
+        crs = CRS.from_user_input(crs_input)
+        if crs.to_epsg() in (4326, 3857):
+            return None
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # proj4 is lossy; accepted for a render hint
+            proj4 = crs.to_proj4()
+        return proj4.strip() if proj4 else None
+    except Exception:
+        return None
 
 
 def dataset_crs(ds: "xr.Dataset", default: str = "EPSG:4326") -> str:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -224,9 +225,10 @@ def _canonical_crs_code(code: str) -> str:
     (``CRS84``, ``OGC:CRS84``, or a CRS84 URI) could arrive from an external store.
     proj4js — the map client's reprojector — only resolves ``EPSG:4326`` / ``EPSG:3857``
     from a code, so mapping the alias to ``EPSG:4326`` here lets every downstream
-    consumer work with a single canonical code.
+    consumer work with a single canonical code. Strips separators first so the short
+    OGC form ``CRS:84`` is matched as well as ``CRS84`` / ``OGC:CRS84`` / CRS84 URIs.
     """
-    return "EPSG:4326" if code.strip().upper().endswith("CRS84") else code
+    return "EPSG:4326" if re.sub(r"[^A-Z0-9]", "", code.upper()).endswith("CRS84") else code
 
 
 def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_crs: str) -> None:
@@ -246,6 +248,9 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
       proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
       strings as lossy), so it lives under our namespace rather than ``proj:``.
+      zarr-layer only accepts a built-in ``crs`` code or a ``proj4`` string today; once
+      carbonplan/zarr-layer#61 lands (auto-resolving any EPSG code) this proj4 hint
+      becomes unnecessary and only ``proj:wkt2`` need remain, for other STAC clients.
     """
     if store_crs.upper() in _BUILTIN_CRS_CODES:
         return
@@ -262,7 +267,9 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
             wkt = spatial_ref.attrs.get("crs_wkt") or spatial_ref.attrs.get("spatial_ref")
         crs = CRS.from_wkt(wkt) if wkt else CRS.from_user_input(store_crs)
 
-        template.extra_fields["proj:wkt2"] = crs.to_wkt()
+        # Force WKT2 explicitly — pyproj's to_wkt() default can vary by version and could
+        # emit WKT1 (PROJCS); the STAC Projection extension defines proj:wkt2 as WKT2.
+        template.extra_fields["proj:wkt2"] = crs.to_wkt(version="WKT2_2019")
         with warnings.catch_warnings():
             # to_proj4() warns that proj4 is lossy; that's acceptable for a render hint.
             warnings.simplefilter("ignore")

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -20,6 +19,7 @@ from open_climate_service.data_manager.services.utils import get_time_dim, get_x
 from open_climate_service.data_registry.services import datasets as registry_datasets
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
+from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
 from open_climate_service.shared.time import (
     parse_period_string_to_datetime,
     period_type_to_iso_step,
@@ -212,25 +212,6 @@ def _build_collection_template(
     return template
 
 
-# CRSes that proj4js (the map client's reprojector) resolves from the authority code
-# alone; any other CRS needs a full definition surfaced in the collection metadata.
-# CRS84 aliases are normalized to EPSG:4326 before this check (see _canonical_crs_code).
-_BUILTIN_CRS_CODES = frozenset({"EPSG:4326", "EPSG:3857"})
-
-
-def _canonical_crs_code(code: str) -> str:
-    """Collapse CRS84 geographic aliases to the canonical ``EPSG:4326``.
-
-    ``proj:code`` is written as ``EPSG:<n>`` by the ingest path, but a CRS84 alias
-    (``CRS84``, ``OGC:CRS84``, or a CRS84 URI) could arrive from an external store.
-    proj4js — the map client's reprojector — only resolves ``EPSG:4326`` / ``EPSG:3857``
-    from a code, so mapping the alias to ``EPSG:4326`` here lets every downstream
-    consumer work with a single canonical code. Strips separators first so the short
-    OGC form ``CRS:84`` is matched as well as ``CRS84`` / ``OGC:CRS84`` / CRS84 URIs.
-    """
-    return "EPSG:4326" if re.sub(r"[^A-Z0-9]", "", code.upper()).endswith("CRS84") else code
-
-
 def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_crs: str) -> None:
     """Surface CRS render hints on the collection for projected (non-built-in) stores.
 
@@ -252,7 +233,7 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
       carbonplan/zarr-layer#61 lands (auto-resolving any EPSG code) this proj4 hint
       becomes unnecessary and only ``proj:wkt2`` need remain, for other STAC clients.
     """
-    if store_crs.upper() in _BUILTIN_CRS_CODES:
+    if is_builtin_crs(store_crs):
         return
     try:
         import warnings
@@ -301,7 +282,7 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         # store data in WGS84 (e.g. CHIRPS3) should not inherit the instance UTM CRS.
         store_crs = ds.attrs.get("proj:code")
         if store_crs:
-            store_crs = _canonical_crs_code(store_crs)
+            store_crs = canonical_crs_code(store_crs)
             template.extra_fields["proj:code"] = store_crs
             _add_crs_render_hints(template=template, ds=ds, store_crs=store_crs)
         x_dimension, y_dimension = get_x_y_dims(ds)

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -221,7 +221,7 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     fetch one at render time (an external epsg.io lookup). Publishing the definition
     in STAC removes that runtime dependency.
 
-    Two fields are emitted:
+    Three fields are emitted:
 
     * ``proj:wkt2`` — the STAC Projection-extension standard, lossless CRS
       representation. It is the same information GeoZarr already carries in the CF
@@ -232,6 +232,10 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
       zarr-layer only accepts a built-in ``crs`` code or a ``proj4`` string today; once
       carbonplan/zarr-layer#61 lands (auto-resolving any EPSG code) this proj4 hint
       becomes unnecessary and only ``proj:wkt2`` need remain, for other STAC clients.
+    * ``proj:bbox`` — the data extent in the store's native CRS. Without it, a client
+      reprojecting the Zarr must fetch the x/y coordinate arrays at render time to
+      derive bounds (zarr-layer's "proj4 provided without explicit bounds" warning);
+      publishing it lets the client pass explicit bounds and skip that round-trip.
     """
     if is_builtin_crs(store_crs):
         return
@@ -259,6 +263,19 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
             template.extra_fields["open_climate_service:proj4"] = proj4.strip()
     except Exception:
         logger.warning("Could not derive CRS render hints for '%s'", store_crs, exc_info=True)
+
+    # proj:bbox — the native-CRS extent. Prefer the value the ingest orchestrator
+    # writes to the store root (``attrs["bounds"]``); fall back to the x/y coordinate
+    # arrays (cell centres) for stores written before that attr existed.
+    try:
+        bbox = ds.attrs.get("bounds")
+        if not (isinstance(bbox, (list, tuple)) and len(bbox) == 4):
+            x_dim, y_dim = get_x_y_dims(ds)
+            xs, ys = ds[x_dim].values, ds[y_dim].values
+            bbox = [xs.min(), ys.min(), xs.max(), ys.max()]
+        template.extra_fields["proj:bbox"] = [float(v) for v in bbox]
+    except Exception:
+        logger.warning("Could not derive proj:bbox for '%s'", store_crs, exc_info=True)
 
 
 def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.Collection) -> dict[str, Any]:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -144,7 +144,9 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         collection_payload,
         resolve_iso_period_step(source_dataset) or period_type_to_iso_step(source_dataset.get("period_type")),
     )
-    _override_spatial_extent_from_artifact(collection_payload, artifact)
+    # Spatial extent comes from the live store (set in _build_collection_with_xstac),
+    # not the artifact coverage — see _wgs84_extent_from_store. Temporal still tracks the
+    # artifact's materialized coverage.
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
     return collection_payload
@@ -278,6 +280,29 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
         logger.warning("Could not derive proj:bbox for '%s'", store_crs, exc_info=True)
 
 
+def _wgs84_extent_from_store(ds: xr.Dataset, store_crs: str, x_dim: str, y_dim: str) -> list[float] | None:
+    """Return the store's spatial extent as WGS84 ``[west, south, east, north]``.
+
+    STAC collections must report their spatial extent in WGS84. Deriving it live from the
+    published store (the same coordinates ``cube:dimensions`` reads) keeps the two
+    consistent and avoids the cached ``coverage`` record, which can go stale or hold a
+    native-CRS (metre) bbox for projected stores.
+    """
+    try:
+        xmin, xmax = float(ds[x_dim].min()), float(ds[x_dim].max())
+        ymin, ymax = float(ds[y_dim].min()), float(ds[y_dim].max())
+        if canonical_crs_code(store_crs) == "EPSG:4326":
+            return [xmin, ymin, xmax, ymax]
+        from pyproj import Transformer
+
+        transformer = Transformer.from_crs(store_crs, "EPSG:4326", always_xy=True)
+        west, south, east, north = transformer.transform_bounds(xmin, ymin, xmax, ymax)
+        return [west, south, east, north]
+    except Exception:
+        logger.warning("Could not derive WGS84 extent from store for '%s'", store_crs, exc_info=True)
+        return None
+
+
 def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.Collection) -> dict[str, Any]:
     cached_payload = _xstac_collection_cache.get(artifact.artifact_id)
     if cached_payload is not None:
@@ -340,6 +365,11 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         ordinal_dims = _build_ordinal_dimensions(ds, x_dimension, y_dimension, time_dimension)
         if ordinal_dims:
             payload.setdefault("cube:dimensions", {}).update(ordinal_dims)
+        # WGS84 spatial extent from the live store — consistent with cube:dimensions and
+        # immune to a stale/native-CRS cached coverage record (see _wgs84_extent_from_store).
+        extent_bbox = _wgs84_extent_from_store(ds, store_crs or "EPSG:4326", x_dimension, y_dimension)
+        if extent_bbox is not None:
+            payload.setdefault("extent", {}).setdefault("spatial", {})["bbox"] = [extent_bbox]
         _cache_xstac_collection_payload(artifact.artifact_id, payload)
         return deepcopy(payload)
     except HTTPException:
@@ -528,11 +558,6 @@ def _round_spatial_steps(collection: dict[str, Any]) -> None:
         if isinstance(step, int | float):
             value["step"] = round(float(step), SPATIAL_STEP_DECIMALS)
             dimensions[key] = value
-
-
-def _override_spatial_extent_from_artifact(collection: dict[str, Any], artifact: ArtifactRecord) -> None:
-    spatial = artifact.coverage.spatial_wgs84 or artifact.coverage.spatial
-    collection["extent"]["spatial"]["bbox"] = [[spatial.xmin, spatial.ymin, spatial.xmax, spatial.ymax]]
 
 
 def _override_temporal_extent_from_artifact(collection: dict[str, Any], artifact: ArtifactRecord) -> None:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -213,7 +213,20 @@ def _build_collection_template(
 
 # CRSes that proj4js (the map client's reprojector) resolves from the authority code
 # alone; any other CRS needs a full definition surfaced in the collection metadata.
-_BUILTIN_CRS_CODES = frozenset({"EPSG:4326", "OGC:CRS84", "CRS84", "EPSG:3857"})
+# CRS84 aliases are normalized to EPSG:4326 before this check (see _canonical_crs_code).
+_BUILTIN_CRS_CODES = frozenset({"EPSG:4326", "EPSG:3857"})
+
+
+def _canonical_crs_code(code: str) -> str:
+    """Collapse CRS84 geographic aliases to the canonical ``EPSG:4326``.
+
+    ``proj:code`` is written as ``EPSG:<n>`` by the ingest path, but a CRS84 alias
+    (``CRS84``, ``OGC:CRS84``, or a CRS84 URI) could arrive from an external store.
+    proj4js — the map client's reprojector — only resolves ``EPSG:4326`` / ``EPSG:3857``
+    from a code, so mapping the alias to ``EPSG:4326`` here lets every downstream
+    consumer work with a single canonical code.
+    """
+    return "EPSG:4326" if code.strip().upper().endswith("CRS84") else code
 
 
 def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_crs: str) -> None:
@@ -281,6 +294,7 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         # store data in WGS84 (e.g. CHIRPS3) should not inherit the instance UTM CRS.
         store_crs = ds.attrs.get("proj:code")
         if store_crs:
+            store_crs = _canonical_crs_code(store_crs)
             template.extra_fields["proj:code"] = store_crs
             _add_crs_render_hints(template=template, ds=ds, store_crs=store_crs)
         x_dimension, y_dimension = get_x_y_dims(ds)

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -223,11 +223,15 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     fetch one at render time (an external epsg.io lookup). Publishing the definition
     in STAC removes that runtime dependency.
 
-    Three fields are emitted:
+    Four fields are emitted:
 
     * ``proj:wkt2`` — the STAC Projection-extension standard, lossless CRS
       representation. It is the same information GeoZarr already carries in the CF
       ``spatial_ref`` grid-mapping's ``crs_wkt`` attribute.
+    * ``proj:projjson`` — the same CRS as PROJJSON. Also a STAC Projection-extension
+      standard (and the GeoZarr ``proj:`` convention), but a JSON object a JS/STAC
+      client can consume directly instead of parsing WKT2 — the convention-aligned
+      sibling of the namespaced proj4 hint below.
     * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
       proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
       strings as lossy), so it lives under our namespace rather than ``proj:``.
@@ -257,6 +261,9 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
         # Force WKT2 explicitly — pyproj's to_wkt() default can vary by version and could
         # emit WKT1 (PROJCS); the STAC Projection extension defines proj:wkt2 as WKT2.
         template.extra_fields["proj:wkt2"] = crs.to_wkt(version="WKT2_2019")
+        # PROJJSON alongside it — the same CRS as a JSON object, cheaper for JS/STAC
+        # clients than parsing WKT2. Cheap to emit next to the WKT2 above.
+        template.extra_fields["proj:projjson"] = crs.to_json_dict()
         with warnings.catch_warnings():
             # to_proj4() warns that proj4 is lossy; that's acceptable for a render hint.
             warnings.simplefilter("ignore")
@@ -267,13 +274,14 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
         logger.warning("Could not derive CRS render hints for '%s'", store_crs, exc_info=True)
 
     # proj:bbox — the native-CRS extent. Prefer the GeoZarr ``spatial:bbox`` the store
-    # root already carries; fall back to the x/y coordinate arrays (cell centres) for
-    # stores that lack it.
+    # root already carries; fall back to the x/y coordinate arrays for stores that lack it.
     try:
         bbox = ds.attrs.get("spatial:bbox")
         if not (isinstance(bbox, (list, tuple)) and len(bbox) == 4):
             x_dim, y_dim = get_x_y_dims(ds)
             xs, ys = ds[x_dim].values, ds[y_dim].values
+            # Coordinates are cell centres, so this bbox sits a half-pixel inside the
+            # true data edge — acceptable for a render/placement hint.
             bbox = [xs.min(), ys.min(), xs.max(), ys.max()]
         template.extra_fields["proj:bbox"] = [float(v) for v in bbox]
     except Exception:
@@ -680,9 +688,8 @@ def _build_renders(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> 
     nodata = display.get("nodata")
     if nodata is not None:
         render["nodata"] = float(nodata)
-    units = source_dataset.get("units")
-    if isinstance(units, str):
-        render["open_climate_service:units"] = units
+    # Units aren't duplicated here: they're published on the datacube-standard
+    # ``cube:variables[<var>].unit``, which clients read instead.
     return {"default": render}
 
 

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -264,11 +264,11 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     except Exception:
         logger.warning("Could not derive CRS render hints for '%s'", store_crs, exc_info=True)
 
-    # proj:bbox — the native-CRS extent. Prefer the value the ingest orchestrator
-    # writes to the store root (``attrs["bounds"]``); fall back to the x/y coordinate
-    # arrays (cell centres) for stores written before that attr existed.
+    # proj:bbox — the native-CRS extent. Prefer the GeoZarr ``spatial:bbox`` the store
+    # root already carries; fall back to the x/y coordinate arrays (cell centres) for
+    # stores that lack it.
     try:
-        bbox = ds.attrs.get("bounds")
+        bbox = ds.attrs.get("spatial:bbox")
         if not (isinstance(bbox, (list, tuple)) and len(bbox) == 4):
             x_dim, y_dim = get_x_y_dims(ds)
             xs, ys = ds[x_dim].values, ds[y_dim].values

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -211,6 +211,55 @@ def _build_collection_template(
     return template
 
 
+# CRSes that proj4js (the map client's reprojector) resolves from the authority code
+# alone; any other CRS needs a full definition surfaced in the collection metadata.
+_BUILTIN_CRS_CODES = frozenset({"EPSG:4326", "OGC:CRS84", "CRS84", "EPSG:3857"})
+
+
+def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_crs: str) -> None:
+    """Surface CRS render hints on the collection for projected (non-built-in) stores.
+
+    Map clients reproject Zarr on the fly with proj4js, which resolves only the
+    built-in ``EPSG:4326`` / ``EPSG:3857`` from their code — any other CRS (e.g.
+    seNorge's UTM33, ``EPSG:32633``) needs a full definition, or the client has to
+    fetch one at render time (an external epsg.io lookup). Publishing the definition
+    in STAC removes that runtime dependency.
+
+    Two fields are emitted:
+
+    * ``proj:wkt2`` — the STAC Projection-extension standard, lossless CRS
+      representation. It is the same information GeoZarr already carries in the CF
+      ``spatial_ref`` grid-mapping's ``crs_wkt`` attribute.
+    * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
+      proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
+      strings as lossy), so it lives under our namespace rather than ``proj:``.
+    """
+    if store_crs.upper() in _BUILTIN_CRS_CODES:
+        return
+    try:
+        import warnings
+
+        from pyproj import CRS
+
+        # Prefer the CRS the data was actually written with (the CF grid-mapping WKT)
+        # over re-deriving from the code, when the store carries it.
+        wkt: str | None = None
+        spatial_ref = ds.get("spatial_ref")
+        if spatial_ref is not None:
+            wkt = spatial_ref.attrs.get("crs_wkt") or spatial_ref.attrs.get("spatial_ref")
+        crs = CRS.from_wkt(wkt) if wkt else CRS.from_user_input(store_crs)
+
+        template.extra_fields["proj:wkt2"] = crs.to_wkt()
+        with warnings.catch_warnings():
+            # to_proj4() warns that proj4 is lossy; that's acceptable for a render hint.
+            warnings.simplefilter("ignore")
+            proj4 = crs.to_proj4()
+        if proj4:
+            template.extra_fields["open_climate_service:proj4"] = proj4.strip()
+    except Exception:
+        logger.warning("Could not derive CRS render hints for '%s'", store_crs, exc_info=True)
+
+
 def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.Collection) -> dict[str, Any]:
     cached_payload = _xstac_collection_cache.get(artifact.artifact_id)
     if cached_payload is not None:
@@ -233,6 +282,7 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         store_crs = ds.attrs.get("proj:code")
         if store_crs:
             template.extra_fields["proj:code"] = store_crs
+            _add_crs_render_hints(template=template, ds=ds, store_crs=store_crs)
         x_dimension, y_dimension = get_x_y_dims(ds)
         try:
             time_dimension: str | None = get_time_dim(ds)

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from geozarr_toolkit import create_geozarr_attrs
 
-from open_climate_service.shared.crs import crs_to_proj4, is_builtin_crs
 from open_climate_service.streaming.protocol import GridSpec
 
 logger = logging.getLogger(__name__)
@@ -116,18 +115,12 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
     )
     crs_code = f"EPSG:{spec.crs}"
     attrs["proj:code"] = crs_code
+    # Native-CRS extent, in the GeoZarr `spatial:bbox` convention. Direct-Zarr clients
+    # (GDAL/QGIS, zarr-layer) read the CRS from the CF grid-mapping (`crs_wkt`) / `proj:`
+    # convention that create_geozarr_attrs already writes, and the extent from here or the
+    # coordinate arrays — no non-standard `proj4`/`bounds` attrs required. The STAC hints
+    # (open_climate_service:proj4, proj:bbox) in stac/services.py serve the map viewer.
     attrs["spatial:bbox"] = bbox
-    # Direct-Zarr clients (GeoLibre's native panel, GDAL/QGIS) that never see OCS's STAC
-    # need the CRS embedded in the store to place a projected grid. proj:code isn't enough
-    # for those clients — surface a proj4 string (the STAC counterpart is emitted in
-    # stac/services.py) plus the native-CRS bounds so they auto-reproject without input.
-    if not is_builtin_crs(crs_code):
-        # The native-CRS bounds are useful on their own (a client needs them to place the
-        # grid), so write them for any projected store even if proj4 derivation fails.
-        attrs["bounds"] = list(bbox)
-        proj4 = crs_to_proj4(crs_code)
-        if proj4:
-            attrs["proj4"] = proj4
     attrs.update(spec.attrs)
 
     root = zarr.open_group(store, mode="r+")

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -122,10 +122,12 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
     # for those clients — surface a proj4 string (the STAC counterpart is emitted in
     # stac/services.py) plus the native-CRS bounds so they auto-reproject without input.
     if not is_builtin_crs(crs_code):
+        # The native-CRS bounds are useful on their own (a client needs them to place the
+        # grid), so write them for any projected store even if proj4 derivation fails.
+        attrs["bounds"] = list(bbox)
         proj4 = crs_to_proj4(crs_code)
         if proj4:
             attrs["proj4"] = proj4
-            attrs["bounds"] = list(bbox)
     attrs.update(spec.attrs)
 
     root = zarr.open_group(store, mode="r+")

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from geozarr_toolkit import create_geozarr_attrs
 
+from open_climate_service.shared.crs import crs_to_proj4, is_builtin_crs
 from open_climate_service.streaming.protocol import GridSpec
 
 logger = logging.getLogger(__name__)
@@ -113,8 +114,18 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
         bbox=bbox,
         shape=(spec.shape[1], spec.shape[0]),
     )
-    attrs["proj:code"] = f"EPSG:{spec.crs}"
+    crs_code = f"EPSG:{spec.crs}"
+    attrs["proj:code"] = crs_code
     attrs["spatial:bbox"] = bbox
+    # Direct-Zarr clients (GeoLibre's native panel, GDAL/QGIS) that never see OCS's STAC
+    # need the CRS embedded in the store to place a projected grid. proj:code isn't enough
+    # for those clients — surface a proj4 string (the STAC counterpart is emitted in
+    # stac/services.py) plus the native-CRS bounds so they auto-reproject without input.
+    if not is_builtin_crs(crs_code):
+        proj4 = crs_to_proj4(crs_code)
+        if proj4:
+            attrs["proj4"] = proj4
+            attrs["bounds"] = list(bbox)
     attrs.update(spec.attrs)
 
     root = zarr.open_group(store, mode="r+")

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Map viewer — {{ name }}</title>
-    <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
-    <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
       *,
       *::before,
@@ -233,6 +232,9 @@
     </div>
 
     <script type="module">
+      // MapLibre 6 is ESM-only (no UMD `dist/maplibre-gl.js`), so import it here as a
+      // namespace rather than relying on a global from a <script src> tag.
+      import * as maplibregl from "https://esm.sh/maplibre-gl@6.0.0";
       import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -537,10 +537,11 @@
         // (open_climate_service:proj4) so we don't depend on an external epsg.io lookup at
         // render time; fall back to epsg.io only for older stores that predate the field.
         let nativeCrs = collection["proj:code"] ?? "EPSG:4326";
-        // CRS84 aliases (CRS84, OGC:CRS84, or a CRS84 URI) are geographic WGS84; ZarrLayer
-        // only recognizes EPSG:4326 / EPSG:3857 by code, so normalize to EPSG:4326 before
-        // both the built-in check and passing `crs` into new ZarrLayer.
-        if (/CRS84$/i.test(nativeCrs)) nativeCrs = "EPSG:4326";
+        // CRS84 aliases (CRS84, OGC:CRS84, CRS:84, or a CRS84 URI) are geographic WGS84;
+        // ZarrLayer only recognizes EPSG:4326 / EPSG:3857 by code, so normalize to EPSG:4326
+        // before both the built-in check and passing `crs` into new ZarrLayer. Separators
+        // are stripped first so the short OGC form CRS:84 is matched too.
+        if (nativeCrs.toUpperCase().replace(/[^A-Z0-9]/g, "").endsWith("CRS84")) nativeCrs = "EPSG:4326";
         const BUILTIN_CRS = new Set(["EPSG:4326", "EPSG:3857"]);
         const isBuiltinCrs = BUILTIN_CRS.has(nativeCrs.toUpperCase());
         let proj4String = collection["open_climate_service:proj4"] ?? null;

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -536,8 +536,12 @@
         // Prefer the proj4 string published in the STAC collection
         // (open_climate_service:proj4) so we don't depend on an external epsg.io lookup at
         // render time; fall back to epsg.io only for older stores that predate the field.
-        const nativeCrs = collection["proj:code"] ?? "EPSG:4326";
-        const BUILTIN_CRS = new Set(["EPSG:4326", "OGC:CRS84", "CRS84", "EPSG:3857"]);
+        let nativeCrs = collection["proj:code"] ?? "EPSG:4326";
+        // CRS84 aliases (CRS84, OGC:CRS84, or a CRS84 URI) are geographic WGS84; ZarrLayer
+        // only recognizes EPSG:4326 / EPSG:3857 by code, so normalize to EPSG:4326 before
+        // both the built-in check and passing `crs` into new ZarrLayer.
+        if (/CRS84$/i.test(nativeCrs)) nativeCrs = "EPSG:4326";
+        const BUILTIN_CRS = new Set(["EPSG:4326", "EPSG:3857"]);
         const isBuiltinCrs = BUILTIN_CRS.has(nativeCrs.toUpperCase());
         let proj4String = collection["open_climate_service:proj4"] ?? null;
         if (!isBuiltinCrs && !proj4String) {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -233,8 +233,8 @@
     </div>
 
     <script type="module">
-      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer";
-      import chroma from "https://esm.sh/chroma-js";
+      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
+      import chroma from "https://esm.sh/chroma-js@3.2.0";
 
       // Suffix _r means the scale is reversed (matplotlib convention).
       // chroma-js resolves ColorBrewer/D3 scale names case-insensitively.
@@ -522,13 +522,17 @@
         selector = {};
         for (const d of dimStates) selector[d.key] = d.index;
 
-        // For projected-CRS stores, pass crs + proj4 string so ZarrLayer
-        // reprojects natively instead of treating coordinates as WGS84 degrees.
+        // ZarrLayer resolves only its built-in CRSes (EPSG:4326 / EPSG:3857) from the
+        // code alone; every other CRS — e.g. seNorge's UTM33 (EPSG:32633) — needs an
+        // explicit proj4 definition, or it is treated as WGS84 degrees and lands in the
+        // wrong place. Fetch the proj4 string from epsg.io for those. See ZarrLayerOptions
+        // `crs` docs: "built-in projections (EPSG:4326 or EPSG:3857). For any other CRS,
+        // provide a matching proj4 definition."
         const nativeCrs = collection["proj:code"] ?? "EPSG:4326";
-        const WGS84 = new Set(["EPSG:4326", "OGC:CRS84", "CRS84"]);
-        const isWgs84 = WGS84.has(nativeCrs.toUpperCase());
+        const BUILTIN_CRS = new Set(["EPSG:4326", "OGC:CRS84", "CRS84", "EPSG:3857"]);
+        const isBuiltinCrs = BUILTIN_CRS.has(nativeCrs.toUpperCase());
         let proj4String = null;
-        if (!isWgs84) {
+        if (!isBuiltinCrs) {
           try {
             const match = nativeCrs.match(/(\d+)$/);
             const epsgId = match?.[1];

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -232,9 +232,12 @@
     </div>
 
     <script type="module">
-      // MapLibre 6 is ESM-only (no UMD `dist/maplibre-gl.js`), so import it here as a
-      // namespace rather than relying on a global from a <script src> tag.
-      import * as maplibregl from "https://esm.sh/maplibre-gl@6.0.0";
+      // MapLibre 6 is ESM-only (no UMD `dist/maplibre-gl.js`), so import it as a
+      // namespace. Load the official dist `.mjs` from unpkg — NOT esm.sh: MapLibre's
+      // worker is a real sibling URL (`./maplibre-gl-worker.mjs`) resolved from
+      // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
+      // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
+      import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
       import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -527,14 +527,17 @@
         // ZarrLayer resolves only its built-in CRSes (EPSG:4326 / EPSG:3857) from the
         // code alone; every other CRS — e.g. seNorge's UTM33 (EPSG:32633) — needs an
         // explicit proj4 definition, or it is treated as WGS84 degrees and lands in the
-        // wrong place. Fetch the proj4 string from epsg.io for those. See ZarrLayerOptions
-        // `crs` docs: "built-in projections (EPSG:4326 or EPSG:3857). For any other CRS,
-        // provide a matching proj4 definition."
+        // wrong place. See ZarrLayerOptions `crs` docs: "built-in projections (EPSG:4326
+        // or EPSG:3857). For any other CRS, provide a matching proj4 definition."
+        //
+        // Prefer the proj4 string published in the STAC collection
+        // (open_climate_service:proj4) so we don't depend on an external epsg.io lookup at
+        // render time; fall back to epsg.io only for older stores that predate the field.
         const nativeCrs = collection["proj:code"] ?? "EPSG:4326";
         const BUILTIN_CRS = new Set(["EPSG:4326", "OGC:CRS84", "CRS84", "EPSG:3857"]);
         const isBuiltinCrs = BUILTIN_CRS.has(nativeCrs.toUpperCase());
-        let proj4String = null;
-        if (!isBuiltinCrs) {
+        let proj4String = collection["open_climate_service:proj4"] ?? null;
+        if (!isBuiltinCrs && !proj4String) {
           try {
             const match = nativeCrs.match(/(\d+)$/);
             const epsgId = match?.[1];

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -601,10 +601,7 @@
             k !== variable &&
             k !== collection.id
         );
-        const units =
-          renders["open_climate_service:units"] ??
-          collection["cube:variables"]?.[variable]?.unit ??
-          "";
+        const units = collection["cube:variables"]?.[variable]?.unit ?? "";
         metaSource.textContent = source ?? "—";
         metaUnits.textContent = units || "—";
         datasetMeta.classList.remove("hidden");

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -8,6 +8,8 @@ hints in ``stac/services.py``.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 import zarr
@@ -17,13 +19,13 @@ from open_climate_service.streaming.protocol import GridSpec
 from open_climate_service.streaming.store import write_geozarr_attrs
 
 
-def _init_group(path) -> str:
+def _init_group(path: Path) -> str:
     store = str(path / "s.zarr")
     zarr.open_group(store, mode="w", zarr_format=3)
     return store
 
 
-def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path) -> None:
+def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path: Path) -> None:
     store = _init_group(tmp_path)
     spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
     bbox = [-74500.0, 6450500.0, 1119500.0, 7999500.0]  # native UTM33 metres
@@ -32,11 +34,12 @@ def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path) -> No
 
     attrs = dict(zarr.open_group(store, mode="r").attrs)
     assert attrs["proj:code"] == "EPSG:32633"
-    assert "proj=utm" in attrs["proj4"] and "zone=33" in attrs["proj4"]
+    proj4 = str(attrs["proj4"])
+    assert "proj=utm" in proj4 and "zone=33" in proj4
     assert attrs["bounds"] == bbox  # native-CRS [xMin, yMin, xMax, yMax] for the client
 
 
-def test_write_geozarr_attrs_omits_proj4_for_wgs84(tmp_path) -> None:
+def test_write_geozarr_attrs_omits_proj4_for_wgs84(tmp_path: Path) -> None:
     store = _init_group(tmp_path)
     spec = GridSpec(shape=(3, 3), crs=4326, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
 

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -53,14 +53,41 @@ def test_write_geozarr_attrs_omits_proj4_for_wgs84(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "code,is_builtin",
-    [("EPSG:4326", True), ("EPSG:3857", True), ("CRS84", True), ("CRS:84", True), ("EPSG:32633", False)],
+    [
+        ("EPSG:4326", True),
+        ("EPSG:3857", True),
+        ("CRS84", True),
+        ("CRS:84", True),
+        ("EPSG:32633", False),
+        (4326, True),  # bare EPSG int normalizes to EPSG:4326
+        (32633, False),
+    ],
 )
-def test_is_builtin_crs(code: str, is_builtin: bool) -> None:
+def test_is_builtin_crs(code: str | int, is_builtin: bool) -> None:
     assert is_builtin_crs(code) is is_builtin
 
 
 def test_crs_to_proj4() -> None:
     assert crs_to_proj4("EPSG:4326") is None  # built-in → no proj4 hint
+    assert crs_to_proj4(4326) is None  # int form too
+    assert crs_to_proj4("OGC:CRS84") is None  # CRS84 alias is built-in despite to_epsg()==None
     proj4 = crs_to_proj4("EPSG:32633")
     assert proj4 is not None and "proj=utm" in proj4 and "zone=33" in proj4
     assert crs_to_proj4("not-a-crs") is None
+
+
+def test_write_geozarr_attrs_writes_bounds_even_if_proj4_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native-CRS bounds are written for any projected store, even when proj4 derivation
+    fails — a direct-Zarr client still needs bounds to place the grid."""
+    monkeypatch.setattr("open_climate_service.streaming.store.crs_to_proj4", lambda _: None)
+    store = _init_group(tmp_path)
+    spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
+    bbox = [-74500.0, 6450500.0, 1119500.0, 7999500.0]
+
+    write_geozarr_attrs(store, spec=spec, bbox=bbox)
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["bounds"] == bbox
+    assert "proj4" not in attrs

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -1,9 +1,10 @@
-"""Store-level CRS attributes written by ``write_geozarr_attrs``.
+"""Store-level CRS/extent attributes written by ``write_geozarr_attrs``.
 
-Direct-Zarr clients (GeoLibre's native Zarr panel, GDAL/QGIS) never see OCS's STAC,
-so a projected store must embed a ``proj4`` string + native-CRS ``bounds`` in its root
-attributes to auto-reproject. This is the store-side counterpart of the STAC render
-hints in ``stac/services.py``.
+The store conveys its CRS through the CF grid-mapping (``crs_wkt``) / GeoZarr ``proj:``
+convention that ``create_geozarr_attrs`` writes, and its native-CRS extent through the
+GeoZarr ``spatial:bbox`` root attribute. No non-standard ``proj4`` / ``bounds`` attrs are
+written — those duplicated the above and nothing consumed them (map clients read the STAC
+hints in ``stac/services.py``; GDAL/QGIS read ``crs_wkt``).
 """
 
 from __future__ import annotations
@@ -25,7 +26,9 @@ def _init_group(path: Path) -> str:
     return store
 
 
-def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path: Path) -> None:
+def test_write_geozarr_attrs_writes_standard_extent_not_custom_attrs(tmp_path: Path) -> None:
+    """A projected store carries proj:code + the GeoZarr spatial:bbox, and no bespoke
+    proj4/bounds attrs (which nothing reads and which duplicate crs_wkt / spatial:bbox)."""
     store = _init_group(tmp_path)
     spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
     bbox = [-74500.0, 6450500.0, 1119500.0, 7999500.0]  # native UTM33 metres
@@ -34,20 +37,22 @@ def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path: Path)
 
     attrs = dict(zarr.open_group(store, mode="r").attrs)
     assert attrs["proj:code"] == "EPSG:32633"
-    proj4 = str(attrs["proj4"])
-    assert "proj=utm" in proj4 and "zone=33" in proj4
-    assert attrs["bounds"] == bbox  # native-CRS [xMin, yMin, xMax, yMax] for the client
+    assert attrs["spatial:bbox"] == bbox  # native-CRS extent, GeoZarr convention
+    assert "proj4" not in attrs
+    assert "bounds" not in attrs
 
 
-def test_write_geozarr_attrs_omits_proj4_for_wgs84(tmp_path: Path) -> None:
+def test_write_geozarr_attrs_wgs84_extent(tmp_path: Path) -> None:
     store = _init_group(tmp_path)
+    bbox = [-13.5, 6.9, -10.1, 10.0]
     spec = GridSpec(shape=(3, 3), crs=4326, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
 
-    write_geozarr_attrs(store, spec=spec, bbox=[-13.5, 6.9, -10.1, 10.0])
+    write_geozarr_attrs(store, spec=spec, bbox=bbox)
 
     attrs = dict(zarr.open_group(store, mode="r").attrs)
     assert attrs["proj:code"] == "EPSG:4326"
-    assert "proj4" not in attrs  # built-in → client resolves from the code
+    assert attrs["spatial:bbox"] == bbox
+    assert "proj4" not in attrs
     assert "bounds" not in attrs
 
 
@@ -74,20 +79,3 @@ def test_crs_to_proj4() -> None:
     proj4 = crs_to_proj4("EPSG:32633")
     assert proj4 is not None and "proj=utm" in proj4 and "zone=33" in proj4
     assert crs_to_proj4("not-a-crs") is None
-
-
-def test_write_geozarr_attrs_writes_bounds_even_if_proj4_unavailable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Native-CRS bounds are written for any projected store, even when proj4 derivation
-    fails — a direct-Zarr client still needs bounds to place the grid."""
-    monkeypatch.setattr("open_climate_service.streaming.store.crs_to_proj4", lambda _: None)
-    store = _init_group(tmp_path)
-    spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
-    bbox = [-74500.0, 6450500.0, 1119500.0, 7999500.0]
-
-    write_geozarr_attrs(store, spec=spec, bbox=bbox)
-
-    attrs = dict(zarr.open_group(store, mode="r").attrs)
-    assert attrs["bounds"] == bbox
-    assert "proj4" not in attrs

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -1,0 +1,63 @@
+"""Store-level CRS attributes written by ``write_geozarr_attrs``.
+
+Direct-Zarr clients (GeoLibre's native Zarr panel, GDAL/QGIS) never see OCS's STAC,
+so a projected store must embed a ``proj4`` string + native-CRS ``bounds`` in its root
+attributes to auto-reproject. This is the store-side counterpart of the STAC render
+hints in ``stac/services.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import zarr
+
+from open_climate_service.shared.crs import crs_to_proj4, is_builtin_crs
+from open_climate_service.streaming.protocol import GridSpec
+from open_climate_service.streaming.store import write_geozarr_attrs
+
+
+def _init_group(path) -> str:
+    store = str(path / "s.zarr")
+    zarr.open_group(store, mode="w", zarr_format=3)
+    return store
+
+
+def test_write_geozarr_attrs_adds_proj4_and_bounds_for_projected(tmp_path) -> None:
+    store = _init_group(tmp_path)
+    spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
+    bbox = [-74500.0, 6450500.0, 1119500.0, 7999500.0]  # native UTM33 metres
+
+    write_geozarr_attrs(store, spec=spec, bbox=bbox)
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["proj:code"] == "EPSG:32633"
+    assert "proj=utm" in attrs["proj4"] and "zone=33" in attrs["proj4"]
+    assert attrs["bounds"] == bbox  # native-CRS [xMin, yMin, xMax, yMax] for the client
+
+
+def test_write_geozarr_attrs_omits_proj4_for_wgs84(tmp_path) -> None:
+    store = _init_group(tmp_path)
+    spec = GridSpec(shape=(3, 3), crs=4326, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
+
+    write_geozarr_attrs(store, spec=spec, bbox=[-13.5, 6.9, -10.1, 10.0])
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["proj:code"] == "EPSG:4326"
+    assert "proj4" not in attrs  # built-in → client resolves from the code
+    assert "bounds" not in attrs
+
+
+@pytest.mark.parametrize(
+    "code,is_builtin",
+    [("EPSG:4326", True), ("EPSG:3857", True), ("CRS84", True), ("CRS:84", True), ("EPSG:32633", False)],
+)
+def test_is_builtin_crs(code: str, is_builtin: bool) -> None:
+    assert is_builtin_crs(code) is is_builtin
+
+
+def test_crs_to_proj4() -> None:
+    assert crs_to_proj4("EPSG:4326") is None  # built-in → no proj4 hint
+    proj4 = crs_to_proj4("EPSG:32633")
+    assert proj4 is not None and "proj=utm" in proj4 and "zone=33" in proj4
+    assert crs_to_proj4("not-a-crs") is None

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -787,7 +787,9 @@ def test_build_collection_normalizes_crs84_alias_to_epsg4326(tmp_path: Path) -> 
     ],
 )
 def test_canonical_crs_code(code: str, expected: str) -> None:
-    assert stac_services._canonical_crs_code(code) == expected
+    from open_climate_service.shared.crs import canonical_crs_code
+
+    assert canonical_crs_code(code) == expected
 
 
 def test_build_collection_crs_render_hints_use_store_wkt(tmp_path: Path) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -712,6 +712,16 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
     # proj:bbox derived from the x/y coordinate arrays (no spatial:bbox on this store)
     assert payload["proj:bbox"] == [100000.0, 6998000.0, 102000.0, 7000000.0]
+    # extent.spatial.bbox is reprojected to WGS84 from the store — not the native metres
+    from pyproj import Transformer
+
+    expected_wgs84 = list(
+        Transformer.from_crs("EPSG:32633", "EPSG:4326", always_xy=True).transform_bounds(
+            100000.0, 6998000.0, 102000.0, 7000000.0
+        )
+    )
+    assert payload["extent"]["spatial"]["bbox"][0] == pytest.approx(expected_wgs84)
+    assert payload["extent"]["spatial"]["bbox"][0] != [100000.0, 6998000.0, 102000.0, 7000000.0]
 
 
 def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> None:
@@ -744,6 +754,37 @@ def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> No
     assert "open_climate_service:proj4" not in payload
     assert "proj:wkt2" not in payload
     assert "proj:bbox" not in payload
+
+
+def test_build_collection_spatial_extent_derives_from_store_not_coverage(tmp_path: Path) -> None:
+    """The collection's spatial extent is read live from the store, so a stale or degenerate
+    coverage/template extent (the worldpop/chirps bug) never leaks into STAC."""
+    zarr_path = tmp_path / "worldpop_population_yearly.zarr"
+    ds = xr.Dataset(
+        {"pop": (["time", "latitude", "longitude"], np.ones((1, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2020-01-01", periods=1, freq="YS"),
+            "latitude": [60.0, 59.0, 58.0],
+            "longitude": [4.0, 5.0, 6.0],
+        },
+        attrs={"proj:code": "EPSG:4326"},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="worldpop_population_yearly",
+        description="test",
+        extent=pystac.Extent(
+            # A degenerate/stale coverage bbox — must NOT reach the payload.
+            spatial=pystac.SpatialExtent([[10.5113, 0.0005, 10.5115, 0.0006]]),
+            temporal=pystac.TemporalExtent([[datetime(2020, 1, 1, tzinfo=UTC), datetime(2020, 1, 1, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    assert payload["extent"]["spatial"]["bbox"] == [[4.0, 58.0, 6.0, 60.0]]
 
 
 def test_build_collection_proj_bbox_prefers_store_spatial_bbox_attr(tmp_path: Path) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -677,3 +677,67 @@ def test_build_collection_with_xstac_reads_normalised_zarr_coordinates(tmp_path:
     assert cube_dims["longitude"]["axis"] == "x"
     assert cube_dims["latitude"]["axis"] == "y"
     assert cube_dims["time"]["type"] == "temporal"
+
+
+def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: Path) -> None:
+    """Projected (non-built-in) stores get proj:wkt2 + open_climate_service:proj4 so map
+    clients can reproject without a runtime epsg.io lookup."""
+    zarr_path = tmp_path / "senorge_temperature_daily.zarr"
+    ds = xr.Dataset(
+        {"tg": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "y": [7000000.0, 6999000.0, 6998000.0],
+            "x": [100000.0, 101000.0, 102000.0],
+        },
+        attrs={"proj:code": "EPSG:32633"},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="senorge_temperature_daily",
+        description="test",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[100000.0, 6998000.0, 102000.0, 7000000.0]]),
+            temporal=pystac.TemporalExtent([[datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    assert payload["proj:code"] == "EPSG:32633"
+    proj4 = payload["open_climate_service:proj4"]
+    assert "proj=utm" in proj4 and "zone=33" in proj4
+    assert "PROJCRS" in payload["proj:wkt2"] or "PROJCS" in payload["proj:wkt2"]
+
+
+def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> None:
+    """Built-in CRSes (EPSG:4326) resolve on the client from their code, so no hint is emitted."""
+    zarr_path = tmp_path / "era5land_temperature_daily.zarr"
+    ds = xr.Dataset(
+        {"t2m": (["time", "latitude", "longitude"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "latitude": [4.0, 3.0, 2.0],
+            "longitude": [1.0, 2.0, 3.0],
+        },
+        attrs={"proj:code": "EPSG:4326"},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="era5land_temperature_daily",
+        description="test",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[1.0, 2.0, 3.0, 4.0]]),
+            temporal=pystac.TemporalExtent([[datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    assert payload["proj:code"] == "EPSG:4326"
+    assert "open_climate_service:proj4" not in payload
+    assert "proj:wkt2" not in payload

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -818,9 +818,12 @@ def test_build_collection_normalizes_crs84_alias_to_epsg4326(tmp_path: Path) -> 
         ("urn:ogc:def:crs:OGC:1.3:CRS84", "EPSG:4326"),
         ("EPSG:4326", "EPSG:4326"),
         ("EPSG:32633", "EPSG:32633"),  # projected code passes through unchanged
+        (4326, "EPSG:4326"),  # bare EPSG int is prefixed so is_builtin_crs(4326) holds
+        ("4326", "EPSG:4326"),  # ...and the bare-number string form too
+        (32633, "EPSG:32633"),
     ],
 )
-def test_canonical_crs_code(code: str, expected: str) -> None:
+def test_canonical_crs_code(code: str | int, expected: str) -> None:
     from open_climate_service.shared.crs import canonical_crs_code
 
     assert canonical_crs_code(code) == expected

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -710,6 +710,9 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     proj4 = payload["open_climate_service:proj4"]
     assert "proj=utm" in proj4 and "zone=33" in proj4
     assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
+    # proj:projjson — same CRS as a PROJJSON object (EPSG:32633 = UTM zone 33N)
+    assert payload["proj:projjson"]["type"] == "ProjectedCRS"
+    assert payload["proj:projjson"]["id"] == {"authority": "EPSG", "code": 32633}
     # proj:bbox derived from the x/y coordinate arrays (no spatial:bbox on this store)
     assert payload["proj:bbox"] == [100000.0, 6998000.0, 102000.0, 7000000.0]
     # extent.spatial.bbox is reprojected to WGS84 from the store — not the native metres

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -710,7 +710,7 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     proj4 = payload["open_climate_service:proj4"]
     assert "proj=utm" in proj4 and "zone=33" in proj4
     assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
-    # proj:bbox derived from the x/y coordinate arrays (no attrs["bounds"] on this store)
+    # proj:bbox derived from the x/y coordinate arrays (no spatial:bbox on this store)
     assert payload["proj:bbox"] == [100000.0, 6998000.0, 102000.0, 7000000.0]
 
 
@@ -746,9 +746,9 @@ def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> No
     assert "proj:bbox" not in payload
 
 
-def test_build_collection_proj_bbox_prefers_store_bounds_attr(tmp_path: Path) -> None:
-    """When the store root carries attrs["bounds"] (native-CRS extent written by the
-    ingest orchestrator), proj:bbox uses it verbatim rather than re-deriving from coords."""
+def test_build_collection_proj_bbox_prefers_store_spatial_bbox_attr(tmp_path: Path) -> None:
+    """When the store root carries the GeoZarr ``spatial:bbox`` (native-CRS extent),
+    proj:bbox uses it verbatim rather than re-deriving from coords."""
     zarr_path = tmp_path / "senorge_temperature_daily.zarr"
     ds = xr.Dataset(
         {"tg": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
@@ -758,7 +758,7 @@ def test_build_collection_proj_bbox_prefers_store_bounds_attr(tmp_path: Path) ->
             "x": [100000.0, 101000.0, 102000.0],
         },
         # Half-pixel-expanded edges differ from the coord centres above.
-        attrs={"proj:code": "EPSG:32633", "bounds": [99500.0, 6997500.0, 102500.0, 7000500.0]},
+        attrs={"proj:code": "EPSG:32633", "spatial:bbox": [99500.0, 6997500.0, 102500.0, 7000500.0]},
     )
     ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -710,6 +710,8 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     proj4 = payload["open_climate_service:proj4"]
     assert "proj=utm" in proj4 and "zone=33" in proj4
     assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
+    # proj:bbox derived from the x/y coordinate arrays (no attrs["bounds"] on this store)
+    assert payload["proj:bbox"] == [100000.0, 6998000.0, 102000.0, 7000000.0]
 
 
 def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> None:
@@ -741,6 +743,38 @@ def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> No
     assert payload["proj:code"] == "EPSG:4326"
     assert "open_climate_service:proj4" not in payload
     assert "proj:wkt2" not in payload
+    assert "proj:bbox" not in payload
+
+
+def test_build_collection_proj_bbox_prefers_store_bounds_attr(tmp_path: Path) -> None:
+    """When the store root carries attrs["bounds"] (native-CRS extent written by the
+    ingest orchestrator), proj:bbox uses it verbatim rather than re-deriving from coords."""
+    zarr_path = tmp_path / "senorge_temperature_daily.zarr"
+    ds = xr.Dataset(
+        {"tg": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "y": [7000000.0, 6999000.0, 6998000.0],
+            "x": [100000.0, 101000.0, 102000.0],
+        },
+        # Half-pixel-expanded edges differ from the coord centres above.
+        attrs={"proj:code": "EPSG:32633", "bounds": [99500.0, 6997500.0, 102500.0, 7000500.0]},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="senorge_temperature_daily",
+        description="test",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[100000.0, 6998000.0, 102000.0, 7000000.0]]),
+            temporal=pystac.TemporalExtent([[datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    assert payload["proj:bbox"] == [99500.0, 6997500.0, 102500.0, 7000500.0]
 
 
 def test_build_collection_normalizes_crs84_alias_to_epsg4326(tmp_path: Path) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -709,7 +709,7 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     assert payload["proj:code"] == "EPSG:32633"
     proj4 = payload["open_climate_service:proj4"]
     assert "proj=utm" in proj4 and "zone=33" in proj4
-    assert "PROJCRS" in payload["proj:wkt2"] or "PROJCS" in payload["proj:wkt2"]
+    assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
 
 
 def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> None:
@@ -773,3 +773,54 @@ def test_build_collection_normalizes_crs84_alias_to_epsg4326(tmp_path: Path) -> 
     assert payload["proj:code"] == "EPSG:4326"  # normalized from OGC:CRS84
     assert "open_climate_service:proj4" not in payload  # built-in → no hint
     assert "proj:wkt2" not in payload
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("CRS84", "EPSG:4326"),
+        ("OGC:CRS84", "EPSG:4326"),
+        ("CRS:84", "EPSG:4326"),  # short OGC form (separators stripped)
+        ("urn:ogc:def:crs:OGC:1.3:CRS84", "EPSG:4326"),
+        ("EPSG:4326", "EPSG:4326"),
+        ("EPSG:32633", "EPSG:32633"),  # projected code passes through unchanged
+    ],
+)
+def test_canonical_crs_code(code: str, expected: str) -> None:
+    assert stac_services._canonical_crs_code(code) == expected
+
+
+def test_build_collection_crs_render_hints_use_store_wkt(tmp_path: Path) -> None:
+    """When the store carries a CF grid-mapping WKT (spatial_ref/crs_wkt), the hints derive
+    from it (the CRS.from_wkt branch), and proj:wkt2 is emitted as WKT2."""
+    from pyproj import CRS as PyCRS
+
+    wkt = PyCRS.from_epsg(32633).to_wkt(version="WKT2_2019")
+    zarr_path = tmp_path / "senorge_temperature_daily.zarr"
+    ds = xr.Dataset(
+        {"tg": (["time", "y", "x"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "y": [7000000.0, 6999000.0, 6998000.0],
+            "x": [100000.0, 101000.0, 102000.0],
+            "spatial_ref": ((), 0, {"crs_wkt": wkt, "spatial_ref": wkt}),
+        },
+        attrs={"proj:code": "EPSG:32633"},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="senorge_temperature_daily",
+        description="test",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[100000.0, 6998000.0, 102000.0, 7000000.0]]),
+            temporal=pystac.TemporalExtent([[datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    proj4 = payload["open_climate_service:proj4"]
+    assert "proj=utm" in proj4 and "zone=33" in proj4
+    assert payload["proj:wkt2"].startswith("PROJCRS")

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -741,3 +741,35 @@ def test_build_collection_omits_crs_render_hints_for_wgs84(tmp_path: Path) -> No
     assert payload["proj:code"] == "EPSG:4326"
     assert "open_climate_service:proj4" not in payload
     assert "proj:wkt2" not in payload
+
+
+def test_build_collection_normalizes_crs84_alias_to_epsg4326(tmp_path: Path) -> None:
+    """A CRS84 alias in the store is emitted as canonical EPSG:4326 (and treated as built-in),
+    so the map client never receives an alias ZarrLayer can't resolve."""
+    zarr_path = tmp_path / "chirps3_precipitation_daily.zarr"
+    ds = xr.Dataset(
+        {"precip": (["time", "latitude", "longitude"], np.ones((2, 3, 3), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "latitude": [4.0, 3.0, 2.0],
+            "longitude": [1.0, 2.0, 3.0],
+        },
+        attrs={"proj:code": "OGC:CRS84"},
+    )
+    ds.to_zarr(str(zarr_path), mode="w", consolidated=True)
+
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ZARR, path=str(zarr_path))
+    template = pystac.Collection(
+        id="chirps3_precipitation_daily",
+        description="test",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[1.0, 2.0, 3.0, 4.0]]),
+            temporal=pystac.TemporalExtent([[datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)]]),
+        ),
+    )
+
+    payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
+
+    assert payload["proj:code"] == "EPSG:4326"  # normalized from OGC:CRS84
+    assert "open_climate_service:proj4" not in payload  # built-in → no hint
+    assert "proj:wkt2" not in payload


### PR DESCRIPTION
Implements #313.

## What & why

The `/map` viewer imported its CDN dependencies **unpinned**, silently riding every upstream release — including breaking ones (zarr-layer v0.6.0 changed `customFrag` NaN semantics). This pins them, moves MapLibre to the current major (v6), and lets the viewer reproject projected datasets from CRS metadata **published in STAC** instead of a runtime epsg.io lookup.

## Changes

**`templates/map-viewer.html`**
- **Pin** `@carbonplan/zarr-layer@0.6.1` and `chroma-js@3.2.0`.
- **MapLibre 6.0.0 (pinned).** v6 is ESM-only (the UMD `dist/maplibre-gl.js` is gone), so the global becomes a namespace ESM import. Loaded from unpkg's `dist/maplibre-gl.mjs`, **not** esm.sh — esm.sh's build 404s MapLibre's worker (`maplibre-gl-worker.mjs`), which blanks the map; MapLibre resolves the worker as a sibling of `import.meta.url`, and unpkg serves it (plus shared-chunk siblings) with CORS.
- **CRS handling.** zarr-layer resolves only the built-in `EPSG:4326`/`EPSG:3857` from a code; any other CRS needs a proj4 string. Prefer the STAC-published `open_climate_service:proj4`, with the epsg.io lookup kept only as a fallback for stores that predate the hint. CRS84 aliases are normalized to `EPSG:4326`.

**`stac/services.py` + `shared/crs.py`**
- For a projected (non-built-in) collection, emit CRS render hints so clients reproject without a runtime lookup:
  - **`proj:bbox`** — the native-CRS extent (STAC Projection extension); sourced from the store's `spatial:bbox`, else the coordinate arrays.
  - **`proj:wkt2`** — the lossless CRS (STAC Projection extension), mirroring the CF `crs_wkt` grid-mapping the store already carries. Useful to any STAC client (QGIS/GDAL, cf. #263).
  - **`open_climate_service:proj4`** — a proj4 string for proj4js. proj4 is intentionally *not* a STAC field (PROJ treats it as lossy), so it is namespaced rather than placed under `proj:`.
- CRS helpers (`canonical_crs_code`, `is_builtin_crs`, `crs_to_proj4`) are factored into `shared/crs.py`; CRS84 aliases normalized to `EPSG:4326`.
- **Collection spatial extent now derives from the live store**, not the cached `coverage` record. The old `_override_spatial_extent_from_artifact` served `coverage.spatial`, which could go stale (worldpop + chirps3 daily reported a degenerate `~[10.5, 0.0005]` bbox while their stores were correct) or hold a native-CRS **metre** bbox for projected stores (the normal/anomaly collections). `extent.spatial.bbox` is now read from the same store coordinates as `cube:dimensions` and reprojected to WGS84 for projected stores — so the two can't disagree, it's correct for clients that frame on the dataset extent (e.g. the GeoLibre plugin), and it needs no re-ingest. `coverage.spatial` stays for temporal sync/scope.

## Conventions

Everything published here is standard: `proj:wkt2` / `proj:bbox` are STAC Projection-extension fields, and the store keeps conveying its CRS the standard way (CF `crs_wkt` grid-mapping + GeoZarr `proj:` convention) and its extent via `spatial:bbox`. **No custom Zarr attributes are introduced.** The one non-standard field, `open_climate_service:proj4`, is a namespaced convenience for proj4js and retires once carbonplan/zarr-layer#61 (auto-resolve any EPSG code) lands — tracked in #316.

## Version-bump audit

- **zarr-layer 0.6.1:** every option the viewer passes is valid in `ZarrLayerOptions`; the `customFrag` v0.6.0 breaking change isn't used → no migration.
- **MapLibre 6:** the viewer only uses `new maplibregl.Map`, `map.on('load'|'error')`, `map.getStyle().layers` — none affected by the v6 breaking changes.

## Testing

- `tests/test_stac.py` — projected store emits the three hints (and derives them from the store WKT when present); WGS84 emits none; CRS84 aliases normalized; `proj:bbox` prefers `spatial:bbox` with a coordinate-array fallback. `extent.spatial.bbox` is reprojected to WGS84 for a projected store, and a degenerate cached coverage no longer leaks into a WGS84 store's extent.
- `tests/test_geozarr_attrs.py` — the shared CRS helpers, and that the store writes the standard `proj:code` / `spatial:bbox` (no custom attrs).

## Manual verification (no JS test harness in this repo)

Checked in-browser on the Sierra Leone + Norway instances:
- [x] MapLibre 6 basemap renders (via the unpkg worker).
- [x] zarr-layer raster renders on MapLibre 6 (`era5land_temperature_daily`).
- [x] Projected seNorge `EPSG:32633` positioned correctly over Norway **via `open_climate_service:proj4` from STAC — no epsg.io request**.
- [x] Ordinal day-of-year slider (`senorge_temperature_daily_normal_1991_2020`).

> Existing published stores need a STAC rebuild (or re-open) to pick up the hint fields; the viewer's epsg.io fallback keeps them working until then.
