### PR TITLE
feat(plugins): installable dataset plugins via entry points

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -271,14 +271,21 @@ The `plugins_dir` above is ideal for instance-specific customisation. To make a 
 
 ### Package layout
 
-Mirror the `plugins_dir` layout inside an importable package:
+Mirror the `plugins_dir` layout inside an importable package. A plugin can ship any
+combination of the three extension points — **datasets, processes, and workflows are all
+auto-discovered** when the package is installed:
 
 ```
-open_climate_service_myplugin/
+osc_myplugin/
   __init__.py
-  myplugin.py            # your BaseDatasetPlugin subclass
   datasets/
+    __init__.py
+    myplugin.py          # your BaseDatasetPlugin subclass
     myplugin.yaml        # dataset templates
+  processes/             # optional: @process-decorated callables
+    my_process.py
+  workflows/             # optional: openEO UDP JSON graphs
+    my_workflow.json
 ```
 
 ### Declare the entry point
@@ -307,8 +314,10 @@ uv add open-climate-service-myplugin
 ```
 
 OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
-its `datasets/*.yaml` templates. The plugin's Python (the ingestion class, any transforms or
-processes) is importable by dotted path because the package is installed.
+its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), and its
+`workflows/*.json` (openEO UDPs). The ingestion class and any transforms are importable by dotted
+path because the package is installed. Each extension point follows the same precedence as datasets
+— built-in < installed plugins < instance `plugins_dir`.
 
 ### Naming and precedence
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -265,69 +265,9 @@ curl -s http://127.0.0.1:9000/stac/catalog.json | jq '.links[] | select(.rel == 
 ## Distributing a plugin as an installable package
 
 The `plugins_dir` above is ideal for instance-specific customisation. To make a plugin
-**reusable across instances** — installable from PyPI or GitHub with no manual path wiring
-([#118](https://github.com/dhis2/open-climate-service/issues/118)) — package it and declare an
-`open_climate_service.plugins` entry point.
-
-### Package layout
-
-An importable package can ship any combination of the three extension points — **datasets,
-processes, and workflows are all auto-discovered** when the package is installed. `datasets/`
-and `processes/` hold importable Python, so each needs an `__init__.py` (`workflows/` is plain
-JSON and does not):
-
-```
-osc_example_plugin/
-  __init__.py
-  datasets/
-    __init__.py
-    example.py           # your BaseDatasetPlugin subclass
-    example.yaml         # dataset templates
-  processes/             # optional: @process-decorated callables
-    __init__.py
-    my_process.py
-  workflows/             # optional: openEO UDP JSON graphs
-    my_workflow.json
-```
-
-### Declare the entry point
-
-In the package's `pyproject.toml`, point the entry point at the top-level package:
-
-```toml
-[project.entry-points."open_climate_service.plugins"]
-example = "osc_example_plugin"
-```
-
-The `ingestion.plugin` in the template YAML uses the class's **full dotted path** (not a
-`plugins_dir`-relative one), since the package is installed on `PYTHONPATH`:
-
-```yaml
-ingestion:
-  plugin: osc_example_plugin.datasets.example.ExamplePlugin
-```
-
-### Install and discover
-
-An operator installs the package — nothing else:
-
-```bash
-uv add osc-example-plugin
-```
-
-OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
-its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), and its
-`workflows/*.json` (openEO UDPs). The ingestion class and any transforms are importable by dotted
-path because the package is installed. Each extension point follows the same precedence as datasets
-— built-in < installed plugins < instance `plugins_dir`.
-
-### Naming and precedence
-
-- **Distribution name:** `osc-<name>-plugin`; **import package:** `osc_<name>_plugin` (e.g.
-  `osc-senorge-plugin` / `osc_senorge_plugin`).
-- **Precedence** (increasing): built-in datasets → installed plugins → the instance `plugins_dir`.
-  So `plugins_dir` always wins on an id conflict, letting an operator override an installed plugin
-  locally. Dataset overrides are logged at load time.
+**reusable across instances** — packaged and installed with `uv add`, no path wiring — see the
+[Installable plugins](installable_plugins.md) guide. The layout mirrors `plugins_dir`, so migrating
+is mostly moving the files into a package and declaring one entry point.
 
 The [seNorge plugin](https://github.com/dhis2/open-climate-service-senorge-plugin) is the reference
 implementation.

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -271,18 +271,20 @@ The `plugins_dir` above is ideal for instance-specific customisation. To make a 
 
 ### Package layout
 
-Mirror the `plugins_dir` layout inside an importable package. A plugin can ship any
-combination of the three extension points — **datasets, processes, and workflows are all
-auto-discovered** when the package is installed:
+An importable package can ship any combination of the three extension points — **datasets,
+processes, and workflows are all auto-discovered** when the package is installed. `datasets/`
+and `processes/` hold importable Python, so each needs an `__init__.py` (`workflows/` is plain
+JSON and does not):
 
 ```
-osc_myplugin/
+osc_example_plugin/
   __init__.py
   datasets/
     __init__.py
-    myplugin.py          # your BaseDatasetPlugin subclass
-    myplugin.yaml        # dataset templates
+    example.py           # your BaseDatasetPlugin subclass
+    example.yaml         # dataset templates
   processes/             # optional: @process-decorated callables
+    __init__.py
     my_process.py
   workflows/             # optional: openEO UDP JSON graphs
     my_workflow.json
@@ -294,15 +296,15 @@ In the package's `pyproject.toml`, point the entry point at the top-level packag
 
 ```toml
 [project.entry-points."open_climate_service.plugins"]
-myplugin = "open_climate_service_myplugin"
+example = "osc_example_plugin"
 ```
 
-The `ingestion.plugin` in the template YAML uses the package's **full dotted path** (not a
+The `ingestion.plugin` in the template YAML uses the class's **full dotted path** (not a
 `plugins_dir`-relative one), since the package is installed on `PYTHONPATH`:
 
 ```yaml
 ingestion:
-  plugin: open_climate_service_myplugin.myplugin.MyPlugin
+  plugin: osc_example_plugin.datasets.example.ExamplePlugin
 ```
 
 ### Install and discover
@@ -310,7 +312,7 @@ ingestion:
 An operator installs the package — nothing else:
 
 ```bash
-uv add open-climate-service-myplugin
+uv add osc-example-plugin
 ```
 
 OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
@@ -321,11 +323,11 @@ path because the package is installed. Each extension point follows the same pre
 
 ### Naming and precedence
 
-- **Distribution name:** `open-climate-service-<name>-plugin`; **import package:**
-  `open_climate_service_<name>_plugin`.
+- **Distribution name:** `osc-<name>-plugin`; **import package:** `osc_<name>_plugin` (e.g.
+  `osc-senorge-plugin` / `osc_senorge_plugin`).
 - **Precedence** (increasing): built-in datasets → installed plugins → the instance `plugins_dir`.
   So `plugins_dir` always wins on an id conflict, letting an operator override an installed plugin
-  locally. Overrides are logged at load time.
+  locally. Dataset overrides are logged at load time.
 
 The [seNorge plugin](https://github.com/dhis2/open-climate-service-senorge-plugin) is the reference
 implementation.

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -261,3 +261,62 @@ Verify it appears in the STAC catalog:
 ```bash
 curl -s http://127.0.0.1:9000/stac/catalog.json | jq '.links[] | select(.rel == "child")'
 ```
+
+## Distributing a plugin as an installable package
+
+The `plugins_dir` above is ideal for instance-specific customisation. To make a plugin
+**reusable across instances** — installable from PyPI or GitHub with no manual path wiring
+([#118](https://github.com/dhis2/open-climate-service/issues/118)) — package it and declare an
+`open_climate_service.plugins` entry point.
+
+### Package layout
+
+Mirror the `plugins_dir` layout inside an importable package:
+
+```
+open_climate_service_myplugin/
+  __init__.py
+  myplugin.py            # your BaseDatasetPlugin subclass
+  datasets/
+    myplugin.yaml        # dataset templates
+```
+
+### Declare the entry point
+
+In the package's `pyproject.toml`, point the entry point at the top-level package:
+
+```toml
+[project.entry-points."open_climate_service.plugins"]
+myplugin = "open_climate_service_myplugin"
+```
+
+The `ingestion.plugin` in the template YAML uses the package's **full dotted path** (not a
+`plugins_dir`-relative one), since the package is installed on `PYTHONPATH`:
+
+```yaml
+ingestion:
+  plugin: open_climate_service_myplugin.myplugin.MyPlugin
+```
+
+### Install and discover
+
+An operator installs the package — nothing else:
+
+```bash
+uv add open-climate-service-myplugin
+```
+
+OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
+its `datasets/*.yaml` templates. The plugin's Python (the ingestion class, any transforms or
+processes) is importable by dotted path because the package is installed.
+
+### Naming and precedence
+
+- **Distribution name:** `open-climate-service-<name>-plugin`; **import package:**
+  `open_climate_service_<name>_plugin`.
+- **Precedence** (increasing): built-in datasets → installed plugins → the instance `plugins_dir`.
+  So `plugins_dir` always wins on an id conflict, letting an operator override an installed plugin
+  locally. Overrides are logged at load time.
+
+The [seNorge plugin](https://github.com/dhis2/open-climate-service-senorge-plugin) is the reference
+implementation.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -8,6 +8,10 @@ The Open Climate Service supports three plugin types, all following the same pat
 | Processes | `plugins_dir/processes/` | `.py` |
 | Workflows | `plugins_dir/workflows/` | `.json` |
 
+The same three plugin types can also be packaged and **installed** (`uv add`), so a reusable plugin
+is shared across instances without any `plugins_dir` wiring — see [Installable plugins](installable_plugins.md).
+`plugins_dir` still takes precedence, so it can override an installed plugin locally.
+
 ---
 
 ## Datasets

--- a/docs/installable_plugins.md
+++ b/docs/installable_plugins.md
@@ -72,9 +72,9 @@ uv add osc-example-plugin
 
 OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
 its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), and its
-`workflows/*.json` (openEO UDPs). The ingestion class and any transforms are importable by dotted
-path because the package is installed. The datasets then appear in `/datasets` and can be ingested
-like any built-in.
+`workflows/*.json` (openEO UDPs). The ingestion plugin class is importable by dotted path because
+the package is installed. The datasets then appear in `/datasets` and can be ingested like any
+built-in.
 
 ## Precedence
 
@@ -95,5 +95,5 @@ For example, `osc-senorge-plugin` / `osc_senorge_plugin`.
 ## Reference implementation
 
 The [seNorge plugin](https://github.com/MasterMaps/osc-senorge-plugin) is the reference
-implementation: it ships the seNorge 2018 datasets (source + derived) and the download plugin, and
+implementation: it ships the seNorge 2018 datasets (source + derived) and the ingestion plugin, and
 is consumed by the Norway instance via `uv add`.

--- a/docs/installable_plugins.md
+++ b/docs/installable_plugins.md
@@ -1,0 +1,99 @@
+# Installable plugins
+
+There are two ways to add datasets, processes, and workflows to an instance, and they
+complement each other:
+
+- **`plugins_dir`** — drop files into the instance's local plugins folder. Ideal for
+  instance-specific customisation, one-off datasets, or overriding a built-in. No packaging.
+  See [Extensibility](extensibility.md) and [Adding custom datasets](adding_custom_datasets.md).
+- **Installable packages** — package a plugin and publish it, so any instance can `uv add` it
+  and OCS discovers it automatically ([#118](https://github.com/dhis2/open-climate-service/issues/118)).
+  Ideal for a **reusable** plugin shared across countries or organisations, versioned independently.
+
+This guide covers the installable-package option. It is purely additive — `plugins_dir`
+keeps working exactly as before, and still takes precedence (see [Precedence](#precedence)).
+
+## Package layout
+
+An importable package can ship any combination of the three extension points — **datasets,
+processes, and workflows are all auto-discovered** when the package is installed. `datasets/`
+and `processes/` hold importable Python, so each needs an `__init__.py` (`workflows/` is plain
+JSON and does not):
+
+```
+osc_example_plugin/
+  __init__.py
+  datasets/
+    __init__.py
+    example.py           # your BaseDatasetPlugin subclass
+    example.yaml         # dataset templates
+  processes/             # optional: @process-decorated callables
+    __init__.py
+    my_process.py
+  workflows/             # optional: openEO UDP JSON graphs
+    my_workflow.json
+```
+
+The layout mirrors `plugins_dir`, so migrating a `plugins_dir`-based plugin to a distributable
+package is mostly moving the files into a package and adding the entry point below.
+
+## Declare the entry point
+
+In the package's `pyproject.toml`, point an [entry point](https://packaging.python.org/en/latest/specifications/entry-points/)
+in the `open_climate_service.plugins` group at the top-level package:
+
+```toml
+[project.entry-points."open_climate_service.plugins"]
+example = "osc_example_plugin"
+```
+
+Declare `open-climate-service` as a dependency, but **do not** pin its VCS source — the consuming
+instance decides which OCS revision to run:
+
+```toml
+dependencies = ["open-climate-service"]
+```
+
+The `ingestion.plugin` in a dataset template uses the class's **full dotted path** (not a
+`plugins_dir`-relative one), since the package is installed on `PYTHONPATH`:
+
+```yaml
+ingestion:
+  plugin: osc_example_plugin.datasets.example.ExamplePlugin
+```
+
+## Install and discover
+
+An operator installs the package — nothing else, no `plugins_dir` wiring:
+
+```bash
+uv add osc-example-plugin
+```
+
+OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
+its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), and its
+`workflows/*.json` (openEO UDPs). The ingestion class and any transforms are importable by dotted
+path because the package is installed. The datasets then appear in `/datasets` and can be ingested
+like any built-in.
+
+## Precedence
+
+Templates are merged in increasing order of precedence, per extension point:
+
+**built-in → installed plugins → instance `plugins_dir`**
+
+So `plugins_dir` always wins on an id conflict — an operator can drop a YAML into their local
+`plugins/datasets/` to override an installed plugin's dataset. Overrides are logged at load time.
+
+## Naming convention
+
+- **Distribution name:** `osc-<name>-plugin`
+- **Import package:** `osc_<name>_plugin`
+
+For example, `osc-senorge-plugin` / `osc_senorge_plugin`.
+
+## Reference implementation
+
+The [seNorge plugin](https://github.com/MasterMaps/osc-senorge-plugin) is the reference
+implementation: it ships the seNorge 2018 datasets (source + derived) and the download plugin, and
+is consumed by the Norway instance via `uv add`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - GeoLibre plugin: geolibre_plugin.md
       - Adding custom datasets: adding_custom_datasets.md
       - Extensibility: extensibility.md
+      - Installable plugins: installable_plugins.md
       - API reference: managed_data_api_guide.md
   - Roadmap: roadmap.md
   - Team: team.md

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -19,10 +19,6 @@ CONFIGS_DIR: Path | None = None
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
-# Installable community plugins declare an entry point in this group pointing at their
-# top-level import package; OCS loads that package's datasets/*.yaml templates (#118).
-PLUGIN_ENTRY_POINT_GROUP = "open_climate_service.plugins"
-
 
 def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
@@ -175,34 +171,28 @@ def _load_builtin_datasets() -> list[dict[str, Any]]:
 def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
     """Load dataset templates contributed by installed plugin packages (#118).
 
-    Each installed package that declares an ``open_climate_service.plugins`` entry
-    point exposes its top-level import package as the entry-point value; its
-    ``datasets/*.yaml`` templates are loaded here. The package's Python — the
-    ``ingestion.plugin`` class, transforms, processes — is importable by dotted path
+    A plugin's ``datasets/*.yaml`` templates are loaded here; the package's Python —
+    the ``ingestion.plugin`` class and any transforms — is importable by dotted path
     because the package is installed, so no ``sys.path`` handling is needed.
 
     Returns ``(plugin_name, template)`` pairs so the caller can report conflicts.
     """
-    from importlib.metadata import entry_points
+    from open_climate_service.plugin_discovery import iter_plugin_subdirs
 
     results: list[tuple[str, dict[str, Any]]] = []
-    for entry_point in entry_points(group=PLUGIN_ENTRY_POINT_GROUP):
+    for plugin_name, _package, datasets_res in iter_plugin_subdirs("datasets"):
         try:
-            # entry_point.module is the package path (before any ":attr" suffix).
-            datasets_res = importlib.resources.files(entry_point.module) / "datasets"
-            if not datasets_res.is_dir():
-                continue
             for resource in datasets_res.iterdir():
                 if not resource.name.endswith((".yaml", ".yml")):
                     continue
                 file_datasets = yaml.safe_load(resource.read_text(encoding="utf-8"))
                 if not isinstance(file_datasets, list):
-                    raise ValueError(f"{entry_point.name} ({resource.name}) must contain a list of dataset templates")
+                    raise ValueError(f"{plugin_name} ({resource.name}) must contain a list of dataset templates")
                 for dataset in file_datasets:
-                    _validate_dataset_template(dataset, source=f"plugin '{entry_point.name}' ({resource.name})")
-                    results.append((entry_point.name, dataset))
+                    _validate_dataset_template(dataset, source=f"plugin '{plugin_name}' ({resource.name})")
+                    results.append((plugin_name, dataset))
         except Exception:
-            logger.exception("Error loading dataset templates from plugin '%s'", entry_point.name)
+            logger.exception("Error loading dataset templates from plugin '%s'", plugin_name)
             raise
     return results
 

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -70,7 +70,10 @@ def list_datasets() -> list[dict[str, Any]]:
         datasets_subdir = root / "datasets"
         if datasets_subdir.is_dir():
             for dataset in _load_from_dir(datasets_subdir):
-                merged[dataset["id"]] = dataset
+                ds_id = dataset["id"]
+                if ds_id in merged:
+                    logger.info("plugins_dir template '%s' overrides an existing dataset template", ds_id)
+                merged[ds_id] = dataset
 
     return list(merged.values())
 

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -175,8 +175,8 @@ def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
     """Load dataset templates contributed by installed plugin packages (#118).
 
     A plugin's ``datasets/*.yaml`` templates are loaded here; the package's Python —
-    the ``ingestion.plugin`` class and any transforms — is importable by dotted path
-    because the package is installed, so no ``sys.path`` handling is needed.
+    the ``ingestion.plugin`` class — is importable by dotted path because the package
+    is installed, so no ``sys.path`` handling is needed.
 
     Returns ``(plugin_name, template)`` pairs so the caller can report conflicts.
     """

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -19,13 +19,23 @@ CONFIGS_DIR: Path | None = None
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
+# Installable community plugins declare an entry point in this group pointing at their
+# top-level import package; OCS loads that package's datasets/*.yaml templates (#118).
+PLUGIN_ENTRY_POINT_GROUP = "open_climate_service.plugins"
+
 
 def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
 
-    Built-in templates from open_climate_service/plugins/datasets/ are always loaded. When
-    plugins_dir is set in CLIMATE_SERVICE_CONFIG, templates from that directory are
-    merged on top — a custom template with the same id overrides the built-in one.
+    Templates are merged in increasing order of precedence:
+
+    1. Built-in templates from open_climate_service/plugins/datasets/.
+    2. Installed plugin packages that declare an ``open_climate_service.plugins``
+       entry point (auto-discovered — no config change beyond installing them, #118).
+    3. The instance ``plugins_dir`` from CLIMATE_SERVICE_CONFIG.
+
+    A template with the same id overrides one from an earlier stage, so ``plugins_dir``
+    always wins and an installed plugin overrides a built-in. Overrides are logged.
 
     CONFIGS_DIR (test override via monkeypatch) bypasses this and loads only
     from the given directory, as tests supply a fully controlled set.
@@ -34,6 +44,12 @@ def list_datasets() -> list[dict[str, Any]]:
         return _load_from_dir(CONFIGS_DIR)
 
     merged: dict[str, dict[str, Any]] = {d["id"]: d for d in _load_builtin_datasets()}
+
+    for plugin_name, dataset in _load_entry_point_datasets():
+        ds_id = dataset["id"]
+        if ds_id in merged:
+            logger.warning("Plugin '%s' template '%s' overrides an existing dataset template", plugin_name, ds_id)
+        merged[ds_id] = dataset
 
     config = api_config.get_config()
     if config.get("templates_dir"):
@@ -154,6 +170,43 @@ def _load_builtin_datasets() -> list[dict[str, Any]]:
             logger.exception("Error loading %s", resource.name)
             raise
     return datasets
+
+
+def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
+    """Load dataset templates contributed by installed plugin packages (#118).
+
+    Each installed package that declares an ``open_climate_service.plugins`` entry
+    point exposes its top-level import package as the entry-point value; its
+    ``datasets/*.yaml`` templates are loaded here. The package's Python — the
+    ``ingestion.plugin`` class, transforms, processes — is importable by dotted path
+    because the package is installed, so no ``sys.path`` handling is needed.
+
+    Returns ``(plugin_name, template)`` pairs so the caller can report conflicts.
+    """
+    from importlib.metadata import entry_points
+
+    results: list[tuple[str, dict[str, Any]]] = []
+    for entry_point in entry_points(group=PLUGIN_ENTRY_POINT_GROUP):
+        try:
+            # entry_point.module is the package path (before any ":attr" suffix).
+            datasets_res = importlib.resources.files(entry_point.module) / "datasets"
+            if not datasets_res.is_dir():
+                continue
+            for resource in datasets_res.iterdir():
+                if not resource.name.endswith((".yaml", ".yml")):
+                    continue
+                file_datasets = yaml.safe_load(resource.read_text(encoding="utf-8"))
+                if not isinstance(file_datasets, list):
+                    raise ValueError(
+                        f"{entry_point.name} ({resource.name}) must contain a list of dataset templates"
+                    )
+                for dataset in file_datasets:
+                    _validate_dataset_template(dataset, source=f"plugin '{entry_point.name}' ({resource.name})")
+                    results.append((entry_point.name, dataset))
+        except Exception:
+            logger.exception("Error loading dataset templates from plugin '%s'", entry_point.name)
+            raise
+    return results
 
 
 def _load_from_dir(folder: Path) -> list[dict[str, Any]]:

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -197,9 +197,7 @@ def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
                     continue
                 file_datasets = yaml.safe_load(resource.read_text(encoding="utf-8"))
                 if not isinstance(file_datasets, list):
-                    raise ValueError(
-                        f"{entry_point.name} ({resource.name}) must contain a list of dataset templates"
-                    )
+                    raise ValueError(f"{entry_point.name} ({resource.name}) must contain a list of dataset templates")
                 for dataset in file_datasets:
                     _validate_dataset_template(dataset, source=f"plugin '{entry_point.name}' ({resource.name})")
                     results.append((entry_point.name, dataset))

--- a/open_climate_service/openeo/plugin_processes.py
+++ b/open_climate_service/openeo/plugin_processes.py
@@ -23,7 +23,8 @@ def load_plugin_processes() -> list[tuple[str, Any]]:
     Resolution order (last wins):
     1. xclim indicators — auto-registered from all indicator modules
     2. Built-in file plugins — ``open_climate_service/plugins/processes/``
-    3. Instance plugins — ``plugins_dir/processes/`` (override everything)
+    3. Installed plugin packages — ``<package>/processes/`` (entry-point plugins, #118)
+    4. Instance plugins — ``plugins_dir/processes/`` (override everything)
     """
     found: dict[str, Any] = {}
     for func in xclim_processes.scan():
@@ -31,6 +32,10 @@ def load_plugin_processes() -> list[tuple[str, Any]]:
         if meta:
             found[meta["id"]] = func
     for func in _scan_builtin_processes():
+        meta = get_process_metadata(func)
+        if meta:
+            found[meta["id"]] = func
+    for func in _scan_plugin_package_processes():
         meta = get_process_metadata(func)
         if meta:
             found[meta["id"]] = func
@@ -60,6 +65,24 @@ def _scan_builtin_processes() -> list[Any]:
             funcs.extend(_load_from_module(module_name))
     except (FileNotFoundError, NotADirectoryError):
         pass
+    return funcs
+
+
+def _scan_plugin_package_processes() -> list[Any]:
+    """Scan ``processes/`` in each installed plugin package (#118).
+
+    The package is on ``PYTHONPATH`` (it is installed), so its process modules are
+    imported by their full dotted path — no ``sys.path`` handling like the
+    ``plugins_dir`` scan needs.
+    """
+    from open_climate_service.plugin_discovery import iter_plugin_subdirs
+
+    funcs: list[Any] = []
+    for _name, package, processes_res in iter_plugin_subdirs("processes"):
+        for resource in processes_res.iterdir():
+            if not resource.name.endswith(".py") or resource.name.startswith("_"):
+                continue
+            funcs.extend(_load_from_module(f"{package}.processes.{resource.name[:-3]}"))
     return funcs
 
 

--- a/open_climate_service/openeo/workflows.py
+++ b/open_climate_service/openeo/workflows.py
@@ -46,7 +46,12 @@ def list_workflows() -> WorkflowListResponse:
     workflows override both.
     """
     merged: dict[str, dict[str, object]] = {}
-    for raw in (*_load_builtin_workflows(), *_load_plugin_workflows(), *_load_records()):
+    for raw in (
+        *_load_builtin_workflows(),
+        *_load_entry_point_workflows(),
+        *_load_plugin_workflows(),
+        *_load_records(),
+    ):
         wid = raw.get("id")
         if not isinstance(wid, str) or not wid:
             logger.warning("Skipping workflow with missing or non-string id")
@@ -73,6 +78,9 @@ def get_workflow(process_graph_id: str) -> WorkflowRecord | None:
         if raw.get("id") == process_graph_id:
             return WorkflowRecord.model_validate(raw)
     for raw in _load_plugin_workflows():
+        if raw.get("id") == process_graph_id:
+            return WorkflowRecord.model_validate(raw)
+    for raw in _load_entry_point_workflows():
         if raw.get("id") == process_graph_id:
             return WorkflowRecord.model_validate(raw)
     for raw in _load_builtin_workflows():
@@ -174,6 +182,27 @@ def _load_plugin_workflows() -> list[dict[str, object]]:
             workflows.append(data)
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Skipping workflow file %s: %s", path, exc)
+    return workflows
+
+
+def _load_entry_point_workflows() -> list[dict[str, object]]:
+    """Load workflows/*.json shipped by installed plugin packages (#118)."""
+    from open_climate_service.plugin_discovery import iter_plugin_subdirs
+
+    workflows: list[dict[str, object]] = []
+    for _name, _package, workflows_res in iter_plugin_subdirs("workflows"):
+        for resource in workflows_res.iterdir():
+            if not resource.name.endswith(".json"):
+                continue
+            try:
+                data = json.loads(resource.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Skipping plugin workflow file %s: %s", resource.name, exc)
+                continue
+            if not isinstance(data, dict):
+                logger.warning("Skipping plugin workflow file %s: expected a JSON object", resource.name)
+                continue
+            workflows.append(data)
     return workflows
 
 

--- a/open_climate_service/plugin_discovery.py
+++ b/open_climate_service/plugin_discovery.py
@@ -1,0 +1,40 @@
+"""Discovery of installable OCS plugins via entry points (#118).
+
+A plugin package declares an ``open_climate_service.plugins`` entry point whose value
+is its top-level import package. The framework then loads the package's ``datasets/``,
+``processes/`` and ``workflows/`` folders the same way it reads an instance's
+``plugins_dir`` — so an installed package contributes the same extension points, with
+no config wiring beyond installing it.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import logging
+from collections.abc import Iterator
+from importlib.metadata import entry_points
+from importlib.resources.abc import Traversable
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_ENTRY_POINT_GROUP = "open_climate_service.plugins"
+
+
+def iter_plugin_subdirs(subdir: str) -> Iterator[tuple[str, str, Traversable]]:
+    """Yield ``(plugin_name, package, <package>/<subdir>)`` for installed plugins.
+
+    Only plugins that actually ship the requested ``<subdir>`` (``datasets`` /
+    ``processes`` / ``workflows``) are yielded. ``package`` is the plugin's import
+    package, so a caller that needs to *import* modules (processes) can build the
+    dotted path, while a caller that reads files (datasets, workflows) can iterate
+    the returned traversable.
+    """
+    for entry_point in entry_points(group=PLUGIN_ENTRY_POINT_GROUP):
+        package = entry_point.module
+        try:
+            resource = importlib.resources.files(package) / subdir
+        except (ImportError, ModuleNotFoundError, TypeError):
+            logger.exception("Could not resolve resources for plugin '%s'", entry_point.name)
+            continue
+        if resource.is_dir():
+            yield entry_point.name, package, resource

--- a/open_climate_service/plugins_diagnostics.py
+++ b/open_climate_service/plugins_diagnostics.py
@@ -62,7 +62,10 @@ def log_plugin_loading() -> None:
     for sub, pattern in _PLUGIN_SUBDIRS:
         directory = root / sub
         if not directory.is_dir():
-            logger.warning("Instance plugins: '%s/' is missing under %s — those plugins will not load.", sub, root)
+            # A missing subdir is normal — most instances ship only one or two of
+            # datasets/processes/workflows. The summary line below reports it as
+            # sub=0, so this is only a debug detail, not a warning.
+            logger.debug("Instance plugins: no '%s/' directory under %s.", sub, root)
             counts.append(f"{sub}=0")
             continue
         # Only skip _-prefixed files for Python process plugins; dataset YAML and

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -268,8 +268,14 @@ def test_entry_point_plugin_dataset_is_discovered(monkeypatch: pytest.MonkeyPatc
 def test_entry_point_plugin_overrides_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
     """A plugin template with a built-in id overrides the built-in one."""
     monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
-    monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [{"id": "x", "name": "builtin", "sync": {"kind": "static"}}])
-    monkeypatch.setattr(datasets, "_load_entry_point_datasets", lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})])
+    monkeypatch.setattr(
+        datasets, "_load_builtin_datasets", lambda: [{"id": "x", "name": "builtin", "sync": {"kind": "static"}}]
+    )
+    monkeypatch.setattr(
+        datasets,
+        "_load_entry_point_datasets",
+        lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})],
+    )
     monkeypatch.setattr(api_config, "get_config", lambda: {})
     result = {d["id"]: d for d in datasets.list_datasets()}
     assert result["x"]["name"] == "plugin"
@@ -282,7 +288,11 @@ def test_plugins_dir_overrides_entry_point_plugin(monkeypatch: pytest.MonkeyPatc
     (datasets_dir / "x.yaml").write_text("- id: x\n  name: plugins_dir\n  sync:\n    kind: static\n", encoding="utf-8")
     monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
     monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [])
-    monkeypatch.setattr(datasets, "_load_entry_point_datasets", lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})])
+    monkeypatch.setattr(
+        datasets,
+        "_load_entry_point_datasets",
+        lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})],
+    )
     monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": str(tmp_path)})
     monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
     result = {d["id"]: d for d in datasets.list_datasets()}

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -240,3 +240,50 @@ def test_write_dataset_template_rejects_path_traversal_id(
                 "display": {"colormap": "RdBu", "range": [-10.0, 10.0]},
             }
         )
+
+
+def test_entry_point_plugin_dataset_is_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An installed plugin's dataset template is merged into list_datasets (#118)."""
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
+    monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [])
+    monkeypatch.setattr(
+        datasets,
+        "_load_entry_point_datasets",
+        lambda: [
+            (
+                "senorge",
+                {
+                    "id": "senorge_temperature_daily",
+                    "sync": {"kind": "temporal"},
+                    "ingestion": {"plugin": "pkg.senorge.SeNorgePlugin"},
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(api_config, "get_config", lambda: {})
+    ids = [d["id"] for d in datasets.list_datasets()]
+    assert "senorge_temperature_daily" in ids
+
+
+def test_entry_point_plugin_overrides_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plugin template with a built-in id overrides the built-in one."""
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
+    monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [{"id": "x", "name": "builtin", "sync": {"kind": "static"}}])
+    monkeypatch.setattr(datasets, "_load_entry_point_datasets", lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})])
+    monkeypatch.setattr(api_config, "get_config", lambda: {})
+    result = {d["id"]: d for d in datasets.list_datasets()}
+    assert result["x"]["name"] == "plugin"
+
+
+def test_plugins_dir_overrides_entry_point_plugin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """plugins_dir takes precedence over an installed plugin on id conflict."""
+    datasets_dir = tmp_path / "datasets"
+    datasets_dir.mkdir()
+    (datasets_dir / "x.yaml").write_text("- id: x\n  name: plugins_dir\n  sync:\n    kind: static\n", encoding="utf-8")
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
+    monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [])
+    monkeypatch.setattr(datasets, "_load_entry_point_datasets", lambda: [("p", {"id": "x", "name": "plugin", "sync": {"kind": "static"}})])
+    monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": str(tmp_path)})
+    monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
+    result = {d["id"]: d for d in datasets.list_datasets()}
+    assert result["x"]["name"] == "plugins_dir"

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,60 @@
+"""Entry-point plugin discovery for processes and workflows (#118).
+
+Dataset-template discovery is covered in test_dataset_registry.py; these exercise
+the other two extension points a plugin package can ship.
+"""
+
+import importlib.resources
+from pathlib import Path
+
+import pytest
+
+from open_climate_service import plugin_discovery
+from open_climate_service.openeo import plugin_processes, workflows
+
+
+def test_entry_point_processes_are_discovered(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A tiny importable plugin package that ships a @process in processes/.
+    pkg = tmp_path / "fakeproc_plugin"
+    (pkg / "processes").mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "processes" / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "processes" / "myproc.py").write_text(
+        "from open_climate_service.process import process\n\n"
+        "@process\n"
+        "def my_plugin_process(data):\n"
+        '    """A test plugin process."""\n'
+        "    return data\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def fake_iter(subdir: str):
+        if subdir == "processes":
+            yield "fakeproc", "fakeproc_plugin", importlib.resources.files("fakeproc_plugin") / "processes"
+
+    monkeypatch.setattr(plugin_discovery, "iter_plugin_subdirs", fake_iter)
+
+    ids = [pid for pid, _ in plugin_processes.load_plugin_processes()]
+    assert "my_plugin_process" in ids
+
+
+def test_entry_point_workflows_are_discovered(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    (workflows_dir / "wf.json").write_text('{"id": "plugin_workflow", "process_graph": {}}', encoding="utf-8")
+
+    def fake_iter(subdir: str):
+        if subdir == "workflows":
+            yield "fake", "fake", workflows_dir
+
+    monkeypatch.setattr(plugin_discovery, "iter_plugin_subdirs", fake_iter)
+
+    assert [w["id"] for w in workflows._load_entry_point_workflows()] == ["plugin_workflow"]
+
+
+def test_no_installed_plugins_yields_nothing() -> None:
+    # With no plugin shipping these, discovery is a clean no-op (no crash).
+    assert list(plugin_discovery.iter_plugin_subdirs("processes")) == [] or True
+    assert workflows._load_entry_point_workflows() == []
+    assert plugin_processes._scan_plugin_package_processes() == []

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -53,8 +53,9 @@ def test_entry_point_workflows_are_discovered(monkeypatch: pytest.MonkeyPatch, t
     assert [w["id"] for w in workflows._load_entry_point_workflows()] == ["plugin_workflow"]
 
 
-def test_no_installed_plugins_yields_nothing() -> None:
-    # With no plugin shipping these, discovery is a clean no-op (no crash).
-    assert list(plugin_discovery.iter_plugin_subdirs("processes")) == [] or True
+def test_no_installed_plugins_yields_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With no plugins declaring the entry point, discovery is a clean no-op.
+    monkeypatch.setattr(plugin_discovery, "entry_points", lambda group: [])
+    assert list(plugin_discovery.iter_plugin_subdirs("processes")) == []
     assert workflows._load_entry_point_workflows() == []
     assert plugin_processes._scan_plugin_package_processes() == []


### PR DESCRIPTION
Implements [CLIM-850](https://dhis2.atlassian.net/browse/CLIM-850): **installable, distributable OCS plugins** discovered via entry points, with the seNorge plugin extracted as the reference implementation.

## What

An installed package that declares an `open_climate_service.plugins` entry point (pointing at its top-level package) is auto-discovered, and OCS loads its three extension folders — **`datasets/`, `processes/`, and `workflows/`** — with no `plugins_dir` wiring. An operator just:

```bash
uv add osc-senorge-plugin
```

## Precedence

For every extension point, increasing: **built-in → installed plugins → instance `plugins_dir`**. So `plugins_dir` still wins on a conflict (an operator can override an installed plugin locally); dataset overrides are logged.

## Changes

- `plugin_discovery.py`: shared `iter_plugin_subdirs(subdir)` — walks the `open_climate_service.plugins` entry points and yields each plugin's `datasets/` / `processes/` / `workflows/` folder.
- `data_registry/services/datasets.py`: dataset-template discovery (built-in < plugin < plugins_dir).
- `openeo/plugin_processes.py`: `@process` callables from a plugin's `processes/`.
- `openeo/workflows.py`: openEO UDP JSON from a plugin's `workflows/`.
- Tests: dataset, process, and workflow discovery + the precedence chain.
- Docs (`adding_custom_datasets.md`): package layout, naming (`osc-<name>-plugin` / `osc_<name>_plugin`), the entry point, and precedence.

## Reference implementation + rollout

- **seNorge plugin:** https://github.com/MasterMaps/osc-senorge-plugin — ships all four seNorge datasets (2 source + 2 derived normal/anomaly), the `SeNorgePlugin` download class in `datasets/senorge.py`. *(To be transferred to `dhis2/`.)*
- **Norway instance** wired to consume it (MasterMaps/norway-climate-service#2): removes the local `senorge.py` and templates entirely. Verified end-to-end: with the plugin installed, `list_datasets()` returns all four seNorge datasets and the plugin class instantiates (`crs=32633`).

## Notes

- Entry-point group is `open_climate_service.plugins` (the issue's `climate_api.plugins` predates the package rename).
- Local lint gate green (mypy, ruff, format); mkdocs `--strict` builds.


[CLIM-850]: https://dhis2.atlassian.net/browse/CLIM-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ