### PR TITLE
feat(pyramid): upgrade topozarr and delegate nearest coarsening upstream

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -188,7 +188,9 @@ Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map sta
 - **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.
 - **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a *different, non-existent* class (e.g. `mean(10, 80) = 45`).
 
-`mean`/`max`/`min`/`sum` are computed by [topozarr](https://github.com/carbonplan/topozarr); `mode` and `nearest` are resampled from the native resolution by Open Climate Service, because they can't be built level-from-level (a first-class `mode`/`nearest` in topozarr is requested in [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26)).
+`mean`/`max`/`min`/`sum`/`nearest` are computed by [topozarr](https://github.com/carbonplan/topozarr), which builds each level from the one above. That is valid for all five because they are *composable* — for `nearest`, taking the corner of each corner gives the same cell as taking every nth cell of the original.
+
+`mode` is not composable: mode-of-modes is not mode-of-native, since a locally dominant class can win at coarse zoom even when it is globally rare. So Open Climate Service resamples `mode` levels from the native resolution itself. A first-class `mode` upstream is still open as [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26); when it lands, that local path can go.
 
 **Spatial and temporal extents** — declares what the source dataset covers. Used to validate ingest requests before hitting the provider:
 

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -144,11 +144,12 @@ def _overwrite_native_resampled_levels(
 ) -> None:
     """Replace topozarr's coarsened levels with a native resample for categorical data.
 
-    topozarr block-reduces each level from the level above, which is wrong for ``mode`` /
-    ``nearest`` (a coarse cell must be derived from the native cells it covers, not from an
-    already-coarsened parent). topozarr has still written every level's group/array with the
-    right shape, chunking and encoding, so we recompute levels 1..N-1 straight from the
-    native (level-0) arrays and write the values back in place.
+    topozarr block-reduces each level from the level above, which is wrong for ``mode``: a
+    coarse cell's majority class must be derived from the native cells it covers, not from an
+    already-coarsened parent, or a locally dominant class can win at coarse zoom while being
+    globally rare. topozarr has still written every level's group/array with the right shape,
+    chunking and encoding, so we recompute levels 1..N-1 straight from the native (level-0)
+    arrays and write the values back in place.
     """
     root = zarr.open_group(store, mode="a")
     spatial_vars = [str(name) for name, da in ds.data_vars.items() if {x_dim, y_dim} <= set(da.dims)]
@@ -349,9 +350,9 @@ def write_to_icechunk_store(
         # Validate/normalize here too, so a direct caller passing e.g. "MAX" or a mistyped
         # value never reaches topozarr as an invalid CoarseningMethod (falls back to mean).
         pyramid_method = _normalize_resampling_method(pyramid_method)
-        # topozarr only offers composable coarsening (mean/max/min/sum). For categorical
-        # methods (mode/nearest) it writes valid structure with a placeholder here, then we
-        # overwrite the coarsened levels from native below (see #293).
+        # topozarr only offers composable coarsening (mean/max/min/sum/nearest). For `mode`
+        # it writes valid structure with a placeholder here, then we overwrite the coarsened
+        # levels from native below (see #293 and carbonplan/topozarr#26).
         native_resample = pyramid_method in _NATIVE_RESAMPLE_METHODS
         composable_method = "max" if native_resample else pyramid_method
         pyramid = create_pyramid(

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -49,12 +49,17 @@ def _pyramid_levels(ds: xr.Dataset, x_dim: str, y_dim: str) -> int:
     return max(2, min(levels, _PYRAMID_MAX_LEVELS))
 
 
-# Coarsening methods topozarr computes itself, each level block-reduced from the one above
-# (valid because they are composable). Correct for *continuous* data.
-_COMPOSABLE_METHODS = frozenset({"mean", "max", "min", "sum"})
-# Categorical methods topozarr cannot do: they are non-composable and must be resampled from
-# the native (level-0) array, so OCS recomputes those levels itself (see #293, carbonplan/topozarr#26).
-_NATIVE_RESAMPLE_METHODS = frozenset({"mode", "nearest"})
+# Coarsening methods topozarr computes itself, each level block-reduced from the one above.
+# That is valid because they are composable — `nearest` included, since corner-of-corners
+# equals corner-of-native. `nearest` arrived in topozarr 0.1.3 (carbonplan/topozarr#26) and
+# is now delegated rather than recomputed here.
+_COMPOSABLE_METHODS = frozenset({"mean", "max", "min", "sum", "nearest"})
+# Methods topozarr cannot do: non-composable, so each level must be resampled from the
+# native (level-0) array rather than from an already-coarsened parent, and OCS recomputes
+# those levels itself. Only `mode` remains — carbonplan/topozarr#26 is still open for it, and
+# upstream's own note says such methods "must reduce from native instead". Delete this path
+# and the helpers below once it lands.
+_NATIVE_RESAMPLE_METHODS = frozenset({"mode"})
 _RESAMPLING_METHODS = _COMPOSABLE_METHODS | _NATIVE_RESAMPLE_METHODS
 _DEFAULT_RESAMPLING = "mean"
 
@@ -125,16 +130,13 @@ def _coarsen_native(da: xr.DataArray, x_dim: str, y_dim: str, factor: int, metho
     ``boundary="trim"`` drops the trailing partial window, so the result is
     ``floor(size / factor)`` per spatial dim — the same shape topozarr produces by
     repeatedly halving, so the output drops straight into the level's existing array.
+
+    Only ``mode`` reaches here. ``nearest`` used to as well, but topozarr 0.1.3 does it
+    natively and composably, so it is delegated (see ``_COMPOSABLE_METHODS``).
     """
-    window = {x_dim: factor, y_dim: factor}
-    coarsen = da.coarsen(window, boundary="trim")
-    if method == "nearest":
-        # Decimation: keep the top-left cell of each window (a real, unaltered value).
-        constructed = coarsen.construct({x_dim: (x_dim, "_ocs_wx"), y_dim: (y_dim, "_ocs_wy")})
-        return constructed.isel(_ocs_wx=0, _ocs_wy=0)
-    if method == "mode":
-        return coarsen.reduce(_mode_reduce)
-    raise ValueError(f"unsupported native-resample method {method!r}")
+    if method != "mode":
+        raise ValueError(f"unsupported native-resample method {method!r}")
+    return da.coarsen({x_dim: factor, y_dim: factor}, boundary="trim").reduce(_mode_reduce)
 
 
 def _overwrite_native_resampled_levels(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,15 @@ server = [
     "zarr>=3.1.6,<4",
     "icechunk>=2.0,<3",
     "geozarr-toolkit==0.1.*",
-    "topozarr>=0.0.91,<0.1",
+    # 0.1.3 added the `nearest` coarsening method, so categorical pyramids no longer need a
+    # local decimation path (carbonplan/topozarr#26). `mode` is still ours — see downloader.
+    "topozarr>=0.1.3,<0.2",
+    # Pinned explicitly because topozarr's own constraint is `topozarr-core>=0.1.0,<0.2`,
+    # which is too loose: the `nearest` kernel only exists from core 0.1.2. Resolving to
+    # 0.1.0 leaves `nearest` accepted by the Python layer but failing inside the kernel with
+    # "method must be one of 'mean', 'max', 'min', 'sum'" — and only at ingest time, not on
+    # import. Drop this once upstream raises its own lower bound.
+    "topozarr-core>=0.1.2,<0.2",
     "rioxarray>=0.17",
     # Directly imported (shared/time.py, streaming, openeo). Capped to 2.x; pandas
     # 3.0 is a breaking major and not yet validated against this stack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,15 @@ server = [
     "geozarr-toolkit==0.1.*",
     # 0.1.3 added the `nearest` coarsening method, so categorical pyramids no longer need a
     # local decimation path (carbonplan/topozarr#26). `mode` is still ours — see downloader.
-    "topozarr>=0.1.3,<0.2",
-    # Pinned explicitly because topozarr's own constraint is `topozarr-core>=0.1.0,<0.2`,
-    # which is too loose: the `nearest` kernel only exists from core 0.1.2. Resolving to
-    # 0.1.0 leaves `nearest` accepted by the Python layer but failing inside the kernel with
-    # "method must be one of 'mean', 'max', 'min', 'sum'" — and only at ingest time, not on
-    # import. Drop this once upstream raises its own lower bound.
-    "topozarr-core>=0.1.2,<0.2",
+    # The floor is 0.1.4 rather than 0.1.3 for a packaging reason: `topozarr` and
+    # `topozarr-core` are separate distributions, and 0.1.3 declared only
+    # `topozarr-core>=0.1.0,<0.2` — too loose, since the `nearest` kernel exists only from core
+    # 0.1.2. That combination installs cleanly and then fails *at ingest time* with "method must
+    # be one of 'mean', 'max', 'min', 'sum'", because the Python layer accepts `nearest` and the
+    # Rust kernel rejects it. 0.1.4 pins `topozarr-core==0.1.4` and adds a lockstep release
+    # check (carbonplan/topozarr#28), so the pair can no longer be mismatched and OCS no longer
+    # needs a `topozarr-core` pin of its own. Do not lower this floor.
+    "topozarr>=0.1.4,<0.2",
     "rioxarray>=0.17",
     # Directly imported (shared/time.py, streaming, openeo). Capped to 2.x; pandas
     # 3.0 is a breaking major and not yet validated against this stack.

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -142,9 +142,10 @@ def test_coarsen_native_only_handles_mode() -> None:
 def test_topozarr_nearest_keeps_the_top_left_cell() -> None:
     """Pin the upstream kernel's corner choice, since our equivalence argument rests on it.
 
-    Also guards the packaging trap: `nearest` only exists from topozarr-core 0.1.2, and
-    topozarr's own constraint (`>=0.1.0`) would allow an older core where this raises
-    "method must be one of 'mean', 'max', 'min', 'sum'" — at ingest time, not on import.
+    Also the last line of defence against a `topozarr` / `topozarr-core` version mismatch. That
+    used to be reachable — 0.1.3 declared only `topozarr-core>=0.1.0` while the `nearest` kernel
+    exists from core 0.1.2 — and it failed at ingest time rather than on import. 0.1.4 pins the
+    pair exactly, so it should no longer be possible; this asserts that rather than assuming it.
     """
     from topozarr_core import block_reduce
 

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -115,10 +115,42 @@ def test_coarsen_native_mode_picks_block_majority() -> None:
     np.testing.assert_array_equal(out.values, np.array([[10, 20], [30, 40]], dtype="uint8"))
 
 
-def test_coarsen_native_nearest_takes_top_left() -> None:
-    out = _coarsen_native(_categorical_block_da(), "x", "y", 2, "nearest").transpose("y", "x")
-    # Top-left cell of each 2x2 block: 99/20/30/40.
-    np.testing.assert_array_equal(out.values, np.array([[99, 20], [30, 40]], dtype="uint8"))
+def test_nearest_is_delegated_to_topozarr() -> None:
+    """`nearest` arrived upstream in topozarr 0.1.3, so OCS no longer computes it.
+
+    It is composable — corner-of-corners equals corner-of-native — so level-from-previous
+    (what topozarr does) and level-from-native (what OCS used to do) agree. Verified
+    byte-identical across a real 3-level pyramid when the delegation was made.
+    """
+    from open_climate_service.data_manager.services.downloader import (
+        _COMPOSABLE_METHODS,
+        _NATIVE_RESAMPLE_METHODS,
+    )
+
+    assert "nearest" in _COMPOSABLE_METHODS
+    assert "nearest" not in _NATIVE_RESAMPLE_METHODS
+    # Still a valid template value — it just takes the upstream path now.
+    assert _normalize_resampling_method("nearest") == "nearest"
+
+
+def test_coarsen_native_only_handles_mode() -> None:
+    """`mode` is the sole remaining local method; anything else is a programming error."""
+    with pytest.raises(ValueError, match="unsupported native-resample method"):
+        _coarsen_native(_categorical_block_da(), "x", "y", 2, "nearest")
+
+
+def test_topozarr_nearest_keeps_the_top_left_cell() -> None:
+    """Pin the upstream kernel's corner choice, since our equivalence argument rests on it.
+
+    Also guards the packaging trap: `nearest` only exists from topozarr-core 0.1.2, and
+    topozarr's own constraint (`>=0.1.0`) would allow an older core where this raises
+    "method must be one of 'mean', 'max', 'min', 'sum'" — at ingest time, not on import.
+    """
+    from topozarr_core import block_reduce
+
+    block = np.arange(16, dtype="int16").reshape(4, 4)
+    out = np.asarray(block_reduce(block, (2, 2), "nearest", 0, True))
+    np.testing.assert_array_equal(out, np.array([[0, 2], [8, 10]], dtype="int16"))
 
 
 def _categorical_pyramid_cube():

--- a/uv.lock
+++ b/uv.lock
@@ -1984,6 +1984,7 @@ server = [
     { name = "stac-validator" },
     { name = "starlette" },
     { name = "topozarr" },
+    { name = "topozarr-core" },
     { name = "uvicorn" },
     { name = "xarray" },
     { name = "xclim" },
@@ -2039,7 +2040,8 @@ requires-dist = [
     { name = "rioxarray", marker = "extra == 'server'", specifier = ">=0.17" },
     { name = "stac-validator", marker = "extra == 'server'", specifier = ">=3.3.1" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.27.0" },
-    { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.0.91,<0.1" },
+    { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.1.3,<0.2" },
+    { name = "topozarr-core", marker = "extra == 'server'", specifier = ">=0.1.2,<0.2" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.41.0" },
     { name = "xarray", marker = "extra == 'server'", specifier = ">=2025.12.0" },
     { name = "xarray", marker = "extra == 'xarray'", specifier = ">=2025.12.0" },
@@ -2127,7 +2129,7 @@ name = "oschmod"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/64/6e522f0a1b500470ae14dcd1a4bb8f8751f5cf441e85e9fee7dfc712cb7b/oschmod-0.3.12.tar.gz", hash = "sha256:bec99216f31615ee653b2a5c87cacfb4e4b6184c0e9f71da186300dacae974f3", size = 20064, upload-time = "2020-10-30T00:38:42.409Z" }
 wheels = [
@@ -3393,7 +3395,7 @@ wheels = [
 
 [[package]]
 name = "topozarr"
-version = "0.0.91"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -3404,24 +3406,24 @@ dependencies = [
     { name = "xproj" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/fe/d0c1187dadf2f4bc47f82ebf6215add47242fc9f6ae4197191846ef0dc74/topozarr-0.0.91.tar.gz", hash = "sha256:4eab2046abe868232320f2d113a8b0e5ea8a92e0c89199dd7a143fb691feada5", size = 14017, upload-time = "2026-06-11T04:19:15.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/01/1edf239494253f99c2709d63ecad54cd2f4d0a56b7b466c064a8171e3268/topozarr-0.1.3.tar.gz", hash = "sha256:27161b3d25f607397b51ccedf9e2ab0b06bb71301217ab9c057d031d0fccd958", size = 21502, upload-time = "2026-08-03T20:58:50.624Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/43/95e8171ddafa2058531bb6093d12ba42b9051f69b1e0514b508252cdb72c/topozarr-0.0.91-py3-none-any.whl", hash = "sha256:c1c1107541d6c432ee82c22f9fe9262f4c2d1223c0427415665af43a2709bbc9", size = 17013, upload-time = "2026-06-11T04:19:15.92Z" },
+    { url = "https://files.pythonhosted.org/packages/93/36/40fd1ba12ac9024243c25b99d9b67c4371da33347f8017587793d9bac240/topozarr-0.1.3-py3-none-any.whl", hash = "sha256:cb3d883549b4f7bea07449fbcbed63721a813d342b440c3ec768078bccdd1702", size = 25289, upload-time = "2026-08-03T20:58:49.669Z" },
 ]
 
 [[package]]
 name = "topozarr-core"
-version = "0.1.0"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/1a/20ab04138a05d452ccfbffda1473c89649335ecfb6674bd91e202fc121cf/topozarr_core-0.1.0.tar.gz", hash = "sha256:a6ecf677ad8e466be4af65655523049e9cd25c2b0435a80d0408ec3bb798abf7", size = 5292, upload-time = "2026-06-10T21:21:27.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/1d/97ff7fc7028c1093c279632eaf8f941d20ab0c6389427d6d423e73e1eafb/topozarr_core-0.1.2.tar.gz", hash = "sha256:e504388029df432866ad0ba35abb2ef7f2b26523bbf49a7c3707f430638d5023", size = 30593, upload-time = "2026-08-03T20:58:25.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/e1/5befadd853f2fcf2e1709274ddd12182c00ca35b16a084fd800227509e85/topozarr_core-0.1.0-cp312-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f1cf23ca24d69a0e14c3dc5814cbdfcbdf8ed4dad122c5927e08c99a8171049f", size = 611901, upload-time = "2026-06-10T21:21:30.942Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/53/755f1b8fc242e1f605462fae7f8c8fba5adb675abf38baba2c6d9cd73a31/topozarr_core-0.1.0-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fb73cbace9866d9a5a2c21ba956cda82619c96375e65af338664ba834286940", size = 332258, upload-time = "2026-06-10T21:21:28.756Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/a6/6a5771596ba0c6baa1ad8f3e91df44b51241b58cb109aa12b5014b707513/topozarr_core-0.1.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7b5e3cc694fecf04e4f0d00f3ecef3c15beda55cef097f3aeefe582f24af6e7", size = 338095, upload-time = "2026-06-10T21:21:32.088Z" },
-    { url = "https://files.pythonhosted.org/packages/26/8f/51752ed5ea272422759c8a366ce624a10f51b7d770109d3ea481900b5881/topozarr_core-0.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:8aaddccf62bd762244080ea7f4cda856f07e6ae546242952295a5f8fcced5a21", size = 223939, upload-time = "2026-06-10T21:21:29.972Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/1b289c38412da4835e44e031b144e9822ef1021a4a8bf2b83d6a53daabcc/topozarr_core-0.1.2-cp312-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f4638eb68d1883a090d6b4b9e7abb52275f26909bfa97c449217108776505d61", size = 9408282, upload-time = "2026-08-03T20:58:19.647Z" },
+    { url = "https://files.pythonhosted.org/packages/63/11/a7bd819337f4594c6c1ea646e370a5ee3c1b09ba17e51b43b9ab513fb0a8/topozarr_core-0.1.2-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5d9543c3277c9ae3d55879630d9896b339171b903040351b3d445789ded289d", size = 5069340, upload-time = "2026-08-03T20:58:21.465Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e2/57735c975e563b0e2c1b4ddb493826858fab8422074f0ef8ce5637292dd6/topozarr_core-0.1.2-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e38032bd050c5749d6c7b3fd46d88f4e9348ea5ea75a2dc60023d2568e4cf37f", size = 4899842, upload-time = "2026-08-03T20:58:22.682Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6d/4daacf77cfef5568a14efe0aea495c70bdac1befc2e9da0274dfb3f6e30e/topozarr_core-0.1.2-cp312-abi3-win_amd64.whl", hash = "sha256:75bd8c0d7a6a88cedc4d74de97254c9f394465ad0033be709ffb4640b938e72d", size = 4650377, upload-time = "2026-08-03T20:58:24.145Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1984,7 +1984,6 @@ server = [
     { name = "stac-validator" },
     { name = "starlette" },
     { name = "topozarr" },
-    { name = "topozarr-core" },
     { name = "uvicorn" },
     { name = "xarray" },
     { name = "xclim" },
@@ -2040,8 +2039,7 @@ requires-dist = [
     { name = "rioxarray", marker = "extra == 'server'", specifier = ">=0.17" },
     { name = "stac-validator", marker = "extra == 'server'", specifier = ">=3.3.1" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.27.0" },
-    { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.1.3,<0.2" },
-    { name = "topozarr-core", marker = "extra == 'server'", specifier = ">=0.1.2,<0.2" },
+    { name = "topozarr", marker = "extra == 'server'", specifier = ">=0.1.4,<0.2" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.41.0" },
     { name = "xarray", marker = "extra == 'server'", specifier = ">=2025.12.0" },
     { name = "xarray", marker = "extra == 'xarray'", specifier = ">=2025.12.0" },
@@ -3395,7 +3393,7 @@ wheels = [
 
 [[package]]
 name = "topozarr"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -3406,24 +3404,24 @@ dependencies = [
     { name = "xproj" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/01/1edf239494253f99c2709d63ecad54cd2f4d0a56b7b466c064a8171e3268/topozarr-0.1.3.tar.gz", hash = "sha256:27161b3d25f607397b51ccedf9e2ab0b06bb71301217ab9c057d031d0fccd958", size = 21502, upload-time = "2026-08-03T20:58:50.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/69/1dc1576664a6ce93c2d54164bf48756521d8fd65803cc971e2c14efc5539/topozarr-0.1.4.tar.gz", hash = "sha256:6e869e762b7effbad52955e5510793ec99c5f7e3501ad73830f5855ce2598d67", size = 21614, upload-time = "2026-08-05T21:52:03.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/36/40fd1ba12ac9024243c25b99d9b67c4371da33347f8017587793d9bac240/topozarr-0.1.3-py3-none-any.whl", hash = "sha256:cb3d883549b4f7bea07449fbcbed63721a813d342b440c3ec768078bccdd1702", size = 25289, upload-time = "2026-08-03T20:58:49.669Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9b/6cb9600418d684295abb23d04f05e3a8a27f384080b761b5fe55b67029b7/topozarr-0.1.4-py3-none-any.whl", hash = "sha256:5c1be4b855b9496be85ff2216ff9520c8611f1b2c5194cf31762b8b25a781e90", size = 25286, upload-time = "2026-08-05T21:52:02.84Z" },
 ]
 
 [[package]]
 name = "topozarr-core"
-version = "0.1.2"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/97ff7fc7028c1093c279632eaf8f941d20ab0c6389427d6d423e73e1eafb/topozarr_core-0.1.2.tar.gz", hash = "sha256:e504388029df432866ad0ba35abb2ef7f2b26523bbf49a7c3707f430638d5023", size = 30593, upload-time = "2026-08-03T20:58:25.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/2c/33dd53cc34459ced29d969345396f05f9c7bc4f1d7f9ea4da1fa642d9116/topozarr_core-0.1.4.tar.gz", hash = "sha256:3a5d4e875d6830fc6a5cafa1b46a01c23f8553a77651c465c05514dcf3fefb3f", size = 30590, upload-time = "2026-08-05T21:51:30.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/6a/1b289c38412da4835e44e031b144e9822ef1021a4a8bf2b83d6a53daabcc/topozarr_core-0.1.2-cp312-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f4638eb68d1883a090d6b4b9e7abb52275f26909bfa97c449217108776505d61", size = 9408282, upload-time = "2026-08-03T20:58:19.647Z" },
-    { url = "https://files.pythonhosted.org/packages/63/11/a7bd819337f4594c6c1ea646e370a5ee3c1b09ba17e51b43b9ab513fb0a8/topozarr_core-0.1.2-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5d9543c3277c9ae3d55879630d9896b339171b903040351b3d445789ded289d", size = 5069340, upload-time = "2026-08-03T20:58:21.465Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e2/57735c975e563b0e2c1b4ddb493826858fab8422074f0ef8ce5637292dd6/topozarr_core-0.1.2-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e38032bd050c5749d6c7b3fd46d88f4e9348ea5ea75a2dc60023d2568e4cf37f", size = 4899842, upload-time = "2026-08-03T20:58:22.682Z" },
-    { url = "https://files.pythonhosted.org/packages/43/6d/4daacf77cfef5568a14efe0aea495c70bdac1befc2e9da0274dfb3f6e30e/topozarr_core-0.1.2-cp312-abi3-win_amd64.whl", hash = "sha256:75bd8c0d7a6a88cedc4d74de97254c9f394465ad0033be709ffb4640b938e72d", size = 4650377, upload-time = "2026-08-03T20:58:24.145Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f7/84a5a5acffcbbcaee736d9e34ba86a9fb046c40b81751ee5bd4341fbe9b0/topozarr_core-0.1.4-cp312-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ce242bab60bdd034ffb91bcdb8cd72603d389266ab5d00806ddd482a587d5b53", size = 9409284, upload-time = "2026-08-05T21:51:24.311Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0e/22ec5455b1a28fd3785dd4f355769e98eef5bd4afa0683fb05295eb7cad4/topozarr_core-0.1.4-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff56c67cddca564abf85ad5ef87b77e62c08d29f5c046e8210a52b6fb4a069a5", size = 5069299, upload-time = "2026-08-05T21:51:26.205Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2f/92a409321172f462354ebd32ff6700ae26b7a8984fab404790bcc9473a63/topozarr_core-0.1.4-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e36606f1ae170f2e46821b673bceed7548e2d45ddf8b903e53a9695708ac2919", size = 4899420, upload-time = "2026-08-05T21:51:27.569Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1b/624af33ffad959813b72975617c2b8f974878baa32d38ce2d934054f6485/topozarr_core-0.1.4-cp312-abi3-win_amd64.whl", hash = "sha256:f4a9ac124defe92091d2e9e74ae75588c7d694211f49ce0965331cb43b09db9c", size = 4651040, upload-time = "2026-08-05T21:51:28.99Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements [CLIM-870](https://dhis2.atlassian.net/browse/CLIM-870).

topozarr 0.1.3 added the `nearest` coarsening method we asked for in [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26), so the local decimation path from #320 is no longer needed. **`mode` stays ours** — upstream hasn't implemented it, and their code now carries the composability note from that issue verbatim: non-composable methods *"must reduce from native instead"*.

This also lifts the `topozarr>=0.0.91,<0.1` cap, which had kept us two months behind the current line (0.1.1 shipped 14 June) and made the fix unreachable.

## Two risks the ticket flagged, both closed by measurement

I wrote real pyramids and compared the **stored layout** — level shapes, chunks, shards, dtype, fill value and a value checksum at every level, for all three methods — rather than only checking that values looked right.

**1. The upgrade alone changes nothing.** `create_pyramid` has grown `factors`, `target_chunk_bytes`, `chunks_per_shard` and `layer_hints`. We pass none of them, so new defaults could have silently re-chunked every store and quietly hurt browser read performance:

```
0.0.91 -> 0.1.3, code unchanged
mean    L0/L1/L2: identical      nearest L0/L1/L2: identical      mode L0/L1/L2: identical

0.1.3  -> 0.1.4  (re-run after the upstream fix, since it is a real version bump)
mean    L0/L1/L2: identical      nearest L0/L1/L2: identical      mode L0/L1/L2: identical
```

**2. Delegated `nearest` is byte-identical to the native path it replaces**, across a real 3-level pyramid. The equivalence argument — corner-of-corners equals corner-of-native — now holds in practice, not just on paper:

```
BEFORE: topozarr 0.0.91, nearest computed natively by OCS
AFTER : topozarr 0.1.4, nearest delegated to topozarr
=> every level byte-identical
```

## A packaging trap the upgrade exposed — since fixed upstream

The first attempt failed at ingest, not at import:

```
ValueError: method must be one of 'mean', 'max', 'min', 'sum'; got "nearest"
  topozarr/pyramid.py:44 -> topozarr_core block_reduce
```

`topozarr` and `topozarr-core` are **separate packages**, and topozarr 0.1.3 declared only
`topozarr-core>=0.1.0,<0.2`. That bound is too loose — the `nearest` kernel exists from **core
0.1.2** — so the resolver could pair them into a build where the Python layer *accepts*
`nearest` and the Rust kernel then rejects it.

Two things made it nasty: it surfaces only when a categorical layer is actually materialised,
so import checks and most tests pass; and `uv lock --upgrade-package topozarr` doesn't fix it,
because the constraint is satisfied.

**Reported upstream, and fixed in [topozarr 0.1.4](https://github.com/carbonplan/topozarr/releases/tag/v0.1.4)** —
more thoroughly than suggested. Rather than raising the lower bound, [PR #28](https://github.com/carbonplan/topozarr/pull/28)
pins `topozarr-core==0.1.4` exactly and adds a lockstep release check:

```
topozarr 0.1.3 requires  topozarr-core>=0.1.0,<0.2     <- the trap
topozarr 0.1.4 requires  topozarr-core==0.1.4
```

So this PR now takes `topozarr>=0.1.4` and carries **no `topozarr-core` requirement at all** —
it is transitive only. The two halves are coupled: dropping our pin while leaving the floor at
0.1.3 would reinstate the bug, since 0.1.3 still permits core 0.1.0. The reasoning stays in
`pyproject.toml` so nobody lowers the floor later on the grounds that 0.1.3 "has nearest".

## What changed in the code

- `nearest` moves from `_NATIVE_RESAMPLE_METHODS` to `_COMPOSABLE_METHODS`, so it flows through `create_pyramid` normally.
- The `nearest` branch of `_coarsen_native` is gone; the function now handles `mode` only and raises otherwise.
- `_mode_reduce` and `_overwrite_native_resampled_levels` stay unchanged — still the `mode` path, one fewer caller.
- The `composable_method = "max" if native_resample else ...` substitution now applies only to `mode`, where it is genuinely needed.
- Comments point at #26 so the remaining divergence is traceable and deletable when `mode` lands.

## Tests

The removed branch's test is replaced by three:

- `nearest` is delegated (in `_COMPOSABLE_METHODS`, not in `_NATIVE_RESAMPLE_METHODS`) and still accepted as a template value
- `_coarsen_native` rejects anything but `mode`
- the upstream kernel keeps the **top-left** cell — pinning the corner our equivalence argument depends on, and failing loudly if the core version ever regresses to one without `nearest`

```
514 passed
make lint clean (ruff, format, mypy, pyright)
```

The 3 excluded failures in `test_openeo_execution.py` are the pre-existing local PROJ database conflict, verified identical on `main`.

## Docs

`adding_custom_datasets.md` no longer claims `nearest` is resampled locally. It now explains *why* the five composable methods can build level-from-level while `mode` cannot — mode-of-modes isn't mode-of-native, since a locally dominant class can win at coarse zoom even when globally rare.


[CLIM-870]: https://dhis2.atlassian.net/browse/CLIM-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
