### PR TITLE
feat(chirps3): add monthly precipitation as a built-in dataset

### DIFF
--- a/docs/built_in_datasets.md
+++ b/docs/built_in_datasets.md
@@ -27,6 +27,29 @@ CHIRPS (Climate Hazards Group InfraRed Precipitation with Station data) v3 is a 
 
 ---
 
+## CHIRPS v3 — monthly precipitation
+
+| Property               | Value                                              |
+| ---------------------- | -------------------------------------------------- |
+| **Dataset ID**         | `chirps3_precipitation_monthly`                    |
+| **Variable**           | `precip`                                           |
+| **Units**              | mm/d                                               |
+| **Period**             | Monthly                                            |
+| **Spatial coverage**   | Global land, 50°S–50°N                             |
+| **Spatial resolution** | ~5 km                                              |
+| **Record start**       | 1981-01                                            |
+| **Source**             | [CHIRPS v3](https://www.chc.ucsb.edu/data/chirps3) |
+
+The monthly CHIRPS product, published as one global raster per calendar month. Prefer it over aggregating the daily dataset when you only need monthly values: it is roughly 30× less data to ingest, and drought indices such as SPI and SPEI are conventionally computed monthly.
+
+**Sync behaviour** — as for the daily dataset, the latest published month is discovered by probing the CHIRPS server rather than assuming a fixed lag. The monthly final product typically trails the calendar by a month or two.
+
+**Transforms** — the source raster is a monthly **total** in mm; it is divided by the number of days in the month and stored as a mean daily rate (`mm/d`). Unlike the daily dataset, where mm and mm/day are the same number, this is a real conversion.
+
+That choice keeps every monthly precipitation dataset on the same units, which matters because `chirps3_precipitation_monthly_normal_1991_2020` is also `mm/d` and is the natural partner for a monthly anomaly — storing the raw total under the same label would make that comparison wrong by a factor of about 30. It is also the form xclim's drought indices expect.
+
+---
+
 ## ERA5-Land — temperature and precipitation
 
 ERA5-Land provides temperature and precipitation at hourly, daily, and monthly resolution. Nine dataset templates are available covering both variables and all resolutions, with options for UTC or local-timezone daily aggregation.

--- a/open_climate_service/plugins/datasets/chirps3.py
+++ b/open_climate_service/plugins/datasets/chirps3.py
@@ -1,13 +1,13 @@
-"""CHIRPS3 plugin for per-period streaming ingest.
+"""CHIRPS3 plugins for per-period streaming ingest.
 
 CHIRPS3 keeps the first vertical slice small:
-- daily periods
+- daily and monthly periods
 - grid inferred from the first fetched period
 - one remote raster per period
 - straightforward bbox clipping into the requested extent
 
-This plugin stays intentionally source-focused. It knows how to derive the
-available periods and fetch one day, but it does not know anything about job
+These plugins stay intentionally source-focused. They know how to derive the
+available periods and fetch one period, but they do not know anything about job
 state, artifact records, or store mutation beyond returning one dataset.
 """
 
@@ -15,14 +15,55 @@ from __future__ import annotations
 
 import asyncio
 import calendar
+from collections.abc import Callable
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, TypeVar
 
 import xarray as xr
 
-from open_climate_service.streaming import BaseDatasetPlugin, daily_period_ids, normalize_period
+from open_climate_service.streaming import (
+    BaseDatasetPlugin,
+    daily_period_ids,
+    monthly_period_ids,
+    normalize_period,
+)
 
 _CHIRPS3_NODATA = -9999.0
+
+_T = TypeVar("_T")
+
+
+def _latest_published(
+    candidates: Callable[[int], _T],
+    url_for: Callable[[_T], str],
+    *,
+    lookback: int,
+    description: str,
+) -> _T:
+    """Return the most recent candidate period whose raster is actually published.
+
+    Issues a HEAD request per candidate, walking backwards from the present, so the
+    availability cutoff reflects real CDN state rather than a hardcoded lag assumption —
+    CHIRPS3's publication delay varies. Shared by the daily and monthly plugins, which
+    differ only in what a candidate is and how its URL is built.
+
+    Args:
+        candidates: maps a step count (0 = most recent candidate) to a candidate period.
+        url_for: builds the raster URL to probe for a candidate.
+        lookback: how many steps back to try before giving up.
+        description: used in the error message when nothing is published.
+
+    Raises:
+        RuntimeError: if no candidate within ``lookback`` steps is published.
+    """
+    import httpx
+
+    for step in range(lookback):
+        candidate = candidates(step)
+        response = httpx.head(url_for(candidate), timeout=10, follow_redirects=True)
+        if response.status_code == 200:
+            return candidate
+    raise RuntimeError(f"No published CHIRPS3 {description} found in the last {lookback} steps")
 
 
 class CHIRPS3DailyPlugin(BaseDatasetPlugin):
@@ -66,26 +107,16 @@ class CHIRPS3DailyPlugin(BaseDatasetPlugin):
         return normalize_period(da, variable="precip", period=period_id, nodata=_CHIRPS3_NODATA, bbox=bbox)
 
     def _availability_cutoff(self) -> date:
-        """Return the last day of the most recently published complete month.
+        """Return the last day of the most recently published complete month."""
 
-        Scans backward with a HEAD request on the last-day COG URL so the
-        cutoff reflects actual CDN state rather than a hardcoded lag assumption.
-        Raises if no published month is found within the last 6 months.
-        """
-        import httpx
+        def candidate(step: int) -> date:
+            today = datetime.now(UTC).date()
+            months_back = step + 1  # the current month is never complete
+            year, month = divmod(today.year * 12 + today.month - 1 - months_back, 12)
+            month += 1
+            return date(year, month, calendar.monthrange(year, month)[1])
 
-        today = datetime.now(UTC).date()
-        y, m = today.year, today.month
-        for _ in range(6):
-            m -= 1
-            if m == 0:
-                m, y = 12, y - 1
-            last_day = calendar.monthrange(y, m)[1]
-            candidate = date(y, m, last_day)
-            resp = httpx.head(self._url_for_day(candidate), timeout=10, follow_redirects=True)
-            if resp.status_code == 200:
-                return candidate
-        raise RuntimeError("No published CHIRPS3 month found in the last 6 months")
+        return _latest_published(candidate, self._url_for_day, lookback=6, description="daily month")
 
     def _url_for_day(self, day: date) -> str:
         """Build the remote CHIRPS3 raster URL for one day."""
@@ -98,3 +129,84 @@ class CHIRPS3DailyPlugin(BaseDatasetPlugin):
             f"https://data.chc.ucsb.edu/products/CHIRPS/v3.0/daily/prelim/sat/{day.year}/"
             f"chirps-v3.0.prelim.{day.year}.{day.month:02d}.{day.day:02d}.tif"
         )
+
+
+class CHIRPS3MonthlyPlugin(BaseDatasetPlugin):
+    """Streaming plugin for CHIRPS3 monthly precipitation.
+
+    One global COG per calendar month, so no ``stage``/``flavor`` variants and no
+    constructor arguments. The archive runs from 1981-01.
+
+    Stored as **mm/day**, not the raw monthly total. That is a real conversion rather than
+    the relabel the daily plugin gets away with: the source raster is a monthly *total* in
+    mm — verified against the sum of the same month's dailies, which matches to four decimal
+    places — so the rate is ``total / days_in_month``. It matters because every other monthly
+    precipitation dataset here is mm/d, including ``chirps3_precipitation_monthly_normal_1991_2020``,
+    which is the natural partner for a monthly anomaly. Storing the total under the same
+    units would make that pairing silently wrong by a factor of ~30.
+    """
+
+    max_concurrency = 4
+    commit_batch_size = 12
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        """Return ordered ``YYYY-MM`` periods, clamped to the latest published month."""
+        cutoff = await asyncio.to_thread(self._availability_cutoff)
+        return monthly_period_ids(start, end, cutoff=cutoff)
+
+    def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        """Fetch one month, convert the total to a mean daily rate, and clip to the bbox."""
+        import rioxarray
+
+        year, month = self._parse_month(period_id)
+        da = rioxarray.open_rasterio(self._url_for_month(year, month), chunks=None, masked=True)
+        if not isinstance(da, xr.DataArray):
+            raise TypeError(f"Expected DataArray from CHIRPS3 monthly raster read, got {type(da).__name__}")
+
+        # Convert before masking so the nodata sentinel is still recognisable: -9999 / 31
+        # would no longer match _CHIRPS3_NODATA. normalize_period masks on the raw value,
+        # so scale only the valid data and leave the sentinel alone.
+        days_in_month = calendar.monthrange(year, month)[1]
+        da = da.where(da == _CHIRPS3_NODATA, da / days_in_month)
+
+        # Stamp the first of the month as the time coordinate, matching the monthly
+        # convention used by the ERA5-Land monthly datasets.
+        return normalize_period(
+            da,
+            variable="precip",
+            period=f"{year:04d}-{month:02d}-01",
+            nodata=_CHIRPS3_NODATA,
+            bbox=bbox,
+        )
+
+    def _availability_cutoff(self) -> str:
+        """Return the ``YYYY-MM`` of the most recently published monthly COG."""
+
+        def candidate(step: int) -> tuple[int, int]:
+            today = datetime.now(UTC).date()
+            year, month = divmod(today.year * 12 + today.month - 1 - step, 12)
+            return year, month + 1
+
+        year, month = _latest_published(
+            candidate,
+            lambda ym: self._url_for_month(*ym),
+            # The monthly final product trails the calendar by a month or two; 24 is ample
+            # headroom for a longer-than-usual upstream delay.
+            lookback=24,
+            description="monthly COG",
+        )
+        return f"{year:04d}-{month:02d}"
+
+    @staticmethod
+    def _parse_month(period_id: str) -> tuple[int, int]:
+        """Accept ``YYYY-MM`` or any ``YYYY-MM-DD`` within the month."""
+        text = str(period_id)
+        try:
+            return int(text[:4]), int(text[5:7])
+        except (ValueError, IndexError) as exc:
+            raise ValueError(f"Invalid CHIRPS3 monthly period id {period_id!r}: expected YYYY-MM") from exc
+
+    @staticmethod
+    def _url_for_month(year: int, month: int) -> str:
+        """Build the remote CHIRPS3 monthly COG URL for one month."""
+        return f"https://data.chc.ucsb.edu/products/CHIRPS/v3.0/monthly/global/cogs/chirps-v3.0.{year}.{month:02d}.cog"

--- a/open_climate_service/plugins/datasets/chirps3.py
+++ b/open_climate_service/plugins/datasets/chirps3.py
@@ -21,6 +21,7 @@ from typing import Any, TypeVar
 
 import xarray as xr
 
+from open_climate_service.shared.time import normalize_period_string
 from open_climate_service.streaming import (
     BaseDatasetPlugin,
     daily_period_ids,
@@ -199,12 +200,17 @@ class CHIRPS3MonthlyPlugin(BaseDatasetPlugin):
 
     @staticmethod
     def _parse_month(period_id: str) -> tuple[int, int]:
-        """Accept ``YYYY-MM`` or any ``YYYY-MM-DD`` within the month."""
-        text = str(period_id)
+        """Accept ``YYYY-MM`` or any ``YYYY-MM-DD`` within the month.
+
+        Delegates to the canonical monthly parser so an out-of-range month is rejected here,
+        with the plugin's own contract in the message, rather than surfacing further in as a
+        ``calendar.IllegalMonthError`` from ``monthrange``.
+        """
         try:
-            return int(text[:4]), int(text[5:7])
-        except (ValueError, IndexError) as exc:
+            canonical = normalize_period_string(str(period_id), "monthly")
+        except (ValueError, TypeError) as exc:
             raise ValueError(f"Invalid CHIRPS3 monthly period id {period_id!r}: expected YYYY-MM") from exc
+        return int(canonical[:4]), int(canonical[5:7])
 
     @staticmethod
     def _url_for_month(year: int, month: int) -> str:

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -28,6 +28,39 @@
     range: [0.0, 20.0]
     nodata: -9999.0
 
+- id: chirps3_precipitation_monthly
+  name: Precipitation rate (CHIRPS3, monthly)
+  short_name: Precipitation
+  standard_name: lwe_precipitation_rate
+  variable: precip
+  period_type: monthly
+  sync:
+    kind: temporal
+    execution: append
+  extents:
+    spatial:
+      bbox: [-180, -50, 180, 50]
+    temporal:
+      begin: "1981-01-01"
+      resolution: P1M
+  ingestion:
+    plugin: open_climate_service.plugins.datasets.chirps3.CHIRPS3MonthlyPlugin
+  # The source raster is a monthly *total* in mm — confirmed against the sum of the same
+  # month's dailies, which matches exactly — so the plugin divides by the number of days to
+  # store a mean daily rate. Unlike the daily dataset this is a real conversion, not a
+  # relabel. mm/d is what every other monthly precipitation dataset here uses, including
+  # chirps3_precipitation_monthly_normal_1991_2020 below: storing the raw total under the
+  # same units would make a monthly anomaly against that normal wrong by a factor of ~30.
+  units: mm/d
+  cell_methods: "time: mean"
+  resolution: 5 km x 5 km
+  source: CHIRPS v3 (monthly)
+  source_url: https://www.chc.ucsb.edu/data/chirps3
+  display:
+    colormap: blues
+    range: [0.0, 20.0]
+    nodata: -9999.0
+
 # ---------------------------------------------------------------------------
 # Climate-normal output templates for the `climate_normal` openEO workflow (normals
 # computed from the already-ingested CHIRPS3 store). No ingestion plugin — the data is

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -22,7 +22,7 @@ from open_climate_service.shared.time import (
     datetime_to_period_string,
     parse_period_string_to_datetime,
 )
-from open_climate_service.streaming import BaseDatasetPlugin
+from open_climate_service.streaming import BaseDatasetPlugin, monthly_period_ids
 from open_climate_service.transforms.unit_conversion import kelvin_to_celsius, metres_to_mm
 
 # CDS API long-name variables for reanalysis-era5-land-monthly-means
@@ -213,18 +213,7 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
 
     async def periods(self, start: str, end: str) -> list[str]:
         cutoff = await asyncio.to_thread(_monthly_availability_cutoff)
-        start_dt = _parse_monthly(start)
-        end_dt = min(_parse_monthly(end), datetime(cutoff.year, cutoff.month, 1))
-        if start_dt > end_dt:
-            return []
-        result: list[str] = []
-        current = start_dt
-        while current <= end_dt:
-            result.append(f"{current.year:04d}-{current.month:02d}")
-            month = current.month % 12 + 1
-            year = current.year + (1 if current.month == 12 else 0)
-            current = datetime(year, month, 1)
-        return result
+        return monthly_period_ids(_parse_monthly(start), _parse_monthly(end), cutoff=cutoff)
 
     def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
         year, month = int(period_id[:4]), int(period_id[5:7])

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -166,6 +166,39 @@ def daily_period_ids(start: str | date, end: str | date, *, cutoff: str | date |
     return out
 
 
+def monthly_period_ids(start: str | date, end: str | date, *, cutoff: str | date | None = None) -> list[str]:
+    """Return ``YYYY-MM`` strings for every month in ``[start, end]`` inclusive.
+
+    The monthly counterpart of :func:`daily_period_ids`, with the same contract: accepts ISO
+    strings (``2024-03`` or ``2024-03-17``) or ``date``/``datetime`` objects, returns an
+    empty list when ``start`` is after ``end``, and ``cutoff`` caps ``end`` so a plugin owns
+    only its availability clamp rather than the month arithmetic.
+
+    Any day within a month selects that month, so a caller need not normalise to the first.
+    """
+
+    def _as_year_month(value: str | date) -> tuple[int, int]:
+        if isinstance(value, datetime):
+            return value.year, value.month
+        if isinstance(value, date):
+            return value.year, value.month
+        text = str(value)
+        return int(text[:4]), int(text[5:7])
+
+    year, month = _as_year_month(start)
+    last_year, last_month = _as_year_month(end)
+    if cutoff is not None:
+        cutoff_year, cutoff_month = _as_year_month(cutoff)
+        if (cutoff_year, cutoff_month) < (last_year, last_month):
+            last_year, last_month = cutoff_year, cutoff_month
+
+    out: list[str] = []
+    while (year, month) <= (last_year, last_month):
+        out.append(f"{year:04d}-{month:02d}")
+        year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+    return out
+
+
 def parse_hourly_period_string(value: str) -> datetime:
     """Parse a dataset-native hourly period string or full ISO datetime."""
     if len(value) == 13:

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -175,6 +175,11 @@ def monthly_period_ids(start: str | date, end: str | date, *, cutoff: str | date
     only its availability clamp rather than the month arithmetic.
 
     Any day within a month selects that month, so a caller need not normalise to the first.
+
+    Raises:
+        ValueError: for a malformed or out-of-range value, matching how ``daily_period_ids``
+            fails fast via ``date.fromisoformat``. Strictness is not cosmetic here: a month
+            outside 1..12 used to walk the increment past its 12 → 1 wrap and loop forever.
     """
 
     def _as_year_month(value: str | date) -> tuple[int, int]:
@@ -182,8 +187,10 @@ def monthly_period_ids(start: str | date, end: str | date, *, cutoff: str | date
             return value.year, value.month
         if isinstance(value, date):
             return value.year, value.month
-        text = str(value)
-        return int(text[:4]), int(text[5:7])
+        # Reuse the canonical monthly parser rather than slicing: it accepts YYYY-MM or any
+        # ISO date within the month and rejects everything else with a clear message.
+        canonical = normalize_period_string(str(value), "monthly")
+        return int(canonical[:4]), int(canonical[5:7])
 
     year, month = _as_year_month(start)
     last_year, last_month = _as_year_month(end)

--- a/open_climate_service/streaming/__init__.py
+++ b/open_climate_service/streaming/__init__.py
@@ -6,12 +6,12 @@ streaming path introduced for issue #64 / CLIM-715.
 
 This package is also the single import surface for writing a dataset plugin —
 `BaseDatasetPlugin` plus the helpers a plugin reaches for (`normalize_period`,
-`daily_period_ids`) — so contributors don't have to hunt across modules.
-`daily_period_ids` is re-exported from `open_climate_service.shared.time`, its
-canonical home.
+`daily_period_ids`, `monthly_period_ids`) — so contributors don't have to hunt across
+modules. The period-id helpers are re-exported from `open_climate_service.shared.time`,
+their canonical home.
 """
 
-from open_climate_service.shared.time import daily_period_ids
+from open_climate_service.shared.time import daily_period_ids, monthly_period_ids
 from open_climate_service.streaming.base import BaseDatasetPlugin
 from open_climate_service.streaming.helpers import normalize_period
 from open_climate_service.streaming.orchestrator import StreamingIngestResult, run_streaming_ingest_sync
@@ -22,6 +22,7 @@ __all__ = [
     "IngestionPlugin",
     "StreamingIngestResult",
     "daily_period_ids",
+    "monthly_period_ids",
     "normalize_period",
     "run_streaming_ingest_sync",
 ]

--- a/tests/test_streaming_chirps3_monthly.py
+++ b/tests/test_streaming_chirps3_monthly.py
@@ -82,6 +82,40 @@ def test_accepts_date_objects() -> None:
     assert monthly_period_ids(date(2024, 11, 17), date(2025, 1, 3)) == ["2024-11", "2024-12", "2025-01"]
 
 
+def test_an_out_of_range_month_does_not_loop_forever() -> None:
+    """Regression: month 13 used to hang, not merely return a wrong answer.
+
+    The increment only wraps at exactly 12, so a month of 13 climbed indefinitely while the
+    ``(year, month) <= (last_year, last_month)`` guard stayed true — an unbounded loop
+    appending to a list. Validation is what makes it unreachable.
+    """
+    import signal
+
+    def _bail(*_: object) -> None:
+        raise TimeoutError("monthly_period_ids did not terminate")
+
+    original = signal.signal(signal.SIGALRM, _bail)
+    signal.alarm(5)
+    try:
+        with pytest.raises(ValueError, match="Invalid monthly period"):
+            monthly_period_ids("2025-13", "2026-01")
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original)
+
+
+@pytest.mark.parametrize("value", ["2025-13", "2025-00", "2025-1", "2025", "garbage", ""])
+def test_rejects_malformed_months(value: str) -> None:
+    """Fails fast like ``daily_period_ids`` does via ``date.fromisoformat``."""
+    with pytest.raises(ValueError, match="Invalid monthly period"):
+        monthly_period_ids(value, "2026-01")
+
+
+def test_rejects_a_malformed_end_too() -> None:
+    with pytest.raises(ValueError, match="Invalid monthly period"):
+        monthly_period_ids("2025-01", "2025-13")
+
+
 def test_era5_land_monthly_uses_the_shared_helper() -> None:
     """It hand-rolled the same month loop before; the third copy is what prompted this."""
     from open_climate_service.plugins.datasets import era5_land
@@ -138,9 +172,12 @@ def test_accepts_a_full_date_period_id(stub_raster: None) -> None:
     assert np.datetime_as_string(ds["t"].values[0], unit="D") == "2025-03-01"
 
 
-def test_rejects_an_unparseable_period_id(stub_raster: None) -> None:
+@pytest.mark.parametrize("value", ["not-a-month", "2025-13", "2025-00", "2025-1", "2025"])
+def test_rejects_an_unparseable_period_id(stub_raster: None, value: str) -> None:
+    """An out-of-range month should name the plugin's contract, not surface as
+    ``calendar.IllegalMonthError`` from ``monthrange`` further in."""
     with pytest.raises(ValueError, match="expected YYYY-MM"):
-        CHIRPS3MonthlyPlugin().fetch_period("not-a-month", [33.0, -14.0, 34.0, -13.0])
+        CHIRPS3MonthlyPlugin().fetch_period(value, [33.0, -14.0, 34.0, -13.0])
 
 
 # --- URLs and availability ------------------------------------------------------------

--- a/tests/test_streaming_chirps3_monthly.py
+++ b/tests/test_streaming_chirps3_monthly.py
@@ -1,0 +1,221 @@
+"""Tests for the CHIRPS3 monthly plugin and the shared monthly period helper (CLIM-867)."""
+
+from __future__ import annotations
+
+import asyncio
+import calendar
+from datetime import date
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from open_climate_service.data_registry.services import datasets as registry
+from open_climate_service.plugins.datasets import chirps3
+from open_climate_service.plugins.datasets.chirps3 import CHIRPS3MonthlyPlugin
+from open_climate_service.shared.time import monthly_period_ids
+
+_NODATA = -9999.0
+
+
+def _source_raster(total_mm: float = 310.0, with_nodata: bool = False) -> xr.DataArray:
+    """A CHIRPS3-shaped monthly raster: a total in mm, with a raw -9999 sentinel.
+
+    Carries an explicit CRS because the real COGs do, and ``normalize_period`` needs one to
+    reproject the request bbox for the spatial clip.
+    """
+    import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio
+
+    values = np.full((1, 2, 2), total_mm, dtype="float32")
+    if with_nodata:
+        values[0, 0, 1] = _NODATA
+    da = xr.DataArray(
+        values,
+        dims=("band", "y", "x"),
+        coords={"band": [1], "y": [-13.0, -14.0], "x": [33.0, 34.0]},
+    )
+    return da.rio.write_crs(4326)
+
+
+@pytest.fixture
+def stub_raster(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serve a synthetic raster instead of reaching the CHC CDN."""
+
+    def fake_open(url: str, **_: Any) -> xr.DataArray:
+        return _source_raster(with_nodata="ocean" in url)
+
+    import rioxarray
+
+    monkeypatch.setattr(rioxarray, "open_rasterio", fake_open)
+
+
+# --- monthly_period_ids ---------------------------------------------------------------
+
+
+def test_enumerates_months_across_a_year_boundary() -> None:
+    assert monthly_period_ids("2024-11", "2025-02") == ["2024-11", "2024-12", "2025-01", "2025-02"]
+
+
+def test_single_month() -> None:
+    assert monthly_period_ids("2025-01", "2025-01") == ["2025-01"]
+
+
+def test_reversed_range_is_empty() -> None:
+    assert monthly_period_ids("2025-03", "2025-01") == []
+
+
+def test_cutoff_caps_the_end() -> None:
+    assert monthly_period_ids("2024-11", "2025-06", cutoff="2024-12") == ["2024-11", "2024-12"]
+
+
+def test_cutoff_beyond_the_end_is_ignored() -> None:
+    assert monthly_period_ids("2025-01", "2025-02", cutoff="2030-01") == ["2025-01", "2025-02"]
+
+
+@pytest.mark.parametrize("value", ["2024-11-17", "2024-11-01"])
+def test_any_day_within_a_month_selects_that_month(value: str) -> None:
+    assert monthly_period_ids(value, "2024-12") == ["2024-11", "2024-12"]
+
+
+def test_accepts_date_objects() -> None:
+    assert monthly_period_ids(date(2024, 11, 17), date(2025, 1, 3)) == ["2024-11", "2024-12", "2025-01"]
+
+
+def test_era5_land_monthly_uses_the_shared_helper() -> None:
+    """It hand-rolled the same month loop before; the third copy is what prompted this."""
+    from open_climate_service.plugins.datasets import era5_land
+
+    source = __import__("pathlib").Path(era5_land.__file__).read_text(encoding="utf-8")
+    assert "monthly_period_ids(" in source
+
+
+# --- the mm/d conversion --------------------------------------------------------------
+
+
+def test_monthly_total_becomes_a_mean_daily_rate(stub_raster: None) -> None:
+    """310 mm over a 31-day month is 10 mm/d. The core of CLIM-867's units decision."""
+    ds = CHIRPS3MonthlyPlugin().fetch_period("2025-01", [33.0, -14.0, 34.0, -13.0])
+    assert float(ds["precip"].mean()) == pytest.approx(10.0)
+
+
+@pytest.mark.parametrize(
+    ("period", "days"),
+    [("2025-01", 31), ("2025-02", 28), ("2024-02", 29), ("2025-04", 30)],
+)
+def test_divides_by_the_actual_days_in_month(stub_raster: None, period: str, days: int) -> None:
+    """February differs between years, so a fixed 30 or 31 would be wrong twice over."""
+    ds = CHIRPS3MonthlyPlugin().fetch_period(period, [33.0, -14.0, 34.0, -13.0])
+    assert float(ds["precip"].mean()) == pytest.approx(310.0 / days)
+    assert days == calendar.monthrange(int(period[:4]), int(period[5:7]))[1]
+
+
+def test_nodata_is_masked_not_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reason the conversion guards the sentinel.
+
+    The monthly COGs declare no nodata, so a masked read leaves a raw -9999 in the array.
+    Dividing it by the day count would give ~-322.5, which no longer matches the sentinel
+    normalize_period masks on — so it would be stored as a plausible negative rainfall rate.
+    """
+    import rioxarray
+
+    monkeypatch.setattr(rioxarray, "open_rasterio", lambda url, **_: _source_raster(with_nodata=True))
+    ds = CHIRPS3MonthlyPlugin().fetch_period("2025-01", [33.0, -14.0, 34.0, -13.0])
+    values = ds["precip"].values
+    assert np.isnan(values).sum() == 1, "the sentinel cell should be NaN"
+    finite = values[np.isfinite(values)]
+    assert finite.min() > 0, "no negative rate should survive"
+    assert not np.any(np.isclose(finite, _NODATA / 31, atol=1.0)), "the sentinel was scaled instead of masked"
+
+
+def test_time_coordinate_is_the_first_of_the_month(stub_raster: None) -> None:
+    ds = CHIRPS3MonthlyPlugin().fetch_period("2025-03", [33.0, -14.0, 34.0, -13.0])
+    assert np.datetime_as_string(ds["t"].values[0], unit="D") == "2025-03-01"
+
+
+def test_accepts_a_full_date_period_id(stub_raster: None) -> None:
+    ds = CHIRPS3MonthlyPlugin().fetch_period("2025-03-01", [33.0, -14.0, 34.0, -13.0])
+    assert np.datetime_as_string(ds["t"].values[0], unit="D") == "2025-03-01"
+
+
+def test_rejects_an_unparseable_period_id(stub_raster: None) -> None:
+    with pytest.raises(ValueError, match="expected YYYY-MM"):
+        CHIRPS3MonthlyPlugin().fetch_period("not-a-month", [33.0, -14.0, 34.0, -13.0])
+
+
+# --- URLs and availability ------------------------------------------------------------
+
+
+def test_url_matches_the_published_layout() -> None:
+    assert CHIRPS3MonthlyPlugin._url_for_month(2025, 1) == (
+        "https://data.chc.ucsb.edu/products/CHIRPS/v3.0/monthly/global/cogs/chirps-v3.0.2025.01.cog"
+    )
+
+
+def test_periods_are_clamped_to_the_published_month(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(CHIRPS3MonthlyPlugin, "_availability_cutoff", lambda self: "2025-02")
+    periods = asyncio.run(CHIRPS3MonthlyPlugin().periods("2024-12", "2025-06"))
+    assert periods == ["2024-12", "2025-01", "2025-02"]
+
+
+def test_availability_probe_walks_back_to_the_newest_published_month(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The current month and the one before are typically unpublished."""
+    published = "chirps-v3.0.2025.03.cog"
+    calls: list[str] = []
+
+    class _Response:
+        def __init__(self, url: str) -> None:
+            self.status_code = 200 if published in url else 404
+
+    def fake_head(url: str, **_: Any) -> _Response:
+        calls.append(url)
+        return _Response(url)
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "head", fake_head)
+    monkeypatch.setattr(chirps3, "datetime", _FrozenDatetime)
+    assert CHIRPS3MonthlyPlugin()._availability_cutoff() == "2025-03"
+    assert len(calls) == 3, "should stop at the first published month (May, April, March)"
+
+
+def test_availability_probe_raises_when_nothing_is_published(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Missing:
+        status_code = 404
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "head", lambda url, **_: _Missing())
+    monkeypatch.setattr(chirps3, "datetime", _FrozenDatetime)
+    with pytest.raises(RuntimeError, match="No published CHIRPS3 monthly COG"):
+        CHIRPS3MonthlyPlugin()._availability_cutoff()
+
+
+class _FrozenDatetime:
+    """Pin "now" so the probe's candidate months are deterministic."""
+
+    @staticmethod
+    def now(_tz: Any = None) -> Any:
+        class _Now:
+            @staticmethod
+            def date() -> date:
+                return date(2025, 5, 20)
+
+        return _Now()
+
+
+# --- the template ---------------------------------------------------------------------
+
+
+def test_template_is_registered_with_the_monthly_plugin() -> None:
+    template = {d["id"]: d for d in registry.list_datasets()}["chirps3_precipitation_monthly"]
+    assert template["period_type"] == "monthly"
+    assert template["ingestion"]["plugin"].endswith("CHIRPS3MonthlyPlugin")
+
+
+def test_template_units_match_the_monthly_normal() -> None:
+    """The whole point of converting: an anomaly pairs these two, so units must agree."""
+    loaded = {d["id"]: d for d in registry.list_datasets()}
+    assert loaded["chirps3_precipitation_monthly"]["units"] == "mm/d"
+    assert loaded["chirps3_precipitation_monthly_normal_1991_2020"]["units"] == "mm/d"
+    assert loaded["era5land_precipitation_monthly"]["units"] == "mm/d"


### PR DESCRIPTION
Implements [CLIM-867](https://dhis2.atlassian.net/browse/CLIM-867).

Adds `chirps3_precipitation_monthly`, so monthly CHIRPS is available without ingesting daily data and reducing it — roughly **30× less data to fetch**, and monthly is the resolution drought work actually uses, since SPI/SPEI are conventionally monthly.

Both the plugin and the template live in the **existing** `chirps3.py` / `chirps3.yaml`, matching how `era5_land.py` already holds hourly, daily and monthly plugins side by side. No new files.

## The units decision, verified rather than assumed

The source raster is a monthly **total in mm**. I checked rather than trusting the docs — over a 1×1° box in Malawi for January 2025:

```
monthly COG mean        :   399.69
sum of 31 daily COGs    :   399.69
ratio                   :   1.0000   -> the monthly raster IS the daily total
```

So the plugin divides by the days in the month and stores **mm/d**. Unlike the daily dataset — where mm and mm/day are the same number, a relabel — this is a real conversion.

It matters because **`chirps3_precipitation_monthly_normal_1991_2020` already exists in `mm/d`** and is the natural partner for a monthly anomaly. Storing the raw total under the same units label would make that pairing silently wrong by a factor of ~30: right shape, plausible map, no error. It also keeps CHIRPS3 comparable with `era5land_precipitation_monthly`, and `mm/d` is what xclim's drought indices consume.

End-to-end cross-check through both plugins against live data:

```
monthly plugin  -> 12.8934 mm/d
daily aggregate -> 12.8934 mm/d   (sum of 31 days / 31)
difference      -> 0.0000%
```

## A guard that turned out to be necessary, not defensive

I wrote the conversion to skip the nodata sentinel, then checked whether that was actually needed. It was:

```
declared nodata : None
masked=True -> any -9999 remaining: True
```

**The monthly COGs declare no nodata**, so `masked=True` masks nothing and a raw `-9999.0` survives into the array. Dividing it by 31 gives ~`-322.5`, which `normalize_period(nodata=-9999.0)` no longer recognises — it would be stored as a plausible negative rainfall rate. Verified over an ocean box that the sentinel is masked to NaN and no scaled sentinel survives.

## Two extractions

**`monthly_period_ids` in `shared/time.py`**, mirroring `daily_period_ids` down to the `cutoff` parameter. `ERA5LandMonthlyPlugin` hand-rolled the same month loop, so a new plugin would have been the *third* copy — it now uses the helper and loses 12 lines. Exported from `open_climate_service.streaming` alongside `daily_period_ids`.

**One shared availability probe.** Both CHIRPS3 plugins walk backwards issuing HEAD requests until one returns 200 — they differed only in what a candidate is and how its URL is built. Now one `_latest_published` helper. Since this refactors working code, I verified the new daily cutoff is **identical to the original across 30 today/step combinations** before switching.

Also per the ticket: no constructor on the monthly plugin (one global path, so no `stage`/`flavor` to validate), and the nodata handling is unchanged from the daily path.

## Verification

24 tests (`tests/test_streaming_chirps3_monthly.py`):

- month enumeration — year boundaries, cutoff clamping, `date` objects, reversed ranges, any-day-selects-the-month
- the mm/d conversion, including **February in both a leap and a non-leap year**, since a fixed 30 or 31 would be wrong twice over
- nodata masked rather than scaled, asserting no value near `-9999/31` survives
- the time coordinate lands on the first of the month
- URL layout, availability probing, and its failure mode when nothing is published
- that all three monthly precipitation templates agree on `mm/d` — the invariant the whole units decision rests on

```
536 passed
make lint clean (ruff, format, mypy, pyright)
```

The 3 excluded failures in `test_openeo_execution.py` are the pre-existing local PROJ database conflict, verified identical on `main`.

## Docs

`built_in_datasets.md` gains a monthly CHIRPS section covering the mm/d conversion and why it is that way, plus when to prefer it over aggregating the daily dataset.

## Out of scope

An SPI-3 dataset derived from this, as the ticket notes. It needs [#331](https://github.com/dhis2/open-climate-service/pull/331) (CLIM-826) first, without which `spi` cannot accept calibration bounds at all. Worth a separate ticket once both land.


[CLIM-867]: https://dhis2.atlassian.net/browse/CLIM-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ