### PR TITLE
feat(ingest): allow a forecast dataset to be ingested without a date range

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -155,6 +155,66 @@ from the dimension's metadata, so there's nothing extra to configure.
 | `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `monthly`, `yearly`                                       |
 | `sync.kind`      | Yes      | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced        |
 | `sync.execution` | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync |
+| `temporal_direction` | No   | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below |
+
+### Which way the periods run: `temporal_direction`
+
+Most datasets are historical, and the default (`past`) suits them. Two other shapes exist, and they behave differently at ingest time:
+
+| Value | Periods | `start` on an ingestion |
+| --- | --- | --- |
+| `past` (default) | All historical | Required |
+| `future` | All ahead of now — a forecast | **Optional**, meaning "from now" |
+| `spanning` | Cross now — WorldPop Global2 (2015–2030), climate projections | Required |
+
+`spanning` requires a start *on purpose*. Defaulting it to "now" would ingest only the projected years and silently drop every historical one, which is usually the half you actually want. What declaring it does buy you: the ingest form prefills the end from the dataset's declared `extents.temporal.end`, so selecting WorldPop offers the full range through 2030 instead of truncating at today.
+
+### Forecast datasets (`temporal_direction: future`)
+
+A forecast's periods lie in the *future*, which changes what an ingestion request means. Declare it:
+
+```yaml
+- id: tmax_forecast_daily
+  period_type: daily
+  temporal_direction: future
+  sync:
+    kind: temporal          # still temporal: re-running fetches a fresher forecast
+  ingestion:
+    plugin: datasets.my_forecast.MyForecastPlugin
+    params:
+      max_lead_days: 7
+```
+
+With that declared, **`start` may be omitted** from an ingestion request, and means "from now":
+
+```bash
+curl -X POST http://localhost:9000/ingestions \
+  -H 'Content-Type: application/json' \
+  -d '{"dataset_id": "tmax_forecast_daily"}'
+```
+
+Omitting it is usually what you want. A fixed `start` is only correct on the day it is written — tomorrow it under-requests — so a scheduled refresh with hardcoded dates drifts out of the forecast window and then quietly fetches nothing. Supplying `start`/`end` still works, and narrows the window when you deliberately want a subset.
+
+**What your `periods()` receives.** For a historical dataset an omitted end is filled in with "now" — "through the latest available period". A forecast cannot use that, because "now" is the *start* of its window: filling it in would hand you `start == end == today` and collapse a seven-day forecast to one day. So a forecast instead receives a **forward horizon** — the template's declared `extents.temporal.end` if it has one, otherwise a year ahead. It is deliberately generous: the real limit is your plugin's lead time, and a tighter bound in core would silently truncate a longer forecast.
+
+Your plugin clips to what it actually publishes:
+
+```python
+async def periods(self, start: str, end: str) -> list[str]:
+    base = date.fromisoformat(start[:10])           # core resolves this to today
+    days = [(base + timedelta(days=i)).isoformat() for i in range(self.max_lead_days)]
+    return [d for d in days if d <= end[:10]]       # clip to the requested window
+```
+
+Note `end` stays a plain `str`, so there is no missing-value case to handle.
+
+**Honour `end` when it is given.** If your plugin returns periods outside the requested scope, the ingestion is refused with `Materialized artifact coverage does not match the requested scope`. That guard is helpful — it catches a plugin that ignores the range rather than silently storing more than was asked for — but it means a lead-day plugin has to filter rather than ignore.
+
+`temporal_direction` is separate from `sync.kind` on purpose: a forecast is still `temporal` for sync (re-run it and you get fresher data); what differs is which way its periods run. It cannot be combined with `sync.kind: static`, which has no upstream to look ahead into.
+
+**How far ahead belongs in the template, not the request.** A source often publishes further out than is useful — 40 days when only 7 verify well. That cap is a property of the dataset, so express it in `ingestion.params` (as `max_lead_days` above) and let your plugin's `periods()` honour it. The request then narrows *within* that window rather than re-deciding it on every run.
+
+The response reports the window that was actually ingested, under `dataset.extent.temporal`, so you can confirm what an omitted `start` resolved to.
 
 **Ingestion**
 

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -19,6 +19,50 @@ CONFIGS_DIR: Path | None = None
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
 
+# Which way a dataset's periods run relative to now. Deliberately separate from
+# `sync.kind`: a forecast is still `temporal` for sync purposes (re-run it and you get
+# fresh data), so this is an orthogonal property rather than a fourth kind. Keeping them
+# apart also means the sync engine's decision logic is untouched.
+#
+# `past` (the default) — periods are historical, so an ingestion must say where to start.
+# `future` — every period lies ahead of now, as for a weather forecast. An omitted start
+#     means "from now", because a fixed date would be stale the next day.
+# `spanning` — periods cross now: WorldPop Global2 runs 2015–2030, and climate projections
+#     behave the same way. An explicit start is still required, because defaulting to "now"
+#     would silently drop the historical half — which is usually the half you want.
+#     Declaring it is not decoration: it tells the ingest form to offer the dataset's
+#     declared future end rather than truncating at today.
+SUPPORTED_TEMPORAL_DIRECTIONS = {"past", "future", "spanning"}
+DEFAULT_TEMPORAL_DIRECTION = "past"
+
+
+def temporal_direction(dataset: dict[str, Any]) -> str:
+    """Return a dataset template's temporal direction, defaulting to ``past``."""
+    raw = dataset.get("temporal_direction")
+    return raw if isinstance(raw, str) and raw else DEFAULT_TEMPORAL_DIRECTION
+
+
+def is_future_facing(dataset: dict[str, Any]) -> bool:
+    """True when *every* period lies ahead of now, so an omitted start can mean "now".
+
+    Deliberately excludes ``spanning``. A dataset straddling now (WorldPop Global2's
+    2015–2030, or a climate projection) must still be given an explicit start: defaulting
+    it to "now" would quietly ingest only the projected half and drop all the history.
+    """
+    return temporal_direction(dataset) == "future"
+
+
+def declared_temporal_end(dataset: dict[str, Any]) -> str | None:
+    """Return the template's declared temporal end, if any.
+
+    Used by the ingest form to offer a ``spanning`` dataset's full range rather than
+    stopping at today, which would truncate the projected periods.
+    """
+    extents = dataset.get("extents")
+    temporal = extents.get("temporal") if isinstance(extents, dict) else None
+    end = temporal.get("end") if isinstance(temporal, dict) else None
+    return str(end) if end is not None else None
+
 
 def list_datasets() -> list[dict[str, Any]]:
     """Load all dataset templates and return a flat list.
@@ -197,6 +241,20 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
             f"Dataset template '{dataset_id}' in {source} has unsupported sync.kind "
             f"'{sync_kind}'. Supported values: {supported}"
         )
+
+    direction = dataset.get("temporal_direction")
+    if direction is not None:
+        if not isinstance(direction, str) or direction not in SUPPORTED_TEMPORAL_DIRECTIONS:
+            supported = ", ".join(sorted(SUPPORTED_TEMPORAL_DIRECTIONS))
+            raise ValueError(
+                f"Dataset template '{dataset_id}' in {source} has unsupported temporal_direction "
+                f"{direction!r}. Supported values: {supported}"
+            )
+        if direction == "future" and sync_kind == "static":
+            raise ValueError(
+                f"Dataset template '{dataset_id}' in {source} declares temporal_direction: future "
+                "with sync.kind: static. A static dataset has no upstream to look ahead into."
+            )
 
     sync_execution = sync_block.get("execution") if isinstance(sync_block, dict) else None
     if sync_execution is not None:

--- a/open_climate_service/ingestions/processes.py
+++ b/open_climate_service/ingestions/processes.py
@@ -16,7 +16,7 @@ from open_climate_service.ingestions.schemas import IngestionResponse, SyncRespo
 def execute_ingestion(
     *,
     dataset_id: str,
-    start: str,
+    start: str | None = None,
     end: str | None = None,
     overwrite: bool = False,
     publish: bool = True,

--- a/open_climate_service/ingestions/schemas.py
+++ b/open_climate_service/ingestions/schemas.py
@@ -119,7 +119,14 @@ class CreateIngestionRequest(BaseModel):
     """Request payload for creating or updating a managed dataset."""
 
     dataset_id: str = Field(description="Source dataset template id from the Open Climate Service registry.")
-    start: str = Field(description="Start period to ingest.")
+    start: str | None = Field(
+        default=None,
+        description=(
+            "Start period to ingest. Required for historical datasets. May be omitted for a "
+            "dataset declaring 'temporal_direction: future' (e.g. a forecast), where it means "
+            "'from now' — a fixed date would be stale by the next day."
+        ),
+    )
     end: str | None = Field(default=None, description="Optional end period to ingest.")
     overwrite: bool = Field(
         default=False,

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -215,7 +215,7 @@ def get_latest_artifact_for_dataset_or_404(dataset_id: str) -> ArtifactRecord:
 def create_artifact(
     *,
     dataset: dict[str, object],
-    start: str,
+    start: str | None,
     end: str | None,
     bbox: list[float] | None,
     country_code: str | None,
@@ -237,7 +237,7 @@ def create_artifact(
     are actually missing from the committed store.
     """
     period_type = str(dataset["period_type"])
-    start = _normalize_request_period(start, period_type=period_type, field_name="start")
+    start = _resolve_request_start(start, dataset=dataset, period_type=period_type)
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
     download_start = _normalize_optional_request_period(
         download_start, period_type=period_type, field_name="download_start"
@@ -251,7 +251,14 @@ def create_artifact(
     )
     resolved_download_end = download_end if download_end is not None else end
     if resolved_download_end is None:
-        resolved_download_end = _default_request_end(period_type)
+        if registry_datasets.is_future_facing(dataset):
+            # "Now" is this dataset's *start*, so using it as the end would collapse a
+            # seven-day forecast to a single day. Offer a generous horizon instead and let
+            # the plugin clip to whatever it actually publishes. `request_scope.end` stays
+            # None, so the coverage check does not hold the plugin to this wider bound.
+            resolved_download_end = _forecast_horizon(dataset, period_type)
+        else:
+            resolved_download_end = _current_request_period(period_type)
     request_scope = ArtifactRequestScope(
         start=start,
         end=end,
@@ -974,8 +981,69 @@ def _normalize_optional_request_period(value: str | None, *, period_type: str, f
     return _normalize_request_period(value, period_type=period_type, field_name=field_name)
 
 
-def _default_request_end(period_type: str) -> str:
-    """Return the current dataset-native period string for omitted ingestion end values."""
+def _resolve_request_start(value: str | None, *, dataset: dict[str, object], period_type: str) -> str:
+    """Return the normalized start period, substituting "now" for a forecast dataset.
+
+    A future-facing dataset may omit ``start``: its periods lie ahead of now, so any fixed
+    date would be stale by the next day and a scheduled re-ingest would silently drift out
+    of the forecast window. Omitting it means "from now", resolved here in the dataset's
+    native period format.
+
+    Note what is deliberately *not* done: ``None`` is never passed through to
+    ``plugin.periods()``. Every existing plugin's signature is ``periods(start: str, end:
+    str)`` and several parse the value immediately (``date.fromisoformat(start)``), so
+    handing them ``None`` would turn an omitted field into a ``TypeError`` deep inside a
+    plugin. Resolving here keeps the plugin contract exactly as it is.
+
+    A historical dataset with no start is a client error, not a defaulted one — silently
+    ingesting from "now" backwards would be a guess about intent, and the whole record is
+    rarely what someone wants.
+    """
+    if value is not None:
+        return _normalize_request_period(value, period_type=period_type, field_name="start")
+
+    if not registry_datasets.is_future_facing(dataset):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Dataset '{dataset.get('id')}' requires a start period: its periods are historical. "
+                "Only datasets declaring 'temporal_direction: future' (e.g. forecasts) may omit it."
+            ),
+        )
+    return _current_request_period(period_type)
+
+
+def _forecast_horizon(dataset: dict[str, object], period_type: str) -> str:
+    """Return how far ahead to ask a forecast plugin for, when no end was requested.
+
+    Prefers the template's declared ``extents.temporal.end``. Otherwise offers a year
+    ahead — deliberately generous, because the real limit belongs to the plugin (its own
+    lead-time parameter) and a bound here would silently truncate a longer forecast. The
+    plugin is expected to clip to what it publishes; ``request_scope.end`` remains None so
+    the coverage check does not require it to fill this whole window.
+
+    A year rather than no bound at all keeps ``periods()`` typed as ``end: str``, so a
+    plugin author never has to handle a missing end.
+    """
+    declared = registry_datasets.declared_temporal_end(dataset)
+    if declared:
+        return declared
+    horizon = utc_today().replace(year=utc_today().year + 1)
+    if period_type == "yearly":
+        return str(horizon.year)
+    if period_type == "monthly":
+        return f"{horizon.year:04d}-{horizon.month:02d}"
+    if period_type in {"hourly", "weekly"}:
+        return datetime_to_period_string(datetime.combine(horizon, datetime.min.time(), tzinfo=UTC), period_type)
+    return horizon.isoformat()
+
+
+def _current_request_period(period_type: str) -> str:
+    """Return "now" as a dataset-native period string.
+
+    Used for both an omitted ``end`` (sync through the latest period) and an omitted
+    ``start`` on a future-facing dataset (ingest from now forward).
+    """
     if period_type == "hourly":
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "daily":
@@ -991,7 +1059,7 @@ def _default_request_end(period_type: str) -> str:
         # Day-of-year climatology: the plugin enumerates 1..366 regardless of the
         # request range, so the end value is unused — return a stable sentinel.
         return "366"
-    raise HTTPException(status_code=400, detail=f"Invalid period_type '{period_type}' for request end defaulting")
+    raise HTTPException(status_code=400, detail=f"Invalid period_type '{period_type}' for request period defaulting")
 
 
 def _validate_download_scope(

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Protocol, cast
 from uuid import uuid4
@@ -1028,7 +1028,11 @@ def _forecast_horizon(dataset: dict[str, object], period_type: str) -> str:
     declared = registry_datasets.declared_temporal_end(dataset)
     if declared:
         return declared
-    horizon = utc_today().replace(year=utc_today().year + 1)
+    # 365 days rather than replace(year=+1): the latter raises "day is out of range for
+    # month" on 29 February, since the following year has no such date — a crash on leap
+    # day for a horizon that is approximate by design. Read the date once, so a run
+    # crossing midnight cannot mix two different days.
+    horizon = utc_today() + timedelta(days=365)
     if period_type == "yearly":
         return str(horizon.year)
     if period_type == "monthly":

--- a/open_climate_service/plugins/datasets/worldpop.yaml
+++ b/open_climate_service/plugins/datasets/worldpop.yaml
@@ -3,6 +3,10 @@
   short_name: Total population
   variable: pop_total
   period_type: yearly
+  # Runs 2015-2030, so periods straddle now. Requires an explicit start
+  # (defaulting to "now" would drop the historical half), but lets the ingest
+  # form offer the full range instead of truncating at today.
+  temporal_direction: spanning
   sync:
     kind: release
   extents:
@@ -33,6 +37,10 @@
   short_name: Age/sex population
   variable: population
   period_type: yearly
+  # Runs 2015-2030, so periods straddle now. Requires an explicit start
+  # (defaulting to "now" would drop the historical half), but lets the ingest
+  # form offer the full range instead of truncating at today.
+  temporal_direction: spanning
   sync:
     kind: release
   extents:

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -82,6 +82,7 @@ async def manage_ingest(request: Request) -> Response:
     """Handle ingest form submission and stream progress via SSE."""
     from fastapi import HTTPException
 
+    from open_climate_service.data_registry.services import datasets as registry_datasets
     from open_climate_service.data_registry.services.datasets import get_dataset
     from open_climate_service.extents.services import get_extent_or_404
     from open_climate_service.ingestions.services import create_artifact
@@ -90,17 +91,23 @@ async def manage_ingest(request: Request) -> Response:
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
-        start = str(form.get("start", "")).strip()
+        # A blank field submits "" rather than being absent, so normalise to None.
+        start = str(form.get("start", "")).strip() or None
         end = str(form.get("end", "")).strip() or None
         publish = "publish" in form
         overwrite = "overwrite" in form
 
-        if not start:
-            raise HTTPException(status_code=400, detail="Start date is required")
-
         template = get_dataset(dataset_id)
         if template is None:
             msg = urllib.parse.quote(f"Dataset template '{dataset_id}' not found")
+            return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+
+        # Validate the blank start here rather than leaving it to create_artifact. The work
+        # below runs inside an SSE stream, and a response that has already begun cannot
+        # redirect — the operator would get a progress bar that fails mid-flight instead of
+        # the error banner. Only a forecast may omit it (see temporal_direction).
+        if start is None and not registry_datasets.is_future_facing(template):
+            msg = urllib.parse.quote(f"Start period is required for '{dataset_id}': its periods are not in the future")
             return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
 
         extent = get_extent_or_404()

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -396,7 +396,9 @@
               <select id="dataset_id" name="dataset_id" required>
                 <option value="">Select a template…</option>
                 {% for t in templates %}
-                <option value="{{ t.id }}">
+                <option value="{{ t.id }}"
+                        data-direction="{{ t.temporal_direction | default('past', true) }}"
+                        data-declared-end="{{ (t.extents.temporal.end if t.extents and t.extents.temporal else '') | default('', true) }}">
                   {{ t.name }} ({{ t.period_type }})
                 </option>
                 {% endfor %}
@@ -404,7 +406,7 @@
             </div>
 
             <div class="field">
-              <label for="start">Start</label>
+              <label for="start">Start <span id="start-optional-note" style="font-weight:400;text-transform:none;letter-spacing:0;display:none">(optional)</span></label>
               <input
                 type="text"
                 id="start"
@@ -413,7 +415,7 @@
                 placeholder="YYYY-MM-DD"
                 required
               />
-              <span class="hint">e.g. 2024-01-01 for daily, 2024-01 for monthly, 2024 for yearly</span>
+              <span class="hint" id="start-hint">e.g. 2024-01-01 for daily, 2024-01 for monthly, 2024 for yearly</span>
             </div>
 
             <div class="field">
@@ -553,6 +555,56 @@
     </footer>
 
     <script>
+      // Historical and forward-looking datasets want opposite date ranges. The default
+      // (a year ago → today) is right for history and contains *none* of a forecast's
+      // periods, so react to the selected template rather than assuming one direction.
+      (function () {
+        const select = document.getElementById('dataset_id');
+        const start = document.getElementById('start');
+        const end = document.getElementById('end');
+        if (!select || !start || !end) return;
+        const optionalNote = document.getElementById('start-optional-note');
+        const hint = document.getElementById('start-hint');
+        const pastDefaults = { start: start.value, end: end.value };
+        const pastHint = hint ? hint.textContent : '';
+
+        select.addEventListener('change', function () {
+          const option = select.selectedOptions[0];
+          const direction = option ? option.dataset.direction : 'past';
+          const declaredEnd = option ? (option.dataset.declaredEnd || '') : '';
+
+          if (direction === 'future') {
+            // Blank means "from now, as far ahead as the source offers" — the only
+            // range that stays correct tomorrow.
+            start.value = '';
+            end.value = '';
+            start.removeAttribute('required');
+            if (hint) hint.textContent = 'Leave blank to ingest the full forecast window from now.';
+            if (optionalNote) optionalNote.style.display = '';
+            return;
+          }
+
+          start.setAttribute('required', 'required');
+          if (optionalNote) optionalNote.style.display = 'none';
+          if (direction === 'spanning') {
+            // Periods straddle now (e.g. WorldPop 2015-2030). Today's date as the end
+            // would silently truncate the projected years, so offer the declared end.
+            start.value = pastDefaults.start;
+            end.value = declaredEnd || pastDefaults.end;
+            if (hint) {
+              hint.textContent = declaredEnd
+                ? `This dataset runs through ${declaredEnd}; the end is prefilled to cover it.`
+                : pastHint;
+            }
+            return;
+          }
+
+          if (!start.value) start.value = pastDefaults.start;
+          if (!end.value) end.value = pastDefaults.end;
+          if (hint) hint.textContent = pastHint;
+        });
+      })();
+
       function openSyncPanel(syncDomId) {
         const panel = document.getElementById(`sync-panel-${syncDomId}`);
         const input = document.getElementById(`sync-end-${syncDomId}`);

--- a/tests/test_forecast_ingest_range.py
+++ b/tests/test_forecast_ingest_range.py
@@ -198,6 +198,22 @@ def test_forecast_horizon_prefers_a_declared_end() -> None:
 
 
 @pytest.mark.parametrize("period_type", ["daily", "monthly", "yearly", "hourly", "weekly"])
+def test_forecast_horizon_survives_a_leap_day(monkeypatch: pytest.MonkeyPatch, period_type: str) -> None:
+    """29 February has no counterpart in the following year.
+
+    An earlier version advanced the year with ``replace(year=+1)``, which raises "day is
+    out of range for month" on a leap day — a crash on one day every four years, for a
+    horizon that is approximate by design.
+    """
+    import datetime as _datetime
+
+    monkeypatch.setattr(ingestion_services, "utc_today", lambda: _datetime.date(2028, 2, 29))
+    horizon = ingestion_services._forecast_horizon({"id": "f"}, period_type)
+    assert horizon  # did not raise
+    assert horizon > "2028"
+
+
+@pytest.mark.parametrize("period_type", ["daily", "monthly", "yearly", "hourly", "weekly"])
 def test_forecast_horizon_is_period_native(period_type: str) -> None:
     """It is handed straight to the plugin, so it has to parse as that period type."""
     from open_climate_service.shared.time import normalize_period_string
@@ -233,9 +249,16 @@ def test_manage_form_exposes_each_template_direction(client: TestClient) -> None
     assert 'data-direction="past"' in body
 
 
-def test_manage_form_no_longer_hardcodes_a_start_requirement_message(client: TestClient) -> None:
-    """The blank-start rejection is now dataset-aware, made in create_artifact."""
+def test_manage_form_start_rejection_is_dataset_aware(client: TestClient) -> None:
+    """The unconditional "Start date is required" gate is gone from the manage route.
+
+    The rejection still happens in ``manage_ingest`` rather than downstream in
+    ``create_artifact`` — deliberately, because the ingest runs inside an SSE stream and a
+    response that has begun cannot redirect. What changed is that it now consults
+    ``is_future_facing()`` instead of rejecting every blank start.
+    """
     from open_climate_service.system import routes
 
     source = Path(routes.__file__).read_text(encoding="utf-8")
     assert 'detail="Start date is required"' not in source
+    assert "is_future_facing(template)" in source

--- a/tests/test_forecast_ingest_range.py
+++ b/tests/test_forecast_ingest_range.py
@@ -1,0 +1,241 @@
+"""A forecast dataset may be ingested without a fixed date range (CLIM-868).
+
+Historical datasets are unchanged: `start` is still required. A dataset declaring
+`temporal_direction: future` may omit it, meaning "from now" — a fixed date would be stale
+by the next day, and a scheduled re-ingest would silently drift out of the forecast window.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from open_climate_service.data_registry.services import datasets as registry
+from open_climate_service.ingestions import services as ingestion_services
+from open_climate_service.ingestions.schemas import CreateIngestionRequest
+from open_climate_service.shared.time import utc_today
+
+
+def _write_template(tmp_path: Path, body: str, name: str = "forecast.yaml") -> None:
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+# --- how a template declares direction -----------------------------------------------
+
+
+def test_defaults_to_past_when_undeclared() -> None:
+    assert registry.temporal_direction({"id": "x"}) == "past"
+    assert registry.is_future_facing({"id": "x"}) is False
+
+
+def test_reads_a_declared_direction() -> None:
+    assert registry.is_future_facing({"id": "x", "temporal_direction": "future"}) is True
+    assert registry.is_future_facing({"id": "x", "temporal_direction": "past"}) is False
+
+
+def test_accepts_a_future_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_template(
+        tmp_path,
+        """
+- id: tmax_forecast_daily
+  name: Max temperature forecast
+  variable: tmax
+  period_type: daily
+  temporal_direction: future
+  sync:
+    kind: temporal
+  ingestion:
+    plugin: does.not.matter.ForTemplateValidation
+""",
+    )
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    loaded = {d["id"]: d for d in registry.list_datasets()}
+    assert registry.is_future_facing(loaded["tmax_forecast_daily"]) is True
+
+
+def test_spanning_is_not_treated_as_future() -> None:
+    """A dataset straddling now must still be given a start, or history is silently lost.
+
+    WorldPop Global2 runs 2015–2030. Defaulting its start to "now" would ingest only the
+    projected years and drop every historical one — usually the half that is wanted.
+    """
+    spanning = {"id": "worldpop_population_global2_R2025A_100m", "temporal_direction": "spanning"}
+    assert registry.temporal_direction(spanning) == "spanning"
+    assert registry.is_future_facing(spanning) is False
+
+
+def test_worldpop_global2_declares_itself_spanning() -> None:
+    """The built-in that motivated the third value: declared extent 2015 → 2030."""
+    loaded = {d["id"]: d for d in registry.list_datasets()}
+    for dataset_id in ("worldpop_population_global2_R2025A_100m", "worldpop_agesex_global2_R2025A_100m"):
+        dataset = loaded[dataset_id]
+        assert registry.temporal_direction(dataset) == "spanning"
+        assert registry.declared_temporal_end(dataset) == "2030"
+        assert registry.is_future_facing(dataset) is False
+
+
+def test_declared_temporal_end_is_none_when_absent() -> None:
+    assert registry.declared_temporal_end({"id": "x"}) is None
+    assert registry.declared_temporal_end({"id": "x", "extents": {}}) is None
+    assert registry.declared_temporal_end({"id": "x", "extents": {"temporal": {"begin": "1981"}}}) is None
+
+
+def test_spanning_dataset_still_requires_a_start_over_http(client: TestClient) -> None:
+    response = client.post("/ingestions", json={"dataset_id": "worldpop_population_global2_R2025A_100m"})
+    assert response.status_code == 400, response.text
+    assert "requires a start period" in response.json()["detail"]
+
+
+def test_manage_form_offers_the_declared_end_for_a_spanning_dataset(client: TestClient) -> None:
+    """So selecting WorldPop prefills through 2030 rather than truncating at today."""
+    body = client.get("/manage").text
+    assert 'data-direction="spanning"' in body
+    assert 'data-declared-end="2030"' in body
+
+
+def test_rejects_an_unsupported_direction(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_template(
+        tmp_path,
+        """
+- id: sideways
+  name: Sideways
+  variable: v
+  period_type: daily
+  temporal_direction: sideways
+  sync:
+    kind: temporal
+  ingestion:
+    plugin: a.b.C
+""",
+    )
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="unsupported temporal_direction 'sideways'"):
+        registry.list_datasets()
+
+
+def test_rejects_future_combined_with_static_sync(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A static dataset has no upstream to look ahead into, so the pair is incoherent."""
+    _write_template(
+        tmp_path,
+        """
+- id: static_forecast
+  name: Static forecast
+  variable: v
+  period_type: daily
+  temporal_direction: future
+  sync:
+    kind: static
+""",
+    )
+    monkeypatch.setattr(registry, "CONFIGS_DIR", tmp_path)
+    with pytest.raises(ValueError, match="has no upstream to look ahead into"):
+        registry.list_datasets()
+
+
+# --- resolving an omitted start -------------------------------------------------------
+
+
+def test_supplied_start_is_used_unchanged() -> None:
+    resolved = ingestion_services._resolve_request_start(
+        "2024-01-01", dataset={"id": "x", "period_type": "daily"}, period_type="daily"
+    )
+    assert resolved == "2024-01-01"
+
+
+def test_omitted_start_on_a_forecast_resolves_to_today() -> None:
+    resolved = ingestion_services._resolve_request_start(
+        None,
+        dataset={"id": "tmax_forecast_daily", "temporal_direction": "future"},
+        period_type="daily",
+    )
+    assert resolved == utc_today().isoformat()
+
+
+@pytest.mark.parametrize(
+    ("period_type", "expected"),
+    [
+        ("daily", lambda: utc_today().isoformat()),
+        ("monthly", lambda: f"{utc_today().year:04d}-{utc_today().month:02d}"),
+        ("yearly", lambda: str(utc_today().year)),
+    ],
+)
+def test_resolved_start_is_in_the_dataset_native_period_format(period_type: str, expected: object) -> None:
+    resolved = ingestion_services._resolve_request_start(
+        None, dataset={"id": "f", "temporal_direction": "future"}, period_type=period_type
+    )
+    assert resolved == expected()  # type: ignore[operator]
+
+
+def test_omitted_start_on_a_historical_dataset_is_a_client_error() -> None:
+    with pytest.raises(HTTPException) as exc:
+        ingestion_services._resolve_request_start(
+            None, dataset={"id": "chirps3_precipitation_daily"}, period_type="daily"
+        )
+    assert exc.value.status_code == 400
+    # The message must name the dataset and how to opt in, not just say "required".
+    assert "chirps3_precipitation_daily" in exc.value.detail
+    assert "temporal_direction: future" in exc.value.detail
+
+
+def test_forecast_horizon_reaches_beyond_now() -> None:
+    """The bug this guards: an omitted end collapsed a 7-day forecast to a single day.
+
+    An omitted end means "through the latest available period" for a historical dataset, so
+    core substitutes now. For a forecast, now is the *start* of the window — substituting it
+    there hands the plugin ``start == end == today``, one period comes back, and the whole
+    point of an omittable start is cancelled out. A forecast gets a forward horizon instead.
+    """
+    horizon = ingestion_services._forecast_horizon({"id": "f"}, "daily")
+    assert horizon > utc_today().isoformat()
+
+
+def test_forecast_horizon_prefers_a_declared_end() -> None:
+    dataset: dict[str, object] = {"id": "f", "extents": {"temporal": {"end": "2030"}}}
+    assert ingestion_services._forecast_horizon(dataset, "yearly") == "2030"
+
+
+@pytest.mark.parametrize("period_type", ["daily", "monthly", "yearly", "hourly", "weekly"])
+def test_forecast_horizon_is_period_native(period_type: str) -> None:
+    """It is handed straight to the plugin, so it has to parse as that period type."""
+    from open_climate_service.shared.time import normalize_period_string
+
+    horizon = ingestion_services._forecast_horizon({"id": "f"}, period_type)
+    assert normalize_period_string(horizon, period_type) == horizon
+
+
+# --- the request contract -------------------------------------------------------------
+
+
+def test_request_schema_allows_an_omitted_start() -> None:
+    assert CreateIngestionRequest(dataset_id="x").start is None
+
+
+def test_request_schema_still_accepts_a_start() -> None:
+    assert CreateIngestionRequest(dataset_id="x", start="2024-01-01").start == "2024-01-01"
+
+
+def test_post_ingestions_without_start_rejects_a_historical_dataset(client: TestClient) -> None:
+    """End to end: the API must refuse, with the actionable message rather than a 422."""
+    response = client.post("/ingestions", json={"dataset_id": "chirps3_precipitation_daily"})
+    assert response.status_code == 400, response.text
+    assert "temporal_direction: future" in response.json()["detail"]
+
+
+# --- the manage form -----------------------------------------------------------------
+
+
+def test_manage_form_exposes_each_template_direction(client: TestClient) -> None:
+    """The form switches its date defaults on the selected template, so it needs this."""
+    body = client.get("/manage").text
+    assert 'data-direction="past"' in body
+
+
+def test_manage_form_no_longer_hardcodes_a_start_requirement_message(client: TestClient) -> None:
+    """The blank-start rejection is now dataset-aware, made in create_artifact."""
+    from open_climate_service.system import routes
+
+    source = Path(routes.__file__).read_text(encoding="utf-8")
+    assert 'detail="Start date is required"' not in source

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -263,7 +263,10 @@ async def test_manage_ingest_rejects_blank_start(monkeypatch: pytest.MonkeyPatch
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == "http://testserver/manage?error=Start%20date%20is%20required"
+    # The rejection is now dataset-aware: only a forecast (temporal_direction: future) may
+    # omit the start, so a historical template still gets a redirect with an error.
+    assert "Start%20period%20is%20required" in response.headers["location"]
+    assert "chirps3_precipitation_daily" in response.headers["location"]
 
 
 def test_manage_page_shows_split_publication_and_sync_columns(


### PR DESCRIPTION
Implements [CLIM-868](https://dhis2.atlassian.net/browse/CLIM-868).

## What was wrong

The ingest contract assumed every dataset is historical. The form defaulted `start` to **a year ago** with `required`, and `end` to **today** — so for a forward-looking dataset the prefilled range contained *none* of the data. And since a forecast plugin ignores the range anyway, the operator was being asked for a value that did nothing.

Reported from the Malawi forecast plugin ([MWI-Climate-Service#6](https://github.com/HISP-MALAWI/MWI-Climate-Service/pull/6)):

> in the ingestion manage page the service still requires a definition of the start and from … i think we have to discuss the best approach between defining the lead time in the yaml file or in the ingestion page

## The answer: both places, different jobs

**How far ahead** belongs in the template — it's a property of the dataset ("meaningful 7 days out, though the API offers 40"), not a per-run choice. **The range** belongs in the request, narrowing within that when you want a subset. And it must be *omittable*, because for a forecast any fixed date is stale the next day and a scheduled refresh would drift out of the window and silently fetch nothing.

## Templates declare which way their periods run

```yaml
temporal_direction: future     # past (default) | future | spanning
```

| | Periods | `start` |
|---|---|---|
| `past` (default) | All historical | Required |
| `future` | All ahead of now — a forecast | **Optional**, meaning "from now" |
| `spanning` | Cross now | Required |

**Orthogonal to `sync.kind`, not a fourth kind of it.** A forecast is still `temporal` for sync purposes — re-run it and you get fresher data. `sync.kind` is a validated enum driving the sync engine's decisions, and this leaves it untouched.

### `spanning` — because WorldPop Global2 is both

Raised in review: WorldPop Global2 runs **2015–2030**, so a binary past/future can't describe it. It's now a third value, and both WorldPop templates are marked.

It still **requires** an explicit start, deliberately: defaulting to "now" would ingest only the projected years and silently drop every historical one — usually the half you want. What declaring it buys is on the form — the end prefills from the declared `extents.temporal.end`, so selecting WorldPop offers the full range through 2030 rather than truncating at today.

## `None` never reaches a plugin

Every plugin's signature is `periods(start: str, end: str)`, and several parse immediately (`date.fromisoformat(start)`), so passing an omitted field straight through would turn it into a `TypeError` deep inside a plugin. Core resolves it instead, in the dataset's native period format — reusing the helper that already computed exactly that for an omitted `end` (renamed `_default_request_end` → `_current_request_period`, since it now serves both ends).

I did try widening the contract to `end: str | None`. mypy correctly turned every subclass into a Liskov violation and then flagged the inner `daily_period_ids(start, end)` calls — 11 errors across 3 files, in plugins that can never receive `None` because they aren't future-facing. Reverted; the narrow contract is the better one.

## Two things only running it revealed

**1. An omitted `end` still collapsed the forecast to a single day.** I'd made `start` optional, but the existing end-defaulting substitutes "now" — which for a forecast is the *start* of the window. The plugin got `start == end == today`, returned one period, and the feature cancelled itself out. Unit tests passed throughout; a real ingest showed `2026-08-05 .. 2026-08-05` instead of seven days.

A forecast now gets a forward **horizon** — the declared `extents.temporal.end` if present, else a year ahead. Deliberately generous, since the real limit is the plugin's own lead time and a tighter bound in core would silently truncate a longer forecast. The plugin clips; `request_scope.end` stays `None` so the coverage check doesn't hold it to the wider bound. There's a regression test.

**2. Core already rejects a plugin that overshoots the requested scope** — `Materialized artifact coverage does not match the requested scope: coverage=2026-08-06..2026-08-12, request=2026-08-06..2026-08-07`. My throwaway test plugin ignored `end`, and core caught it. That's a useful guard rather than an obstacle, and it means a lead-day plugin has to *filter* on `end` rather than ignore it. Relevant to the Malawi plugin, and now documented.

## Validation placement

The blank-start rejection happens in the route, not `create_artifact`. The ingest work runs inside an SSE stream, and a response that has already begun can't redirect — leaving it downstream gave the operator a progress bar that failed mid-flight instead of the error banner. An existing test caught that regression; it's updated to assert the now dataset-aware message.

## Verification

Driven against a real instance with a lead-day forecast plugin, not just TestClient:

```
200  no start, no end (full window)   -> 2026-08-05 .. 2026-08-11
200  explicit narrow range            -> 2026-08-06 .. 2026-08-07
400  historical, no start             -> "requires a start period: its periods are historical…"
400  spanning (WorldPop), no start    -> "requires a start period…"
```

28 tests in `tests/test_forecast_ingest_range.py`: all three directions over HTTP, template validation (including `future` + `static` rejected as incoherent), the horizon regression, period-native horizons across five period types, and the form exposing each template's direction and declared end.

```
540 passed
make lint clean (ruff, format, mypy, pyright)
```

The 3 excluded failures in `test_openeo_execution.py` are the pre-existing local PROJ database conflict, verified identical on `main`.

## Docs

`adding_custom_datasets.md` gains the `temporal_direction` row, a table of the three values with what each means for `start`, a worked forecast example, the lead-time-in-the-template guidance, and what `periods()` actually receives — including that it must clip on `end` or hit the scope check.

## Follow-up for the instance side

The Malawi plugin can now drop the "ignores start/end" behaviour and filter its lead days by the requested range, which makes the form field meaningful whenever it's supplied. Covered in that PR's review; not changed here.


[CLIM-868]: https://dhis2.atlassian.net/browse/CLIM-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ