### PR TITLE
feat(stac): advertise profile=multiscales for pyramided GeoZarr stores

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -26,6 +26,7 @@ from open_climate_service.openeo.schemas import (
     OpenEOJobStatus,
     OpenEOJobUpdate,
 )
+from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import utc_now
 
 _T = TypeVar("_T")
@@ -953,7 +954,7 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
             },
             "zarr": {
                 "href": f"/zarr/{dataset_id}",
-                "type": "application/vnd.zarr; version=3",
+                "type": ZARR_V3_MEDIA_TYPE,
                 "title": "Zarr store",
                 "roles": ["data"],
                 "xarray:open_kwargs": {"consolidated": True},
@@ -962,14 +963,23 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
         # Advertise the STAC collection only when the dataset is actually published.
         try:
             from open_climate_service.ingestions import services as _ingestion_services
+            from open_climate_service.ingestions.schemas import ArtifactFormat
 
-            if dataset_id in _ingestion_services.latest_published_zarr_artifacts_by_dataset():
+            artifact = _ingestion_services.latest_published_zarr_artifacts_by_dataset().get(dataset_id)
+            if artifact is not None:
                 assets["stac"] = {
                     "href": f"/stac/collections/{dataset_id}",
                     "type": "application/json",
                     "title": "STAC collection",
                     "roles": ["metadata"],
                 }
+                # Keep the media type in step with the STAC collection's zarr asset,
+                # so a client sees the same pyramid claim from either surface.
+                store_path = artifact.path or (artifact.asset_paths[0] if artifact.asset_paths else None)
+                if store_path:
+                    assets["zarr"]["type"] = zarr_media_type(
+                        store_path, icechunk=artifact.format == ArtifactFormat.ICECHUNK
+                    )
         except Exception:
             logger.debug("Could not resolve STAC publication for managed dataset '%s'", dataset_id, exc_info=True)
         return assets

--- a/open_climate_service/shared/geozarr.py
+++ b/open_climate_service/shared/geozarr.py
@@ -1,0 +1,124 @@
+"""Media type resolution for published GeoZarr stores.
+
+A published store is either flat (one resolution) or pyramided (a multiscales
+group of resolution levels). STAC has no way to tell those apart from the plain
+Zarr media type, so clients that only render pyramided stores cannot decide
+whether an asset is safe to open.
+
+The `profile` media type parameter closes that gap. It is recommended by the
+STAC Zarr best practices, which note it is not (yet) part of the official Zarr
+media type registration:
+
+    https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md
+
+Consumers match it literally rather than parsing parameters — OpenLayers'
+``ol/source/GeoZarr`` is reached only for the exact web-optimized string — so
+``WEB_OPTIMIZED_ZARR_MEDIA_TYPE`` must stay byte-identical to what they expect.
+
+The profile is only ever advertised for stores that really are pyramided:
+claiming it for a flat store would send a renderer looking for levels that do
+not exist.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ZARR_V3_MEDIA_TYPE = "application/vnd.zarr; version=3"
+"""Media type for a published Zarr v3 store with no resolution pyramid."""
+
+WEB_OPTIMIZED_ZARR_MEDIA_TYPE = f"{ZARR_V3_MEDIA_TYPE}; profile=multiscales"
+"""Media type for a pyramided ("web-optimized") Zarr v3 store.
+
+Byte-identical to the string web clients match on; do not reformat the
+parameters or reorder them.
+"""
+
+MULTISCALES_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
+"""UUID of the Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)."""
+
+
+def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
+    """Return True when root group *attributes* describe a multiscales pyramid.
+
+    Mirrors what pyramid-aware renderers require: the multiscales convention
+    declared in ``zarr_conventions``, plus a non-empty ``multiscales.layout``
+    listing the resolution levels. A store that declares the convention but has
+    no levels is treated as flat — there is nothing extra for a client to read.
+    """
+    conventions = attributes.get("zarr_conventions")
+    if not isinstance(conventions, list):
+        return False
+    declared = any(
+        isinstance(convention, Mapping)
+        and (convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales")
+        for convention in conventions
+    )
+    if not declared:
+        return False
+    multiscales = attributes.get("multiscales")
+    if not isinstance(multiscales, Mapping):
+        return False
+    layout = multiscales.get("layout")
+    return isinstance(layout, list) and len(layout) > 0
+
+
+def read_root_attributes(store_path: str, *, icechunk: bool) -> Mapping[str, Any]:
+    """Read the root group attributes of a published store.
+
+    Reads only group metadata, never chunk data. Deliberately reads the *root*
+    group: the store accessors descend into pyramid level ``0``, whose
+    attributes do not carry the multiscales layout.
+
+    Returns an empty mapping when the attributes cannot be read (remote store,
+    missing path, unreadable metadata).
+    """
+    if icechunk:
+        return _read_icechunk_root_attributes(store_path)
+    if "://" in store_path:
+        # Remote stores would need a network round trip per request; the caller
+        # falls back to the flat media type rather than paying for it here.
+        return {}
+    zarr_json = Path(store_path) / "zarr.json"
+    try:
+        payload = json.loads(zarr_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    attributes = payload.get("attributes")
+    return attributes if isinstance(attributes, Mapping) else {}
+
+
+def _read_icechunk_root_attributes(store_path: str) -> Mapping[str, Any]:
+    import icechunk
+    import zarr
+
+    if not Path(store_path).exists():
+        return {}
+    storage = icechunk.local_filesystem_storage(store_path)
+    repo = icechunk.Repository.open(storage)
+    session = repo.readonly_session("main")
+    group = zarr.open_group(session.store, mode="r")
+    return dict(group.attrs)
+
+
+def zarr_media_type(store_path: str, *, icechunk: bool) -> str:
+    """Return the media type to advertise for the store at *store_path*.
+
+    Falls back to the flat :data:`ZARR_V3_MEDIA_TYPE` whenever the pyramid
+    cannot be confirmed. Understating is safe (a client opens the store the
+    ordinary way); overstating is not.
+    """
+    try:
+        attributes = read_root_attributes(store_path, icechunk=icechunk)
+    except Exception:
+        logger.debug("Could not read root attributes of store %r", store_path, exc_info=True)
+        return ZARR_V3_MEDIA_TYPE
+    if attributes_declare_multiscales(attributes):
+        return WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+    return ZARR_V3_MEDIA_TYPE

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -20,6 +20,7 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
+from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import (
     parse_period_string_to_datetime,
     period_type_to_iso_step,
@@ -206,7 +207,7 @@ def _build_collection_template(
         "zarr",
         pystac.Asset(
             href=zarr_href,
-            media_type="application/vnd.zarr; version=3",
+            media_type=_zarr_media_type(artifact),
             title="Zarr store",
             roles=["data"],
         ),
@@ -656,6 +657,20 @@ def _zarr_asset_metadata(artifact: ArtifactRecord) -> dict[str, object]:
         if zgroup.exists():
             metadata["zarr:zarr_format"] = 2
     return metadata
+
+
+def _zarr_media_type(artifact: ArtifactRecord) -> str:
+    """Advertise the pyramided Zarr media type when the store really is pyramided.
+
+    Lets pyramid-aware clients (e.g. STAC Browser via ol/source/GeoZarr) tell a
+    multiscales store from a flat one, which the plain Zarr media type cannot
+    express. Falls back to the flat type if the store can't be inspected.
+    """
+    try:
+        store_path = _artifact_store_path(artifact)
+    except HTTPException:
+        return ZARR_V3_MEDIA_TYPE
+    return zarr_media_type(store_path, icechunk=artifact.format == ArtifactFormat.ICECHUNK)
 
 
 def _zarr_open_kwargs(artifact: ArtifactRecord) -> dict[str, bool | None]:

--- a/tests/test_geozarr_media_type.py
+++ b/tests/test_geozarr_media_type.py
@@ -1,0 +1,124 @@
+"""Media type advertised for published GeoZarr stores (flat vs pyramided)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from open_climate_service.shared.geozarr import (
+    MULTISCALES_CONVENTION_UUID,
+    WEB_OPTIMIZED_ZARR_MEDIA_TYPE,
+    ZARR_V3_MEDIA_TYPE,
+    attributes_declare_multiscales,
+    read_root_attributes,
+    zarr_media_type,
+)
+
+
+def _multiscales_attrs(levels: int = 3) -> dict[str, Any]:
+    """Root attributes as geozarr_toolkit writes them for a pyramided store."""
+    return {
+        "zarr_conventions": [
+            {"name": "spatial:", "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"},
+            {"name": "proj:", "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"},
+            {"name": "multiscales", "uuid": MULTISCALES_CONVENTION_UUID},
+        ],
+        "multiscales": {
+            "layout": [{"path": str(level)} for level in range(levels)],
+            "resampling_method": "mean",
+        },
+        "proj:code": "EPSG:4326",
+        "spatial:bbox": [0.0, 0.0, 1.0, 1.0],
+    }
+
+
+def _write_zarr_store(root: Path, attributes: dict[str, Any]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "zarr.json").write_text(
+        json.dumps({"zarr_format": 3, "node_type": "group", "attributes": attributes}),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_web_optimized_media_type_is_byte_identical_to_client_expectation() -> None:
+    # Consumers match this string literally (no media type parameter parsing),
+    # so any reformatting silently disables pyramid rendering everywhere.
+    assert WEB_OPTIMIZED_ZARR_MEDIA_TYPE == "application/vnd.zarr; version=3; profile=multiscales"
+    assert ZARR_V3_MEDIA_TYPE == "application/vnd.zarr; version=3"
+
+
+class TestAttributesDeclareMultiscales:
+    def test_true_for_declared_convention_with_levels(self) -> None:
+        assert attributes_declare_multiscales(_multiscales_attrs()) is True
+
+    def test_matches_convention_by_name_when_uuid_absent(self) -> None:
+        attrs = _multiscales_attrs()
+        attrs["zarr_conventions"] = [{"name": "multiscales"}]
+        assert attributes_declare_multiscales(attrs) is True
+
+    def test_false_for_flat_store(self) -> None:
+        assert attributes_declare_multiscales({"proj:code": "EPSG:4326"}) is False
+
+    def test_false_when_convention_declared_but_layout_empty(self) -> None:
+        # Nothing extra for a client to read — advertising a pyramid would lie.
+        attrs = _multiscales_attrs()
+        attrs["multiscales"]["layout"] = []
+        assert attributes_declare_multiscales(attrs) is False
+
+    def test_false_when_layout_missing(self) -> None:
+        attrs = _multiscales_attrs()
+        del attrs["multiscales"]["layout"]
+        assert attributes_declare_multiscales(attrs) is False
+
+    def test_false_when_convention_missing_but_layout_present(self) -> None:
+        attrs = _multiscales_attrs()
+        attrs["zarr_conventions"] = []
+        assert attributes_declare_multiscales(attrs) is False
+
+    @pytest.mark.parametrize("conventions", ["multiscales", 42, None])
+    def test_false_for_malformed_conventions(self, conventions: Any) -> None:
+        assert attributes_declare_multiscales({"zarr_conventions": conventions}) is False
+
+
+class TestReadRootAttributes:
+    def test_reads_plain_zarr_v3_root(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "store.zarr", _multiscales_attrs())
+        assert read_root_attributes(str(store), icechunk=False)["multiscales"]["resampling_method"] == "mean"
+
+    def test_empty_for_missing_store(self, tmp_path: Path) -> None:
+        assert read_root_attributes(str(tmp_path / "absent.zarr"), icechunk=False) == {}
+
+    def test_empty_for_unreadable_metadata(self, tmp_path: Path) -> None:
+        store = tmp_path / "broken.zarr"
+        store.mkdir()
+        (store / "zarr.json").write_text("{not json", encoding="utf-8")
+        assert read_root_attributes(str(store), icechunk=False) == {}
+
+    def test_empty_for_remote_store(self) -> None:
+        # Detection must not make a network round trip per STAC request.
+        assert read_root_attributes("s3://bucket/store.zarr", icechunk=False) == {}
+
+
+class TestZarrMediaType:
+    def test_pyramided_store_advertises_profile(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "pyramid.zarr", _multiscales_attrs())
+        assert zarr_media_type(str(store), icechunk=False) == WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+
+    def test_flat_store_advertises_plain_type(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "flat.zarr", {"proj:code": "EPSG:4326"})
+        assert zarr_media_type(str(store), icechunk=False) == ZARR_V3_MEDIA_TYPE
+
+    def test_falls_back_to_plain_type_when_store_absent(self, tmp_path: Path) -> None:
+        assert zarr_media_type(str(tmp_path / "absent.zarr"), icechunk=False) == ZARR_V3_MEDIA_TYPE
+
+    def test_falls_back_to_plain_type_when_detection_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A broken/locked store must never take the STAC collection down with it.
+        def _boom(*_args: object, **_kwargs: object) -> dict[str, Any]:
+            raise RuntimeError("store is locked")
+
+        monkeypatch.setattr("open_climate_service.shared.geozarr.read_root_attributes", _boom)
+        assert zarr_media_type("/tmp/whatever.icechunk", icechunk=True) == ZARR_V3_MEDIA_TYPE

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -21,6 +21,7 @@ from open_climate_service.ingestions.schemas import (
     PublicationStatus,
 )
 from open_climate_service.openeo import collections as openeo_collections
+from open_climate_service.shared.geozarr import WEB_OPTIMIZED_ZARR_MEDIA_TYPE, ZARR_V3_MEDIA_TYPE
 from open_climate_service.stac import services as stac_services
 
 
@@ -392,6 +393,51 @@ def test_collection_uses_root_href_for_icechunk_store(client: TestClient, monkey
     assert payload["assets"]["zarr"]["href"].endswith("/zarr/chirps3_precipitation_daily")
     assert payload["assets"]["zarr"]["xarray:open_kwargs"] == {"consolidated": True}
     assert payload["assets"]["zarr"]["zarr:zarr_format"] == 3
+
+
+def _stub_collection_for_media_type(monkeypatch: pytest.MonkeyPatch, *, path: str) -> None:
+    artifact = _artifact(artifact_id="a1", format=ArtifactFormat.ICECHUNK, path=path)
+    monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services, "_build_collection_with_xstac", lambda **_: _minimal_xstac_payload())
+    monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {})
+    monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {})
+
+
+def test_collection_advertises_multiscales_profile_for_pyramided_store(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pyramided store is advertised as web-optimized so clients will render it."""
+    _stub_collection_for_media_type(monkeypatch, path="/tmp/pyramided.icechunk")
+    monkeypatch.setattr(stac_services, "zarr_media_type", lambda *_, **__: WEB_OPTIMIZED_ZARR_MEDIA_TYPE)
+
+    response = client.get("/collections/chirps3_precipitation_daily")
+
+    assert response.status_code == 200
+    assert response.json()["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3; profile=multiscales"
+
+
+def test_collection_advertises_plain_type_for_flat_store(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A flat store keeps the plain media type — no pyramid is claimed."""
+    _stub_collection_for_media_type(monkeypatch, path="/tmp/flat.icechunk")
+    monkeypatch.setattr(stac_services, "zarr_media_type", lambda *_, **__: ZARR_V3_MEDIA_TYPE)
+
+    response = client.get("/collections/chirps3_precipitation_daily")
+
+    assert response.status_code == 200
+    assert response.json()["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3"
+
+
+def test_collection_media_type_falls_back_when_store_is_unreadable(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable store yields the plain type rather than failing the collection."""
+    _stub_collection_for_media_type(monkeypatch, path="/tmp/does-not-exist.icechunk")
+
+    response = client.get("/collections/chirps3_precipitation_daily")
+
+    assert response.status_code == 200
+    assert response.json()["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3"
 
 
 def test_collection_returns_404_for_unknown_dataset(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

Every published store is advertised as `application/vnd.zarr; version=3`, whether it is flat or pyramided. STAC alone therefore gives a client no way to tell the two apart, so renderers that only handle pyramided stores skip **all** OCS datasets.

Concretely: STAC Browser v5 shows a "Show on map" button only for assets whose media type matches its web-optimized Zarr list, and `application/vnd.zarr; version=3` isn't in it. Our stores get the ZARR badge but no map button — even the ones that *are* pyramided.

## Change

Resolve the media type per artifact. A pyramided store now advertises:

```
application/vnd.zarr; version=3; profile=multiscales
```

The `profile` parameter is the one recommended by the [STAC Zarr best practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md), which note it is not (yet) part of the official Zarr media type registration. It is also what ESA's EOPF Sentinel-2 catalogs publish.

New `open_climate_service/shared/geozarr.py` owns the detection and the two media type constants. It requires **both** the multiscales convention in `zarr_conventions` **and** a non-empty `multiscales.layout` — the same conditions a pyramid-aware renderer checks — so the profile is never claimed for a store with no levels. It reads the *root* group attributes deliberately: the store accessors descend into level `0`, whose attributes don't carry the layout.

Wired into both surfaces that publish the asset:
- the STAC collection (`stac/services.py`)
- the openEO managed-publish job result (`openeo/jobs.py`), so a client sees the same claim from either

### Safety

Detection is exception-safe and always degrades to the flat media type. Understating is harmless (a client opens the store the ordinary way); overstating would send a renderer hunting for levels that don't exist. Remote (`s3://`, …) stores fall back too, rather than paying a network round trip per STAC request.

## Verification

Against the Norway instance's seven real Icechunk stores:

```
WOZ levels=6  worldpop_population_yearly       application/vnd.zarr; version=3; profile=multiscales
    levels=0  chirps3_precipitation_daily      application/vnd.zarr; version=3
    levels=0  era5land_temperature_monthly     application/vnd.zarr; version=3
    levels=0  senorge_precipitation_daily      application/vnd.zarr; version=3
    levels=0  senorge_temperature_daily        application/vnd.zarr; version=3
    levels=0  senorge_temperature_daily_anomaly_1991_2020   application/vnd.zarr; version=3
    levels=0  senorge_temperature_daily_normal_1991_2020    application/vnd.zarr; version=3
```

Only the genuinely pyramided store changes. Its root attributes carry all three zarr-conventions UUIDs (multiscales / proj: / spatial:) plus a 6-entry `multiscales.layout`, which is exactly what a pyramid-aware renderer needs.

- 18 new unit tests for detection and fallback, 3 new STAC collection tests
- `make lint` clean (ruff, format, mypy, pyright)
- `pytest tests/` — 533 passed. The 3 failures in `test_openeo_execution.py` are pre-existing on `main` (a local PROJ install conflict: `proj.db` layout v5 vs >= 6 expected), confirmed by re-running them with this branch stashed.

## Follow-ups (not in this PR)

- **Flat stores stay unrenderable in STAC Browser.** That is an upstream gap, not ours: OpenLayers' `ol/source/GeoZarr` *does* support single-resolution stores (it derives a one-level tile grid from `spatial:bbox` + `spatial:shape`), but `ol-stac` hardcodes optimized-only for GeoZarr while giving GeoTIFF a `displayGeoTiffByDefault` escape hatch. Worth an upstream issue asking for the equivalent flag. Note this affects our *small* datasets — exactly the ones that would be safe to render at native resolution.

- **`spatial:` axis order is written (X, Y) where the convention specifies (Y, X).** [`spatial:shape`](https://github.com/zarr-conventions/spatial) is defined as `[height, width]`, but `data_manager/services/downloader.py` writes `(ds.sizes[x_dim], ds.sizes[y_dim])` — the WorldPop store reports `spatial:shape = [31998, 15871]` where its actual dims are `y=15871, x=31998`. `spatial:dimensions` has the same inversion: we write `['x', 'y']`, and the convention's ordering is positional (its example declares `["lat", "lon"]` to mean Y then X). Harmless on the multiscale render path (which uses `layout`), but it would break the single-scale tile grid a reader derives from these fields. Deserves its own issue.

- **CRS mismatch on the WorldPop store.** Its coordinates are degrees (`x: 4.50 → 31.17`, `y: 71.18 → 57.96`) while its grid mapping claims `EPSG:32633` / `PROJCS["WGS 84 / UTM zone 33N"]` — a projected CRS stamped onto geographic coordinates, the exact failure the comment at `downloader.py:304-309` warns against. `spatial:bbox` is correct here and simply reports the real degree extent; the fault is `proj:code`. Because `spatial:bbox` is CRS-relative per the convention, a reader still ends up pairing a degree extent with a metre CRS, so this could defeat rendering even with the right media type. Belongs with CLIM-821.
