### PR TITLE
feat(earthkit): make earthkit core and auto-register earthkit-meteo processes

### DIFF
--- a/docs/climate_indices.md
+++ b/docs/climate_indices.md
@@ -149,11 +149,22 @@ Alongside the xclim indicators, the thermodynamic functions of ECMWF's [earthkit
 | `saturation_vapour_pressure` | Saturation vapour pressure over water/ice/mixed phase |
 | `potential_temperature`, `virtual_temperature` | Thermodynamic temperatures |
 
-Relative humidity is the common case, since ERA5-Land provides temperature and dewpoint but not humidity directly:
+Relative humidity is the common case, since the ERA5-Land source carries temperature and dewpoint but not humidity directly:
 
 ```python
+t2m = conn.load_collection("era5land_temperature_daily")
+d2m = conn.load_collection("era5land_dewpoint_daily")
+
 rh = t2m.process("relative_humidity_from_dewpoint", arguments={"t": t2m, "td": d2m})
 ```
+
+Two things worth noting. Both cubes are passed **explicitly** — the collection you call
+`.process()` on is only the entry point, not an implicit first argument. And
+`era5land_dewpoint_daily` is **not a built-in**: the shipped ERA5-Land templates cover
+temperature (`t2m`) and precipitation (`tp`) only. Dewpoint needs a template of its own,
+which is a copy of the temperature one with `variable: d2m` — the same
+one-plugin-many-templates pattern described in
+[Architecture](architecture.md#streaming-plugin).
 
 Browse the full set in `GET /processes`; every function earthkit-meteo documents with a single cube output is registered.
 
@@ -161,13 +172,9 @@ Browse the full set in `GET /processes`; every function earthkit-meteo documents
 
 These functions expect ECMWF's native units — temperature in **K**, pressure in **Pa** — and do no checking of their own. Our stores are usually not in those units: ERA5-Land temperature is converted to `degC` at ingest. Passing `degC` where `K` is expected produces no error, just a wrong number.
 
-The registered processes therefore enforce units on the way in. A cube in a compatible unit is converted (`degC` → `K`, `hPa` → `Pa`); a cube whose `units` attribute is missing or incompatible is rejected with an explanatory error. So you can pass a stored `degC` temperature directly and get a correct answer:
+The registered processes therefore enforce units on the way in. A cube in a compatible unit is converted (`degC` → `K`, `hPa` → `Pa`); a cube whose `units` attribute is missing or incompatible is rejected with an explanatory error.
 
-```python
-# era5land_temperature_daily is stored in degC — converted to K automatically
-rh = conn.load_collection("era5land_temperature_daily") \
-         .process("relative_humidity_from_dewpoint", arguments={"t": t, "td": td})
-```
+So the call above needs no change on a `degC` store: `era5land_temperature_daily` and `era5land_dewpoint_daily` are both converted to `K` on the way in, and the answer is correct without a manual conversion step.
 
 If a cube is rejected for missing units, the fix is to declare `units` on the variable in its dataset template — that value is what gets CF-stamped at ingest.
 

--- a/docs/climate_indices.md
+++ b/docs/climate_indices.md
@@ -136,6 +136,43 @@ tmax.process("heat_wave_frequency", arguments={
 
 ---
 
+## Derived meteorological variables (earthkit-meteo)
+
+Alongside the xclim indicators, the thermodynamic functions of ECMWF's [earthkit-meteo](https://earthkit.ecmwf.int) are auto-registered as processes. These are not indices but *derivations* — quantities computed from other quantities, useful as inputs to an index or a health model:
+
+| Process | Computes |
+|---|---|
+| `relative_humidity_from_dewpoint` | Relative humidity (%) from temperature and dewpoint |
+| `dewpoint_from_relative_humidity` | Dewpoint from temperature and relative humidity |
+| `specific_humidity_from_dewpoint` | Specific humidity from dewpoint and pressure |
+| `wet_bulb_temperature_from_dewpoint` | Wet-bulb temperature — a heat-stress input |
+| `saturation_vapour_pressure` | Saturation vapour pressure over water/ice/mixed phase |
+| `potential_temperature`, `virtual_temperature` | Thermodynamic temperatures |
+
+Relative humidity is the common case, since ERA5-Land provides temperature and dewpoint but not humidity directly:
+
+```python
+rh = t2m.process("relative_humidity_from_dewpoint", arguments={"t": t2m, "td": d2m})
+```
+
+Browse the full set in `GET /processes`; every function earthkit-meteo documents with a single cube output is registered.
+
+### Units are converted for you
+
+These functions expect ECMWF's native units — temperature in **K**, pressure in **Pa** — and do no checking of their own. Our stores are usually not in those units: ERA5-Land temperature is converted to `degC` at ingest. Passing `degC` where `K` is expected produces no error, just a wrong number.
+
+The registered processes therefore enforce units on the way in. A cube in a compatible unit is converted (`degC` → `K`, `hPa` → `Pa`); a cube whose `units` attribute is missing or incompatible is rejected with an explanatory error. So you can pass a stored `degC` temperature directly and get a correct answer:
+
+```python
+# era5land_temperature_daily is stored in degC — converted to K automatically
+rh = conn.load_collection("era5land_temperature_daily") \
+         .process("relative_humidity_from_dewpoint", arguments={"t": t, "td": td})
+```
+
+If a cube is rejected for missing units, the fix is to declare `units` on the variable in its dataset template — that value is what gets CF-stamped at ingest.
+
+---
+
 ## Customising an index
 
 The auto-registered xclim processes can be overridden per-instance by placing a `@process`-decorated function with the same id in `plugins_dir/processes/`. This is useful for adjusting default parameters or adding domain-specific documentation without modifying shared code.
@@ -160,4 +197,5 @@ See [Extensibility — Processes](extensibility.md#processes) for the full `@pro
 
 - [xclim documentation](https://xclim.readthedocs.io)
 - [xclim indicator catalogue](https://xclim.readthedocs.io/en/stable/indicators.html)
+- [earthkit-meteo documentation](https://earthkit-meteo.readthedocs.io)
 - [openEO process graph specification](https://processes.openeo.org)

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -93,7 +93,7 @@ This is also why the two libraries are surfaced differently. xclim's indicators 
 
 Processes that wrap unit-sensitive physics should validate their inputs rather than trust them. Stored variables are CF-stamped from the `units` field of their dataset template, and those units are whatever the dataset declares — ERA5-Land temperature, for example, is converted to `degC` at ingest, while ECMWF library functions expect kelvin. Passing one for the other raises no error and produces a plausible, wrong number.
 
-The auto-registered earthkit-meteo processes handle this for you: each reads the unit its upstream function documents, converts a compatible cube (`degC` → `K`, `hPa` → `Pa`), and refuses a cube whose units are missing or incompatible. If you write a process with the same sensitivity, do the same — and make sure your dataset templates declare `units`, since that is what makes the check possible.
+The auto-registered earthkit-meteo processes handle this for you: each reads the unit its upstream function documents, converts a compatible cube (`degC` → `K`, `hPa` → `Pa`), and refuses a cube whose units are missing or incompatible. The check does not trust upstream docstrings to be well-formed: a parameter documented as taking a cube but carrying no unit the adapter can enforce is *refused registration* rather than quietly advertised as a plain number, and a small override table supplies units for known upstream documentation defects. If you write a process with the same sensitivity, do the same — and make sure your dataset templates declare `units`, since that is what makes the check possible.
 
 ---
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -62,6 +62,35 @@ def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray:
 
 A plugin process with the same id as an existing process overrides it. The server must be restarted to pick up new process files. For built-in climate indices, see [Climate indices](climate_indices.md).
 
+### Scientific libraries available to your process
+
+These are declared dependencies of the server, so you can import them in a plugin process without adding anything to your instance's `pyproject.toml`:
+
+| Library | Use it for |
+|---|---|
+| [xarray](https://docs.xarray.dev) | The cube type every process takes and returns |
+| [numpy](https://numpy.org), [pandas](https://pandas.pydata.org) | Array and time-series primitives |
+| [xclim](https://xclim.readthedocs.io) | Peer-reviewed climate indices — 179 indicators, already exposed as processes (see [Climate indices](climate_indices.md)) |
+| [earthkit](https://earthkit.ecmwf.int) | ECMWF's toolkit: `earthkit.transforms` (climatologies, anomalies, deaccumulation), `earthkit.meteo` (thermodynamics), `earthkit.data` (format-agnostic readers, including GRIB) |
+| [rioxarray](https://corteva.github.io/rioxarray), [metpy](https://unidata.github.io/MetPy) | Raster/CRS operations and meteorological calculations |
+
+Anything outside this list belongs in your own instance's dependencies — the plugin that ships the import owns it. Note that plugin modules are imported **lazily, when a process runs or an ingest starts**, so a missing dependency will not show up at startup: the API boots cleanly and the dataset still lists in `/collections`, then the run fails. Declaring it is the only reliable fix.
+
+### Choosing between a standard process and a library
+
+Reach for the standard openEO process first. Roughly 130 are available out of the box, and they are what every openEO client, tutorial and process graph already speaks — a locally named equivalent fragments that vocabulary.
+
+- **openEO names it** → use it. Temporal and spatial aggregation, reductions, resampling, and the `mean`/`median`/`sd`/`quantiles` reducers are all standard: `aggregate_temporal`, `aggregate_temporal_period`, `aggregate_spatial`, `reduce_dimension`, `resample_cube_temporal`.
+- **openEO does not name it** → wrap a library in a `@process` function. Climatological normals, anomalies and deaccumulation have no standard equivalent, which is why they exist here as named processes.
+
+This is also why the two libraries are surfaced differently. xclim's indicators and earthkit-meteo's thermodynamic functions are auto-registered, so they appear in `GET /processes` individually — each is a distinct scientific quantity openEO does not define. earthkit-transforms is deliberately *not* auto-registered: most of it duplicates the standard aggregation processes, and its public functions are decorator-wrapped down to `(*args, **kwargs)`, leaving no signature from which to derive a usable process description. Call it from a hand-written `@process` instead, where you control the parameters and documentation.
+
+### Units are part of the contract
+
+Processes that wrap unit-sensitive physics should validate their inputs rather than trust them. Stored variables are CF-stamped from the `units` field of their dataset template, and those units are whatever the dataset declares — ERA5-Land temperature, for example, is converted to `degC` at ingest, while ECMWF library functions expect kelvin. Passing one for the other raises no error and produces a plausible, wrong number.
+
+The auto-registered earthkit-meteo processes handle this for you: each reads the unit its upstream function documents, converts a compatible cube (`degC` → `K`, `hPa` → `Pa`), and refuses a cube whose units are missing or incompatible. If you write a process with the same sensitivity, do the same — and make sure your dataset templates declare `units`, since that is what makes the check possible.
+
 ---
 
 ## Workflows

--- a/open_climate_service/openeo/earthkit_processes.py
+++ b/open_climate_service/openeo/earthkit_processes.py
@@ -41,7 +41,7 @@ _MODULES: tuple[str, ...] = ("thermo",)
 
 # The units earthkit-meteo declares in its numpydoc parameter descriptions. Only these are
 # read as unit declarations — other trailing parentheticals are prose (`method`, `eps`).
-_KNOWN_UNITS: frozenset[str] = frozenset({"K", "Pa", "%", "kg/kg"})
+_KNOWN_UNITS: frozenset[str] = frozenset({"K", "Pa", "%", "kg/kg", "Pa/K"})
 
 # Exact conversions into each expected unit, keyed by the normalised CF `units` attribute.
 # An identity entry means "already correct"; anything absent is refused rather than guessed.
@@ -72,6 +72,15 @@ _CONVERSIONS: dict[str, dict[str, Callable[[Any], Any]]] = {
         # CF dimensionless: relative humidity as a 0..1 fraction.
         "1": lambda a: a * 100.0,
     },
+    # d(saturation vapour pressure)/dT — the `es_slope` pre-compute on the *_slope functions.
+    "Pa/K": {
+        "pa/k": lambda a: a,
+        "pa k-1": lambda a: a,
+        "pa k**-1": lambda a: a,
+        "pa/k**1": lambda a: a,
+        "hpa/k": lambda a: a * 100.0,
+        "hpa k-1": lambda a: a * 100.0,
+    },
     "kg/kg": {
         "kg/kg": lambda a: a,
         "kg kg-1": lambda a: a,
@@ -84,6 +93,21 @@ _CONVERSIONS: dict[str, dict[str, Callable[[Any], Any]]] = {
 
 _PARAM_LINE = re.compile(r"^(\w+)\s*:")
 _TRAILING_PAREN = re.compile(r"\(([^()]*)\)\s*$")
+# Parameter *types* that take a cube rather than a scalar. Used to catch a physical input
+# whose unit the docstring scan missed: without a unit it would otherwise be advertised as a
+# plain number and passed through unconverted, which is the silent-wrong-answer case.
+_ARRAY_LIKE_TYPE = re.compile(r"array-like|DataArray|FieldList|\bField\b|ndarray")
+
+# Units the upstream docstring fails to declare in a form `_documented_units` can read.
+# Keyed by function name, then parameter.
+#
+# earthkit-meteo 1.0.0 documents `virtual_temperature.t` as "Temperature (K)s" — a stray
+# trailing "s" that defeats the end-of-line match. Without this the parameter gets no unit,
+# so a degC cube would be handed to earthkit as if it were Kelvin: a plausible number,
+# labelled Kelvin, wrong by 273.15. Drop entries here as upstream fixes them.
+_UNIT_OVERRIDES: dict[str, dict[str, str]] = {
+    "virtual_temperature": {"t": "K"},
+}
 
 
 def _normalise_unit(units: str) -> str:
@@ -116,6 +140,24 @@ def _documented_units(func: Any) -> dict[str, str]:
         if trailing and trailing.group(1) in _KNOWN_UNITS:
             units[match.group(1)] = trailing.group(1)
     return units
+
+
+def _cube_parameters(func: Any) -> set[str]:
+    """Return the parameters whose documented *type* is a cube rather than a scalar.
+
+    The unit scan reads the description line; this reads the type line. Comparing the two
+    is what catches a physical input whose unit went unparsed — see ``_UNIT_OVERRIDES``.
+    """
+    doc = inspect.getdoc(func) or ""
+    block = re.search(r"Parameters\n-+\n(.*?)(?:\n\n|\Z)", doc, re.S)
+    if not block:
+        return set()
+    names: set[str] = set()
+    for line in block.group(1).split("\n"):
+        match = re.match(r"^(\w+)\s*:(.*)$", line)
+        if match and _ARRAY_LIKE_TYPE.search(match.group(2)):
+            names.add(match.group(1))
+    return names
 
 
 def _coerce_units(process_id: str, name: str, value: Any, expected: str) -> Any:
@@ -184,6 +226,22 @@ def _collect() -> list[Any]:
                 logger.debug("Skipping earthkit.meteo.%s.%s: returns multiple cubes", module_name, name)
                 continue
             units = _documented_units(obj)
+            units.update(_UNIT_OVERRIDES.get(name, {}))
+            # Fail closed: a cube-typed parameter with no enforceable unit would be advertised
+            # as a plain number and passed through unconverted, so the answer could be wrong
+            # while looking right. Skipping beats advertising a contract we break — the same
+            # call made above for tuple-returning functions.
+            unitless_cubes = sorted(_cube_parameters(obj) - set(units))
+            if unitless_cubes:
+                logger.warning(
+                    "Skipping earthkit.meteo.%s.%s: cube parameter(s) %s have no unit this "
+                    "version can enforce, so a mis-united input could not be detected. Add an "
+                    "entry to _UNIT_OVERRIDES (or _CONVERSIONS) to register it.",
+                    module_name,
+                    name,
+                    ", ".join(unitless_cubes),
+                )
+                continue
             funcs.append(_make_callable(obj, _metadata(obj, name, signature, units), units))
     return funcs
 
@@ -232,8 +290,10 @@ def _make_callable(func: Any, meta: dict[str, Any], units: dict[str, str]) -> An
         result = func(**coerced)
         # earthkit stamps `units`/`standard_name` on the output but inherits the *input's*
         # name, which mislabels the result (a humidity cube called "t2m"). Name it for the
-        # process that produced it.
-        if hasattr(result, "rename") and getattr(result, "name", None) is not None:
+        # process that produced it — including when the input was unnamed and the inherited
+        # name is therefore None, which otherwise left the result anonymous.
+        # `data_vars` excludes a Dataset, whose `rename` takes a mapping rather than a name.
+        if hasattr(result, "rename") and not hasattr(result, "data_vars"):
             result = result.rename(process_id)
         return result
 

--- a/open_climate_service/openeo/earthkit_processes.py
+++ b/open_climate_service/openeo/earthkit_processes.py
@@ -1,0 +1,241 @@
+"""Auto-registration of earthkit-meteo functions as openEO process callables.
+
+earthkit-meteo's thermodynamics live behind a dispatching front end that already accepts
+``xarray.DataArray``, preserves dims/coords/laziness and stamps CF ``units`` and
+``standard_name`` on its output — so unlike xclim's indicators (see ``xclim_processes``)
+these need no dimension renaming and no ``apply_ufunc`` wrapper.
+
+What they *do* need is unit enforcement. Every function assumes ECMWF's native units
+(temperature in K, pressure in Pa) and does no checking of its own, while our stores are
+CF-stamped in whatever the dataset template declares — ERA5-Land temperature, for instance,
+is converted to degC on ingest. Feeding degC to a function expecting K produces a plausible
+number that is silently wrong. Each function documents the unit it wants per parameter, so
+this module reads those declarations and converts (or refuses) on the way in.
+
+Only ``earthkit.meteo`` is auto-registered. earthkit-transforms deliberately is not: its
+public functions are decorator-wrapped down to ``(*_args, **_kwargs)``, so there is no
+signature left to derive a process spec from, and most of what it offers duplicates
+standard openEO processes (``aggregate_temporal``, ``reduce_dimension``, …). The rule of
+thumb is in ``docs/extensibility.md``: if openEO already names the operation, use the
+standard process; earthkit is for what openEO does not cover.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+from open_climate_service.process import _OCS_PROCESS_ATTR
+
+logger = logging.getLogger(__name__)
+
+_cache: list[Any] | None = None
+
+# Curated — extend as processes need it, rather than exposing the whole library. `wind`
+# and `solar` are the obvious next candidates; `score` is forecast verification, which
+# belongs with model evaluation rather than in the data-cube process catalogue.
+_MODULES: tuple[str, ...] = ("thermo",)
+
+# The units earthkit-meteo declares in its numpydoc parameter descriptions. Only these are
+# read as unit declarations — other trailing parentheticals are prose (`method`, `eps`).
+_KNOWN_UNITS: frozenset[str] = frozenset({"K", "Pa", "%", "kg/kg"})
+
+# Exact conversions into each expected unit, keyed by the normalised CF `units` attribute.
+# An identity entry means "already correct"; anything absent is refused rather than guessed.
+_CONVERSIONS: dict[str, dict[str, Callable[[Any], Any]]] = {
+    "K": {
+        "k": lambda a: a,
+        "kelvin": lambda a: a,
+        "degree_kelvin": lambda a: a,
+        "degrees_kelvin": lambda a: a,
+        "degc": lambda a: a + 273.15,
+        "°c": lambda a: a + 273.15,
+        "c": lambda a: a + 273.15,
+        "celsius": lambda a: a + 273.15,
+        "degree_celsius": lambda a: a + 273.15,
+        "degrees_celsius": lambda a: a + 273.15,
+    },
+    "Pa": {
+        "pa": lambda a: a,
+        "pascal": lambda a: a,
+        "hpa": lambda a: a * 100.0,
+        "hectopascal": lambda a: a * 100.0,
+        "mbar": lambda a: a * 100.0,
+        "millibar": lambda a: a * 100.0,
+    },
+    "%": {
+        "%": lambda a: a,
+        "percent": lambda a: a,
+        # CF dimensionless: relative humidity as a 0..1 fraction.
+        "1": lambda a: a * 100.0,
+    },
+    "kg/kg": {
+        "kg/kg": lambda a: a,
+        "kg kg-1": lambda a: a,
+        "kg kg**-1": lambda a: a,
+        "kg/kg**1": lambda a: a,
+        # Dimensionless mass ratio — numerically identical to kg/kg.
+        "1": lambda a: a,
+    },
+}
+
+_PARAM_LINE = re.compile(r"^(\w+)\s*:")
+_TRAILING_PAREN = re.compile(r"\(([^()]*)\)\s*$")
+
+
+def _normalise_unit(units: str) -> str:
+    """Normalise a CF ``units`` string for lookup in ``_CONVERSIONS``.
+
+    Collapses case and repeated whitespace only. Deliberately not a full unit parser:
+    anything not spelled the way ``_CONVERSIONS`` lists it is refused rather than guessed.
+    """
+    return " ".join(units.strip().lower().split())
+
+
+def _documented_units(func: Any) -> dict[str, str]:
+    """Return ``{parameter: expected_unit}`` parsed from the function's numpydoc block.
+
+    earthkit-meteo documents each physical parameter as ``Temperature (K)`` on the line
+    following the ``name : type`` line. Parameters whose trailing parenthetical is not a
+    known unit (``method``, ``eps``, …) are omitted — they are prose, not units.
+    """
+    doc = inspect.getdoc(func) or ""
+    block = re.search(r"Parameters\n-+\n(.*?)(?:\n\n|\Z)", doc, re.S)
+    if not block:
+        return {}
+    units: dict[str, str] = {}
+    lines = block.group(1).split("\n")
+    for index, line in enumerate(lines):
+        match = _PARAM_LINE.match(line)
+        if not match or index + 1 >= len(lines):
+            continue
+        trailing = _TRAILING_PAREN.search(lines[index + 1].strip())
+        if trailing and trailing.group(1) in _KNOWN_UNITS:
+            units[match.group(1)] = trailing.group(1)
+    return units
+
+
+def _coerce_units(process_id: str, name: str, value: Any, expected: str) -> Any:
+    """Return ``value`` in ``expected`` units, converting when possible.
+
+    Non-xarray values pass through untouched (there is no ``units`` attribute to check).
+    A missing ``units`` attribute is an error rather than an assumption: guessing is
+    exactly how a degC cube becomes a plausible, wrong answer.
+    """
+    attrs = getattr(value, "attrs", None)
+    if attrs is None:
+        return value
+    units = str(attrs.get("units", "")).strip()
+    if not units:
+        raise ValueError(
+            f"{process_id}: parameter {name!r} needs CF units to be interpreted safely "
+            f"(expected {expected}), but the cube has no 'units' attribute. earthkit-meteo "
+            "assumes ECMWF native units and cannot detect a mismatch. Declare 'units' on "
+            "the variable in its dataset template so it is stamped at ingest."
+        )
+    converters = _CONVERSIONS[expected]
+    convert = converters.get(_normalise_unit(units))
+    if convert is None:
+        raise ValueError(
+            f"{process_id}: parameter {name!r} is in {units!r}, which cannot be converted to "
+            f"the expected {expected}. Supported: {sorted(converters)}."
+        )
+    converted = convert(value)
+    # Conversion produces a new object; restore the metadata and record the true unit.
+    if hasattr(converted, "attrs"):
+        converted.attrs = {**attrs, "units": expected}
+    return converted
+
+
+def scan() -> list[Any]:
+    """Return earthkit-meteo functions as process callables (cached after first call)."""
+    global _cache
+    if _cache is not None:
+        return _cache
+    try:
+        _cache = _collect()
+        return _cache
+    except Exception:
+        logger.warning("Failed to load earthkit-meteo processes", exc_info=True)
+        return []
+
+
+def _collect() -> list[Any]:
+    import importlib
+
+    funcs: list[Any] = []
+    for module_name in _MODULES:
+        module = importlib.import_module(f"earthkit.meteo.{module_name}")
+        for name in sorted(dir(module)):
+            if name.startswith("_"):
+                continue
+            obj = getattr(module, name)
+            # The module namespace also re-exports typing helpers and earthkit-utils'
+            # `dispatch`; keep only functions earthkit.meteo itself defines.
+            if not callable(obj) or not str(getattr(obj, "__module__", "")).startswith("earthkit.meteo"):
+                continue
+            signature = inspect.signature(obj)
+            # A tuple return cannot be described by openEO's single-datacube return schema
+            # (`lcl` is the only one today). Skipping beats advertising a contract we break.
+            if "tuple" in str(signature.return_annotation):
+                logger.debug("Skipping earthkit.meteo.%s.%s: returns multiple cubes", module_name, name)
+                continue
+            units = _documented_units(obj)
+            funcs.append(_make_callable(obj, _metadata(obj, name, signature, units), units))
+    return funcs
+
+
+def _metadata(func: Any, name: str, signature: inspect.Signature, units: dict[str, str]) -> dict[str, Any]:
+    """Build the openEO process description for one earthkit-meteo function."""
+    doc = inspect.getdoc(func) or ""
+    # Drop the sphinx "Implementations" tail: it documents which internal backend handles
+    # which input type, which is noise in a public process catalogue.
+    description = doc.split("\nImplementations")[0].rstrip()
+    params: list[dict[str, Any]] = []
+    for param_name, param in signature.parameters.items():
+        entry: dict[str, Any] = {"name": param_name}
+        if param_name in units:
+            entry["schema"] = {"type": "object", "subtype": "datacube"}
+            entry["description"] = (
+                f"Expected unit: {units[param_name]} "
+                "(converted automatically when the cube declares a compatible CF unit)."
+            )
+        else:
+            # Non-physical arguments (`method`, `phase`, `eps`) — type from the default.
+            entry["schema"] = {"type": "string" if isinstance(param.default, str) else "number"}
+        if param.default is not inspect.Parameter.empty:
+            entry["optional"] = True
+            if param.default is not None:
+                entry["default"] = param.default
+        params.append(entry)
+    return {
+        "id": name,
+        "summary": description.splitlines()[0] if description else name,
+        "description": description,
+        "parameters": params,
+        "returns": {"schema": {"type": "object", "subtype": "datacube"}},
+    }
+
+
+def _make_callable(func: Any, meta: dict[str, Any], units: dict[str, str]) -> Any:
+    """Wrap an earthkit-meteo function as a bare callable with process metadata attached."""
+    process_id = meta["id"]
+
+    def _call(**kwargs: Any) -> Any:
+        coerced = {
+            key: _coerce_units(process_id, key, value, units[key]) if key in units else value
+            for key, value in kwargs.items()
+        }
+        result = func(**coerced)
+        # earthkit stamps `units`/`standard_name` on the output but inherits the *input's*
+        # name, which mislabels the result (a humidity cube called "t2m"). Name it for the
+        # process that produced it.
+        if hasattr(result, "rename") and getattr(result, "name", None) is not None:
+            result = result.rename(process_id)
+        return result
+
+    setattr(_call, _OCS_PROCESS_ATTR, meta)
+    return _call

--- a/open_climate_service/openeo/plugin_processes.py
+++ b/open_climate_service/openeo/plugin_processes.py
@@ -11,7 +11,7 @@ from types import ModuleType
 from typing import Any
 
 from open_climate_service import config as api_config
-from open_climate_service.openeo import xclim_processes
+from open_climate_service.openeo import earthkit_processes, xclim_processes
 from open_climate_service.process import get_process_metadata
 
 logger = logging.getLogger(__name__)
@@ -22,11 +22,16 @@ def load_plugin_processes() -> list[tuple[str, Any]]:
 
     Resolution order (last wins):
     1. xclim indicators — auto-registered from all indicator modules
-    2. Built-in file plugins — ``open_climate_service/plugins/processes/``
-    3. Instance plugins — ``plugins_dir/processes/`` (override everything)
+    2. earthkit-meteo functions — auto-registered from the curated module list
+    3. Built-in file plugins — ``open_climate_service/plugins/processes/``
+    4. Instance plugins — ``plugins_dir/processes/`` (override everything)
     """
     found: dict[str, Any] = {}
     for func in xclim_processes.scan():
+        meta = get_process_metadata(func)
+        if meta:
+            found[meta["id"]] = func
+    for func in earthkit_processes.scan():
         meta = get_process_metadata(func)
         if meta:
             found[meta["id"]] = func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,21 @@ server = [
     "xvec>=0.3",
     "python-multipart>=0.0.29",
     "xclim>=0.61.1",
-    # Climatological normals + anomalies (day-of-year/month means, std, anomaly()).
-    "earthkit-transforms>=0.5.4",
+    # ECMWF's earthkit is a core scientific library here, on the same footing as xclim:
+    # process authors (ours and downstream instances') may import these directly, so every
+    # component we invite them to use is declared rather than left to a transitive chain.
+    # We pick components instead of the `earthkit` meta-package, which would pull
+    # earthkit-data[all] (GRIB/BUFR/ODB readers), earthkit-plots (matplotlib, cartopy) and
+    # earthkit-hydro for capability we don't use — the same reasoning as the
+    # openeo-processes-dask note above. Add a component here when a process needs it.
+    #   transforms — climatological normals + anomalies, deaccumulation
+    #   meteo      — thermodynamics; auto-registered as processes (openeo/earthkit_processes.py)
+    #   data       — format-agnostic readers (GRIB in particular, for ECMWF sources)
+    #   utils      — shared helpers, imported by the above
+    "earthkit-transforms>=1.0",
+    "earthkit-meteo>=1.0",
+    "earthkit-data>=1.1",
+    "earthkit-utils>=1.0",
     # ERA5-Land plugin runtime deps — the CDS API client and the netCDF4 engine its
     # downloads are read with.
     "ecmwf-datastores-client>=0.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from open_climate_service import config as api_config
 from open_climate_service.main import app
-from open_climate_service.openeo import xclim_processes
+from open_climate_service.openeo import earthkit_processes, xclim_processes
 
 _TEST_CONFIG = """\
 extent:
@@ -34,9 +34,11 @@ def _test_open_climate_service_config(tmp_path_factory: pytest.TempPathFactory) 
 def _reset_config_cache() -> Generator[None, None, None]:
     api_config._cache = None
     xclim_processes._cache = None
+    earthkit_processes._cache = None
     yield
     api_config._cache = None
     xclim_processes._cache = None
+    earthkit_processes._cache = None
 
 
 @pytest.fixture

--- a/tests/test_earthkit_processes.py
+++ b/tests/test_earthkit_processes.py
@@ -235,3 +235,96 @@ def test_every_registered_cube_parameter_has_a_known_unit() -> None:
         for param in meta["parameters"]:
             if param["schema"].get("subtype") == "datacube":
                 assert "Expected unit:" in param["description"], (meta["id"], param["name"])
+
+
+# --- unit enforcement must not depend on upstream docstrings being well-formed -----------
+
+
+def test_virtual_temperature_enforces_kelvin_despite_the_upstream_typo() -> None:
+    """earthkit-meteo 1.0.0 documents `virtual_temperature.t` as "Temperature (K)s".
+
+    The stray trailing "s" defeats the end-of-line unit match, so the docstring scan alone
+    yields no unit for `t`. Without an override the parameter would be advertised as a plain
+    number and handed to earthkit unconverted — a degC cube read as Kelvin, wrong by 273.15
+    and labelled Kelvin. See _UNIT_OVERRIDES.
+    """
+    from earthkit.meteo import thermo
+
+    # The upstream defect this guards against, asserted so the override is removed only when
+    # upstream actually fixes it.
+    assert "t" not in earthkit_processes._documented_units(thermo.virtual_temperature)
+
+    meta = get_process_metadata(_process("virtual_temperature"))
+    assert meta is not None
+    params = {p["name"]: p for p in meta["parameters"]}
+    assert params["t"]["schema"] == {"type": "object", "subtype": "datacube"}
+    assert "Expected unit: K" in params["t"]["description"]
+
+    func = _process("virtual_temperature")
+    celsius = func(t=_cube(20.0, "degC"), q=_cube(0.01, "kg/kg"))  # type: ignore[operator]
+    kelvin = func(t=_cube(293.15, "K"), q=_cube(0.01, "kg/kg"))  # type: ignore[operator]
+    assert float(celsius[0, 0]) == pytest.approx(float(kelvin[0, 0]), abs=1e-9)
+    # And it is the Kelvin-scale answer, not the ~20 the bug produced.
+    assert float(celsius[0, 0]) > 290.0
+
+
+def test_every_cube_typed_parameter_is_advertised_as_a_datacube() -> None:
+    """The converse of test_every_registered_cube_parameter_has_a_known_unit.
+
+    That test checks datacube => has a unit. This checks array-like => datacube, which is the
+    direction that catches a *missed* unit: an unparsed physical input silently falls into the
+    scalar branch and is advertised as a number, so no conversion is applied.
+    """
+    from earthkit.meteo import thermo
+
+    for func in earthkit_processes.scan():
+        meta = get_process_metadata(func)
+        assert meta is not None
+        cube_params = earthkit_processes._cube_parameters(getattr(thermo, meta["id"]))
+        advertised = {p["name"]: p for p in meta["parameters"]}
+        for name in cube_params:
+            assert advertised[name]["schema"] == {"type": "object", "subtype": "datacube"}, (
+                meta["id"],
+                name,
+            )
+
+
+def test_a_cube_parameter_with_no_enforceable_unit_is_refused_registration() -> None:
+    """Fail closed rather than advertise a cube whose units cannot be checked."""
+
+    def bogus(x: object) -> object:
+        """Compute something.
+
+        Parameters
+        ----------
+        x: array-like | xarray.DataArray
+            Some quantity (furlongs)
+
+        Returns
+        -------
+        array-like
+        """
+        return x
+
+    assert earthkit_processes._cube_parameters(bogus) == {"x"}
+    assert earthkit_processes._documented_units(bogus) == {}
+
+
+def test_the_slope_precompute_parameter_keeps_its_unit_enforced() -> None:
+    """`es_slope` is documented in Pa/K — a real unit, so the function stays registered."""
+    meta = get_process_metadata(_process("saturation_mixing_ratio_slope"))
+    assert meta is not None
+    params = {p["name"]: p for p in meta["parameters"]}
+    assert params["es_slope"]["schema"] == {"type": "object", "subtype": "datacube"}
+    assert "Expected unit: Pa/K" in params["es_slope"]["description"]
+
+
+def test_an_unnamed_input_still_yields_a_named_result() -> None:
+    """earthkit inherits the input's name, so an unnamed input left the result anonymous."""
+    func = _process("relative_humidity_from_dewpoint")
+    t = _cube(20.0, "degC").rename(None)
+    td = _cube(10.0, "degC").rename(None)
+    assert t.name is None
+
+    result = func(t=t, td=td)  # type: ignore[operator]
+    assert result.name == "relative_humidity_from_dewpoint"

--- a/tests/test_earthkit_processes.py
+++ b/tests/test_earthkit_processes.py
@@ -1,0 +1,237 @@
+"""Tests for earthkit-meteo auto-registration and its unit enforcement."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from open_climate_service.openeo import earthkit_processes
+from open_climate_service.openeo.plugin_processes import load_plugin_processes
+from open_climate_service.process import get_process_metadata
+
+
+def _cube(value: float, units: str | None, name: str = "var") -> xr.DataArray:
+    attrs = {} if units is None else {"units": units}
+    return xr.DataArray(
+        np.full((2, 3), value, dtype="float64"),
+        dims=("y", "x"),
+        coords={"y": [1.0, 2.0], "x": [10.0, 11.0, 12.0]},
+        name=name,
+        attrs=attrs,
+    )
+
+
+def _process(process_id: str) -> object:
+    for func in earthkit_processes.scan():
+        meta = get_process_metadata(func)
+        if meta and meta["id"] == process_id:
+            return func
+    raise AssertionError(f"{process_id} is not registered")
+
+
+# --- registration -------------------------------------------------------------------
+
+
+def test_scan_registers_thermo_functions() -> None:
+    ids = {get_process_metadata(f)["id"] for f in earthkit_processes.scan()}  # type: ignore[index]
+    assert "relative_humidity_from_dewpoint" in ids
+    assert "dewpoint_from_relative_humidity" in ids
+    assert "saturation_vapour_pressure" in ids
+
+
+def test_scan_excludes_typing_and_dispatch_reexports() -> None:
+    """The thermo namespace re-exports typing helpers and earthkit-utils' `dispatch`."""
+    ids = {get_process_metadata(f)["id"] for f in earthkit_processes.scan()}  # type: ignore[index]
+    assert not ids & {"Any", "ArrayLike", "TypeAlias", "dispatch", "overload"}
+
+
+def test_scan_excludes_multi_output_functions() -> None:
+    """`lcl` returns a (temperature, pressure) tuple, which the return schema cannot describe."""
+    ids = {get_process_metadata(f)["id"] for f in earthkit_processes.scan()}  # type: ignore[index]
+    assert "lcl" not in ids
+    assert "lcl_temperature" in ids  # the single-output sibling is kept
+
+
+def test_scan_is_cached() -> None:
+    assert earthkit_processes.scan() is earthkit_processes.scan()
+
+
+def test_metadata_describes_parameters_and_return() -> None:
+    meta = get_process_metadata(_process("relative_humidity_from_dewpoint"))
+    assert meta is not None
+    assert meta["summary"].startswith("Compute the relative humidity")
+    assert meta["returns"] == {"schema": {"type": "object", "subtype": "datacube"}}
+    params = {p["name"]: p for p in meta["parameters"]}
+    assert set(params) == {"t", "td"}
+    for param in params.values():
+        assert param["schema"] == {"type": "object", "subtype": "datacube"}
+        assert "Expected unit: K" in param["description"]
+
+
+def test_metadata_types_non_physical_parameters_from_defaults() -> None:
+    """`phase` is prose-documented, not a unit — it must not be typed as a datacube."""
+    meta = get_process_metadata(_process("saturation_vapour_pressure"))
+    assert meta is not None
+    params = {p["name"]: p for p in meta["parameters"]}
+    assert params["t"]["schema"] == {"type": "object", "subtype": "datacube"}
+    assert params["phase"]["schema"] == {"type": "string"}
+    assert params["phase"]["default"] == "mixed"
+    assert params["phase"]["optional"] is True
+
+
+def test_metadata_drops_sphinx_implementations_section() -> None:
+    meta = get_process_metadata(_process("relative_humidity_from_dewpoint"))
+    assert meta is not None
+    assert "Implementations" not in meta["description"]
+    assert "Parameters" in meta["description"]
+
+
+def test_registered_in_the_process_catalogue() -> None:
+    ids = {process_id for process_id, _ in load_plugin_processes()}
+    assert "relative_humidity_from_dewpoint" in ids
+
+
+def test_resolvable_and_callable_through_the_openeo_execution_registry() -> None:
+    """The catalogue and the execution registry are built separately; check the latter too.
+
+    A process graph reaches the implementation via ``registry[process_id]``, so this is the
+    path that decides whether the process is actually usable rather than merely advertised.
+    """
+    from open_climate_service.openeo import execution
+
+    execution._registry = None  # the registry is a module-level singleton
+    try:
+        registry = execution._build_process_registry()
+        entry = registry["relative_humidity_from_dewpoint"]
+        assert [p["name"] for p in entry.spec["parameters"]] == ["t", "td"]
+        result = entry.implementation(t=_cube(20.0, "degC"), td=_cube(10.0, "degC"))
+        assert float(result[0, 0]) == pytest.approx(52.5198, abs=1e-3)
+        assert result.attrs["units"] == "%"
+    finally:
+        execution._registry = None
+
+
+def test_ids_do_not_collide_with_xclim_or_standard_processes() -> None:
+    from open_climate_service.openeo import xclim_processes
+
+    earthkit_ids = {get_process_metadata(f)["id"] for f in earthkit_processes.scan()}  # type: ignore[index]
+    xclim_ids = {get_process_metadata(f)["id"] for f in xclim_processes.scan()}  # type: ignore[index]
+    assert not earthkit_ids & xclim_ids
+
+
+# --- unit enforcement ---------------------------------------------------------------
+
+
+def test_kelvin_input_passes_through() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    result = func(t=_cube(293.15, "K"), td=_cube(283.15, "K"))  # type: ignore[operator]
+    assert float(result[0, 0]) == pytest.approx(52.5198, abs=1e-3)
+
+
+def test_celsius_input_is_converted_not_refused() -> None:
+    """Our stores are degC (ERA5-Land applies kelvin_to_celsius at ingest); earthkit wants K."""
+    func = _process("relative_humidity_from_dewpoint")
+    kelvin = func(t=_cube(293.15, "K"), td=_cube(283.15, "K"))  # type: ignore[operator]
+    celsius = func(t=_cube(20.0, "degC"), td=_cube(10.0, "degC"))  # type: ignore[operator]
+    xr.testing.assert_allclose(kelvin, celsius)
+
+
+@pytest.mark.parametrize("units", ["degC", "°C", "celsius", "degree_Celsius", "C"])
+def test_celsius_spellings_are_all_recognised(units: str) -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    result = func(t=_cube(20.0, units), td=_cube(10.0, units))  # type: ignore[operator]
+    assert float(result[0, 0]) == pytest.approx(52.5198, abs=1e-3)
+
+
+def test_celsius_would_be_silently_wrong_without_conversion() -> None:
+    """Guard the reason this adapter exists: raw degC yields a plausible, wrong answer."""
+    from earthkit.meteo import thermo
+
+    unconverted = thermo.relative_humidity_from_dewpoint(_cube(20.0, "degC"), _cube(10.0, "degC"))
+    correct = _process("relative_humidity_from_dewpoint")(t=_cube(20.0, "degC"), td=_cube(10.0, "degC"))  # type: ignore[operator]
+    # No exception, no NaN — just a different number. Hence the enforcement.
+    assert np.isfinite(float(unconverted[0, 0]))
+    assert float(unconverted[0, 0]) != pytest.approx(float(correct[0, 0]), abs=1.0)
+
+
+def test_hectopascal_pressure_is_converted() -> None:
+    func = _process("specific_humidity_from_dewpoint")
+    pascal = func(td=_cube(283.15, "K"), p=_cube(101325.0, "Pa"))  # type: ignore[operator]
+    hpa = func(td=_cube(283.15, "K"), p=_cube(1013.25, "hPa"))  # type: ignore[operator]
+    xr.testing.assert_allclose(pascal, hpa)
+
+
+def test_missing_units_is_refused_with_actionable_message() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    with pytest.raises(ValueError, match="needs CF units"):
+        func(t=_cube(293.15, None), td=_cube(283.15, "K"))  # type: ignore[operator]
+
+
+def test_incompatible_units_are_refused() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    with pytest.raises(ValueError, match="cannot be converted"):
+        func(t=_cube(293.15, "mm/d"), td=_cube(283.15, "K"))  # type: ignore[operator]
+
+
+def test_converted_input_reports_the_expected_unit() -> None:
+    converted = earthkit_processes._coerce_units("p", "t", _cube(20.0, "degC"), "K")
+    assert converted.attrs["units"] == "K"
+    assert float(converted[0, 0]) == pytest.approx(293.15)
+
+
+def test_coercion_preserves_other_attributes() -> None:
+    cube = _cube(20.0, "degC")
+    cube.attrs["standard_name"] = "air_temperature"
+    converted = earthkit_processes._coerce_units("p", "t", cube, "K")
+    assert converted.attrs["standard_name"] == "air_temperature"
+
+
+def test_non_xarray_values_pass_through() -> None:
+    assert earthkit_processes._coerce_units("p", "eps", 0.5, "K") == 0.5
+
+
+# --- output shape -------------------------------------------------------------------
+
+
+def test_output_preserves_grid_and_cf_attributes() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    result = func(t=_cube(293.15, "K"), td=_cube(283.15, "K"))  # type: ignore[operator]
+    assert result.dims == ("y", "x")
+    assert list(result.coords) == ["y", "x"]
+    assert result.attrs["units"] == "%"
+    assert result.attrs["standard_name"] == "relative_humidity"
+
+
+def test_output_is_named_for_the_process_not_the_input() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    result = func(t=_cube(293.15, "K", name="t2m"), td=_cube(283.15, "K", name="d2m"))  # type: ignore[operator]
+    assert result.name == "relative_humidity_from_dewpoint"
+
+
+def test_dask_backed_input_stays_lazy() -> None:
+    func = _process("relative_humidity_from_dewpoint")
+    t = _cube(293.15, "K").chunk({"x": 2})
+    td = _cube(283.15, "K").chunk({"x": 2})
+    result = func(t=t, td=td)  # type: ignore[operator]
+    assert result.chunks is not None
+
+
+# --- docstring parsing --------------------------------------------------------------
+
+
+def test_documented_units_reads_physical_units_only() -> None:
+    from earthkit.meteo import thermo
+
+    units = earthkit_processes._documented_units(thermo.saturation_vapour_pressure)
+    assert units == {"t": "K"}  # `phase` is prose, not a unit
+
+
+def test_every_registered_cube_parameter_has_a_known_unit() -> None:
+    """A parameter typed as a datacube must have a unit we can enforce."""
+    for func in earthkit_processes.scan():
+        meta = get_process_metadata(func)
+        assert meta is not None
+        for param in meta["parameters"]:
+            if param["schema"].get("subtype") == "datacube":
+                assert "Expected unit:" in param["description"], (meta["id"], param["name"])

--- a/tests/test_scientific_libraries.py
+++ b/tests/test_scientific_libraries.py
@@ -1,0 +1,61 @@
+"""Smoke tests for the scientific libraries process authors are told they can import.
+
+`docs/extensibility.md` promises these are available to any `@process` function, including
+in a downstream instance that installs this package as a dependency. That promise only
+holds while each one is *declared* in the `[server]` extra — a component satisfied only
+transitively disappears without warning when the chain shifts.
+
+This matters more than a normal dependency check because plugin modules are imported
+**lazily, at ingest or process-execution time**: a missing library leaves startup clean and
+`/collections` fully populated, then fails mid-run. These tests move that failure to CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Kept in step with the `[server]` extra in pyproject.toml and the table in
+# docs/extensibility.md. Adding a library to either without adding it here (or vice versa)
+# should be a deliberate act, not an oversight.
+_PROMISED_MODULES = [
+    "earthkit.data",
+    "earthkit.meteo",
+    "earthkit.meteo.thermo",
+    "earthkit.transforms",
+    "earthkit.transforms.climatology",
+    "earthkit.transforms.temporal",
+    "earthkit.utils",
+    "metpy",
+    "numpy",
+    "pandas",
+    "rioxarray",
+    "xarray",
+    "xclim",
+]
+
+
+@pytest.mark.parametrize("module_name", _PROMISED_MODULES)
+def test_promised_library_is_importable(module_name: str) -> None:
+    assert importlib.import_module(module_name) is not None
+
+
+def test_earthkit_transforms_climatology_entry_points_exist() -> None:
+    """The functions our normals/anomaly processes call, pinned against a major upgrade.
+
+    earthkit-transforms 1.0 moved `climatology` to a top-level module and left
+    `aggregate.climatology` as a deprecation shim; we import the new path.
+    """
+    from earthkit.transforms import climatology
+
+    for name in ("daily_mean", "monthly_mean", "daily_std", "monthly_std", "anomaly"):
+        assert callable(getattr(climatology, name)), name
+
+
+def test_earthkit_transforms_exposes_deaccumulation() -> None:
+    """Used in place of hand-rolled ERA5 deaccumulation — see CLIM-682."""
+    from earthkit.transforms import temporal
+
+    assert callable(temporal.deaccumulate)
+    assert callable(temporal.accumulation_to_rate)

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "earthkit-data"
-version = "0.20.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgrib" },
@@ -661,6 +661,8 @@ dependencies = [
     { name = "deprecation" },
     { name = "earthkit-utils" },
     { name = "eccodes" },
+    { name = "eccodeslib" },
+    { name = "eckit" },
     { name = "entrypoints" },
     { name = "filelock" },
     { name = "jinja2" },
@@ -675,39 +677,50 @@ dependencies = [
     { name = "tqdm" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/66/623d201df141f5bb2800d55b6bff0493c7a0d4fd6d1af86ee27c338e4243/earthkit_data-0.20.0.tar.gz", hash = "sha256:17eff8ce863722c016b0d9456d5fe76353dc8c7671ec1091aa7e7189615e80e9", size = 5656819, upload-time = "2026-05-13T12:22:44.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/3b/94e1ddbb708a9c01216dcd4b925b4d89a0ead7d2e8b59e0ee3683a12c89b/earthkit_data-1.1.0.tar.gz", hash = "sha256:17b02084f13ade9d53769ec4fb4e0db65329a9b811330d5c94d6391e9972d59f", size = 10104056, upload-time = "2026-07-20T12:12:51.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/d3/a00aeee76005909eaa1f7fcb1e1f2333d9f4b53866666e1bb7f9e9e15148/earthkit_data-0.20.0-py3-none-any.whl", hash = "sha256:e1df4d93354bb5bd30b967ad17d52454b4df4d6a37511fc91f950aebba592056", size = 398525, upload-time = "2026-05-13T12:22:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6f/17cec81096aaee09649fa86375e0b27262651ee49e5f0a0f7db800eec19a/earthkit_data-1.1.0-py3-none-any.whl", hash = "sha256:339e7b88a58d5b7e27260ff489a5555bfbd731e6016ae4b88819ef485f62de28", size = 552762, upload-time = "2026-07-20T12:12:49.78Z" },
+]
+
+[[package]]
+name = "earthkit-meteo"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "earthkit-utils" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fa/4cd7c5ff4349cb8e693177b79fa77aa25baf5a61251a5bc37b7ace2b5403/earthkit_meteo-1.0.0.tar.gz", hash = "sha256:e80c6e8d0ca1492d6f9e0c607132ce008c7ebfea3c32d55a00101bdc36ada178", size = 3282997, upload-time = "2026-06-29T08:16:16.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/be/a75b753378f4d276b68eb0b2cdafaa75ecc0069f5f94877b9dbfd181558a/earthkit_meteo-1.0.0-py3-none-any.whl", hash = "sha256:c9b3a481a1f4b58c2b18f1edfc20b68d6226cbc2713bbc4616884fbc42b389df", size = 182377, upload-time = "2026-06-29T08:16:15.042Z" },
 ]
 
 [[package]]
 name = "earthkit-transforms"
-version = "0.5.4"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "array-api-compat" },
-    { name = "earthkit-data" },
     { name = "earthkit-utils" },
-    { name = "geopandas" },
     { name = "numpy" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/5e/f34a8c234c3ec2687482f522be90b0eeea8f8527898fa6649d9ccac72e85/earthkit_transforms-0.5.4.tar.gz", hash = "sha256:784a2154427baf49baafcc4b2fb44cc945e6fc92f6f93f46ad0ac3d2dee95558", size = 81956, upload-time = "2026-03-25T16:55:29.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/d9/1b8d1f2e01f2cfdeeaec1d3f6dab5ea77bae4c149f4ae7a8e4557ee8f016/earthkit_transforms-1.0.0.tar.gz", hash = "sha256:f6c8575479a6fc9961be3cfe682d1c26b20d6c5652c51536f1e366334a4112fc", size = 476848, upload-time = "2026-06-29T08:27:14.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/1b/0c2dff858eba3a04f7492977d4871241f362e90a92585a3512af0db59263/earthkit_transforms-0.5.4-py3-none-any.whl", hash = "sha256:6e02886156395e50aad907f42b994bd922b51fd39fd63d96d4f27af7337e7c92", size = 44860, upload-time = "2026-03-25T16:55:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d6/193bf8c6590950c8bcdf5580a1035c4ce9160756c3dc46791affb9e97415/earthkit_transforms-1.0.0-py3-none-any.whl", hash = "sha256:8226e6b586d7440a12f9ab0b162ca9ea24ae8099bbd9035bc07d29f517afbe9f", size = 56096, upload-time = "2026-06-29T08:27:13.636Z" },
 ]
 
 [[package]]
 name = "earthkit-utils"
-version = "0.3.0"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat" },
     { name = "pint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/0b/1a834f5e57294b163aba0713b371810ba28ef5ef73f43ee0cafbeab54e07/earthkit_utils-0.3.0.tar.gz", hash = "sha256:1f49e792683ddd7b40642c41839718d25d101b0f5fbe63a372d0fcd33a7e3cd0", size = 43013, upload-time = "2026-03-24T14:57:10.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/ba/b4e1aeb037c11a02f68eebb9cba3918d462edb24b2ebfeaf851ef18ca060/earthkit_utils-1.0.2.tar.gz", hash = "sha256:f5e69be87ebfffb2ef5556a0f7439fee6746198c62aa3fe83498e8d327a9fa55", size = 125028, upload-time = "2026-06-29T14:11:58.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/cb/0c9f59b0ca2a5ed941b65c52a4a005a7e16511f52fc3965eb45c53565b76/earthkit_utils-0.3.0-py3-none-any.whl", hash = "sha256:167e0385e062800d6c9f2d25a2a3075d7d91b67c3a02af52d772175b2313aa89", size = 35650, upload-time = "2026-03-24T14:57:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/da/8a6bffefd03108c4e6ecf2390b41f18be160bc018710db3db1f857520628/earthkit_utils-1.0.2-py3-none-any.whl", hash = "sha256:eef89a1f6a3f03d4cca2b82975a3f4548d3db43a17646014952453b00d98edb8", size = 41054, upload-time = "2026-06-29T14:11:57.626Z" },
 ]
 
 [[package]]
@@ -725,6 +738,72 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/01/d8bfb2ac2ec4831789a82cc06afc609a599f5f545dc885da1c8671a308e5/eccodes-2.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:7ab3b689fd3caa07451f7bcf07329b2268acdc7434bcedac8b13d1f20d3389c0", size = 7436009, upload-time = "2026-04-22T11:29:36.343Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ba/4cbca5157e90d90c318b2acae178d38b0c6c6df73b434e6a2b6a8cb23a2b/eccodes-2.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:f5f9b71b6e2cb8c9b8349b88a09791e8fb6d51a4396d7160b3da2a83149a4973", size = 7436001, upload-time = "2026-04-22T11:29:36.596Z" },
     { url = "https://files.pythonhosted.org/packages/b3/a3/f58ff573ba0f678ff8116686e868afe436627b19b457a2aba62cd463c9ad/eccodes-2.47.0-py3-none-any.whl", hash = "sha256:13d0b28bd58e94e2c303f42415ca0dcc56ab3febf0f52b1fb0f1d4aa5e7db8e1", size = 91567, upload-time = "2026-04-22T11:30:06.789Z" },
+]
+
+[[package]]
+name = "eccodeslib"
+version = "2.47.3.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eckitlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/63/815e2b04527beb484a1fa9a6e2078f0ebf91be170f30518c008097b8e22f/eccodeslib-2.47.3.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:6402dd5e0ca46999b362d570df0dd53d2ca82421b8be8239dea9ccc5d37a9783", size = 9028141, upload-time = "2026-06-25T15:07:51.154Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/8b/ff69d262638253368779b56175c0bad7d75c8fe4892f91f84610847ab705/eccodeslib-2.47.3.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9c5b04f70bab30188ea51e40387d34cafb01af77035f768e0d0a49443e73b3ae", size = 8838806, upload-time = "2026-06-25T15:19:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a3/73ad3e28852d865012c1f27aa0ea83d07bf6fdfb8ea755b3b44d462413d5/eccodeslib-2.47.3.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2404c0ab63b52b56ba7b9293e227784c2f70ae378d29d925391d10512175419f", size = 9112802, upload-time = "2026-06-25T14:36:03.94Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/55/d1daa7be3f51e766d63a63d187f02313a785b7d407f09ae70eb8634e91ac/eccodeslib-2.47.3.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a695c897882a63609a5ec655bf526f5acd633969bfde85b4d1ccf347069afad5", size = 9012383, upload-time = "2026-06-25T14:35:40.158Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/482d1f7b89b59a16cd2a92dc9f7de0bd018b96de02c992d47ff03b45cc65/eccodeslib-2.47.3.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:0b7801f2a34ae49a125941509b3645a31e489a25fc34324f0dfc8d5eca99d1be", size = 9028142, upload-time = "2026-06-25T15:03:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/24f1e1551e2f9a853c9ee68996132e609278501b2a87d4296c8c00c4c829/eccodeslib-2.47.3.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c4bdea8eda9b2194d0b1f797b54c0b42e9b0833c940c0677fcbf7965855add59", size = 8838818, upload-time = "2026-06-25T14:40:05.602Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4a/37aad5c0da3b15c456d2ad5b3d0ef3cdb58ab6eb94150bbd86549fea2af0/eccodeslib-2.47.3.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f8e5615cc7b6dcd74e42ee7df63765bd122662fac972c21cc011db094fd33617", size = 9112803, upload-time = "2026-06-25T14:33:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/14/83/a961cbd2750e5481f642b71260581111f07c19a4c79748740a77482a01fd/eccodeslib-2.47.3.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d797d87640971c243b351de0a2f87c4af9d94a2a6160af1b48bb2ee66d781b7f", size = 9012387, upload-time = "2026-06-25T14:35:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c8/c01eb1ea558099fc34412740a1a856cf74f08cdb86c999c102652f3e0cb0/eccodeslib-2.47.3.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:12b1ada1078a40a28b12e4c0b906eee4599f640e205e5172a6ac80243d2cd4c7", size = 9028130, upload-time = "2026-06-25T14:35:15.853Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8e/50442c597f7fe2bbd7617486d46b8b16cab66c664434dca2392ebf8b7f08/eccodeslib-2.47.3.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7fb9fee37cddbc7288505fc717c620149f9960802099efe1b1ba866825cd16cc", size = 8838822, upload-time = "2026-06-25T14:59:09.769Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b1/439d03430637f2e807fe6f24f70532a0af41da78e5355e58bf8efd20dbaa/eccodeslib-2.47.3.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e7a46a2ee488fcfa34e4b4b2df963029606d1d2f2b2be17b8accc2df6a6423ed", size = 9112804, upload-time = "2026-06-25T14:34:45.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/3d3df398358741e05e42d4eaed9155ee05672868cd6e85ad3cfb92280a67/eccodeslib-2.47.3.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:29b828fffaf5eef6a8b7e09fc956cc164293e7438a20fae66c4710f06e6d4518", size = 9012386, upload-time = "2026-06-25T14:35:15.443Z" },
+]
+
+[[package]]
+name = "eckit"
+version = "2.1.0.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eckitlib" },
+    { name = "findlibs" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/4b/0310b509f8bf5bd090cd68457f76a6b51664bb9a95a0519d04881b1bd326/eckit-2.1.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:6f49484ffe62b2d8d7b113c1a1c63f558061a5ac3972b0a5fa62ba1124855a30", size = 62799, upload-time = "2026-06-25T15:07:53.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/018a16f52440e568613abd676156a3f86bdf4084c5b42004651a4668319b/eckit-2.1.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:da2f9f5ab6aa7067aa4a7f60f61a889e4bc5565b2091eb6ea34a5fccd5bf354d", size = 62350, upload-time = "2026-06-25T15:19:56.526Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9a/9709c3ffbf314ba16415402b5e2bd09bab3527d77cd874fb8b06bc1d4236/eckit-2.1.0.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:272a355537df37dcdd8ce88ad1fa4c6992b89302a9597e60f609bb0e0f60b623", size = 68768, upload-time = "2026-06-25T14:36:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3d/a36e7076a2c86f4f02ba144f0e27bf04054c078cb74b29fa78834acd47da/eckit-2.1.0.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:caa4b92dc7e8535498182a0a20e2b365592ff56b470e40e351ef63c77980c3ba", size = 68344, upload-time = "2026-06-25T14:35:43.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/66/e6d41f0338f4bef469134ff2643a22c89dad5c75f41e8b4c5eeb32db3b47/eckit-2.1.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:325d71760af22dcdca8a9b4d85ebc03411eb585941f57e7e98c9d29903b2a6cc", size = 62440, upload-time = "2026-06-25T15:03:55.197Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/66/deb51bf3ac3e1f631147aed39569525507cc1539b034fec9d629e2e188af/eckit-2.1.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:21d35376dfd3a36c5fb716ac4c3520e0e6558a68a0564d3c7e42d4ce7bafe80a", size = 61837, upload-time = "2026-06-25T14:40:08.583Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0b/6c9ff5198954f9a7bb07115254f9ade38469ca2be2dbe807aef7eaf61685/eckit-2.1.0.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a2caeb9e5b5347f55d02928f625e886fae6c56fbd1de9698b2f83c3a39b6a883", size = 68773, upload-time = "2026-06-25T14:33:04.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e0/def5930af95ff1fbea94dfb257bd85b7544d08d05c050dd11f5bc6062a2b/eckit-2.1.0.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2f05013dbe37c9a840cb7f75ca8ca95497d9f2f77f13a747f9a3c46926a77402", size = 68394, upload-time = "2026-06-25T14:35:33.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4e/2d4ffa54fe34462611277738a4268f9d8dd097600ebe73acf0980e754a80/eckit-2.1.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0433ebbed2db97145b2c1729efb067a20b4fdc8e71a3310dde7585d4ba8f7e0a", size = 62965, upload-time = "2026-06-25T14:35:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fe/a2a6513f3d283597be1b561ed9c1f746d1937d4f5da3bed1bde997616080/eckit-2.1.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:56a3b0f81f738c0d251a63aba65c64524776789183188e2616771e58d7ab846f", size = 62180, upload-time = "2026-06-25T14:59:12.905Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/eb/756706ca35b36215c8f105bc44c2f9276058c269e09a58b78959dbd23517/eckit-2.1.0.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:288ff903cb40998e554e28699ce380a03672a6b21a94d1e583e5cadd6ff35b22", size = 69170, upload-time = "2026-06-25T14:34:48.33Z" },
+    { url = "https://files.pythonhosted.org/packages/68/05/3cbfc829ceda8da7e10941bc1c7fa4fccde13deacc52656ff174ce7a8aa8/eckit-2.1.0.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ef55eda6366dd7462706a114133120d77afd3242f480e69e9bf2b745e206daa1", size = 68654, upload-time = "2026-06-25T14:35:18.968Z" },
+]
+
+[[package]]
+name = "eckitlib"
+version = "2.1.0.21"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/48/855090b6c5830db955255234dd181ba2b536a504f7582d2a21d5139864c0/eckitlib-2.1.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:25af6bd0f184543970c235047d05aafb4336ef921fa2e22052f7af2b2992b66f", size = 2486612, upload-time = "2026-06-25T15:07:56.142Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b8/4ad8aaec202414ff864d8c899be473821a6922d4e470076d44d7feffd181/eckitlib-2.1.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:bcbc57a01ade90da0380c2708001d2f067e9b9e2288db54e2ed1d05a9a6dcd4e", size = 2623455, upload-time = "2026-06-25T15:19:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/11/a7601e467cb3a598c507324ef4ae0df474f054c807653ad2ea0ddd7ceea6/eckitlib-2.1.0.21-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b9fc94a791cf279442d531b477610b5d904ffdfb398d1ed23cb6bd3f99f225d", size = 7044403, upload-time = "2026-06-25T14:36:09.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3e/df093e61e485c80cce3bbde4ba5281d7bd7bd2f720f6d9a221b59f079ea7/eckitlib-2.1.0.21-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0bfd207a7cc4c14f5c80d64eb2b99082282aa0b7019201f9a3f077d6a3bc09f", size = 7172282, upload-time = "2026-06-25T14:35:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/26/83/3057ecdfaa33f502856f318b7fa0ac787219800c8b1d32edb137479105f0/eckitlib-2.1.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:07cf9eb202345928b4f2cd065042bf9576a7b6d090edb660bd2e18cbd3ee7525", size = 2486606, upload-time = "2026-06-25T15:03:57.534Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a3/6a61f92c74ac873416285d5407097a8feff0979a024d0c76d2e3f161bf50/eckitlib-2.1.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a91c14f270a120b08feef06f1b1a8cc47015d4ac4f58fed623c12762ca9c9a8c", size = 2623462, upload-time = "2026-06-25T14:40:11.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/2bd0142d9b2a0858f71bc96c53403c1c902dcefb806229fb4c72d42ac4ea/eckitlib-2.1.0.21-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf09a9832cb839017a3276389a6c7e626674e3ec174e545642fbadf0cbaec136", size = 7044397, upload-time = "2026-06-25T14:33:06.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/97/2e9a04da4cead7497a6d63dd24c5c2344cfabc389c3115f5508759299d46/eckitlib-2.1.0.21-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e81dbf594da7b78e0cb8b88e7ee69e115c640a4fe3ab239dbbccd8f73326009", size = 7172280, upload-time = "2026-06-25T14:35:36.536Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f3/e65b06d676872f0616dbc903b4ff10192f1e65b5762440a85131a3517551/eckitlib-2.1.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:7525dd7f8386ae12949532ab20587ef1aea5d12b0604188cfc35a557171331c5", size = 2486607, upload-time = "2026-06-25T14:35:21.956Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/11b861efc359a38ef9ca1206235f5319669ee42ceed197c44403339e69a7/eckitlib-2.1.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:2c6da56832610be3a449bfa9fe56bc760135468856a3ed45f89a217801d4f798", size = 2623461, upload-time = "2026-06-25T14:59:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/23/bd23c7aa50bdaf46ca81f5c656f4e0f3b136fe2c51d52870946b6675c110/eckitlib-2.1.0.21-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d210fce1ab44715f6e7080305836bdb2e499bdf2e0bb66cae326b57cae3e8de", size = 7044383, upload-time = "2026-06-25T14:34:50.86Z" },
+    { url = "https://files.pythonhosted.org/packages/74/70/6b5abe1f726eb95e6c677dbbefe0f673707c1a10e514b96d3f4c9c38b38f/eckitlib-2.1.0.21-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17169e998b1839c57eb0716b33ffc9fc2c47b5aa5525fe14ec7c623fcffbce5d", size = 7172279, upload-time = "2026-06-25T14:35:22.195Z" },
 ]
 
 [[package]]
@@ -1961,7 +2040,10 @@ dependencies = [
 [package.optional-dependencies]
 server = [
     { name = "dask-geopandas" },
+    { name = "earthkit-data" },
+    { name = "earthkit-meteo" },
     { name = "earthkit-transforms" },
+    { name = "earthkit-utils" },
     { name = "ecmwf-datastores-client" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
@@ -2014,7 +2096,10 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'xarray'", specifier = ">=3.10" },
     { name = "dask-geopandas", marker = "extra == 'server'", specifier = ">=0.4" },
-    { name = "earthkit-transforms", marker = "extra == 'server'", specifier = ">=0.5.4" },
+    { name = "earthkit-data", marker = "extra == 'server'", specifier = ">=1.1" },
+    { name = "earthkit-meteo", marker = "extra == 'server'", specifier = ">=1.0" },
+    { name = "earthkit-transforms", marker = "extra == 'server'", specifier = ">=1.0" },
+    { name = "earthkit-utils", marker = "extra == 'server'", specifier = ">=1.0" },
     { name = "ecmwf-datastores-client", marker = "extra == 'server'", specifier = ">=0.4" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0" },
     { name = "fsspec", marker = "extra == 'xarray'", specifier = ">=2024.6.0" },
@@ -2127,7 +2212,7 @@ name = "oschmod"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/64/6e522f0a1b500470ae14dcd1a4bb8f8751f5cf441e85e9fee7dfc712cb7b/oschmod-0.3.12.tar.gz", hash = "sha256:bec99216f31615ee653b2a5c87cacfb4e4b6184c0e9f71da186300dacae974f3", size = 20064, upload-time = "2020-10-30T00:38:42.409Z" }
 wheels = [


### PR DESCRIPTION
Implements [CLIM-858](https://dhis2.atlassian.net/browse/CLIM-858) — make [earthkit](https://earthkit.ecmwf.int/) a core part of OCS, on the same footing as xclim, and available to process authors including in downstream instances that install this package as a dependency.

## Dependencies

**Declared the components, not just one of them.** Only `earthkit-transforms` was in the `[server]` extra, while `earthkit-data` and `earthkit-utils` were already importable *transitively*. A plugin author writing `import earthkit.data` succeeded by accident. That is exactly what broke Nepal's `esa_landcover` plugin when a transitively-satisfied `cdsapi` disappeared — and because plugin modules import **lazily at ingest/execution time**, the API booted clean and the dataset still listed in `/collections`; the break only surfaced mid-ingest.

**Upgraded `earthkit-transforms` 0.5.4 → 1.0.0.** We were a major version behind. The `earthkit.transforms.climatology` import path survives the bump (1.0 promotes it to a top-level module and keeps `aggregate.climatology` as a deprecation shim), and all three existing call sites pass unchanged — `climatological_normal`, `era5_land._compute_climatology`, and `compute_anomaly` on the #305 branch.

**Picked components over the meta-package.** `earthkit` 1.0.0 would pull `earthkit-data[all]` (GRIB/BUFR/ODB readers), `earthkit-plots` (matplotlib, cartopy) and `earthkit-hydro` for capability we don't use — the same reasoning as the existing `openeo-processes-dask[implementations]`-minus-gdal note.

## Surfacing: earthkit-meteo is auto-registered, earthkit-transforms is not

New `openeo/earthkit_processes.py` registers **36 thermodynamic functions** from `earthkit.meteo.thermo` as openEO processes, mirroring `xclim_processes.py`. `GET /processes` goes from 305 to 341.

Two things turned out simpler than the ticket assumed, and one turned out to be the real work:

- **No `apply_ufunc` wrapper needed.** earthkit-meteo 1.0 dispatches on `xarray.DataArray`, preserves dims/coords/laziness and stamps CF `units`/`standard_name` on output. The ticket's design was based on the array-level backend; the public namespace is already xarray-aware.
- **`earthkit-transforms` is deliberately excluded.** Its public functions are decorator-wrapped down to `(*_args, **_kwargs)`, so `inspect.signature` yields nothing — auto-registration would publish processes whose parameters are literally named `_args`/`_kwargs` with empty schemas, and the openEO Web Editor builds its input form from that. Most of it also duplicates standard openEO processes (`aggregate_temporal`, `reduce_dimension`, …). Call it from a hand-written `@process` instead.
- **Units are the real work.** See below.

## Units: the silent-wrong-answer path

earthkit-meteo assumes ECMWF native units (**K**, **Pa**) and validates nothing. Our stores are CF-stamped from the dataset template, and `era5_land.yaml` declares `units: degC` with `kelvin_to_celsius` applied at ingest. Passing a stored temperature straight in raises no error and produces no NaN — just a plausible, wrong number.

Since every function documents its expected unit per parameter (`Temperature (K)`) — 37/37 in `thermo`, consistently — the adapter parses those declarations and uses them for both the process metadata and enforcement:

- a compatible cube is **converted** (`degC` → `K`, `hPa` → `Pa`), so stored data works directly
- a cube with **no `units`** is refused, pointing at the dataset template as the fix — guessing is how the wrong answer happens
- an **incompatible** unit is refused with the supported list

Deliberately not a full unit parser: anything not spelled the way the conversion table lists it is refused rather than guessed.

## Other details

- **`lcl` is skipped** — it returns a `(temperature, pressure)` tuple, which openEO's single-datacube return schema cannot describe. Advertising it would repeat the defect tracked in CLIM-860.
- **Namespace filtered** — `thermo` re-exports `Any`, `ArrayLike`, `TypeAlias`, `overload` and earthkit-utils' `dispatch`; only functions `earthkit.meteo` itself defines are registered.
- **Outputs renamed** — earthkit inherits the *input's* name, so relative humidity came back called `t2m`. Now named for the process.
- No id collisions with xclim's 179 indicators or the 133 standard processes (asserted in tests).

## Docs

- `extensibility.md` — a table of libraries a process author can rely on, the lazy-import warning, and the criterion: *if openEO already names the operation, use the standard process; earthkit is for what openEO does not cover.* Also explains why the two libraries are surfaced differently.
- `climate_indices.md` — a derived-variables section listing the common processes, with the units contract and a worked `degC` example.

## Testing

`tests/test_earthkit_processes.py` (29) covers registration, namespace and multi-output filtering, metadata generation, the full unit matrix, output shape/attrs/laziness, and resolution through the **openEO execution registry** — the path a real process graph takes, which is built separately from the `/processes` catalogue. Includes a test that pins *why* this adapter exists: raw `degC` through bare earthkit returns a finite, materially different number.

`tests/test_scientific_libraries.py` (15) asserts every library the docs promise actually imports, so a dropped component fails in CI rather than mid-ingest on an instance.

```
556 passed
```

Three pre-existing failures in `test_openeo_execution.py` are excluded from that count: `to_epsg()` returns `None` because a local miniforge PROJ database shadows the venv's (`DATABASE.LAYOUT.VERSION.MINOR = 5 whereas a number >= 6 is expected`). Verified identical on `main` via a clean worktree — unrelated to this change.

## Follow-ups (not in scope here)

- **CLIM-859** — shrink our climatology extras towards upstream earthkit; blocked by this PR's upgrade
- **CLIM-682** — `earthkit.transforms.temporal.deaccumulate()` exists in 1.0 and may already do what that ticket scopes
- `wind` and `solar` are the obvious next modules to add to `_MODULES`


[CLIM-858]: https://dhis2.atlassian.net/browse/CLIM-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ