### PR TITLE
fix(openeo): normalise scalar date arguments to tz-naive at the process boundary

### DIFF
--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -6,9 +6,12 @@ openeo-processes-dask for the standard openEO process implementations.
 
 from __future__ import annotations
 
+import datetime
+import functools
 import importlib
 import inspect
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import xarray as xr
@@ -149,7 +152,10 @@ def _build_process_registry() -> Any:
             "See the instance guide's 'Upgrading and troubleshooting' section."
         ) from exc
 
-    registry = ProcessRegistry(wrap_funcs=[wrap_fn])
+    # Order matters: wrap_funcs are applied left to right, so the first entry ends up
+    # innermost. _normalise_temporal_arguments must sit inside wrap_fn to see arguments
+    # after ParameterReference resolution — see its docstring.
+    registry = ProcessRegistry(wrap_funcs=[_normalise_temporal_arguments, wrap_fn])
 
     for name, func in inspect.getmembers(impls_module, inspect.isfunction):
         spec: dict[str, Any] = getattr(specs_module, name, None) or {}
@@ -495,6 +501,65 @@ def _strip_tz(value: str | None) -> str | None:
         if value.endswith(suffix):
             return value[: -len(suffix)]
     return value
+
+
+def _naive_temporal_scalar(value: Any) -> Any:
+    """Convert a scalar openEO temporal argument to a timezone-naive string.
+
+    The pg-parser validates any date-typed process argument into a pydantic ``RootModel``
+    (``Date``, ``DateTime``, ``Year``, ``Time``) wrapping a **timezone-aware** pendulum
+    ``DateTime``. Our published stores carry timezone-naive time coordinates, so a process
+    that slices with such a value fails inside pandas with
+
+        cannot do slice indexing on DatetimeIndex with these indexers
+        [root=DateTime(1991, 1, 1, 0, 0, 0, tzinfo=Timezone('UTC'))] of type Date
+
+    Anything that is not one of those wrappers is returned untouched. In particular
+    ``TemporalInterval`` is left alone — its ``root`` is a *list*, it is normalised
+    separately by ``_temporal_to_list`` at the ``load_collection`` boundary, and rewriting
+    it to a string here would break that.
+
+    A ``Date`` becomes ``YYYY-MM-DD`` rather than a midnight timestamp. It is the more
+    faithful reading of a date-typed argument, and it behaves better as a slice bound:
+    pandas partial-string indexing treats ``"2020-12-31"`` as the whole day, whereas
+    ``"2020-12-31T00:00:00"`` would exclude everything after midnight on a sub-daily
+    series. Other wrappers keep their time component, minus the zone.
+    """
+    root = getattr(value, "root", None)
+    # pendulum's DateTime subclasses datetime.date, so one check covers every scalar
+    # wrapper while structurally excluding TemporalInterval, whose root is a list.
+    if not isinstance(root, datetime.date):
+        return value
+
+    text = _strip_tz(root.isoformat()) or ""
+    if type(value).__name__ == "Date":
+        return text.split("T", 1)[0]
+    return text
+
+
+def _normalise_temporal_arguments(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a process so scalar date arguments arrive timezone-naive.
+
+    Registered as the **innermost** wrap function, so it runs after
+    openeo-processes-dask's wrapper has resolved ``ParameterReference`` arguments. A date
+    supplied through ``{"from_parameter": ...}`` — as workflows do — is still a reference
+    when the outer wrapper is entered and only becomes a ``Date`` further in, so
+    normalising on the outside would miss exactly that case.
+
+    ``functools.wraps`` matters here beyond cosmetics: the outer wrapper decides whether to
+    forward ``axis``/``keepdims``/``context`` by looking at ``inspect.signature`` of what it
+    wraps, and that follows ``__wrapped__``. Without it every process would appear to accept
+    those arguments and they would be passed on to implementations that reject them.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(
+            *(_naive_temporal_scalar(a) for a in args),
+            **{key: _naive_temporal_scalar(value) for key, value in kwargs.items()},
+        )
+
+    return wrapper
 
 
 # ---------------------------------------------------------------------------

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -525,6 +525,20 @@ def _naive_temporal_scalar(value: Any) -> Any:
     ``"2020-12-31T00:00:00"`` would exclude everything after midnight on a sub-daily
     series. Other wrappers keep their time component, minus the zone.
     """
+    # A timezone-qualified ISO *string* reaches the process raw, because the pg-parser
+    # only coerces plain forms like "1991-01-01" into a Date — "1991-01-01T00:00:00Z"
+    # fails that validation and stays a string. It then fails just as hard, with
+    # "ValueError: Both dates must have the same UTC offset", so strip the offset here.
+    # Narrow on purpose: the string must parse as ISO 8601 *and* carry an offset, so
+    # ordinary string arguments ("MS", "1991", "07-01", "mm/d", "degC") are untouched,
+    # as is a naive ISO string, which is returned unchanged rather than reformatted.
+    if isinstance(value, str):
+        try:
+            parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+        return value if parsed.tzinfo is None else parsed.replace(tzinfo=None).isoformat()
+
     root = getattr(value, "root", None)
     # pendulum's DateTime subclasses datetime.date, so one check covers every scalar
     # wrapper while structurally excluding TemporalInterval, whose root is a list.

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -533,8 +533,11 @@ def _naive_temporal_scalar(value: Any) -> Any:
     # ordinary string arguments ("MS", "1991", "07-01", "mm/d", "degC") are untouched,
     # as is a naive ISO string, which is returned unchanged rather than reformatted.
     if isinstance(value, str):
+        # Rewrite a trailing "Z" only. A blanket replace() would touch any "Z" in the
+        # string, which is harder to reason about than the one position ISO 8601 uses it in.
+        candidate = f"{value[:-1]}+00:00" if value.endswith("Z") else value
         try:
-            parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            parsed = datetime.datetime.fromisoformat(candidate)
         except ValueError:
             return value
         return value if parsed.tzinfo is None else parsed.replace(tzinfo=None).isoformat()
@@ -545,8 +548,13 @@ def _naive_temporal_scalar(value: Any) -> Any:
     if not isinstance(root, datetime.date):
         return value
 
+    # Imported here rather than at module scope to match the rest of this module, which
+    # defers every openeo_pg_parser_networkx import so the package is only required when a
+    # process graph actually runs. After the first call this is a sys.modules lookup.
+    from openeo_pg_parser_networkx.pg_schema import Date
+
     text = _strip_tz(root.isoformat()) or ""
-    if type(value).__name__ == "Date":
+    if isinstance(value, Date):
         return text.split("T", 1)[0]
     return text
 

--- a/tests/test_openeo_temporal_arguments.py
+++ b/tests/test_openeo_temporal_arguments.py
@@ -68,6 +68,36 @@ def test_non_temporal_values_pass_through(value: object) -> None:
     assert _naive_temporal_scalar(value) is value
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1991-01-01T00:00:00+00:00", "1991-01-01T00:00:00"),
+        ("1991-01-01T00:00:00Z", "1991-01-01T00:00:00"),
+        ("2020-06-01T12:30:00+02:00", "2020-06-01T12:30:00"),
+    ],
+)
+def test_tz_qualified_iso_strings_lose_the_offset(value: str, expected: str) -> None:
+    """These reach a process as raw strings, because the pg-parser will not coerce them.
+
+    Only the plain forms ("1991-01-01") validate as a Date. A fully-qualified timestamp
+    fails that validation, stays a string, and then fails inside xclim with
+    "Both dates must have the same UTC offset" — so it has to be handled here too.
+    """
+    assert _naive_temporal_scalar(value) == expected
+
+
+@pytest.mark.parametrize("value", ["MS", "YS", "1991", "07-01", "mm/d", "degC", "1 mm/day", "dayofyear"])
+def test_ordinary_string_arguments_are_untouched(value: str) -> None:
+    """The ISO-with-offset rule must not catch frequencies, units or thresholds."""
+    assert _naive_temporal_scalar(value) is value
+
+
+@pytest.mark.parametrize("value", ["2020-12-31", "2020-06-01T12:00:00"])
+def test_naive_iso_strings_are_returned_unchanged(value: str) -> None:
+    """Nothing to strip, so don't reformat — "2020-12-31" must not become a timestamp."""
+    assert _naive_temporal_scalar(value) is value
+
+
 def test_cube_arguments_pass_through() -> None:
     """A datacube has no `root`; it must not be touched."""
     cube = _monthly_precip(3)
@@ -168,6 +198,30 @@ def test_standard_processes_still_execute(registry: object) -> None:
     cube = _monthly_precip(12)
     result = registry["mean"].implementation(data=cube, axis=0)  # type: ignore[index]
     assert result.shape == (2, 2)
+
+
+@pytest.mark.parametrize(
+    "cal_start",
+    [
+        "1991-01-01",
+        "1991-01-01T00:00:00+00:00",
+        "1991-01-01T00:00:00Z",
+        "1991",
+        None,
+    ],
+)
+def test_spi_accepts_every_bound_form_the_instance_override_handled(registry: object, cal_start: object) -> None:
+    """Parity check against the Uganda instance override this replaces.
+
+    Its `_to_date_str` accepted None, a plain string, a tz-suffixed string and a
+    pendulum/datetime object. All of those must work through the core process before that
+    override can be deleted — the tz-suffixed strings in particular, which the pg-parser
+    does not coerce into a Date and which the first version of this fix let through.
+    """
+    result = registry["spi"].implementation(  # type: ignore[index]
+        pr=_monthly_precip(), window=3, cal_start=cal_start, cal_end="2020-12-31", freq="MS"
+    )
+    assert result.dims == ("t", "y", "x")
 
 
 def test_temporal_extent_normalisation_is_unaffected() -> None:

--- a/tests/test_openeo_temporal_arguments.py
+++ b/tests/test_openeo_temporal_arguments.py
@@ -1,0 +1,181 @@
+"""Scalar openEO date arguments must reach processes timezone-naive (CLIM-826).
+
+The pg-parser validates any date-typed process argument into a pydantic RootModel wrapping
+a *timezone-aware* pendulum DateTime. Our stores carry timezone-naive time coordinates, so
+a process slicing with such a value fails inside pandas. `temporal_extent` was already
+normalised at the load_collection boundary; scalar arguments such as spi's
+cal_start/cal_end were not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+from openeo_pg_parser_networkx.pg_schema import Date, ParameterReference, TemporalInterval
+
+from open_climate_service.openeo import execution
+from open_climate_service.openeo.execution import _naive_temporal_scalar
+
+
+@pytest.fixture
+def registry() -> object:
+    """A freshly built process registry (the module keeps a lazy singleton)."""
+    execution._registry = None
+    try:
+        yield execution._build_process_registry()
+    finally:
+        execution._registry = None
+
+
+def _monthly_precip(periods: int = 60) -> xr.DataArray:
+    """Monthly precipitation on a timezone-naive time axis, as published stores are."""
+    return xr.DataArray(
+        np.random.default_rng(0).gamma(2.0, 20.0, size=(periods, 2, 2)).astype("float32"),
+        dims=("t", "y", "x"),
+        coords={
+            "t": xr.date_range("1991-01-01", periods=periods, freq="MS"),
+            "y": [1.0, 2.0],
+            "x": [3.0, 4.0],
+        },
+        name="pr",
+        attrs={"units": "mm/d", "standard_name": "precipitation_flux"},
+    )
+
+
+# --- the normalisation itself ---------------------------------------------------------
+
+
+def test_date_becomes_a_plain_day() -> None:
+    """A Date is a day, and as a slice bound "2020-12-31" covers the whole of it."""
+    assert _naive_temporal_scalar(Date.model_validate("2020-12-31")) == "2020-12-31"
+
+
+def test_strips_the_timezone_not_the_time() -> None:
+    """Non-Date wrappers keep their time component, minus the zone."""
+    value = TemporalInterval.model_validate(["1991-01-01T06:30:00Z", None]).root[0]
+    assert _naive_temporal_scalar(value) == "1991-01-01T06:30:00"
+
+
+def test_temporal_interval_is_left_alone() -> None:
+    """Its root is a list; load_collection normalises it separately."""
+    interval = TemporalInterval.model_validate(["1991-01-01", "2020-12-31"])
+    assert _naive_temporal_scalar(interval) is interval
+
+
+@pytest.mark.parametrize("value", [None, 3, "1991-01-01", 2.5, True, [1, 2], {"a": 1}])
+def test_non_temporal_values_pass_through(value: object) -> None:
+    assert _naive_temporal_scalar(value) is value
+
+
+def test_cube_arguments_pass_through() -> None:
+    """A datacube has no `root`; it must not be touched."""
+    cube = _monthly_precip(3)
+    assert _naive_temporal_scalar(cube) is cube
+
+
+@pytest.mark.parametrize("value", ["07-01", "0701", "12-25"])
+def test_day_of_year_strings_are_left_intact(value: str) -> None:
+    """Twenty of the date-argument indicators take MM-DD, not a full date.
+
+    `after_date`, `mid_date`, `start_date` and friends expect a day-of-year string. Those
+    never validate as a pg-parser Date, so they arrive as plain strings and must reach
+    xclim unchanged — normalising them into a full date would break those indicators.
+    """
+    with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError, exact type is upstream's
+        Date.model_validate(value)
+    assert _naive_temporal_scalar(value) is value
+
+
+# --- the crash this fixes -------------------------------------------------------------
+
+
+def test_spi_accepts_tz_aware_calibration_bounds(registry: object) -> None:
+    """The reported failure: TypeError from pandas on a tz-naive DatetimeIndex."""
+    result = registry["spi"].implementation(  # type: ignore[index]
+        pr=_monthly_precip(),
+        window=3,
+        cal_start=Date.model_validate("1991-01-01"),
+        cal_end=Date.model_validate("2020-12-31"),
+        freq="MS",
+    )
+    assert result.dims == ("t", "y", "x")
+
+
+def test_spi_still_accepts_plain_string_bounds(registry: object) -> None:
+    """Strings were never broken; make sure normalisation did not change that."""
+    result = registry["spi"].implementation(  # type: ignore[index]
+        pr=_monthly_precip(), window=3, cal_start="1991-01-01", cal_end="2020-12-31", freq="MS"
+    )
+    assert result.dims == ("t", "y", "x")
+
+
+def test_tz_aware_and_string_bounds_agree(registry: object) -> None:
+    """Both spellings must produce the same answer, not merely both succeed."""
+    kwargs = {"pr": _monthly_precip(), "window": 3, "freq": "MS"}
+    from_dates = registry["spi"].implementation(  # type: ignore[index]
+        cal_start=Date.model_validate("1991-01-01"), cal_end=Date.model_validate("2020-12-31"), **kwargs
+    )
+    from_strings = registry["spi"].implementation(  # type: ignore[index]
+        cal_start="1991-01-01", cal_end="2020-12-31", **kwargs
+    )
+    xr.testing.assert_allclose(from_dates, from_strings)
+
+
+def test_date_arriving_via_from_parameter_is_normalised(registry: object) -> None:
+    """The case that decides where the wrapper sits.
+
+    A workflow passing a date through `{"from_parameter": ...}` is still a
+    ParameterReference when the outer wrapper is entered, and only becomes a Date once that
+    wrapper resolves it. Normalising outside openeo-processes-dask's wrapper would miss it.
+    """
+    result = registry["spi"].implementation(  # type: ignore[index]
+        pr=_monthly_precip(),
+        window=3,
+        cal_start=ParameterReference(from_parameter="cal_start"),
+        cal_end=ParameterReference(from_parameter="cal_end"),
+        freq="MS",
+        named_parameters={
+            "cal_start": Date.model_validate("1991-01-01"),
+            "cal_end": Date.model_validate("2020-12-31"),
+        },
+    )
+    assert result.dims == ("t", "y", "x")
+
+
+# --- the wrapper must stay transparent ------------------------------------------------
+
+
+def test_wrapper_preserves_the_wrapped_signature() -> None:
+    """openeo-processes-dask decides whether to forward axis/keepdims/context from
+    inspect.signature of what it wraps. An opaque wrapper would make every process look
+    like it accepts them, and they would be forwarded to implementations that reject them.
+    """
+    import inspect
+
+    from open_climate_service.openeo.execution import _normalise_temporal_arguments
+
+    def implementation(data: object, axis: object = None) -> None: ...
+
+    def without_axis(data: object) -> None: ...
+
+    assert "axis" in inspect.signature(_normalise_temporal_arguments(implementation)).parameters
+    assert "axis" not in inspect.signature(_normalise_temporal_arguments(without_axis)).parameters
+
+
+def test_standard_processes_still_execute(registry: object) -> None:
+    """A reducer that relies on the special-argument filtering above."""
+    cube = _monthly_precip(12)
+    result = registry["mean"].implementation(data=cube, axis=0)  # type: ignore[index]
+    assert result.shape == (2, 2)
+
+
+def test_temporal_extent_normalisation_is_unaffected() -> None:
+    """load_collection's own path must keep working — this fix is additive to it."""
+    from open_climate_service.openeo.execution import _temporal_to_list
+
+    assert _temporal_to_list(TemporalInterval.model_validate(["1991-01-01", "2020-12-31"])) == [
+        "1991-01-01T00:00:00",
+        "2020-12-31T00:00:00",
+    ]
+    assert _temporal_to_list(None) is None

--- a/tests/test_openeo_temporal_arguments.py
+++ b/tests/test_openeo_temporal_arguments.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from openeo_pg_parser_networkx.pg_schema import Date, ParameterReference, TemporalInterval
+from pydantic import ValidationError
 
 from open_climate_service.openeo import execution
 from open_climate_service.openeo.execution import _naive_temporal_scalar
@@ -112,7 +113,7 @@ def test_day_of_year_strings_are_left_intact(value: str) -> None:
     never validate as a pg-parser Date, so they arrive as plain strings and must reach
     xclim unchanged — normalising them into a full date would break those indicators.
     """
-    with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError, exact type is upstream's
+    with pytest.raises(ValidationError):
         Date.model_validate(value)
     assert _naive_temporal_scalar(value) is value
 


### PR DESCRIPTION
Fixes [CLIM-826](https://dhis2.atlassian.net/browse/CLIM-826).

## What was broken

Asking for a drought index over a fixed calibration baseline failed. This process graph — SPI-3 calibrated on 1991–2020 — crashed instead of returning a result:

```json
{
  "process_id": "spi",
  "arguments": {
    "pr": {"from_node": "load"},
    "window": 3,
    "cal_start": "1991-01-01",
    "cal_end": "2020-12-31"
  }
}
```

```
TypeError: cannot do slice indexing on DatetimeIndex with these indexers
[root=DateTime(1991, 1, 1, 0, 0, 0, tzinfo=Timezone('UTC'))] of type Date
```

Leaving the calibration dates out worked fine. Supplying them was what broke it — so you could compute SPI, but not pin it to a stable baseline, which is the whole point of using one. Without a fixed baseline, running SPI over two different periods gives results that can't be compared to each other.

## Why it happened: two different ideas of "a date"

Our datasets store timestamps **without a timezone** — `2020-06-01` and nothing more. That's not a shortcut, it's how the file format works: Zarr and the CF conventions store time as plain numbers counted from a reference point, and the array library underneath has no concept of a timezone at all.

The openEO layer that reads incoming requests does the opposite. When it sees `"1991-01-01"` in a request, it helpfully converts it into a full timestamp **with a timezone attached** — midnight UTC.

Those two are then compared, and the comparison is refused. Asking "which rows fall between these two dates?" only works if both sides agree on whether timezones exist. One side says 1 January; the other says 1 January *in UTC*; the date library declines to guess whether they're the same instant.

This had already been solved for the **time range** you load data for (`temporal_extent`) — it gets its timezone stripped before use. But that fix was applied in one specific place, and dates passed as ordinary process arguments, like SPI's calibration bounds, never went through it.

## The fix

Strip the timezone from **every** date argument on its way into a process, in the one place all arguments pass through, rather than fixing each process that happens to take a date.

That matters for coverage: **21 climate indicators take date arguments**, not just the two named in the ticket. Alongside SPI and SPEI's calibration bounds there are `after_date`, `mid_date` and `start_date`/`end_date` on the growing-season and "first day above/below" families. Fixing this per process would have meant 21 patches and a standing invitation to miss the 22nd.

## Two details that decide whether it works

Both checked against the installed libraries rather than assumed.

**The conversion has to happen at the right moment.** Workflows can pass a date indirectly, as "use whatever the caller supplied for this parameter". At the point the outer machinery is entered, such an argument is still a placeholder — it only becomes a real date slightly later, once that machinery resolves it. So converting too early sees a placeholder and does nothing, and the crash comes back. The fix is deliberately registered to run *after* that resolution. There's a test for it, and it fails if the ordering is changed.

**The wrapper has to stay see-through.** The surrounding machinery inspects each process to decide whether it accepts certain optional arguments (`axis`, `keepdims`, `context`). A wrapper that hides the original signature would make every process look like it accepts all of them, and they'd be forwarded to processes that reject them — surfacing as an unrelated-looking error somewhere else entirely. `functools.wraps` preserves the signature, and there's a test asserting it.

## Scope kept deliberately narrow

Only values that are genuinely a single date get touched. A **time range** is structurally excluded (internally it's a list of two dates, not one), so the existing handling for loading data is untouched — with a test pinning that.

**Day-of-year arguments are left alone**, which matters because 20 of those 21 indicators want `MM-DD`, not a full date. `"07-01"` isn't recognised as a date by the openEO layer, so it arrives as plain text and reaches the indicator in the form it expects. That's asserted, because a conversion that started rewriting `"07-01"` into `"2026-07-01"` would quietly break all twenty.

## One judgement call

A date becomes `2020-12-31` rather than `2020-12-31T00:00:00`. It reads more faithfully as a date, and it behaves better as a range boundary: `"2020-12-31"` is understood as the whole day, whereas the midnight version would exclude everything after 00:00 on hourly data. Values that genuinely carry a time of day keep it — only the timezone is removed.

## A second input form, found by checking the override could actually go

The first version of this fix would **not** have made the Uganda override safe to delete. Reading that override, rather than assuming it only handled the converted form, turned up a case it covers and the fix missed.

A fully written-out timestamp such as `"1991-01-01T00:00:00Z"` reaches a process as **plain text**, because the openEO layer only recognises simple forms like `"1991-01-01"` as dates. The longer form isn't recognised, stays as text, and then fails just as hard — this time with `ValueError: Both dates must have the same UTC offset`. That's reachable from an ordinary process graph, and the override handled it by keeping only the first ten characters.

So text arguments are now handled too, under a tight rule: the text must be a valid timestamp **and** carry a timezone. Checked for false positives against `"MS"`, `"YS"`, `"1991"`, `"07-01"`, `"mm/d"`, `"degC"`, `"1 mm/day"`, `"dayofyear"` — none match. Text that's already timezone-free is returned untouched rather than reformatted, so `"2020-12-31"` doesn't silently become a midnight timestamp.

## Retires the instance workaround

[HISP-Uganda/uganda-climate-service-tools#6](https://github.com/HISP-Uganda/uganda-climate-service-tools/pull/6) (CLIM-775) shadows the core `spi` with an instance copy that cleans up the bounds before delegating. That duplicated a whole process per instance, would drift from core, and covered only `spi`. It accepted five forms of calibration bound: nothing, plain text, both written-out timestamp spellings, and a real date object. A parity test runs `spi` across every one of them, so the copy can be deleted once this is released and the instance bumped. It adds nothing else — `window` and `freq` pass straight through, and the index itself is computed by the core process either way.

**Order matters when removing it:** merge here → release (or point the instance at `main`) → bump `open-climate-service` in the instance → then delete `plugins/processes/spi.py`. Deleting it before the bump brings the original crash back.

## Verification

39 tests (`tests/test_openeo_temporal_arguments.py`):

- the reported crash — SPI with timezone-carrying bounds against a timezone-free monthly store
- timezone-carrying and plain-text bounds produce the **same numbers**, not merely both succeed
- the indirect "use the caller's parameter" path
- signature transparency for the optional-argument check
- time ranges passed through untouched; the existing `temporal_extent` handling unchanged
- `MM-DD` day-of-year text left intact; timezone-carrying text stripped; timezone-free text and ordinary arguments (frequencies, units, thresholds) untouched
- parity across every calibration-bound form the Uganda copy accepted
- data cubes, `None`, numbers, booleans, lists and dictionaries all pass through

Confirmed the behavioural tests fail with the fix removed, so they'd catch a regression.

```
551 passed
make lint clean (ruff, format, mypy, pyright)
```

The 3 excluded failures in `test_openeo_execution.py` are a pre-existing local PROJ database conflict (`to_epsg()` returns `None`), unrelated to this change and verified identical on `main`.

## Why the fix is at the boundary, not in the storage model

Asked during review whether OCS should change how it represents time instead. It shouldn't, and the reason is a hard limit rather than a preference — a timestamp with a timezone cannot be written to our storage format at all:

```
DataArray with datetime64[ns, UTC] -> to_zarr()
TypeError: Cannot interpret 'datetime64[ns, UTC]' as a data type
```

The array library has no timezone concept, and the CF conventions put the reference point in the metadata rather than in the values. Since STAC and openEO both use timezone-carrying timestamps in their requests and responses, converting between the two is **unavoidable** for any openEO + STAC service built on Zarr. It has to happen at some boundary, and the process-argument boundary — the one the time range already used — is the right one.

That question did surface a genuine gap, but a different one: timezone-free timestamps are fine *provided you record what they mean*, and we don't. `era5land_temperature_daily` stores UTC days while `era5land_temperature_daily_from_hourly` stores local days, and nothing machine-readable distinguishes them — the two dataset definitions are identical apart from their id, name and plugin. Filed separately as [CLIM-866](https://dhis2.atlassian.net/browse/CLIM-866); latent today, because no instance sets a non-zero UTC offset.


[CLIM-826]: https://dhis2.atlassian.net/browse/CLIM-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-866]: https://dhis2.atlassian.net/browse/CLIM-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ