### PR TITLE
fix: per-dataset pyramid resampling (native mode/nearest for categorical)

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -162,6 +162,7 @@ from the dimension's metadata, so there's nothing extra to configure.
 | ------------------ | -------- | ------------------------------------------------------------------------------------------------ |
 | `ingestion.plugin` | Yes      | Dotted path to the streaming plugin class                                                        |
 | `ingestion.params` | No       | Extra keyword arguments forwarded to `fetch_period` as `**params`, and to the plugin constructor |
+| `ingestion.resampling` | No   | Pyramid coarsening for large layers: `mean` (default; continuous data), `max`/`min`/`sum`, or `mode`/`nearest` for categorical data — see below |
 
 Multiple templates can share the same plugin class and differ only in `params`:
 
@@ -212,7 +213,6 @@ them requires re-ingesting the dataset:
 | `display.colormap` | No       | Colormap name for map rendering (e.g. `blues`, `rdbu_r`) |
 | `display.range`    | No       | `[min, max]` display range for the colormap              |
 | `display.nodata`   | No       | No-data / fill value                                     |
-| `display.resampling` | No     | Pyramid coarsening for large layers: `mean` (default; continuous data), `max`/`min`/`sum`, or `mode`/`nearest` for categorical data — see below |
 
 ### Pyramid resampling for categorical layers
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -212,6 +212,17 @@ them requires re-ingesting the dataset:
 | `display.colormap` | No       | Colormap name for map rendering (e.g. `blues`, `rdbu_r`) |
 | `display.range`    | No       | `[min, max]` display range for the colormap              |
 | `display.nodata`   | No       | No-data / fill value                                     |
+| `display.resampling` | No     | Pyramid coarsening for large layers: `mean` (default; continuous data), `max`/`min`/`sum`, or `mode`/`nearest` for categorical data — see below |
+
+### Pyramid resampling for categorical layers
+
+Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels are aggregated from the full-resolution data, and the method matters:
+
+- **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
+- **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.
+- **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a *different, non-existent* class (e.g. `mean(10, 80) = 45`).
+
+`mean`/`max`/`min`/`sum` are computed by [topozarr](https://github.com/carbonplan/topozarr); `mode` and `nearest` are resampled from the native resolution by Open Climate Service, because they can't be built level-from-level (a first-class `mode`/`nearest` in topozarr is requested in [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26)).
 
 ## Step 3: Point the instance at your plugins directory
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -180,6 +180,16 @@ Multiple templates can share the same plugin class and differ only in `params`:
       variable: total_precipitation
 ```
 
+#### Pyramid resampling for categorical layers
+
+Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels are aggregated from the full-resolution data, and `ingestion.resampling` controls how:
+
+- **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
+- **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.
+- **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a *different, non-existent* class (e.g. `mean(10, 80) = 45`).
+
+`mean`/`max`/`min`/`sum` are computed by [topozarr](https://github.com/carbonplan/topozarr); `mode` and `nearest` are resampled from the native resolution by Open Climate Service, because they can't be built level-from-level (a first-class `mode`/`nearest` in topozarr is requested in [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26)).
+
 **Spatial and temporal extents** — declares what the source dataset covers. Used to validate ingest requests before hitting the provider:
 
 ```yaml
@@ -213,16 +223,6 @@ them requires re-ingesting the dataset:
 | `display.colormap` | No       | Colormap name for map rendering (e.g. `blues`, `rdbu_r`) |
 | `display.range`    | No       | `[min, max]` display range for the colormap              |
 | `display.nodata`   | No       | No-data / fill value                                     |
-
-### Pyramid resampling for categorical layers
-
-Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels are aggregated from the full-resolution data, and the method matters:
-
-- **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
-- **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.
-- **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a *different, non-existent* class (e.g. `mean(10, 80) = 45`).
-
-`mean`/`max`/`min`/`sum` are computed by [topozarr](https://github.com/carbonplan/topozarr); `mode` and `nearest` are resampled from the native resolution by Open Climate Service, because they can't be built level-from-level (a first-class `mode`/`nearest` in topozarr is requested in [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26)).
 
 ## Step 3: Point the instance at your plugins directory
 

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -60,21 +60,24 @@ _DEFAULT_RESAMPLING = "mean"
 
 
 def resampling_method_from_template(template: dict[str, Any] | None) -> str:
-    """Pyramid coarsening method from a dataset template's ``display.resampling`` field.
+    """Pyramid coarsening method from a dataset template's ``ingestion.resampling`` field.
+
+    It lives under ``ingestion`` rather than ``display`` because it changes the *stored*
+    pyramid data (how coarse levels are aggregated), not how the layer is rendered.
 
     Defaults to ``mean`` — correct for continuous data (temperature, precipitation, …).
     Categorical layers should declare ``mode`` (multi-class, e.g. land-cover class codes)
     or ``max`` (binary presence masks); ``mean`` averages class codes into meaningless
     values at coarse zoom. An unrecognised value falls back to ``mean`` with a warning.
     """
-    display = (template or {}).get("display")
-    raw = display.get("resampling") if isinstance(display, dict) else None
+    ingestion = (template or {}).get("ingestion")
+    raw = ingestion.get("resampling") if isinstance(ingestion, dict) else None
     if raw is None:
         return _DEFAULT_RESAMPLING
     method = str(raw).strip().lower()
     if method not in _RESAMPLING_METHODS:
         logger.warning(
-            "Unknown display.resampling %r (expected one of %s); using %r",
+            "Unknown ingestion.resampling %r (expected one of %s); using %r",
             raw,
             sorted(_RESAMPLING_METHODS),
             _DEFAULT_RESAMPLING,

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -3,12 +3,13 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import xarray as xr
 import xproj  # noqa: F401  # type: ignore[import-untyped]  # pyright: ignore[reportUnusedImport]
 import zarr
 from geozarr_toolkit import MultiscalesConventionMetadata, create_geozarr_attrs
+from topozarr import CoarseningMethod
 from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
@@ -46,6 +47,108 @@ def _pyramid_levels(ds: xr.Dataset, x_dim: str, y_dim: str) -> int:
     max_dim = max(ds.sizes[x_dim], ds.sizes[y_dim])
     levels = math.ceil(math.log2(max_dim / _PYRAMID_TARGET_TILE_SIZE))
     return max(2, min(levels, _PYRAMID_MAX_LEVELS))
+
+
+# Coarsening methods topozarr computes itself, each level block-reduced from the one above
+# (valid because they are composable). Correct for *continuous* data.
+_COMPOSABLE_METHODS = frozenset({"mean", "max", "min", "sum"})
+# Categorical methods topozarr cannot do: they are non-composable and must be resampled from
+# the native (level-0) array, so OCS recomputes those levels itself (see #293, carbonplan/topozarr#26).
+_NATIVE_RESAMPLE_METHODS = frozenset({"mode", "nearest"})
+_RESAMPLING_METHODS = _COMPOSABLE_METHODS | _NATIVE_RESAMPLE_METHODS
+_DEFAULT_RESAMPLING = "mean"
+
+
+def resampling_method_from_template(template: dict[str, Any] | None) -> str:
+    """Pyramid coarsening method from a dataset template's ``display.resampling`` field.
+
+    Defaults to ``mean`` — correct for continuous data (temperature, precipitation, …).
+    Categorical layers should declare ``mode`` (multi-class, e.g. land-cover class codes)
+    or ``max`` (binary presence masks); ``mean`` averages class codes into meaningless
+    values at coarse zoom. An unrecognised value falls back to ``mean`` with a warning.
+    """
+    display = (template or {}).get("display")
+    raw = display.get("resampling") if isinstance(display, dict) else None
+    if raw is None:
+        return _DEFAULT_RESAMPLING
+    method = str(raw).strip().lower()
+    if method not in _RESAMPLING_METHODS:
+        logger.warning(
+            "Unknown display.resampling %r (expected one of %s); using %r",
+            raw,
+            sorted(_RESAMPLING_METHODS),
+            _DEFAULT_RESAMPLING,
+        )
+        return _DEFAULT_RESAMPLING
+    return method
+
+
+def _mode_reduce(values: Any, axis: Any = None, **_kwargs: Any) -> Any:
+    """Majority value over ``axis`` — the reducer xarray's ``coarsen(...).reduce`` calls.
+
+    ``axis`` is the tuple of window axes; flatten them and take the per-cell mode so a
+    coarsened cell keeps a real class code instead of an average. NaNs are ignored.
+    """
+    import numpy as np
+    from scipy import stats
+
+    if axis is None:
+        axes: tuple[int, ...] = tuple(range(values.ndim))
+    elif isinstance(axis, (tuple, list)):
+        axes = tuple(int(a) for a in axis)
+    else:
+        axes = (int(axis),)
+    axes = tuple(a % values.ndim for a in axes)
+    keep = [a for a in range(values.ndim) if a not in axes]
+    moved = np.transpose(values, keep + list(axes))
+    flat = moved.reshape(*(values.shape[a] for a in keep), -1)
+    result = stats.mode(flat, axis=-1, nan_policy="omit", keepdims=False)
+    return result.mode
+
+
+def _coarsen_native(da: xr.DataArray, x_dim: str, y_dim: str, factor: int, method: str) -> xr.DataArray:
+    """Coarsen ``da`` by ``factor`` over the spatial dims using a non-composable ``method``.
+
+    ``boundary="trim"`` drops the trailing partial window, so the result is
+    ``floor(size / factor)`` per spatial dim — the same shape topozarr produces by
+    repeatedly halving, so the output drops straight into the level's existing array.
+    """
+    window = {x_dim: factor, y_dim: factor}
+    coarsen = da.coarsen(window, boundary="trim")  # type: ignore[arg-type]
+    if method == "nearest":
+        # Decimation: keep the top-left cell of each window (a real, unaltered value).
+        constructed = coarsen.construct({x_dim: (x_dim, "_ocs_wx"), y_dim: (y_dim, "_ocs_wy")})
+        return constructed.isel(_ocs_wx=0, _ocs_wy=0)
+    if method == "mode":
+        return coarsen.reduce(_mode_reduce)
+    raise ValueError(f"unsupported native-resample method {method!r}")
+
+
+def _overwrite_native_resampled_levels(
+    store: Any, ds: xr.Dataset, x_dim: str, y_dim: str, levels: int, method: str
+) -> None:
+    """Replace topozarr's coarsened levels with a native resample for categorical data.
+
+    topozarr block-reduces each level from the level above, which is wrong for ``mode`` /
+    ``nearest`` (a coarse cell must be derived from the native cells it covers, not from an
+    already-coarsened parent). topozarr has still written every level's group/array with the
+    right shape, chunking and encoding, so we recompute levels 1..N-1 straight from the
+    native (level-0) arrays and write the values back in place.
+    """
+    root = zarr.open_group(store, mode="a")
+    spatial_vars = [str(name) for name, da in ds.data_vars.items() if {x_dim, y_dim} <= set(da.dims)]
+    for lvl in range(1, levels):
+        factor = 2**lvl
+        level_group = cast(zarr.Group, root[str(lvl)])
+        for name in spatial_vars:
+            da = ds[name]
+            coarsened = _coarsen_native(da, x_dim, y_dim, factor, method).transpose(*da.dims)
+            target = cast(zarr.Array, level_group[name])
+            values = coarsened.values
+            if values.shape != target.shape:
+                # Defensive: clip to the level array's shape if trimming disagrees by a cell.
+                values = values[tuple(slice(0, s) for s in target.shape)]
+            target[:] = values.astype(target.dtype, copy=False)
 
 
 def _write_root_time_coordinate(zarr_store: "Path | Any", ds: xr.Dataset, *, time_dim: str) -> None:
@@ -169,6 +272,7 @@ def write_to_icechunk_store(
     t_dim: str | None = "t",
     *,
     crs: str | None = None,
+    pyramid_method: str = "mean",
     commit_message: str = "Materialized dataset",
 ) -> None:
     """Write *ds* to an Icechunk store, building a multiscale pyramid when needed.
@@ -227,7 +331,14 @@ def write_to_icechunk_store(
 
         # topozarr.create_pyramid requires fully materialised numpy arrays.
         ds = ds.load()
-        pyramid = create_pyramid(ds, levels=levels, x_dim=x_dim, y_dim=y_dim, method="mean")
+        # topozarr only offers composable coarsening (mean/max/min/sum). For categorical
+        # methods (mode/nearest) it writes valid structure with a placeholder here, then we
+        # overwrite the coarsened levels from native below (see #293).
+        native_resample = pyramid_method in _NATIVE_RESAMPLE_METHODS
+        composable_method = "max" if native_resample else pyramid_method
+        pyramid = create_pyramid(
+            ds, levels=levels, x_dim=x_dim, y_dim=y_dim, method=cast(CoarseningMethod, composable_method)
+        )
         # Pyramid.write() writes the root group attributes from ``pyramid.attrs``,
         # so merge the GeoZarr conventions (multiscales / proj / spatial) in here.
         pyramid.attrs.update(geozarr_attrs)
@@ -244,6 +355,12 @@ def write_to_icechunk_store(
                 pyramid.fill_values[str(var_name)] = 0
 
         pyramid.write(session.store, mode="w")
+
+        if native_resample:
+            # Categorical data: recompute the coarsened levels from native so class codes /
+            # masks aren't averaged (topozarr wrote them composably above; replace in place).
+            logger.info("Resampling pyramid levels of '%s' from native (%s)", store_path.name, pyramid_method)
+            _overwrite_native_resampled_levels(session.store, ds, x_dim, y_dim, levels, pyramid_method)
 
         # topozarr demotes spatial_ref from coordinate to data variable in the pyramid.
         # Patch the root and each level group: add CRS to multiscales datasets entries so

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -93,7 +93,7 @@ def _mode_reduce(values: Any, axis: Any = None, **_kwargs: Any) -> Any:
     coarsened cell keeps a real class code instead of an average. NaNs are ignored.
     """
     import numpy as np
-    from scipy import stats
+    from scipy import stats  # type: ignore[import-untyped]
 
     if axis is None:
         axes: tuple[int, ...] = tuple(range(values.ndim))
@@ -117,7 +117,7 @@ def _coarsen_native(da: xr.DataArray, x_dim: str, y_dim: str, factor: int, metho
     repeatedly halving, so the output drops straight into the level's existing array.
     """
     window = {x_dim: factor, y_dim: factor}
-    coarsen = da.coarsen(window, boundary="trim")  # type: ignore[arg-type]
+    coarsen = da.coarsen(window, boundary="trim")
     if method == "nearest":
         # Decimation: keep the top-left cell of each window (a real, unaltered value).
         constructed = coarsen.construct({x_dim: (x_dim, "_ocs_wx"), y_dim: (y_dim, "_ocs_wy")})

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -59,6 +59,27 @@ _RESAMPLING_METHODS = _COMPOSABLE_METHODS | _NATIVE_RESAMPLE_METHODS
 _DEFAULT_RESAMPLING = "mean"
 
 
+def _normalize_resampling_method(raw: object) -> str:
+    """Trim/lower-case a resampling method and validate it against the supported set.
+
+    Unknown or missing values fall back to ``mean`` (the safe default for continuous
+    data) with a warning, so neither a mistyped template value nor a stray direct call
+    reaches topozarr as an invalid ``CoarseningMethod``.
+    """
+    if raw is None:
+        return _DEFAULT_RESAMPLING
+    method = str(raw).strip().lower()
+    if method not in _RESAMPLING_METHODS:
+        logger.warning(
+            "Unknown resampling method %r (expected one of %s); using %r",
+            raw,
+            sorted(_RESAMPLING_METHODS),
+            _DEFAULT_RESAMPLING,
+        )
+        return _DEFAULT_RESAMPLING
+    return method
+
+
 def resampling_method_from_template(template: dict[str, Any] | None) -> str:
     """Pyramid coarsening method from a dataset template's ``ingestion.resampling`` field.
 
@@ -72,18 +93,7 @@ def resampling_method_from_template(template: dict[str, Any] | None) -> str:
     """
     ingestion = (template or {}).get("ingestion")
     raw = ingestion.get("resampling") if isinstance(ingestion, dict) else None
-    if raw is None:
-        return _DEFAULT_RESAMPLING
-    method = str(raw).strip().lower()
-    if method not in _RESAMPLING_METHODS:
-        logger.warning(
-            "Unknown ingestion.resampling %r (expected one of %s); using %r",
-            raw,
-            sorted(_RESAMPLING_METHODS),
-            _DEFAULT_RESAMPLING,
-        )
-        return _DEFAULT_RESAMPLING
-    return method
+    return _normalize_resampling_method(raw)
 
 
 def _mode_reduce(values: Any, axis: Any = None, **_kwargs: Any) -> Any:
@@ -334,6 +344,9 @@ def write_to_icechunk_store(
 
         # topozarr.create_pyramid requires fully materialised numpy arrays.
         ds = ds.load()
+        # Validate/normalize here too, so a direct caller passing e.g. "MAX" or a mistyped
+        # value never reaches topozarr as an invalid CoarseningMethod (falls back to mean).
+        pyramid_method = _normalize_resampling_method(pyramid_method)
         # topozarr only offers composable coarsening (mean/max/min/sum). For categorical
         # methods (mode/nearest) it writes valid structure with a placeholder here, then we
         # overwrite the coarsened levels from native below (see #293).

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -462,7 +462,12 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
                 store_path.name,
             )
             return
-        downloader.write_to_icechunk_store(ds.load(), store_path, commit_message="Applied GeoZarr conventions")
+        downloader.write_to_icechunk_store(
+            ds.load(),
+            store_path,
+            pyramid_method=downloader.resampling_method_from_template(dataset),
+            commit_message="Applied GeoZarr conventions",
+        )
     except Exception:
         logger.error(
             "GeoZarr/pyramid write failed for '%s'; flat Icechunk artifact will be used as-is",

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -587,6 +587,7 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
         y_dim,
         t_dim,
         crs=crs,
+        pyramid_method=downloader.resampling_method_from_template(template),
         commit_message=f"Published from openEO job: {dataset_id}",
     )
 

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -20,6 +20,7 @@ zarr = pytest.importorskip("zarr")
 
 from open_climate_service.data_manager.services.downloader import (  # noqa: E402
     _coarsen_native,
+    _normalize_resampling_method,
     needs_pyramid,
     resampling_method_from_template,
     write_to_icechunk_store,
@@ -76,6 +77,17 @@ def test_resampling_method_from_template() -> None:
     assert resampling_method_from_template({"ingestion": {"resampling": "bilinear"}}) == "mean"
     # A display-block value is ignored — resampling is an ingestion concern.
     assert resampling_method_from_template({"display": {"resampling": "mode"}}) == "mean"
+
+
+def test_normalize_resampling_method() -> None:
+    # Case/whitespace are normalized, and unknown or missing values fall back to mean —
+    # so a direct write_to_icechunk_store(pyramid_method=...) caller can't smuggle an
+    # invalid CoarseningMethod through to topozarr.
+    assert _normalize_resampling_method("MAX") == "max"
+    assert _normalize_resampling_method("  mean ") == "mean"
+    assert _normalize_resampling_method("Mode") == "mode"
+    assert _normalize_resampling_method(None) == "mean"
+    assert _normalize_resampling_method("bilinear") == "mean"
 
 
 def _categorical_block_da():

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -19,7 +19,9 @@ pytest.importorskip("rioxarray")
 zarr = pytest.importorskip("zarr")
 
 from open_climate_service.data_manager.services.downloader import (  # noqa: E402
+    _coarsen_native,
     needs_pyramid,
+    resampling_method_from_template,
     write_to_icechunk_store,
 )
 
@@ -62,3 +64,75 @@ def test_write_to_icechunk_store_builds_pyramid(tmp_path: Path) -> None:
     with xr.open_zarr(store, group="0", consolidated=False, zarr_format=3) as lvl0:
         assert "hotspot" in lvl0.data_vars
         assert lvl0.sizes["y"] == 2100 and lvl0.sizes["x"] == 2100
+
+
+def test_resampling_method_from_template() -> None:
+    assert resampling_method_from_template(None) == "mean"
+    assert resampling_method_from_template({}) == "mean"
+    assert resampling_method_from_template({"display": {"colormap": "reds"}}) == "mean"
+    assert resampling_method_from_template({"display": {"resampling": "mode"}}) == "mode"
+    assert resampling_method_from_template({"display": {"resampling": "MAX"}}) == "max"
+    # Unrecognised values fall back to mean rather than being passed downstream.
+    assert resampling_method_from_template({"display": {"resampling": "bilinear"}}) == "mean"
+
+
+def _categorical_block_da():
+    # 4x4 class-code grid. Each 2x2 block has a clear majority that differs from its
+    # top-left cell, so mode and nearest give distinguishable results (and mean would
+    # invent codes that don't exist, e.g. mean(99,10,10,10)=32.25).
+    data = np.array(
+        [
+            [99, 10, 20, 20],
+            [10, 10, 20, 30],
+            [30, 30, 40, 41],
+            [30, 31, 40, 40],
+        ],
+        dtype="uint8",
+    )
+    return xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": np.arange(4.0), "x": np.arange(4.0)},
+    )
+
+
+def test_coarsen_native_mode_picks_block_majority() -> None:
+    out = _coarsen_native(_categorical_block_da(), "x", "y", 2, "mode").transpose("y", "x")
+    np.testing.assert_array_equal(out.values, np.array([[10, 20], [30, 40]], dtype="uint8"))
+
+
+def test_coarsen_native_nearest_takes_top_left() -> None:
+    out = _coarsen_native(_categorical_block_da(), "x", "y", 2, "nearest").transpose("y", "x")
+    # Top-left cell of each 2x2 block: 99/20/30/40.
+    np.testing.assert_array_equal(out.values, np.array([[99, 20], [30, 40]], dtype="uint8"))
+
+
+def _categorical_pyramid_cube():
+    # Pyramid-sized grid of a few land-cover-style class codes (no 0 background).
+    ny = nx = 2100
+    codes = np.array([10, 20, 30, 40, 50], dtype="uint8")
+    rng = np.random.default_rng(0)
+    data = codes[rng.integers(0, len(codes), size=(ny, nx))]
+    return xr.Dataset(
+        {"landcover": (("y", "x"), data)},
+        coords={"y": np.linspace(-2.9, -1.0, ny), "x": np.linspace(28.8, 30.9, nx)},
+    ), set(int(c) for c in codes)
+
+
+def test_write_to_icechunk_store_mode_keeps_class_codes(tmp_path: Path) -> None:
+    import icechunk
+
+    ds, codes = _categorical_pyramid_cube()
+    assert needs_pyramid(ds)
+
+    store_path = tmp_path / "landcover.icechunk"
+    write_to_icechunk_store(ds, store_path, t_dim=None, crs="EPSG:4326", pyramid_method="mode")
+
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path)))
+    store = repo.readonly_session("main").store
+
+    # A coarsened level must contain only real class codes — never an averaged value
+    # (which is exactly what the previous hardcoded "mean" produced for categorical data).
+    with xr.open_zarr(store, group="1", consolidated=False, zarr_format=3) as lvl1:
+        values = np.unique(lvl1["landcover"].values)
+    assert set(int(v) for v in values) <= codes

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -69,11 +69,13 @@ def test_write_to_icechunk_store_builds_pyramid(tmp_path: Path) -> None:
 def test_resampling_method_from_template() -> None:
     assert resampling_method_from_template(None) == "mean"
     assert resampling_method_from_template({}) == "mean"
-    assert resampling_method_from_template({"display": {"colormap": "reds"}}) == "mean"
-    assert resampling_method_from_template({"display": {"resampling": "mode"}}) == "mode"
-    assert resampling_method_from_template({"display": {"resampling": "MAX"}}) == "max"
+    assert resampling_method_from_template({"ingestion": {"plugin": "x"}}) == "mean"
+    assert resampling_method_from_template({"ingestion": {"resampling": "mode"}}) == "mode"
+    assert resampling_method_from_template({"ingestion": {"resampling": "MAX"}}) == "max"
     # Unrecognised values fall back to mean rather than being passed downstream.
-    assert resampling_method_from_template({"display": {"resampling": "bilinear"}}) == "mean"
+    assert resampling_method_from_template({"ingestion": {"resampling": "bilinear"}}) == "mean"
+    # A display-block value is ignored — resampling is an ingestion concern.
+    assert resampling_method_from_template({"display": {"resampling": "mode"}}) == "mean"
 
 
 def _categorical_block_da():


### PR DESCRIPTION
Fixes #293.

## Problem

Pyramid coarsening was hardcoded to `mean` ([downloader.py](../blob/main/open_climate_service/data_manager/services/downloader.py)). Mean is correct for continuous data but wrong for **categorical** layers: it averages land-cover class codes into a *different, non-existent* class (`mean(10, 80) = 45`) and turns 0/1 masks into fractions — garbage colours at coarse zoom for the datasets that actually cross the pyramid threshold (ESA WorldCover, rice-field masks).

## Change

- **`ingestion.resampling`** on a dataset template selects the coarsening method (default `mean`). Threaded through both ingest paths — the openEO job publish and the apply-GeoZarr-conventions rebuild.
- **Composable methods** (`mean`/`max`/`min`/`sum`) pass straight to topozarr, so **binary masks can now use `max`** ("present anywhere in the block").
- **Categorical `mode`/`nearest`** can't be done by topozarr (it only coarsens composably, level-from-level, and those methods are non-composable — mode-of-modes ≠ mode-of-native). So OCS **resamples them from the native (level-0) array** and writes the values back into the level arrays topozarr already laid out (right shape/chunks/encoding). A first-class `mode`/`nearest` in topozarr is requested upstream: [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26).

## Tests (`test_downloader_pyramid.py`)

- `mode` picks the block majority; `nearest` takes the top-left cell.
- `resampling_method_from_template` validates and defaults to `mean`.
- A pyramid-sized categorical store keeps **only real class codes** at coarse levels (the regression the hardcoded `mean` caused).

pyright + ruff clean. Docs (`adding_custom_datasets.md`) note the categorical caveat and the topozarr limitation.

> Note: this covers the OCS-side of #293. The upstream `mode`/`nearest` request (carbonplan/topozarr#26) would later let us drop the native-resample workaround.