### PR TITLE
feat(config): add read-only mode to refuse state-changing requests

### DIFF
--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -267,9 +267,10 @@ read_only: true
 ```
 
 Every state-changing request is then refused with `403`, and the openEO capabilities
-document at `GET /openeo` stops advertising the endpoints that would refuse, so clients
-discover the reduced surface rather than discovering it by failing. `GET /info` reports
-`read_only: true`.
+document at `GET /?f=json` — the instance root under content negotiation — stops advertising
+the endpoints that would refuse, so clients discover the reduced surface rather than
+discovering it by failing. (`/openeo` is a convenience redirect to the hosted openEO Web
+Editor, not the capabilities document.) `GET /info` reports `read_only: true`.
 
 **What stays available**
 

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -259,48 +259,25 @@ dedicated instance Docker guide is planned.
 
 ### Read-only instances
 
-An instance exposed to people who should be able to *browse* the data but not change it —
-a public demo, a shared reference endpoint — should run read-only:
+For an instance that should be browsable but not changeable — a public demo, a shared
+reference endpoint:
 
 ```yaml
 read_only: true
 ```
 
-Every state-changing request is then refused with `403`, and the openEO capabilities
-document at `GET /?f=json` — the instance root under content negotiation — stops advertising
-the endpoints that would refuse, so clients discover the reduced surface rather than
-discovering it by failing. (`/openeo` is a convenience redirect to the hosted openEO Web
-Editor, not the capabilities document.) `GET /info` reports `read_only: true`.
+Every state-changing request is refused with `403`, the openEO capabilities document stops
+advertising the endpoints that would refuse, and `GET /info` reports `read_only: true`.
 
-**What stays available**
+Still available: the catalogue and metadata (`/collections`, `/stac`, `/datasets`,
+`/processes`, `/process_graphs`, `/extent`), the data (`/zarr/…`, `/icechunk/…`, downloads),
+the landing page and `/map`, and `POST /result` for synchronous openEO process graphs.
 
-| | |
-| --- | --- |
-| Catalogue and metadata | `/collections`, `/stac`, `/datasets`, `/processes`, `/process_graphs`, `/extent` |
-| Data | `/zarr/…`, `/icechunk/…`, dataset downloads |
-| Web UI | the landing page and the `/map` viewer |
-| Computation | `POST /result` — synchronous openEO process graphs |
+Refused: ingestion and sync, the `/manage` console, stored process graph writes, and batch
+jobs.
 
-`POST /result` stays open deliberately: it is a POST only because the process graph travels
-in the request body, and it is how anyone actually *uses* the instance. It cannot publish a
-dataset, because the synchronous path rejects Zarr output outright.
-
-**What is refused**
-
-Ingestion and sync, the `/manage` admin console, stored process graphs (`PUT`/`DELETE
-/process_graphs/{id}`), and batch jobs.
-
-Batch jobs are closed entirely rather than merely made read-only. There is no request
-identity yet — `/me` reports `anonymous` for every caller — so the job namespace is shared:
-`GET /jobs` would list every visitor's jobs and `DELETE /jobs/{id}` would let anyone remove
-someone else's. Per-user job isolation arrives with authentication.
-
-**Ingesting on a read-only instance**
-
-Read-only applies to HTTP. Ingestion becomes an operator task performed on the host, which
-is what allows the switch to be absolute — there is no exemption, token or trusted header
-that could be misconfigured into a bypass. Until a dedicated CLI command exists, run the
-ingestion function directly inside the container or virtualenv:
+Read-only applies to HTTP only, so ingestion becomes an operator task on the host. Until a
+CLI command exists, run it inside the container or virtualenv:
 
 ```python
 from open_climate_service.ingestions.processes import execute_ingestion
@@ -308,15 +285,6 @@ from open_climate_service.ingestions.processes import execute_ingestion
 execute_ingestion(dataset_id="era5land_temperature_monthly", start="2016-01", end="2016-12")
 ```
 
-Note in particular that there is deliberately **no** "requests from localhost may write"
-escape hatch. Behind a reverse proxy on the same host every public request arrives from
-`127.0.0.1`, so such an exemption would open the instance to everyone while appearing to
-work during testing.
-
-**Defence in depth**
-
-Read-only mode protects data integrity, not availability. `POST /result` remains an
-unbounded compute endpoint, so a public instance should also sit behind a reverse proxy
-that **allowlists** the routes above — an allowlist, not a denylist, since a denylist
-silently permits every route added in a later release — and applies request timeouts, body
+It protects data integrity, not availability: `POST /result` is still unbounded compute, so
+put a reverse proxy in front that allowlists the routes above and applies timeouts, body
 size limits and per-IP rate limiting.

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -138,6 +138,7 @@ plugins_dir: ./plugins/
 | `extent.country_code` | No | ISO 3166-1 alpha-3 — required for WorldPop downloads |
 | `data_dir` | Yes | Directory for downloaded files and Zarr stores, resolved relative to the config file |
 | `plugins_dir` | No | Directory containing `datasets/`, `processes/`, and `workflows/` plugin subdirectories |
+| `read_only` | No | Set `true` to refuse all state-changing requests — see [Read-only instances](#read-only-instances). Defaults to `false` |
 
 To find the bounding box for a region, [bboxfinder.com](http://bboxfinder.com) is a useful tool.
 
@@ -255,3 +256,66 @@ make run
 For containerised deployment, the core open-climate-service repository ships a `Dockerfile`
 and a `compose.yml` that can serve as a starting point for packaging an instance. A
 dedicated instance Docker guide is planned.
+
+### Read-only instances
+
+An instance exposed to people who should be able to *browse* the data but not change it —
+a public demo, a shared reference endpoint — should run read-only:
+
+```yaml
+read_only: true
+```
+
+Every state-changing request is then refused with `403`, and the openEO capabilities
+document at `GET /openeo` stops advertising the endpoints that would refuse, so clients
+discover the reduced surface rather than discovering it by failing. `GET /info` reports
+`read_only: true`.
+
+**What stays available**
+
+| | |
+| --- | --- |
+| Catalogue and metadata | `/collections`, `/stac`, `/datasets`, `/processes`, `/process_graphs`, `/extent` |
+| Data | `/zarr/…`, `/icechunk/…`, dataset downloads |
+| Web UI | the landing page and the `/map` viewer |
+| Computation | `POST /result` — synchronous openEO process graphs |
+
+`POST /result` stays open deliberately: it is a POST only because the process graph travels
+in the request body, and it is how anyone actually *uses* the instance. It cannot publish a
+dataset, because the synchronous path rejects Zarr output outright.
+
+**What is refused**
+
+Ingestion and sync, the `/manage` admin console, stored process graphs (`PUT`/`DELETE
+/process_graphs/{id}`), and batch jobs.
+
+Batch jobs are closed entirely rather than merely made read-only. There is no request
+identity yet — `/me` reports `anonymous` for every caller — so the job namespace is shared:
+`GET /jobs` would list every visitor's jobs and `DELETE /jobs/{id}` would let anyone remove
+someone else's. Per-user job isolation arrives with authentication.
+
+**Ingesting on a read-only instance**
+
+Read-only applies to HTTP. Ingestion becomes an operator task performed on the host, which
+is what allows the switch to be absolute — there is no exemption, token or trusted header
+that could be misconfigured into a bypass. Until a dedicated CLI command exists, run the
+ingestion function directly inside the container or virtualenv:
+
+```python
+from open_climate_service.ingestions.processes import execute_ingestion
+
+execute_ingestion(dataset_id="era5land_temperature_monthly", start="2016-01", end="2016-12")
+```
+
+Note in particular that there is deliberately **no** "requests from localhost may write"
+escape hatch. Behind a reverse proxy on the same host every public request arrives from
+`127.0.0.1`, so such an exemption would open the instance to everyone while appearing to
+work during testing.
+
+**Defence in depth**
+
+Read-only mode protects data integrity, not availability. `POST /result` remains an
+unbounded compute endpoint, so a public instance should also sit behind a reverse proxy
+that **allowlists** the routes above — an allowlist, not a denylist, since a denylist
+silently permits every route added in a later release — and applies request timeouts, body
+size limits and per-IP rate limiting.

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -284,7 +284,3 @@ from open_climate_service.ingestions.processes import execute_ingestion
 
 execute_ingestion(dataset_id="era5land_temperature_monthly", start="2016-01", end="2016-12")
 ```
-
-It protects data integrity, not availability: `POST /result` is still unbounded compute, so
-put a reverse proxy in front that allowlists the routes above and applies timeouts, body
-size limits and per-IP rate limiting.

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -166,3 +166,23 @@ def get_utc_offset() -> datetime.timedelta:
     as it correctly handles half- and quarter-hour offsets rather than truncating.
     """
     return datetime.timedelta(hours=get_utc_offset_hours())
+
+
+def is_read_only() -> bool:
+    """Return True when the instance refuses state-changing requests.
+
+    Set ``read_only: true`` in climate-service.yaml to serve a public instance that can
+    be browsed but not modified — no ingestion, no batch jobs, no stored process graphs,
+    no admin UI. Defaults to False so local and single-user deployments are unaffected.
+
+    Read-only applies to HTTP only. Ingestion on a read-only instance is an operator
+    task performed on the host, which is what lets this switch be absolute: there is no
+    exemption, token or trusted header that could be misconfigured into a bypass.
+    """
+    raw = get_config().get("read_only", False)
+    if not isinstance(raw, bool):
+        raise ValueError(
+            f"read_only in CLIMATE_SERVICE_CONFIG must be true or false, got {type(raw).__name__}. "
+            "Quoted values like 'false' are strings, not booleans."
+        )
+    return raw

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -15,6 +15,7 @@ from open_climate_service.ingestions import routes as ingestion_routes
 from open_climate_service.jobs.service import get_job_service
 from open_climate_service.openeo import routes as openeo_routes
 from open_climate_service.openeo.jobs import get_openeo_job_service
+from open_climate_service.read_only import read_only_middleware
 from open_climate_service.stac import routes as stac_routes
 from open_climate_service.system import routes as system_routes
 
@@ -76,6 +77,12 @@ def create_app() -> FastAPI:
         app = create_app()
     """
     _app = FastAPI(lifespan=_lifespan)
+
+    # Registered *before* CORS so it ends up innermost: Starlette applies the most recently
+    # added middleware outermost, so CORS wraps this and a 403 still carries the headers a
+    # browser needs in order to read it, rather than surfacing as an opaque network error.
+    # The config is read per request, so the flag can be flipped without rebuilding the app.
+    _app.middleware("http")(read_only_middleware)
 
     _app.add_middleware(
         CORSMiddleware,

--- a/open_climate_service/openeo/capabilities.py
+++ b/open_climate_service/openeo/capabilities.py
@@ -11,6 +11,22 @@ API_VERSION = "1.2.0"
 STAC_VERSION = "1.1.0"
 
 
+def _readable_endpoints(endpoints: list[OpenEOEndpoint]) -> list[OpenEOEndpoint]:
+    """Drop methods and paths that read-only mode refuses, keeping the rest intact.
+
+    Derived from the read-only policy itself rather than a second hand-maintained list, so
+    the advertised surface cannot drift from the enforced one.
+    """
+    from open_climate_service.read_only import is_blocked
+
+    filtered: list[OpenEOEndpoint] = []
+    for endpoint in endpoints:
+        allowed = [method for method in endpoint.methods if not is_blocked(method, endpoint.path)]
+        if allowed:
+            filtered.append(OpenEOEndpoint(path=endpoint.path, methods=allowed))
+    return filtered
+
+
 def build_capabilities(base_url: str) -> OpenEOCapabilities:
     """Return the openEO capabilities document."""
     backend_version = _pkg_version("open-climate-service")
@@ -33,6 +49,13 @@ def build_capabilities(base_url: str) -> OpenEOCapabilities:
         OpenEOEndpoint(path="/result", methods=["POST"]),
         OpenEOEndpoint(path="/health", methods=["GET"]),
     ]
+
+    # A read-only instance must not advertise what it will refuse: openEO clients build
+    # their capability set from this list, so leaving the write endpoints in would have
+    # them offer batch jobs and UDP storage that then 403. The spec permits a backend to
+    # declare only the endpoints it supports.
+    if api_config.is_read_only():
+        endpoints = _readable_endpoints(endpoints)
 
     links = [
         {"rel": "self", "href": base_url, "type": "application/json"},

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -1,0 +1,90 @@
+"""Read-only mode: refuse state-changing requests when ``read_only: true`` is configured.
+
+Serves a public instance that can be browsed but not modified. The policy is deliberately
+expressed as **paths**, not HTTP methods, because method is the wrong axis here:
+
+- ``POST /result`` is a POST only because the process graph travels in the request body.
+  It is the instance's compute path and stays open. It cannot publish a dataset — the
+  synchronous handler rejects ZARR output outright (``openeo/routes.py``), so the only
+  route that writes to the managed store is the batch-job path, which read-only closes.
+- ``GET /manage`` is an admin console behind a GET. Filtering by method would leave it
+  fully browsable with buttons that fail, which reads as broken rather than locked.
+
+Batch jobs are closed entirely rather than merely made unwritable. There is no request
+identity — ``/me`` reports ``anonymous`` for every caller — so the job namespace is shared:
+``GET /jobs`` would list every visitor's jobs and ``DELETE /jobs/{id}`` would let anyone
+remove anyone else's. Partial protection would leave that intact.
+
+Read-only governs HTTP only. Ingestion on a read-only instance is an operator task run on
+the host, which is what lets this be absolute — there is no exemption, token or trusted
+header to misconfigure into a bypass. In particular there is deliberately **no** loopback
+or trusted-CIDR escape hatch: behind a reverse proxy on the same host, every public request
+arrives from ``127.0.0.1``, so such an exemption would silently open the instance to
+everyone while appearing to work in testing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request
+from starlette.responses import JSONResponse, Response
+
+from open_climate_service import config as api_config
+
+_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Mutating paths that remain open. Matched exactly (after stripping a trailing slash).
+_ALLOWED_WRITE_PATHS = frozenset({"/result"})
+
+# Path trees closed to every method, including GET: the admin console and batch jobs.
+_CLOSED_PREFIXES = ("/manage", "/jobs")
+
+_MESSAGE = (
+    "This instance is read-only: {method} {path} is not available. "
+    "Data can be browsed via /collections, /stac, /zarr and /datasets, and process graphs "
+    "can be executed synchronously via POST /result."
+)
+
+
+def _normalise(path: str) -> str:
+    """Strip a trailing slash so ``/result/`` and ``/result`` match the same rule."""
+    return path.rstrip("/") or "/"
+
+
+def is_blocked(method: str, path: str) -> bool:
+    """Return True when read-only mode should refuse this request.
+
+    Pure function of the request line so the policy can be tested without a client, and
+    so the route-coverage test can assert every mutating route in the app is decided.
+    """
+    method = method.upper()
+    path = _normalise(path)
+
+    # Never block CORS preflight: the browser must be able to learn that the real request
+    # is disallowed, and a rejected preflight surfaces as an opaque CORS failure instead
+    # of the 403 below. The actual request is still refused.
+    if method == "OPTIONS":
+        return False
+
+    if any(path == prefix or path.startswith(f"{prefix}/") for prefix in _CLOSED_PREFIXES):
+        return True
+
+    return method in _WRITE_METHODS and path not in _ALLOWED_WRITE_PATHS
+
+
+async def read_only_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """Refuse state-changing and admin requests when the instance is configured read-only."""
+    if api_config.is_read_only() and is_blocked(request.method, request.url.path):
+        message = _MESSAGE.format(method=request.method, path=request.url.path)
+        return JSONResponse(
+            status_code=403,
+            # `detail` matches FastAPI's HTTPException shape for ordinary HTTP clients;
+            # `code`/`message` are the openEO error fields, so openEO clients surface
+            # something meaningful rather than a bare status.
+            content={"id": "read-only", "code": "PermissionsInsufficient", "message": message, "detail": message},
+        )
+    return await call_next(request)

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -233,4 +233,5 @@ def info() -> AppInfo:
         app_version=_pkg_version("open-climate-service"),
         python_version=sys.version,
         uvicorn_version=_pkg_version("uvicorn"),
+        read_only=api_config.is_read_only(),
     )

--- a/open_climate_service/system/schemas.py
+++ b/open_climate_service/system/schemas.py
@@ -46,3 +46,5 @@ class AppInfo(BaseModel):
     app_version: str
     python_version: str
     uvicorn_version: str
+    # Advertised so a client can tell whether writes are possible before attempting one.
+    read_only: bool = False

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -164,6 +164,8 @@ def render_landing(version: str, base: str) -> str:
         extent=_load_extent(),
         datasets=_load_datasets(),
         templates=_load_templates(),
+        # Read-only instances refuse /manage, so offering the link would advertise a 403.
+        read_only=api_config.is_read_only(),
     )
 
 

--- a/open_climate_service/templates/landing_page.html
+++ b/open_climate_service/templates/landing_page.html
@@ -217,6 +217,7 @@
       <div class="card">
         <h2>Explore</h2>
         <ul class="links-list">
+          {% if not read_only %}
           <li>
             <span class="link-label"
               ><a href="{{ base }}/manage">Manage</a></span
@@ -225,6 +226,7 @@
               >Ingest and sync datasets without using the API directly</span
             >
           </li>
+          {% endif %}
           <li>
             <span class="link-label"
               ><a href="{{ base }}/docs">API documentation</a></span

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -1,0 +1,285 @@
+"""Tests for read-only mode (CLIM-861)."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Generator, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_climate_service import config as api_config
+from open_climate_service.main import app
+from open_climate_service.read_only import is_blocked
+
+# The full mutating surface, written with the app's own path templates so
+# test_every_mutating_route_is_covered_by_the_policy can compare exactly rather than
+# approximately. Anything mutating that is intended to stay open goes in _OPEN_WRITES.
+_MUTATING_ROUTES = [
+    ("POST", "/ingestions"),
+    ("DELETE", "/ingestions/jobs/{job_id}"),
+    ("POST", "/jobs"),
+    ("PATCH", "/jobs/{job_id}"),
+    ("DELETE", "/jobs/{job_id}"),
+    ("POST", "/jobs/{job_id}/results"),
+    ("DELETE", "/jobs/{job_id}/results"),
+    ("POST", "/manage/ingest"),
+    ("POST", "/manage/sync"),
+    ("PUT", "/process_graphs/{process_graph_id}"),
+    ("DELETE", "/process_graphs/{process_graph_id}"),
+    ("POST", "/sync/{dataset_id}"),
+]
+
+# Mutating routes deliberately left open by read-only mode.
+_OPEN_WRITES = {("POST", "/result")}
+
+
+def _concrete(path: str) -> str:
+    """Substitute path templates so a declared route can be requested over HTTP."""
+    return re.sub(r"\{[^}]+\}", "abc", path)
+
+
+# Reads a casual visitor must keep. Status is not asserted — only that the request is not
+# refused by read-only mode, since several depend on ingested data this test suite lacks.
+_PUBLIC_READS = [
+    "/",
+    "/health",
+    "/info",
+    "/collections",
+    "/processes",
+    "/process_graphs",
+    "/file_formats",
+    "/extent",
+    "/datasets",
+    "/stac",
+    "/map",
+    "/openeo",
+    "/.well-known/openeo",
+]
+
+
+@pytest.fixture
+def read_only() -> Iterator[None]:
+    """Force the instance read-only for the duration of a test."""
+    original = api_config.get_config
+    api_config.get_config = lambda: {**original(), "read_only": True}  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        api_config.get_config = original  # type: ignore[assignment]
+
+
+@pytest.fixture
+def ro_client(read_only: None) -> Generator[TestClient, None, None]:
+    with TestClient(app) as client:
+        yield client
+
+
+# --- the policy as a pure function ---------------------------------------------------
+
+
+@pytest.mark.parametrize(("method", "path"), _MUTATING_ROUTES)
+def test_policy_blocks_every_mutating_route(method: str, path: str) -> None:
+    assert is_blocked(method, _concrete(path))
+
+
+def test_policy_allows_synchronous_result_execution() -> None:
+    """POST /result is a POST only because the graph travels in the body."""
+    assert not is_blocked("POST", "/result")
+    assert not is_blocked("POST", "/result/")  # trailing slash is the same rule
+
+
+def test_policy_closes_the_admin_console_including_get() -> None:
+    """/manage is an admin UI behind a GET, so method filtering would miss it."""
+    assert is_blocked("GET", "/manage")
+    assert is_blocked("GET", "/manage/ingest")
+
+
+def test_policy_closes_batch_jobs_for_reads_too() -> None:
+    """There is no request identity, so the job namespace is shared between visitors."""
+    assert is_blocked("GET", "/jobs")
+    assert is_blocked("GET", "/jobs/abc")
+    assert is_blocked("GET", "/jobs/abc/results")
+    assert is_blocked("GET", "/jobs/abc/results/result.zarr/zarr.json")
+
+
+@pytest.mark.parametrize("path", _PUBLIC_READS)
+def test_policy_allows_public_reads(path: str) -> None:
+    assert not is_blocked("GET", path)
+
+
+def test_policy_allows_data_endpoints() -> None:
+    assert not is_blocked("GET", "/zarr/some_dataset/zarr.json")
+    assert not is_blocked("GET", "/icechunk/some_dataset/refs/branch.main/ref.json")
+    assert not is_blocked("GET", "/stac/collections/some_dataset")
+
+
+def test_policy_never_blocks_cors_preflight() -> None:
+    """A rejected preflight surfaces as an opaque CORS error instead of a readable 403."""
+    assert not is_blocked("OPTIONS", "/ingestions")
+    assert not is_blocked("OPTIONS", "/manage")
+    assert not is_blocked("OPTIONS", "/jobs")
+
+
+def _live_mutating_routes() -> set[tuple[str, str]]:
+    write_methods = {"POST", "PUT", "PATCH", "DELETE"}
+    live: set[tuple[str, str]] = set()
+    for route in app.routes:
+        methods: set[str] = getattr(route, "methods", None) or set()
+        for method in methods & write_methods:
+            live.add((method, getattr(route, "path", "")))
+    return live
+
+
+def test_every_mutating_route_is_covered_by_the_policy() -> None:
+    """Guard against a new mutating route slipping in undecided.
+
+    Enumerates the live app and compares **exactly** against the declared lists, so adding
+    a write endpoint forces a deliberate choice: block it (add to _MUTATING_ROUTES, which
+    also gives it an HTTP-level test) or leave it open (add to _OPEN_WRITES).
+    """
+    live = _live_mutating_routes()
+    declared = set(_MUTATING_ROUTES) | _OPEN_WRITES
+
+    undeclared = sorted(f"{m} {p}" for m, p in live - declared)
+    assert not undeclared, (
+        f"mutating routes not accounted for by the read-only policy: {undeclared}. "
+        "Add each to _MUTATING_ROUTES (blocked) or _OPEN_WRITES (deliberately open)."
+    )
+
+    stale = sorted(f"{m} {p}" for m, p in declared - live)
+    assert not stale, f"declared routes that no longer exist in the app: {stale}"
+
+
+def test_declared_expectations_match_the_policy() -> None:
+    """Every route declared blocked is blocked, and every route declared open is open."""
+    assert [(m, p) for m, p in _MUTATING_ROUTES if not is_blocked(m, p)] == []
+    assert [(m, p) for m, p in _OPEN_WRITES if is_blocked(m, p)] == []
+
+
+# --- enforcement over HTTP -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(("method", "path"), _MUTATING_ROUTES)
+def test_mutating_routes_are_refused_with_403(ro_client: TestClient, method: str, path: str) -> None:
+    response = ro_client.request(method, _concrete(path), json={})
+    assert response.status_code == 403, response.text
+    body = response.json()
+    assert body["code"] == "PermissionsInsufficient"
+    assert "read-only" in body["message"]
+    # The message should name what the caller can do instead.
+    assert "/result" in body["message"]
+
+
+def test_admin_console_is_refused(ro_client: TestClient) -> None:
+    assert ro_client.get("/manage").status_code == 403
+
+
+@pytest.mark.parametrize("path", ["/health", "/info", "/collections", "/processes"])
+def test_public_reads_still_work(ro_client: TestClient, path: str) -> None:
+    assert ro_client.get(path).status_code == 200
+
+
+def test_refusal_carries_cors_headers(ro_client: TestClient) -> None:
+    """CORS must wrap the refusal, or a browser sees a network error rather than the 403."""
+    response = ro_client.post("/ingestions", json={}, headers={"Origin": "https://example.org"})
+    assert response.status_code == 403
+    assert response.headers.get("access-control-allow-origin") == "*"
+
+
+def test_preflight_for_a_blocked_route_still_succeeds(ro_client: TestClient) -> None:
+    response = ro_client.options(
+        "/ingestions",
+        headers={
+            "Origin": "https://example.org",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "*"
+
+
+def test_info_advertises_read_only(ro_client: TestClient) -> None:
+    assert ro_client.get("/info").json()["read_only"] is True
+
+
+def test_landing_page_hides_the_manage_link(ro_client: TestClient) -> None:
+    assert "/manage" not in ro_client.get("/").text
+
+
+def _capabilities(client: TestClient) -> dict[str, list[str]]:
+    """Return the openEO capabilities endpoint map.
+
+    The capabilities document is served by ``GET /`` under content negotiation — ``?f=json``
+    selects it over the HTML landing page. Note ``/openeo`` is *not* it: that route redirects
+    to the hosted openEO web editor.
+    """
+    response = client.get("/", params={"f": "json"})
+    assert response.status_code == 200
+    return {e["path"]: e["methods"] for e in response.json()["endpoints"]}
+
+
+def test_capabilities_omit_the_write_endpoints(ro_client: TestClient) -> None:
+    endpoints = _capabilities(ro_client)
+    assert "/jobs" not in endpoints
+    assert "/jobs/{job_id}" not in endpoints
+    assert "/jobs/{job_id}/results" not in endpoints
+    assert endpoints["/process_graphs/{process_graph_id}"] == ["GET"]
+    assert endpoints["/result"] == ["POST"]
+    assert endpoints["/collections"] == ["GET"]
+
+
+# --- default (writable) behaviour is unchanged ---------------------------------------
+
+
+def test_disabled_by_default() -> None:
+    assert api_config.is_read_only() is False
+
+
+def test_writable_instance_does_not_refuse(client: TestClient) -> None:
+    """Without the flag, a mutating route reaches its handler (and fails on its own terms)."""
+    response = client.post("/ingestions", json={})
+    assert response.status_code != 403
+
+
+def test_writable_instance_serves_the_admin_console(client: TestClient) -> None:
+    assert client.get("/manage").status_code == 200
+
+
+def test_writable_capabilities_keep_the_write_endpoints(client: TestClient) -> None:
+    endpoints = _capabilities(client)
+    assert endpoints["/jobs"] == ["GET", "POST"]
+    assert endpoints["/jobs/{job_id}"] == ["GET", "PATCH", "DELETE"]
+    assert endpoints["/process_graphs/{process_graph_id}"] == ["GET", "PUT", "DELETE"]
+
+
+def test_info_reports_writable_by_default(client: TestClient) -> None:
+    assert client.get("/info").json()["read_only"] is False
+
+
+# --- config parsing -------------------------------------------------------------------
+
+
+def test_rejects_a_non_boolean_value() -> None:
+    original = api_config.get_config
+    api_config.get_config = lambda: {**original(), "read_only": "true"}  # type: ignore[assignment]
+    try:
+        with pytest.raises(ValueError, match="must be true or false"):
+            api_config.is_read_only()
+    finally:
+        api_config.get_config = original  # type: ignore[assignment]
+
+
+def test_accepts_an_explicit_false() -> None:
+    original = api_config.get_config
+    api_config.get_config = lambda: {**original(), "read_only": False}  # type: ignore[assignment]
+    try:
+        assert api_config.is_read_only() is False
+    finally:
+        api_config.get_config = original  # type: ignore[assignment]
+
+
+def test_policy_is_inert_when_the_flag_is_off(client: TestClient) -> None:
+    """is_blocked() describes the policy; the middleware only applies it when configured."""
+    assert is_blocked("POST", "/ingestions")  # policy says yes...
+    assert client.post("/ingestions", json={}).status_code != 403  # ...but it is not applied


### PR DESCRIPTION
Implements [CLIM-861](https://dhis2.atlassian.net/browse/CLIM-861). Adds `read_only: true` to `climate-service.yaml` so an instance can be published for browsing without being modifiable — the Nepal public demo ([CLIM-848](https://dhis2.atlassian.net/browse/CLIM-848)) being the driver. Defaults to `false`, so local and single-user deployments are untouched.

## Why paths, not HTTP methods

The obvious implementation — block `POST`/`PUT`/`PATCH`/`DELETE` — is wrong in two specific ways:

- **`POST /result` must stay open.** It is a POST only because the process graph travels in the request body, and it is how anyone actually *uses* the instance. Verified safe: `openeo/routes.py` rejects ZARR output on the synchronous path outright, so it is structurally incapable of publishing a dataset. The only route that writes to the managed store is the batch-job path (`openeo/jobs.py`, `fmt == "ZARR" and options.get("dataset_id")`), which read-only closes.
- **`GET /manage` is an admin console behind a GET.** Method filtering leaves it fully browsable with buttons that then fail — reads as broken rather than locked.

**Batch jobs are closed entirely**, not merely made unwritable. There is no request identity — `/me` reports `anonymous` for every caller — so the job namespace is shared: `GET /jobs` would list every visitor's jobs and `DELETE /jobs/{id}` would let anyone remove someone else's.

## Deliberately absent: a loopback exemption

No "requests from localhost may write" escape hatch. Behind a reverse proxy on the same host, `request.client.host` is `127.0.0.1` for **every** public request, so such an exemption would open the instance to the whole internet while appearing to work in testing (your tunnel writes, the public site is blocked in a browser that never sends writes). Trusting `X-Forwarded-For` just moves it to a spoofable header.

That is affordable because ingestion on a read-only instance is an operator task run on the host — `execute_ingestion()` in `ingestions/processes.py` is a plain function with no HTTP dependency. A supported CLI for it is [CLIM-862](https://dhis2.atlassian.net/browse/CLIM-862).

## Advertising the reduced surface

A client shouldn't have to discover the restriction by failing:

- **openEO capabilities** drop the endpoints read-only refuses. Derived from the policy itself (`_readable_endpoints` calls `is_blocked`), so the advertised and enforced surfaces cannot drift apart. The spec permits a backend to declare only what it supports.
- **`GET /info`** reports `read_only`.
- **The landing page** hides the Manage link that would 403.

## Middleware ordering

Registered *before* CORS so it ends up innermost. Starlette applies the most recently added middleware outermost, so CORS wraps the refusal and the 403 carries `access-control-allow-origin` — otherwise a browser sees an opaque network error rather than a readable rejection. CORS preflights are never blocked for the same reason; the real request is still refused.

## Verification

62 tests: the policy as a pure function, enforcement over HTTP, CORS headers on the refusal, capabilities filtering, the unchanged writable default, and config parsing (a non-boolean `read_only` is rejected, since `"false"` is a truthy string).

Two guards were checked by deliberately breaking them, rather than assumed:

- adding a temporary `POST /temp-probe-route` makes the route-coverage test fail with *"mutating routes not accounted for by the read-only policy: ['POST /temp-probe-route']"*, so a new write endpoint forces a decision
- disabling the capabilities filter makes `test_capabilities_omit_the_write_endpoints` fail

**Also driven against a real server** (`uv run climate-service` with `read_only: true`, not just TestClient):

```
GET  /health /info /collections /processes /process_graphs /extent /stac /datasets /map  -> 200
POST /ingestions, /sync/foo, /jobs, /manage/ingest, /manage/sync                         -> 403
PATCH,DELETE /jobs/x   PUT,DELETE /process_graphs/x   GET /manage   GET /jobs             -> 403
POST /result                                                                             -> not 403
capabilities: /jobs, /jobs/{job_id}, /jobs/{job_id}/results omitted;
              /process_graphs/{process_graph_id} -> [GET];  /result -> [POST]
403 body: {"code": "PermissionsInsufficient", ...} with access-control-allow-origin: *
landing page: 0 occurrences of /manage
```

That run also caught two things the unit tests had missed: my first attempt bound to an occupied port and I was unknowingly testing a *different* server, and two capabilities tests were hitting `/openeo` — which redirects to the hosted openEO editor — so they were making real network calls and matching a stray string in its HTML. The capabilities document is served by `GET /?f=json` under content negotiation; both tests now use it, and the one that mattered was confirmed to fail when filtering is off.

```
574 passed
```

The 3 excluded failures in `test_openeo_execution.py` are the pre-existing local PROJ database conflict (`to_epsg()` returns `None`), unrelated to this change and verified identical on `main` earlier today.

## Docs

`instance_guide.md` gains a `read_only` config row and a **Read-only instances** section: what stays available, what is refused and why batch jobs go entirely, how to ingest on a read-only instance, the loopback warning, and a note that this protects integrity not availability — `POST /result` is still unbounded, which is [CLIM-864](https://dhis2.atlassian.net/browse/CLIM-864).

## Not in this PR

- [CLIM-862](https://dhis2.atlassian.net/browse/CLIM-862) — `climate-service ingest` CLI, the supported operator write path
- [CLIM-863](https://dhis2.atlassian.net/browse/CLIM-863) — workflow allowlist, so only `aggregate_to_*` is callable
- [CLIM-864](https://dhis2.atlassian.net/browse/CLIM-864) — timeouts, payload caps, per-IP rate limiting


[CLIM-861]: https://dhis2.atlassian.net/browse/CLIM-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-848]: https://dhis2.atlassian.net/browse/CLIM-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-862]: https://dhis2.atlassian.net/browse/CLIM-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ