### PR TITLE
feat(geozarr/stac): make OCS stores findable and correctly placed by external clients

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,7 +209,7 @@ Every zarr artifact must have GeoZarr root attributes for map rendering to work 
 
 The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Clients that read the store without a catalog (QGIS, GeoZarr viewers) use `spatial:transform` together with the axis order above — see [zarr_and_geozarr.md](zarr_and_geozarr.md#geozarr-root-attributes) for why both the order and the affine matter.
 
-**The framework writes these attributes — plugins do not.** They are written after reprojection, from the stored coordinate arrays of the final written data (not from the requested bbox) and the instance CRS.
+**The framework writes these attributes — plugins do not.** They are derived from the stored coordinate arrays of the final written data — not from the requested bbox, and not from the instance-wide `crs:`. Nothing is reprojected at ingest: each dataset keeps the CRS its source delivered, and `proj:code` records that native CRS. See [Raster conventions](conventions.md#what-the-framework-guarantees).
 
 ---
 
@@ -231,17 +231,20 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 Plugin code (streaming plugins, `@process` functions) can rely on the following being handled automatically by the framework:
 
-| Concern                                               | Where handled                               |
-| ----------------------------------------------------- | ------------------------------------------- |
-| Coordinate name normalisation (`lat` → `y`, etc.)     | `build_dataset_zarr`                        |
-| Reprojection to instance CRS                          | `reproject_to_instance_crs`                 |
-| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `_compute_time_space_chunks`         |
-| Multiscale pyramid generation (when dims > 2048×2048) | `build_dataset_zarr`                        |
-| GeoZarr root attributes (`spatial:bbox`, `proj:code`) | `build_dataset_zarr`                        |
-| Artifact coverage computation                         | `_coverage_from_dataset`                    |
-| Artifact record persistence                           | `_store_artifact`                           |
-| STAC publication                                      | `publish_artifact_record` if `publish=true` |
-| STAC collection generation                            | Dynamic from artifact record                |
+| Concern                                                       | Where handled                                     |
+| ------------------------------------------------------------- | ------------------------------------------------- |
+| Coordinate name normalisation (`lat` → `y`, `time` → `t`)      | `normalize_period` / `normalize_dim_layout`        |
+| Axis order `(…, y, x)` and `y` descending                      | `normalize_dim_layout` / `normalize_y_direction`   |
+| Longitudes rolled to −180…180 for geographic data              | `normalize_longitudes`                            |
+| CRS kept consistent with the coordinates (never reprojected)   | `resolve_store_crs`                               |
+| Zarr chunking (auto-sized from `extents.temporal.resolution`)  | `time_chunk_for_iso_step`                         |
+| Multiscale pyramid generation (when dims > 2048×2048)          | `write_to_icechunk_store`                         |
+| GeoZarr root attributes (`spatial:transform`, `proj:code`, …)  | `grid_geometry` / `write_geozarr_attrs`            |
+| Artifact coverage computation                                  | `_coverage_from_dataset`                          |
+| Artifact record persistence                                    | `_store_artifact_record`                          |
+| STAC publication                                               | `publish_artifact_record` if `publish=true`       |
+| STAC collection generation                                     | Dynamic from the artifact record                  |
+| Media type advertising a pyramid (`profile=multiscales`)        | `zarr_media_type`                                 |
 
 Plugin code only needs to produce data. Everything else is the framework's responsibility.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,16 +200,12 @@ Functions decorated with `@process` and placed in `plugins_dir/processes/` are r
 
 Every zarr artifact must have GeoZarr root attributes for map rendering to work correctly. These are written into `zarr.json` at the store root:
 
-- `spatial:transform` — the affine `[stepX, rotX, originX, rotY, stepY, originY]` that places the grid
-- `spatial:dimensions` — row/column axis names in array order, `["y", "x"]`
-- `spatial:shape` — grid size as `[height, width]`
 - `spatial:bbox` — `[xmin, ymin, xmax, ymax]` in the native CRS
+- `spatial:shape` — grid size as `[height, width]`
+- `spatial:dimensions` — row/column axis names in array order, `["y", "x"]`
+- `spatial:transform` — the affine `[stepX, rotX, originX, rotY, stepY, originY]` that places the grid
 - `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
-
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Clients that read the store without a catalog (QGIS, GeoZarr viewers) use `spatial:transform` together with the axis order above — see [zarr_and_geozarr.md](zarr_and_geozarr.md#geozarr-root-attributes) for why both the order and the affine matter.
-
-**The framework writes these attributes — plugins do not.** They are derived from the stored coordinate arrays of the final written data — not from the requested bbox, and not from the instance-wide `crs:`. Nothing is reprojected at ingest: each dataset keeps the CRS its source delivered, and `proj:code` records that native CRS. See [Raster conventions](conventions.md#what-the-framework-guarantees).
 
 ---
 
@@ -231,20 +227,20 @@ The artifact store keeps the full history of records for sync deduplication and 
 
 Plugin code (streaming plugins, `@process` functions) can rely on the following being handled automatically by the framework:
 
-| Concern                                                       | Where handled                                     |
-| ------------------------------------------------------------- | ------------------------------------------------- |
-| Coordinate name normalisation (`lat` → `y`, `time` → `t`)      | `normalize_period` / `normalize_dim_layout`        |
-| Axis order `(…, y, x)` and `y` descending                      | `normalize_dim_layout` / `normalize_y_direction`   |
-| Longitudes rolled to −180…180 for geographic data              | `normalize_longitudes`                            |
-| CRS kept consistent with the coordinates (never reprojected)   | `resolve_store_crs`                               |
-| Zarr chunking (auto-sized from `extents.temporal.resolution`)  | `time_chunk_for_iso_step`                         |
-| Multiscale pyramid generation (when dims > 2048×2048)          | `write_to_icechunk_store`                         |
-| GeoZarr root attributes (`spatial:transform`, `proj:code`, …)  | `grid_geometry` / `write_geozarr_attrs`            |
-| Artifact coverage computation                                  | `_coverage_from_dataset`                          |
-| Artifact record persistence                                    | `_store_artifact_record`                          |
-| STAC publication                                               | `publish_artifact_record` if `publish=true`       |
-| STAC collection generation                                     | Dynamic from the artifact record                  |
-| Media type advertising a pyramid (`profile=multiscales`)        | `zarr_media_type`                                 |
+| Concern                                                       | Where handled                                    |
+| ------------------------------------------------------------- | ------------------------------------------------ |
+| Coordinate name normalisation (`lat` → `y`, `time` → `t`)     | `normalize_period` / `normalize_dim_layout`      |
+| Axis order `(…, y, x)` and `y` descending                     | `normalize_dim_layout` / `normalize_y_direction` |
+| Longitudes rolled to −180…180 for geographic data             | `normalize_longitudes`                           |
+| CRS kept consistent with the coordinates (never reprojected)  | `resolve_store_crs`                              |
+| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `time_chunk_for_iso_step`                        |
+| Multiscale pyramid generation (when dims > 2048×2048)         | `write_to_icechunk_store`                        |
+| GeoZarr root attributes (`spatial:transform`, `proj:code`, …) | `grid_geometry` / `write_geozarr_attrs`          |
+| Artifact coverage computation                                 | `_coverage_from_dataset`                         |
+| Artifact record persistence                                   | `_store_artifact_record`                         |
+| STAC publication                                              | `publish_artifact_record` if `publish=true`      |
+| STAC collection generation                                    | Dynamic from the artifact record                 |
+| Media type advertising a pyramid (`profile=multiscales`)      | `zarr_media_type`                                |
 
 Plugin code only needs to produce data. Everything else is the framework's responsibility.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,13 +200,16 @@ Functions decorated with `@process` and placed in `plugins_dir/processes/` are r
 
 Every zarr artifact must have GeoZarr root attributes for map rendering to work correctly. These are written into `zarr.json` at the store root:
 
+- `spatial:transform` — the affine `[stepX, rotX, originX, rotY, stepY, originY]` that places the grid
+- `spatial:dimensions` — row/column axis names in array order, `["y", "x"]`
+- `spatial:shape` — grid size as `[height, width]`
 - `spatial:bbox` — `[xmin, ymin, xmax, ymax]` in the native CRS
 - `proj:code` — the CRS EPSG code (e.g. `EPSG:32633` for UTM, `EPSG:4326` for WGS84)
 - `zarr_conventions` — GeoZarr convention declaration
 
-The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map.
+The map viewer reads `spatial:bbox` and `proj:code` to determine where to position tiles on the map. Clients that read the store without a catalog (QGIS, GeoZarr viewers) use `spatial:transform` together with the axis order above — see [zarr_and_geozarr.md](zarr_and_geozarr.md#geozarr-root-attributes) for why both the order and the affine matter.
 
-**The framework writes these attributes — plugins do not.** They are written after reprojection, using the actual coordinate bounds of the final written data and the instance CRS.
+**The framework writes these attributes — plugins do not.** They are written after reprojection, from the stored coordinate arrays of the final written data (not from the requested bbox) and the instance CRS.
 
 ---
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -48,57 +48,34 @@ A plugin may return data in whatever orientation and naming its source delivers.
    for an untagged cube — doing so stamped `EPSG:32633` onto degree coordinates and put the
    store at the projection's origin instead of on the map.
 
-## Why the direction of `y` is guaranteed
+## What this means if you write a plugin
 
-Because real consumers assume one and never check. Two that matter:
+Nothing. Return data in whatever orientation, dimension naming and longitude frame your source
+delivers, and declare a `crs` class attribute only if the source carries no CRS of its own. The
+framework normalises the rest at the write boundary; a plugin that hand-rolls a y-flip or a
+longitude roll is doing work that will simply be re-done.
 
-**OpenLayers' `ol/source/GeoZarr`** — the renderer STAC Browser uses. It derives its tile grid
-origin as the top-left corner and counts rows down from it:
+The reasoning behind each invariant — which external consumers assume what, and why `y`
+descends rather than ascends — is recorded in the module docstring of
+[`shared/raster_contract.py`](https://github.com/dhis2/open-climate-service/blob/main/open_climate_service/shared/raster_contract.py),
+next to the code it constrains.
 
-```js
-const origin = [extent[0], extent[3]];                                  // top-left
-const minRow = Math.round((origin[1] - tileExtent[3]) / bandResolution);
-... get(array, [slice(minRow, maxRow), colSlice])                        // straight into the array
+## What this means if you operate an instance
+
+A store written before these invariants existed can disagree with them, and appending to it
+would put rows or columns under coordinates that no longer describe them. Rather than corrupt
+the store, **the next sync of such a dataset fails** with a message naming both coordinate
+ranges:
+
+```
+Cannot append to senorge_temperature_daily.icechunk: its committed 'y' coordinates do not
+match the normalised ones for this period (store 57.0…60.0, period 60.0…57.0). …
+Re-ingest this dataset from scratch to rebuild it under the current contract.
 ```
 
-There is no `reverse`, no `flip`, and no read of `spatial:transform`'s y step anywhere in that
-file, so array row 0 is always painted at the north edge. Worked through for a 3°-tall grid of
-0.05° rows:
-
-```
-OL asks for array row 0 to paint the northern tile (lat ~59.975)
-  descending store: row 0 holds lat 59.975  -> CORRECT
-  ascending  store: row 0 holds lat 57.025  -> WRONG, mirrored by 2.95 deg
-```
-
-**Result thumbnails** render with `imshow(..., origin="upper")`, which is the same assumption.
-
-Descending rather than ascending, given the choice:
-
-| | descending | ascending |
-| --- | --- | --- |
-| OpenLayers / STAC Browser | correct | mirrored, undetectably |
-| carbonplan/zarr-layer (the `/map` viewer) | detects from the coordinate | detects from the coordinate |
-| GDAL `GeoTransform` | negative y step — the north-up convention | positive — legal but unusual |
-| cost for a typical source | none, already north-up | reverses every raster |
-
-zarr-layer detects the direction either way (`detectedLatAscending = y1 > y0`), so it does not
-constrain the choice; OpenLayers does.
-
-A consumer should still prefer reading the `y` coordinate over assuming — `aggregate_spatial`
-does exactly that, flipping its rasterio mask only when `y` ascends, and stays correct whatever
-it is handed.
-
-## Appending to a store written before this contract
-
-Invariants 3 and 4 reorder the array. An append writes along the time axis only, so a store's
-committed coordinate arrays stay as they are — and a period normalised one way, appended to a
-store written the other, would put rows or columns under coordinates that no longer describe
-them. That is silently mirrored data, worse than metadata being out of date.
-
-So an ingest checks the committed axes before its first append and **fails with an actionable
-message** rather than guessing. The fix is a re-ingest, which rebuilds the store under the
-current contract.
+The fix is a one-off re-ingest of that dataset. Only stores that are south-up, or on the
+0…360 longitude frame, are affected — a north-up store on −180…180 keeps syncing normally.
+The same re-ingest also picks up the corrected `spatial:transform`, extent and CRS metadata.
 
 ## Where the two worlds meet
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -37,29 +37,68 @@ A plugin may return data in whatever orientation and naming its source delivers.
    renders with no time control.
 2. **Spatial dimensions are named `y` / `x` and ordered `(…, y, x)`.** Variables arriving in
    another order are transposed.
-3. **A geographic x axis runs −180…180.** Sources on the 0…360 frame (ERA5 among them) are
+3. **`y` descends — array row 0 is the northernmost row.** South-up sources are reversed,
+   coordinate and data together, so the value at a given latitude does not move; only its row
+   index does. See below for why this is guaranteed rather than left to the reader.
+4. **A geographic x axis runs −180…180.** Sources on the 0…360 frame (ERA5 among them) are
    rolled and re-sorted. Projected eastings are left alone — one legitimately exceeds 180.
-4. **The declared CRS matches the coordinates it describes.** Data is stored in its *native*
+5. **The declared CRS matches the coordinates it describes.** Data is stored in its *native*
    CRS, whatever the source delivered; nothing is reprojected on ingest. The invariant is
    consistency, not a fixed CRS. The instance-wide `crs:` setting is never used as a fallback
    for an untagged cube — doing so stamped `EPSG:32633` onto degree coordinates and put the
    store at the projection's origin instead of on the map.
 
-## What is *not* guaranteed: the direction of `y`
+## Why the direction of `y` is guaranteed
 
-A store keeps the `y` direction its source delivered. Most rasters are north-up, so `y`
-usually descends; some sources (ERA5 among them) ascend. **A reader must honour the `y`
-coordinate array rather than assume a direction.**
+Because real consumers assume one and never check. Two that matter:
 
-This is a deliberate choice, and it used to be the other way. Stores were normalised to
-ascending because the map viewer's `zarr-layer` required it. As of 0.6.1 it detects the
-direction from the `y` coordinate array instead, and OCS stores always take its "untiled"
-path, so both directions render correctly. Normalising would mean reordering every raster's
-rows on ingest, and would make the GDAL `GeoTransform` written alongside south-up (positive
-`stepY`) — unusual for the GDAL and QGIS consumers of the same store.
+**OpenLayers' `ol/source/GeoZarr`** — the renderer STAC Browser uses. It derives its tile grid
+origin as the top-left corner and counts rows down from it:
 
-`aggregate_spatial` is the model for a consumer doing this properly: it rasterises a geometry
-mask top-row-first as rasterio does, then flips it only when the cube's `y` ascends.
+```js
+const origin = [extent[0], extent[3]];                                  // top-left
+const minRow = Math.round((origin[1] - tileExtent[3]) / bandResolution);
+... get(array, [slice(minRow, maxRow), colSlice])                        // straight into the array
+```
+
+There is no `reverse`, no `flip`, and no read of `spatial:transform`'s y step anywhere in that
+file, so array row 0 is always painted at the north edge. Worked through for a 3°-tall grid of
+0.05° rows:
+
+```
+OL asks for array row 0 to paint the northern tile (lat ~59.975)
+  descending store: row 0 holds lat 59.975  -> CORRECT
+  ascending  store: row 0 holds lat 57.025  -> WRONG, mirrored by 2.95 deg
+```
+
+**Result thumbnails** render with `imshow(..., origin="upper")`, which is the same assumption.
+
+Descending rather than ascending, given the choice:
+
+| | descending | ascending |
+| --- | --- | --- |
+| OpenLayers / STAC Browser | correct | mirrored, undetectably |
+| carbonplan/zarr-layer (the `/map` viewer) | detects from the coordinate | detects from the coordinate |
+| GDAL `GeoTransform` | negative y step — the north-up convention | positive — legal but unusual |
+| cost for a typical source | none, already north-up | reverses every raster |
+
+zarr-layer detects the direction either way (`detectedLatAscending = y1 > y0`), so it does not
+constrain the choice; OpenLayers does.
+
+A consumer should still prefer reading the `y` coordinate over assuming — `aggregate_spatial`
+does exactly that, flipping its rasterio mask only when `y` ascends, and stays correct whatever
+it is handed.
+
+## Appending to a store written before this contract
+
+Invariants 3 and 4 reorder the array. An append writes along the time axis only, so a store's
+committed coordinate arrays stay as they are — and a period normalised one way, appended to a
+store written the other, would put rows or columns under coordinates that no longer describe
+them. That is silently mirrored data, worse than metadata being out of date.
+
+So an ingest checks the committed axes before its first append and **fails with an actionable
+message** rather than guessing. The fix is a re-ingest, which rebuilds the store under the
+current contract.
 
 ## Where the two worlds meet
 
@@ -71,5 +110,5 @@ Points to be careful at, all currently consistent:
 - **GeoZarr's `spatial:dimensions` and `spatial:shape` are positional**: the second-to-last
   entry is the row axis and the last is the column axis, so they are `["y", "x"]` and
   `[height, width]`. See [Zarr and GeoZarr](zarr_and_geozarr.md#geozarr-root-attributes).
-- **`spatial:transform` carries the sign of the y step**, negative for a north-up grid. That
-  is what lets a reader place the raster without assuming a direction.
+- **`spatial:transform` carries the sign of the y step**, always negative now that stores are
+  guaranteed north-up. A reader that honours it stays correct even for data from elsewhere.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,75 @@
+# Raster and coordinate conventions
+
+Two different standards apply to two different things, and confusing them is how rasters end
+up transposed or mislocated. This page settles which applies where, and what the framework
+guarantees so that plugin authors do not have to.
+
+## The two orders, and why they don't conflict
+
+| Concern                                | Order                            | Standard                                       |
+| -------------------------------------- | -------------------------------- | ---------------------------------------------- |
+| Raster array / data cube dimensions    | `(…, y, x)` — x last             | NumPy row-major, CF `T,Z,Y,X`, GeoZarr, GDAL   |
+| GeoJSON geometry coordinate pairs      | `[x, y]` = `[lon, lat]`          | RFC 7946                                       |
+| Bounding boxes                         | `[xmin, ymin, xmax, ymax]`       | RFC 7946 (`[west, south, east, north]`)        |
+
+These are not in tension — they describe different objects. `(…, y, x)` is the shape of an
+N-dimensional array, where the row index comes before the column index because that is how
+row-major memory is laid out. `[x, y]` is a coordinate *tuple*, where longitude comes first
+because RFC 7946 says so. A single codebase uses both, in their own places.
+
+So: **array dimensions are `(…, y, x)`; coordinate variables are named `x` / `y`; GeoJSON
+pairs and bboxes are `[x, y]`-ordered.**
+
+openEO, which the processing layer is built on, is deliberately neutral here — it addresses
+dimensions by *name* (`reduce_dimension(dimension="t")`) and spatial extents by *field*
+(`west`/`east`/`south`/`north`), so the question never arises at the API level. But the
+reference implementation runs on xarray, which is NumPy/CF-ordered, so every cube flowing
+through the engine is physically `(…, y, x)` regardless.
+
+## What the framework guarantees
+
+These are properties of a *published store*, not of any one source, so they are enforced once
+at the write boundary — see [`shared/raster_contract.py`](https://github.com/dhis2/open-climate-service/blob/main/open_climate_service/shared/raster_contract.py).
+A plugin may return data in whatever orientation and naming its source delivers.
+
+1. **The temporal dimension is named `t`.** Sources spelling it `time`, `valid_time`, `date`
+   or `time_counter` are renamed. The map viewer looks for `t`; a store that ships `time`
+   renders with no time control.
+2. **Spatial dimensions are named `y` / `x` and ordered `(…, y, x)`.** Variables arriving in
+   another order are transposed.
+3. **A geographic x axis runs −180…180.** Sources on the 0…360 frame (ERA5 among them) are
+   rolled and re-sorted. Projected eastings are left alone — one legitimately exceeds 180.
+4. **The declared CRS matches the coordinates it describes.** Data is stored in its *native*
+   CRS, whatever the source delivered; nothing is reprojected on ingest. The invariant is
+   consistency, not a fixed CRS. The instance-wide `crs:` setting is never used as a fallback
+   for an untagged cube — doing so stamped `EPSG:32633` onto degree coordinates and put the
+   store at the projection's origin instead of on the map.
+
+## What is *not* guaranteed: the direction of `y`
+
+A store keeps the `y` direction its source delivered. Most rasters are north-up, so `y`
+usually descends; some sources (ERA5 among them) ascend. **A reader must honour the `y`
+coordinate array rather than assume a direction.**
+
+This is a deliberate choice, and it used to be the other way. Stores were normalised to
+ascending because the map viewer's `zarr-layer` required it. As of 0.6.1 it detects the
+direction from the `y` coordinate array instead, and OCS stores always take its "untiled"
+path, so both directions render correctly. Normalising would mean reordering every raster's
+rows on ingest, and would make the GDAL `GeoTransform` written alongside south-up (positive
+`stepY`) — unusual for the GDAL and QGIS consumers of the same store.
+
+`aggregate_spatial` is the model for a consumer doing this properly: it rasterises a geometry
+mask top-row-first as rasterio does, then flips it only when the cube's `y` ascends.
+
+## Where the two worlds meet
+
+Points to be careful at, all currently consistent:
+
+- **Bbox unpacking** is always `xmin, ymin, xmax, ymax`, and rasterio's `from_bounds` takes
+  the same order followed by `width, height`.
+- **`out_shape` is `(height, width)`** for mask rasterisation — array order, not bbox order.
+- **GeoZarr's `spatial:dimensions` and `spatial:shape` are positional**: the second-to-last
+  entry is the row axis and the last is the column axis, so they are `["y", "x"]` and
+  `[height, width]`. See [Zarr and GeoZarr](zarr_and_geozarr.md#geozarr-root-attributes).
+- **`spatial:transform` carries the sign of the y step**, negative for a north-up grid. That
+  is what lets a reader place the raster without assuming a direction.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -6,29 +6,29 @@ guarantees so that plugin authors do not have to.
 
 ## The two orders, and why they don't conflict
 
-| Concern                                | Order                            | Standard                                       |
-| -------------------------------------- | -------------------------------- | ---------------------------------------------- |
-| Raster array / data cube dimensions    | `(…, y, x)` — x last             | NumPy row-major, CF `T,Z,Y,X`, GeoZarr, GDAL   |
-| GeoJSON geometry coordinate pairs      | `[x, y]` = `[lon, lat]`          | RFC 7946                                       |
-| Bounding boxes                         | `[xmin, ymin, xmax, ymax]`       | RFC 7946 (`[west, south, east, north]`)        |
+| Concern                             | Order                      | Standard                                     |
+| ----------------------------------- | -------------------------- | -------------------------------------------- |
+| Raster array / data cube dimensions | `(…, y, x)` — x last       | NumPy row-major, CF `T,Z,Y,X`, GeoZarr, GDAL |
+| GeoJSON geometry coordinate pairs   | `[x, y]` = `[lon, lat]`    | RFC 7946                                     |
+| Bounding boxes                      | `[xmin, ymin, xmax, ymax]` | RFC 7946 (`[west, south, east, north]`)      |
 
 These are not in tension — they describe different objects. `(…, y, x)` is the shape of an
 N-dimensional array, where the row index comes before the column index because that is how
-row-major memory is laid out. `[x, y]` is a coordinate *tuple*, where longitude comes first
+row-major memory is laid out. `[x, y]` is a coordinate _tuple_, where longitude comes first
 because RFC 7946 says so. A single codebase uses both, in their own places.
 
 So: **array dimensions are `(…, y, x)`; coordinate variables are named `x` / `y`; GeoJSON
 pairs and bboxes are `[x, y]`-ordered.**
 
 openEO, which the processing layer is built on, is deliberately neutral here — it addresses
-dimensions by *name* (`reduce_dimension(dimension="t")`) and spatial extents by *field*
+dimensions by _name_ (`reduce_dimension(dimension="t")`) and spatial extents by _field_
 (`west`/`east`/`south`/`north`), so the question never arises at the API level. But the
 reference implementation runs on xarray, which is NumPy/CF-ordered, so every cube flowing
 through the engine is physically `(…, y, x)` regardless.
 
 ## What the framework guarantees
 
-These are properties of a *published store*, not of any one source, so they are enforced once
+These are properties of a _published store_, not of any one source, so they are enforced once
 at the write boundary — see [`shared/raster_contract.py`](https://github.com/dhis2/open-climate-service/blob/main/open_climate_service/shared/raster_contract.py).
 A plugin may return data in whatever orientation and naming its source delivers.
 
@@ -42,7 +42,7 @@ A plugin may return data in whatever orientation and naming its source delivers.
    index does. See below for why this is guaranteed rather than left to the reader.
 4. **A geographic x axis runs −180…180.** Sources on the 0…360 frame (ERA5 among them) are
    rolled and re-sorted. Projected eastings are left alone — one legitimately exceeds 180.
-5. **The declared CRS matches the coordinates it describes.** Data is stored in its *native*
+5. **The declared CRS matches the coordinates it describes.** Data is stored in its _native_
    CRS, whatever the source delivered; nothing is reprojected on ingest. The invariant is
    consistency, not a fixed CRS. The instance-wide `crs:` setting is never used as a fallback
    for an untagged cube — doing so stamped `EPSG:32633` onto degree coordinates and put the
@@ -54,38 +54,3 @@ Nothing. Return data in whatever orientation, dimension naming and longitude fra
 delivers, and declare a `crs` class attribute only if the source carries no CRS of its own. The
 framework normalises the rest at the write boundary; a plugin that hand-rolls a y-flip or a
 longitude roll is doing work that will simply be re-done.
-
-The reasoning behind each invariant — which external consumers assume what, and why `y`
-descends rather than ascends — is recorded in the module docstring of
-[`shared/raster_contract.py`](https://github.com/dhis2/open-climate-service/blob/main/open_climate_service/shared/raster_contract.py),
-next to the code it constrains.
-
-## What this means if you operate an instance
-
-A store written before these invariants existed can disagree with them, and appending to it
-would put rows or columns under coordinates that no longer describe them. Rather than corrupt
-the store, **the next sync of such a dataset fails** with a message naming both coordinate
-ranges:
-
-```
-Cannot append to senorge_temperature_daily.icechunk: its committed 'y' coordinates do not
-match the normalised ones for this period (store 57.0…60.0, period 60.0…57.0). …
-Re-ingest this dataset from scratch to rebuild it under the current contract.
-```
-
-The fix is a one-off re-ingest of that dataset. Only stores that are south-up, or on the
-0…360 longitude frame, are affected — a north-up store on −180…180 keeps syncing normally.
-The same re-ingest also picks up the corrected `spatial:transform`, extent and CRS metadata.
-
-## Where the two worlds meet
-
-Points to be careful at, all currently consistent:
-
-- **Bbox unpacking** is always `xmin, ymin, xmax, ymax`, and rasterio's `from_bounds` takes
-  the same order followed by `width, height`.
-- **`out_shape` is `(height, width)`** for mask rasterisation — array order, not bbox order.
-- **GeoZarr's `spatial:dimensions` and `spatial:shape` are positional**: the second-to-last
-  entry is the row axis and the last is the column axis, so they are `["y", "x"]` and
-  `[height, width]`. See [Zarr and GeoZarr](zarr_and_geozarr.md#geozarr-root-attributes).
-- **`spatial:transform` carries the sign of the y step**, always negative now that stores are
-  guaranteed north-up. A reader that honours it stays correct even for data from elsewhere.

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -331,6 +331,21 @@ Both endpoints are advertised as `assets` in the STAC collection:
 }
 ```
 
+A **pyramided** store advertises one extra media type parameter:
+
+```json
+"type": "application/vnd.zarr; version=3; profile=multiscales"
+```
+
+This is how a client learns the store has resolution levels — the plain Zarr media type cannot
+express it, and clients that only render pyramided stores (STAC Browser, via
+`ol/source/GeoZarr`) will not offer to display a store without it. The parameter is only added
+when the store genuinely has a non-empty `multiscales.layout`; claiming it for a flat store
+would send a renderer looking for levels that do not exist.
+
+It is matched as a literal, not parsed, so the string is byte-for-byte fixed: same parameter
+order, one space after each `;`. Reformatting it silently disables rendering.
+
 ## 10. Access published STAC collections
 
 Published Zarr-backed datasets are exposed through `/stac` for discovery.

--- a/docs/project_description.md
+++ b/docs/project_description.md
@@ -176,7 +176,7 @@ The API is built on FastAPI and exposes the following endpoint groups:
 
 All datasets are stored as GeoZarr. Key properties:
 
-- Stored without reprojection — coordinates keep the source's native CRS, recorded in the GeoZarr `proj:code` metadata from the CRS the ingestion declares (the instance `crs:`, default `EPSG:4326`, is the fallback). The framework does not auto-detect per-source CRS or reconcile mixed coordinate systems.
+- Stored without reprojection — coordinates keep the source's native CRS, recorded in the GeoZarr `proj:code` metadata from the CRS the ingestion declares, falling back to what rioxarray detects on the data and then to `EPSG:4326`. The instance-wide `crs:` is deliberately never a fallback: using it stamped a projected code onto degree coordinates and put the store at the projection's origin. A declared CRS that contradicts the coordinates is rejected in favour of the data's own. The framework does not otherwise reconcile mixed coordinate systems.
 - CF-compliant coordinate attributes and `_ARRAY_DIMENSIONS` metadata.
 - Multiscale pyramid overview levels declared under the `multiscales` key in `.zattrs` — required for efficient zoom-level-aware chunk fetching by zarr-layer.
 - Chunk shape tuned per dataset to balance three access patterns: time series queries, polygon aggregation, and browser tile rendering.

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -210,6 +210,40 @@ fields may be used, so a prefixed field is one a client is defined to understand
 passes through the store's own CF attribute names verbatim. The extension is declared in
 `stac_extensions` only when a `cf:` field was actually emitted.
 
+## Opening a local store in a hosted browser viewer
+
+Hosted tools like [zarr-viewer](https://source-cooperative.github.io/zarr-viewer/) and
+[inspect.geozarr.org](https://inspect.geozarr.org) read a store directly over HTTP, which means a
+public page fetching `http://localhost:9000`. Browsers gate that, and there are **two** separate
+gates — only one of which the server controls.
+
+**Server side, handled for you.** The instance answers both spellings of the opt-in Chrome has
+shipped as the spec evolved — Private Network Access and its successor Local Network Access — for
+an allowlist of origins that already includes the two viewers above. Add others with:
+
+```
+CLIMATE_SERVICE_ZARR_BROWSER_ORIGINS="https://inspect.geozarr.org,https://your-viewer.example"
+```
+
+**Browser side, yours to grant.** Current Chrome additionally requires *user permission* to reach
+the loopback address space, and refuses by default. When that is what blocks the request, the
+console says:
+
+```
+Access to fetch at 'http://localhost:9000/zarr/...' from origin 'https://...'
+has been blocked by CORS policy: Permission was denied for this request
+to access the `loopback` address space.
+```
+
+Note the wording — `Permission was denied`, not a missing header. No server change fixes it. The
+options are to allow local network access for the site when the browser prompts (or via the icon
+in the address bar), to run the viewer from `localhost` as well so both are in the same address
+space, or to expose the instance on a public HTTPS origin.
+
+The viewer's own error message is unhelpful here: it reports *"your connection looks slow or
+unstable"* for what is a permission refusal, so check the browser console before suspecting the
+network.
+
 ## How Zarr stores are served
 
 The Open Climate Service provides two endpoints for accessing the same Icechunk store:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -183,8 +183,8 @@ overstating sends a renderer looking for levels that do not exist.
 The `profile` parameter is a
 [STAC Zarr best practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md)
 recommendation, not part of the official Zarr media type registration. Consumers match it as a
-**literal**, not by parsing parameters, so the string is byte-for-byte fixed — same parameter
-order, one space after each `;`. Reformatting it silently disables rendering everywhere.
+literal rather than parsing parameters, so the exact string matters; the constraint is recorded
+next to it in `stac/media_types.py`.
 
 ## CF metadata in the catalog
 

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -163,6 +163,53 @@ alongside it, so catalogue clients that expect geographic coordinates always get
 
 ---
 
+## How a client is told whether a store is pyramided
+
+STAC has no way to distinguish a flat store from a pyramided one through the plain Zarr media
+type, so the collection's `zarr` asset carries an extra parameter when — and only when — the
+store really has levels:
+
+| Store     | Advertised media type                                    |
+| --------- | -------------------------------------------------------- |
+| flat      | `application/vnd.zarr; version=3`                        |
+| pyramided | `application/vnd.zarr; version=3; profile=multiscales`   |
+
+Detection requires **both** the multiscales convention in the root `zarr_conventions` *and* a
+non-empty `multiscales.layout` — the same two conditions a pyramid-aware renderer checks, so the
+claim always matches what a renderer can use. Any failure to inspect the store degrades to the
+flat type: understating is harmless, since a client then opens the store the ordinary way, while
+overstating sends a renderer looking for levels that do not exist.
+
+The `profile` parameter is a
+[STAC Zarr best practices](https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md)
+recommendation, not part of the official Zarr media type registration. Consumers match it as a
+**literal**, not by parsing parameters, so the string is byte-for-byte fixed — same parameter
+order, one space after each `;`. Reformatting it silently disables rendering everywhere.
+
+## CF metadata in the catalog
+
+Variables carry their CF semantics into `cube:variables`, named per the
+[STAC CF extension](https://github.com/stac-extensions/cf):
+
+```json
+"cube:variables": {
+  "tg": {
+    "type": "data",
+    "dimensions": ["t", "y", "x"],
+    "unit": "degree_Celsius",
+    "cf:standard_name": "air_temperature",
+    "cf:cell_methods": "time: mean",
+    "attrs": { "long_name": "...", "units": "degree_Celsius", "standard_name": "air_temperature" }
+  }
+}
+```
+
+The `cf:` prefix matters: the extension explicitly lists `cube:variables` among the places its
+fields may be used, so a prefixed field is one a client is defined to understand, while a bare
+`standard_name` at that level is not. The unprefixed spellings remain inside `attrs`, which
+passes through the store's own CF attribute names verbatim. The extension is declared in
+`stac_extensions` only when a `cf:` field was actually emitted.
+
 ## How Zarr stores are served
 
 The Open Climate Service provides two endpoints for accessing the same Icechunk store:

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -100,13 +100,36 @@ Both flat and pyramid stores are written in **Zarr v3** format using regular chu
 
 A plain Zarr store has no concept of spatial coordinates. A map viewer opening it has no way to know where to position tiles on a map. GeoZarr addresses this by writing a small set of attributes into `zarr.json` at the store root:
 
-| Attribute          | Example value             | Purpose                        |
-| ------------------ | ------------------------- | ------------------------------ |
-| `spatial:bbox`     | `[3.0, 57.0, 32.0, 72.5]` | Bounding box in the stored CRS |
-| `proj:code`        | `EPSG:4326`               | CRS of the stored coordinates  |
-| `zarr_conventions` | `[{...}]`                 | Convention declarations        |
+| Attribute            | Example value                              | Purpose                                          |
+| -------------------- | ------------------------------------------ | ------------------------------------------------ |
+| `spatial:transform`  | `[0.05, 0, 2.95, 0, -0.05, 60.0]`          | Affine placing the grid: cell size and origin     |
+| `spatial:dimensions` | `["y", "x"]`                               | Names of the row and column axes, in array order |
+| `spatial:shape`      | `[60, 581]`                                | Grid size as `[height, width]`                    |
+| `spatial:bbox`       | `[2.95, 57.0, 32.0, 60.0]`                 | Bounding box in the stored CRS                    |
+| `proj:code`          | `EPSG:4326`                                | CRS of the stored coordinates                     |
+| `zarr_conventions`   | `[{...}]`                                  | Convention declarations                           |
 
-These attributes are computed from the actual coordinate bounds of the written data and its CRS. They are always written by the framework after any transforms have run. This guarantees they always reflect the final stored data.
+Two details matter to any client that reads the store directly:
+
+- **Axis order is array order, `(y, x)`.** `spatial:dimensions` and `spatial:shape` are read
+  positionally — the second-to-last entry is the row axis, the last is the column axis. Naming
+  them x-first, or writing the shape as `[width, height]`, transposes the grid.
+- **`spatial:transform` is what actually places the raster.** It is `[stepX, rotX, originX,
+  rotY, stepY, originY]`, with the origin on the outer *edge* of the first cell (pixel
+  registration) and `stepY` negative for a north-up grid. Clients that find no affine fall
+  back to inferring one from the coordinate arrays, and typically assume EPSG:4326 while doing
+  so — which silently mislocates a store held in projected metres.
+
+The same affine is also written to the `spatial_ref` grid-mapping variable as a GDAL
+`GeoTransform`, in GDAL's own coefficient order (`originX stepX rotX originY rotY stepY`).
+That is what makes the store self-describing to GDAL/QGIS, and it is how a viewer recognises
+a projected grid rather than degrees.
+
+These attributes are computed from the **stored coordinate arrays** — not from the requested
+bbox. A source may return less than was asked for (CHIRPS ends at 60°N, so a request reaching
+72.5°N yields a store that stops at 60°N), and describing the request would stretch the raster
+over ground the store does not cover. They are always written by the framework after any
+transforms have run, so they reflect the final stored data.
 
 `zarr_conventions` for a flat store contains the base GeoZarr convention declaration. For pyramid stores it also includes a `multiscales` entry that declares the level structure.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Concepts:
       - Architecture: architecture.md
       - Zarr and GeoZarr: zarr_and_geozarr.md
+      - Raster conventions: conventions.md
       - Project overview: project_description.md
   - Guides:
       - Instance guide: instance_guide.md

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -14,6 +14,7 @@ from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
 from open_climate_service.shared.crs import dataset_crs
+from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
 
 logger = logging.getLogger(__name__)
 
@@ -308,17 +309,30 @@ def write_to_icechunk_store(
         # store off-map.
         crs = dataset_crs(ds)
 
-    dims = [x_dim, y_dim]
-    xmin = float(ds[x_dim].min())
-    xmax = float(ds[x_dim].max())
-    ymin = float(ds[y_dim].min())
-    ymax = float(ds[y_dim].max())
-    geozarr_attrs = create_geozarr_attrs(
-        dimensions=dims,
-        crs=crs,
-        bbox=[xmin, ymin, xmax, ymax],
-        shape=(ds.sizes[x_dim], ds.sizes[y_dim]),
-    )
+    # Array order, (y, x): `spatial:dimensions` and `spatial:shape` are read positionally, so
+    # naming them x-first transposes the grid for any client that trusts the convention.
+    dims = [y_dim, x_dim]
+    geometry = grid_geometry(ds[x_dim], ds[y_dim])
+    if geometry is None:
+        # Degenerate grid (a single cell on an axis) — the cell size can't be derived from
+        # coordinates, so fall back to the centre-based extent and omit the affine.
+        bbox = [
+            float(ds[x_dim].min()),
+            float(ds[y_dim].min()),
+            float(ds[x_dim].max()),
+            float(ds[y_dim].max()),
+        ]
+        shape: tuple[int, ...] = (ds.sizes[y_dim], ds.sizes[x_dim])
+    else:
+        bbox = geometry["bbox"]
+        shape = tuple(geometry["shape"])
+    geozarr_attrs = create_geozarr_attrs(dimensions=dims, crs=crs, bbox=bbox, shape=shape)
+    if geometry is not None:
+        # The affine is what a client places the raster with; without it, viewers infer a grid
+        # from the coordinate arrays and assume EPSG:4326 while doing so, which puts every
+        # projected store off the map. topozarr writes the same affine for pyramid level 0,
+        # and this matches it exactly (pixel registration, so the origin is the cell edge).
+        geozarr_attrs["spatial:transform"] = geometry["transform"]
 
     ds = ds.proj.assign_crs(spatial_ref=crs)
     ds = ds.rio.write_crs(crs)
@@ -393,11 +407,26 @@ def write_to_icechunk_store(
                         ds_entry.setdefault("crs", crs)
                 root_attrs["multiscales"] = ms
                 root.attrs.update(root_attrs)
+        if geometry is not None:
+            write_gdal_geotransform(root, geometry["transform"])
         for level_key in root.keys():
-            if isinstance(root[level_key], zarr.Group):
-                lvl_attrs = dict(root[level_key].attrs)
-                lvl_attrs["coordinates"] = "spatial_ref"
-                root[level_key].attrs.update(lvl_attrs)
+            level_group = root[level_key]
+            if not isinstance(level_group, zarr.Group):
+                continue
+            lvl_attrs = dict(level_group.attrs)
+            lvl_attrs["coordinates"] = "spatial_ref"
+            level_group.attrs.update(lvl_attrs)
+            # Level groups are named by their downsample exponent ("0" = native). Anything
+            # else is not a pyramid level, so leave its georeferencing alone.
+            if geometry is not None and level_key.isdigit():
+                # Each level halves the resolution, so it needs its own GeoTransform — one
+                # copied from level 0 would place every overview at twice its true size.
+                factor = float(2 ** int(level_key))
+                step_x, rot_x, origin_x, rot_y, step_y, origin_y = geometry["transform"]
+                write_gdal_geotransform(
+                    level_group,
+                    [step_x * factor, rot_x, origin_x, rot_y, step_y * factor, origin_y],
+                )
 
         if t_dim is not None:
             _write_root_time_coordinate(session.store, ds, time_dim=t_dim)
@@ -422,5 +451,7 @@ def write_to_icechunk_store(
         flat_attrs = dict(root_flat.attrs)
         flat_attrs["coordinates"] = "spatial_ref"
         root_flat.attrs.update(flat_attrs)
+        if geometry is not None:
+            write_gdal_geotransform(root_flat, geometry["transform"])
 
     session.commit(commit_message)

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -14,12 +14,7 @@ from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
 from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
-from open_climate_service.shared.raster_contract import (
-    normalize_dim_layout,
-    normalize_longitudes,
-    normalize_y_direction,
-    resolve_store_crs,
-)
+from open_climate_service.shared.raster_contract import prepare_for_publication
 
 logger = logging.getLogger(__name__)
 
@@ -307,27 +302,14 @@ def write_to_icechunk_store(
     import icechunk
     import rioxarray as _rxr  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio accessor
 
-    # Enforce the published-store layout contract here, at the write boundary, rather than
-    # relying on every plugin to get it right (CLIM-821). This is the whole-store rewrite
-    # path, so the longitude roll — which changes coordinate values — is safe here.
-    ds = normalize_dim_layout(ds, time_dim="t", x_dim=x_dim, y_dim=y_dim)
+    # Bring the cube up to the published-store contract, and resolve the CRS that describes it,
+    # at the write boundary — rather than relying on every plugin to get it right (CLIM-821).
+    prepared = prepare_for_publication(ds, fallback_crs=crs, x_dim=x_dim, y_dim=y_dim)
+    ds, crs = prepared.dataset, prepared.crs
     if t_dim is not None and t_dim != "t":
         # The caller named the temporal dim as it arrived; normalisation has renamed it, so the
         # rest of this function (root time coordinate, chunking) must follow the new name.
         t_dim = "t" if "t" in ds.dims else t_dim
-
-    # Data is stored in its native CRS — the one the source delivered it in, recovered from
-    # the dataset itself. Never the instance config CRS: stamping e.g. EPSG:32633 onto WGS84
-    # ERA5-Land coordinates puts the store off-map. `resolve_store_crs` also refuses a
-    # *caller-supplied* CRS the coordinates contradict, which is how that used to happen.
-    crs = resolve_store_crs(ds, crs, x_dim=x_dim, y_dim=y_dim)
-    # Must follow the CRS resolution, not precede it: the roll applies to geographic axes only,
-    # so deciding it from an unvalidated declared CRS would skip the roll for exactly the
-    # lon/lat grid mislabelled as projected that resolve_store_crs just corrected.
-    ds = normalize_longitudes(ds, x_dim=x_dim, crs=crs)
-    # Row 0 must be the northernmost row: the thumbnail renderer and OpenLayers' GeoZarr source
-    # both assume it and neither checks. See shared/raster_contract.
-    ds = normalize_y_direction(ds, y_dim=y_dim)
 
     # Array order, (y, x): `spatial:dimensions` and `spatial:shape` are read positionally, so
     # naming them x-first transposes the grid for any client that trusts the convention.

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -17,6 +17,7 @@ from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotra
 from open_climate_service.shared.raster_contract import (
     normalize_dim_layout,
     normalize_longitudes,
+    normalize_y_direction,
     resolve_store_crs,
 )
 
@@ -324,6 +325,9 @@ def write_to_icechunk_store(
     # so deciding it from an unvalidated declared CRS would skip the roll for exactly the
     # lon/lat grid mislabelled as projected that resolve_store_crs just corrected.
     ds = normalize_longitudes(ds, x_dim=x_dim, crs=crs)
+    # Row 0 must be the northernmost row: the thumbnail renderer and OpenLayers' GeoZarr source
+    # both assume it and neither checks. See shared/raster_contract.
+    ds = normalize_y_direction(ds, y_dim=y_dim)
 
     # Array order, (y, x): `spatial:dimensions` and `spatial:shape` are read positionally, so
     # naming them x-first transposes the grid for any client that trusts the convention.

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -13,8 +13,12 @@ from topozarr import CoarseningMethod
 from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.crs import dataset_crs
 from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
+from open_climate_service.shared.raster_contract import (
+    normalize_dim_layout,
+    normalize_longitudes,
+    resolve_store_crs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -302,12 +306,24 @@ def write_to_icechunk_store(
     import icechunk
     import rioxarray as _rxr  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio accessor
 
-    if crs is None:
-        # Data is stored in its native CRS — the one the source delivered it in,
-        # recovered from the dataset itself. Never the instance config CRS:
-        # stamping e.g. EPSG:32633 onto WGS84 ERA5-Land coordinates puts the
-        # store off-map.
-        crs = dataset_crs(ds)
+    # Enforce the published-store layout contract here, at the write boundary, rather than
+    # relying on every plugin to get it right (CLIM-821). This is the whole-store rewrite
+    # path, so the longitude roll — which changes coordinate values — is safe here.
+    ds = normalize_dim_layout(ds, time_dim="t", x_dim=x_dim, y_dim=y_dim)
+    if t_dim is not None and t_dim != "t":
+        # The caller named the temporal dim as it arrived; normalisation has renamed it, so the
+        # rest of this function (root time coordinate, chunking) must follow the new name.
+        t_dim = "t" if "t" in ds.dims else t_dim
+
+    # Data is stored in its native CRS — the one the source delivered it in, recovered from
+    # the dataset itself. Never the instance config CRS: stamping e.g. EPSG:32633 onto WGS84
+    # ERA5-Land coordinates puts the store off-map. `resolve_store_crs` also refuses a
+    # *caller-supplied* CRS the coordinates contradict, which is how that used to happen.
+    crs = resolve_store_crs(ds, crs, x_dim=x_dim, y_dim=y_dim)
+    # Must follow the CRS resolution, not precede it: the roll applies to geographic axes only,
+    # so deciding it from an unvalidated declared CRS would skip the roll for exactly the
+    # lon/lat grid mislabelled as projected that resolve_store_crs just corrected.
+    ds = normalize_longitudes(ds, x_dim=x_dim, crs=crs)
 
     # Array order, (y, x): `spatial:dimensions` and `spatial:shape` are read positionally, so
     # naming them x-first transposes the grid for any client that trusts the convention.

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -852,7 +852,11 @@ def _get_icechunk_store_path_or_404(
     store = session.store
     target = _normalize_icechunk_relative_path(relative_path)
     if target == "":
-        raise HTTPException(status_code=404, detail="Not found")
+        # The store root. A Zarr library never asks for it — it treats the URL as a base and
+        # appends keys — but a person pasting the URL does, and FastAPI's redirect sends the
+        # slashless form here too, so 404 made the root of every store look like a dead store.
+        # Serve the group metadata it stands for, which is also what the appended request gets.
+        target = "zarr.json"
 
     if _icechunk_exists(store, target):
         payload = _icechunk_get(store, target)

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -714,10 +714,24 @@ def _icechunk_list_dir(store: _IcechunkReadableStore, prefix: str) -> list[str]:
 
 
 def _icechunk_exists(store: _IcechunkReadableStore, key: str) -> bool:
+    """Whether *key* exists in the store; False for anything Icechunk cannot address.
+
+    A browser probing an unknown store asks for keys that are not Zarr keys at all, and Icechunk
+    rejects those two different ways: ``KeyError`` for Zarr v2 spellings (``.zgroup``,
+    ``.zarray``), and ``IcechunkError: invalid zarr key format`` for paths outside the Zarr
+    namespace entirely (``repo``, ``refs/branch.main/ref.json`` — the layout probes zarr-viewer
+    uses to decide whether a URL is an Icechunk repository).
+
+    Both mean "not here", so both must answer False. Letting the second escape turned a probe
+    into a 500, and because an unhandled 500 is raised above the CORS middleware it reached the
+    browser with no ``Access-Control-Allow-Origin`` — reported as a CORS failure, which is not
+    where anyone would look for a missing-key bug.
+    """
+    from icechunk import IcechunkError
+
     try:
         return cast(bool, _run_async(store.exists(key)))
-    except KeyError:
-        # Icechunk raises KeyError for Zarr v2 keys (e.g. .zgroup, .zarray)
+    except (KeyError, IcechunkError):
         return False
 
 

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -18,10 +18,21 @@ from open_climate_service.openeo.jobs import get_openeo_job_service
 from open_climate_service.stac import routes as stac_routes
 from open_climate_service.system import routes as system_routes
 
+# Hosted browser tools that read a Zarr store directly over HTTP. They are the reason a local
+# instance needs any cross-origin story at all: each is a public page fetching a store that may
+# be on localhost, which browsers gate behind the private/local network rules handled below.
+DEFAULT_ZARR_BROWSER_ORIGINS = (
+    "https://inspect.geozarr.org",
+    # source-cooperative/zarr-viewer, the reference viewer for GeoZarr stores (CLIM-852).
+    # Omitting it is a dead end an operator cannot diagnose: the viewer reports "your connection
+    # looks slow or unstable" for what is actually a blocked cross-origin request.
+    "https://source-cooperative.github.io",
+)
+
 
 def _zarr_browser_access_origins() -> set[str]:
     """Return allowlisted remote origins permitted to inspect local Zarr endpoints."""
-    raw = os.getenv("CLIMATE_SERVICE_ZARR_BROWSER_ORIGINS", "https://inspect.geozarr.org")
+    raw = os.getenv("CLIMATE_SERVICE_ZARR_BROWSER_ORIGINS", ",".join(DEFAULT_ZARR_BROWSER_ORIGINS))
     return {origin.strip() for origin in raw.split(",") if origin.strip()}
 
 
@@ -32,7 +43,7 @@ def _pna_trusted_origins() -> set[str]:
     CLIMATE_SERVICE_PNA_ORIGINS environment variable (comma-separated).
     """
     default = "https://editor.openeo.org," + os.getenv(
-        "CLIMATE_SERVICE_ZARR_BROWSER_ORIGINS", "https://inspect.geozarr.org"
+        "CLIMATE_SERVICE_ZARR_BROWSER_ORIGINS", ",".join(DEFAULT_ZARR_BROWSER_ORIGINS)
     )
     raw = os.getenv("CLIMATE_SERVICE_PNA_ORIGINS", default)
     return {o.strip() for o in raw.split(",") if o.strip()}
@@ -90,18 +101,27 @@ def create_app() -> FastAPI:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        """Handle Private Network Access preflights and Zarr browser CORS headers.
+        """Handle private/local network preflights and Zarr browser CORS headers.
 
-        Chrome's Private Network Access policy blocks public-origin pages (e.g.
-        editor.openeo.org or inspect.geozarr.org) from fetching localhost resources
-        unless the server explicitly opts in via Access-Control-Allow-Private-Network.
-        We grant this for any origin that is already allowed by the CORS wildcard,
-        which covers both the openEO editor and remote Zarr inspectors.
+        Browsers gate a public-origin page (editor.openeo.org, a hosted Zarr viewer) fetching a
+        localhost resource, and the server has to opt in. Chrome has shipped two spellings of
+        that opt-in as the spec evolved — the older Private Network Access
+        (``Access-Control-Request/Allow-Private-Network``) and the newer Local Network Access
+        (``...-Local-Network-Access``) — so both are answered here rather than betting on one.
+
+        A server header is necessary but, on current Chrome, no longer sufficient: reaching the
+        loopback address space also needs a user permission grant, refused by default. When that
+        is what blocks a request the console says "Permission was denied for this request to
+        access the `loopback` address space" — distinct from a missing-header CORS failure, and
+        not something the server can fix. See docs/zarr_and_geozarr.md.
         """
         origin = request.headers.get("origin")
         is_pna_preflight = (
             request.method == "OPTIONS"
-            and request.headers.get("access-control-request-private-network") == "true"
+            and (
+                request.headers.get("access-control-request-private-network") == "true"
+                or request.headers.get("access-control-request-local-network-access") == "true"
+            )
             and origin is not None
         )
 
@@ -110,6 +130,7 @@ def create_app() -> FastAPI:
             response = Response(status_code=200)
             response.headers["Access-Control-Allow-Origin"] = str(origin)
             response.headers["Access-Control-Allow-Private-Network"] = "true"
+            response.headers["Access-Control-Allow-Local-Network-Access"] = "true"
             response.headers["Access-Control-Allow-Methods"] = request.headers.get(
                 "access-control-request-method", "GET, POST, OPTIONS"
             )
@@ -132,6 +153,7 @@ def create_app() -> FastAPI:
                 request.headers.get("access-control-request-headers", "*"),
             )
             response.headers["Access-Control-Allow-Private-Network"] = "true"
+            response.headers["Access-Control-Allow-Local-Network-Access"] = "true"
 
         return response
 

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -14,7 +14,6 @@ from typing import Any
 import xarray as xr
 from fastapi import HTTPException, Request
 
-from open_climate_service import config as api_config
 from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset, open_zarr_dataset
 from open_climate_service.data_manager.services.utils import get_time_dim
 from open_climate_service.ingestions import services as ingestion_services
@@ -459,16 +458,19 @@ def _ensure_crs(ds: xr.Dataset) -> xr.Dataset:
     downloader/pyramid path already carry ``spatial_ref``; ``write_crs`` is a no-op for
     them, so this is safe and idempotent.
 
-    The CRS is taken from the store's declared ``proj:code`` when present, falling back
-    to the instance CRS. Tagging failures are logged and the dataset returned untouched
-    rather than failing the load.
+    The CRS is taken from the store's declared ``proj:code``, else WGS84 — never the instance
+    config CRS, which would tag an untagged cube with a projection its coordinates are not in
+    and carry that wrong CRS into anything the job publishes (CLIM-821). Tagging failures are
+    logged and the dataset returned untouched rather than failing the load.
     """
     import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio accessor
+
+    from open_climate_service.shared.crs import dataset_crs
 
     try:
         if ds.rio.crs is not None:
             return ds
-        crs = ds.attrs.get("proj:code") or ds.attrs.get("proj:epsg") or api_config.get_crs()
+        crs = dataset_crs(ds)
         tagged: xr.Dataset = ds.rio.write_crs(crs)
         return tagged
     except Exception:  # pragma: no cover - defensive; resampling will surface a clearer error

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -26,8 +26,8 @@ from open_climate_service.openeo.schemas import (
     OpenEOJobStatus,
     OpenEOJobUpdate,
 )
-from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import utc_now
+from open_climate_service.stac.media_types import ZARR_V3_MEDIA_TYPE, zarr_media_type
 
 _T = TypeVar("_T")
 

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -1558,6 +1558,15 @@ def _write_png(ds: Any, results_dir: Any) -> str | None:
 
     fig, ax = plt.subplots(figsize=(fig_w, fig_h), dpi=dpi)
     fig.patch.set_alpha(0)
+    # `origin="upper"` puts array row 0 at the top, which is right because published stores
+    # guarantee y descending (row 0 = north) — see shared/raster_contract. A cube that reaches
+    # here south-up (an in-flight openEO result, not a published store) is flipped first, so the
+    # thumbnail is never upside down.
+    y_name = next((str(d) for d in arr.dims if str(d) in ("y", "lat", "latitude")), None)
+    if y_name is not None and y_name in arr.coords and arr.sizes.get(y_name, 0) >= 2:
+        y_values = arr[y_name].values
+        if float(y_values[1]) > float(y_values[0]):
+            data = data[::-1]
     ax.imshow(data, origin="upper", cmap=cmap, norm=norm, interpolation="nearest")
     ax.axis("off")
     fig.tight_layout(pad=0)

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -26,6 +26,7 @@ from open_climate_service.openeo.schemas import (
     OpenEOJobStatus,
     OpenEOJobUpdate,
 )
+from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import utc_now
 
 _T = TypeVar("_T")
@@ -957,7 +958,7 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
             },
             "zarr": {
                 "href": f"/zarr/{dataset_id}",
-                "type": "application/vnd.zarr; version=3",
+                "type": ZARR_V3_MEDIA_TYPE,
                 "title": "Zarr store",
                 "roles": ["data"],
                 "xarray:open_kwargs": {"consolidated": True},
@@ -966,14 +967,24 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
         # Advertise the STAC collection only when the dataset is actually published.
         try:
             from open_climate_service.ingestions import services as _ingestion_services
+            from open_climate_service.ingestions.schemas import ArtifactFormat
 
-            if dataset_id in _ingestion_services.latest_published_zarr_artifacts_by_dataset():
+            artifact = _ingestion_services.latest_published_zarr_artifacts_by_dataset().get(dataset_id)
+            if artifact is not None:
                 assets["stac"] = {
                     "href": f"/stac/collections/{dataset_id}",
                     "type": "application/json",
                     "title": "STAC collection",
                     "roles": ["metadata"],
                 }
+                # Keep the claim in step with the STAC collection's zarr asset, so a client
+                # sees the same media type from either surface. Uncached, unlike the STAC
+                # side — a job-result read is rare enough not to warrant one.
+                store_path = artifact.path or (artifact.asset_paths[0] if artifact.asset_paths else None)
+                if store_path:
+                    assets["zarr"]["type"] = zarr_media_type(
+                        store_path, icechunk=artifact.format == ArtifactFormat.ICECHUNK
+                    )
         except Exception:
             logger.debug("Could not resolve STAC publication for managed dataset '%s'", dataset_id, exc_info=True)
         return assets

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -564,9 +564,13 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
     # "Mosquito hotspots (Rwanda 2018 Q1)" rather than "mosquito_hotspots".
     dataset_name: str = options.get("dataset_name") or template.get("name") or dataset_id
 
-    from open_climate_service import config as api_config
+    # The cube's own CRS — the store's `proj:code` when it has one, else whatever rioxarray
+    # detects from its grid mapping. Deliberately NOT the instance config CRS: falling back to
+    # that stamped e.g. EPSG:32633 onto an untagged WGS84 cube, which puts the published store
+    # at the projection's origin instead of on the map (CLIM-821).
+    from open_climate_service.shared.crs import dataset_crs
 
-    crs: str = ds.attrs.get("proj:code") or api_config.get_crs()
+    crs: str = dataset_crs(ds)
 
     # Stamp CF attributes (units / standard_name / cell_methods) from the template so the
     # published store is CF-compliant on disk (#280). The template is authoritative for the

--- a/open_climate_service/shared/geozarr.py
+++ b/open_climate_service/shared/geozarr.py
@@ -1,9 +1,8 @@
-"""What OCS writes into a GeoZarr store's root, and what it advertises about it.
+"""GeoZarr ``spatial:`` convention attributes derived from a store's own grid.
 
-Two halves of one contract. The first writes the ``spatial:`` convention attributes that place
-a raster; the second reads them back to decide the media type a STAC client is told, which is
-what gates whether that client will render the store at all. Keeping them in one module means
-the claim and the thing being claimed can't drift apart.
+Write-time only, and deliberately dependency-light: everything here is arithmetic over
+coordinate arrays plus one attribute write. What a *reader* is told about a finished store —
+its media type — is a serving concern and lives in ``stac/media_types.py``.
 
 Both write paths (the streaming per-period appender and the batch downloader) declare the
 `spatial:` convention in ``zarr_conventions``, so both must describe the grid the same way.
@@ -28,13 +27,7 @@ of the data stretches the raster over ground it does not cover.
 
 from __future__ import annotations
 
-import json
-import logging
-from collections.abc import Mapping
-from pathlib import Path
 from typing import Any, Sequence
-
-logger = logging.getLogger(__name__)
 
 # ``spatial:registration: "pixel"`` (what both write paths declare) puts the affine origin on
 # the outer *edge* of the first cell, not its centre — so a half-step is subtracted below.
@@ -121,110 +114,3 @@ def write_gdal_geotransform(root: Any, transform: Sequence[float]) -> None:
     except (KeyError, TypeError):
         return
     spatial_ref.attrs.update({"GeoTransform": gdal_geotransform(transform)})
-
-
-# --- Media type: telling a STAC client whether the store is pyramided ---------------------
-#
-# STAC has no way to distinguish a flat store from a pyramided one through the plain Zarr
-# media type, and clients that only render pyramided stores therefore cannot decide whether an
-# asset is safe to open. The `profile` parameter closes that gap. It is a
-# STAC Zarr best-practices recommendation, which notes it is not (yet) part of the official
-# Zarr media type registration:
-#
-#     https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md
-#
-# Consumers match it as a literal, not by parsing parameters. stac-js holds
-# `wozMediaTypes = ['application/vnd.zarr; version=3; profile=multiscales']` and compares with
-# `allowedTypes.includes(type.toLowerCase())` — so case is forgiven but parameter order and
-# spacing are not. WEB_OPTIMIZED_ZARR_MEDIA_TYPE must stay byte-identical.
-
-ZARR_V3_MEDIA_TYPE = "application/vnd.zarr; version=3"
-"""Media type for a published Zarr v3 store with no resolution pyramid."""
-
-WEB_OPTIMIZED_ZARR_MEDIA_TYPE = f"{ZARR_V3_MEDIA_TYPE}; profile=multiscales"
-"""Media type for a pyramided ("web-optimized") Zarr v3 store.
-
-Byte-identical to the string web clients match on; do not reformat or reorder the parameters.
-"""
-
-MULTISCALES_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
-"""UUID of the Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)."""
-
-
-def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
-    """True when root group *attributes* describe a real multiscales pyramid.
-
-    Requires both the convention declared in ``zarr_conventions`` *and* a non-empty
-    ``multiscales.layout``. Those are the same two conditions pyramid-aware renderers check, so
-    the claim matches what a renderer can actually use. A store that declares the convention but
-    lists no levels is treated as flat — there is nothing extra for a client to read.
-    """
-    conventions = attributes.get("zarr_conventions")
-    if not isinstance(conventions, list):
-        return False
-    declared = any(
-        isinstance(convention, Mapping)
-        and (convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales")
-        for convention in conventions
-    )
-    if not declared:
-        return False
-    multiscales = attributes.get("multiscales")
-    if not isinstance(multiscales, Mapping):
-        return False
-    layout = multiscales.get("layout")
-    return isinstance(layout, list) and len(layout) > 0
-
-
-def read_root_attributes(store_path: str, *, icechunk: bool) -> Mapping[str, Any]:
-    """Root group attributes of a published store; empty mapping when unreadable.
-
-    Reads group metadata only, never chunk data. Deliberately the *root* group: the store
-    accessors descend into pyramid level ``0``, whose attributes do not carry the multiscales
-    layout, so this needs its own path.
-
-    Remote stores return empty rather than paying a network round trip — the caller degrades to
-    the flat media type.
-    """
-    if icechunk:
-        return _read_icechunk_root_attributes(store_path)
-    if "://" in store_path:
-        return {}
-    zarr_json = Path(store_path) / "zarr.json"
-    try:
-        payload = json.loads(zarr_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    attributes = payload.get("attributes")
-    return attributes if isinstance(attributes, Mapping) else {}
-
-
-def _read_icechunk_root_attributes(store_path: str) -> Mapping[str, Any]:
-    import icechunk
-    import zarr
-
-    if not Path(store_path).exists():
-        return {}
-    storage = icechunk.local_filesystem_storage(store_path)
-    repo = icechunk.Repository.open(storage)
-    session = repo.readonly_session("main")
-    group = zarr.open_group(session.store, mode="r")
-    return dict(group.attrs)
-
-
-def zarr_media_type(store_path: str, *, icechunk: bool) -> str:
-    """The media type to advertise for the store at *store_path*.
-
-    Falls back to the flat :data:`ZARR_V3_MEDIA_TYPE` whenever the pyramid cannot be confirmed.
-    The asymmetry is deliberate: understating is harmless — a client opens the store the ordinary
-    way — while overstating sends a renderer looking for levels that do not exist. A locked or
-    corrupt store must never take the STAC collection down with it.
-    """
-    try:
-        attributes = read_root_attributes(store_path, icechunk=icechunk)
-    except Exception:  # noqa: BLE001 — any read failure degrades to the flat type
-        logger.debug("Could not read root attributes of store %r", store_path, exc_info=True)
-        return ZARR_V3_MEDIA_TYPE
-    if attributes_declare_multiscales(attributes):
-        return WEB_OPTIMIZED_ZARR_MEDIA_TYPE
-    return ZARR_V3_MEDIA_TYPE

--- a/open_climate_service/shared/geozarr.py
+++ b/open_climate_service/shared/geozarr.py
@@ -1,4 +1,9 @@
-"""GeoZarr ``spatial:`` convention attributes derived from a store's own grid.
+"""What OCS writes into a GeoZarr store's root, and what it advertises about it.
+
+Two halves of one contract. The first writes the ``spatial:`` convention attributes that place
+a raster; the second reads them back to decide the media type a STAC client is told, which is
+what gates whether that client will render the store at all. Keeping them in one module means
+the claim and the thing being claimed can't drift apart.
 
 Both write paths (the streaming per-period appender and the batch downloader) declare the
 `spatial:` convention in ``zarr_conventions``, so both must describe the grid the same way.
@@ -23,7 +28,13 @@ of the data stretches the raster over ground it does not cover.
 
 from __future__ import annotations
 
+import json
+import logging
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, Sequence
+
+logger = logging.getLogger(__name__)
 
 # ``spatial:registration: "pixel"`` (what both write paths declare) puts the affine origin on
 # the outer *edge* of the first cell, not its centre — so a half-step is subtracted below.
@@ -110,3 +121,110 @@ def write_gdal_geotransform(root: Any, transform: Sequence[float]) -> None:
     except (KeyError, TypeError):
         return
     spatial_ref.attrs.update({"GeoTransform": gdal_geotransform(transform)})
+
+
+# --- Media type: telling a STAC client whether the store is pyramided ---------------------
+#
+# STAC has no way to distinguish a flat store from a pyramided one through the plain Zarr
+# media type, and clients that only render pyramided stores therefore cannot decide whether an
+# asset is safe to open. The `profile` parameter closes that gap. It is a
+# STAC Zarr best-practices recommendation, which notes it is not (yet) part of the official
+# Zarr media type registration:
+#
+#     https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md
+#
+# Consumers match it as a literal, not by parsing parameters. stac-js holds
+# `wozMediaTypes = ['application/vnd.zarr; version=3; profile=multiscales']` and compares with
+# `allowedTypes.includes(type.toLowerCase())` — so case is forgiven but parameter order and
+# spacing are not. WEB_OPTIMIZED_ZARR_MEDIA_TYPE must stay byte-identical.
+
+ZARR_V3_MEDIA_TYPE = "application/vnd.zarr; version=3"
+"""Media type for a published Zarr v3 store with no resolution pyramid."""
+
+WEB_OPTIMIZED_ZARR_MEDIA_TYPE = f"{ZARR_V3_MEDIA_TYPE}; profile=multiscales"
+"""Media type for a pyramided ("web-optimized") Zarr v3 store.
+
+Byte-identical to the string web clients match on; do not reformat or reorder the parameters.
+"""
+
+MULTISCALES_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
+"""UUID of the Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)."""
+
+
+def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
+    """True when root group *attributes* describe a real multiscales pyramid.
+
+    Requires both the convention declared in ``zarr_conventions`` *and* a non-empty
+    ``multiscales.layout``. Those are the same two conditions pyramid-aware renderers check, so
+    the claim matches what a renderer can actually use. A store that declares the convention but
+    lists no levels is treated as flat — there is nothing extra for a client to read.
+    """
+    conventions = attributes.get("zarr_conventions")
+    if not isinstance(conventions, list):
+        return False
+    declared = any(
+        isinstance(convention, Mapping)
+        and (convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales")
+        for convention in conventions
+    )
+    if not declared:
+        return False
+    multiscales = attributes.get("multiscales")
+    if not isinstance(multiscales, Mapping):
+        return False
+    layout = multiscales.get("layout")
+    return isinstance(layout, list) and len(layout) > 0
+
+
+def read_root_attributes(store_path: str, *, icechunk: bool) -> Mapping[str, Any]:
+    """Root group attributes of a published store; empty mapping when unreadable.
+
+    Reads group metadata only, never chunk data. Deliberately the *root* group: the store
+    accessors descend into pyramid level ``0``, whose attributes do not carry the multiscales
+    layout, so this needs its own path.
+
+    Remote stores return empty rather than paying a network round trip — the caller degrades to
+    the flat media type.
+    """
+    if icechunk:
+        return _read_icechunk_root_attributes(store_path)
+    if "://" in store_path:
+        return {}
+    zarr_json = Path(store_path) / "zarr.json"
+    try:
+        payload = json.loads(zarr_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    attributes = payload.get("attributes")
+    return attributes if isinstance(attributes, Mapping) else {}
+
+
+def _read_icechunk_root_attributes(store_path: str) -> Mapping[str, Any]:
+    import icechunk
+    import zarr
+
+    if not Path(store_path).exists():
+        return {}
+    storage = icechunk.local_filesystem_storage(store_path)
+    repo = icechunk.Repository.open(storage)
+    session = repo.readonly_session("main")
+    group = zarr.open_group(session.store, mode="r")
+    return dict(group.attrs)
+
+
+def zarr_media_type(store_path: str, *, icechunk: bool) -> str:
+    """The media type to advertise for the store at *store_path*.
+
+    Falls back to the flat :data:`ZARR_V3_MEDIA_TYPE` whenever the pyramid cannot be confirmed.
+    The asymmetry is deliberate: understating is harmless — a client opens the store the ordinary
+    way — while overstating sends a renderer looking for levels that do not exist. A locked or
+    corrupt store must never take the STAC collection down with it.
+    """
+    try:
+        attributes = read_root_attributes(store_path, icechunk=icechunk)
+    except Exception:  # noqa: BLE001 — any read failure degrades to the flat type
+        logger.debug("Could not read root attributes of store %r", store_path, exc_info=True)
+        return ZARR_V3_MEDIA_TYPE
+    if attributes_declare_multiscales(attributes):
+        return WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+    return ZARR_V3_MEDIA_TYPE

--- a/open_climate_service/shared/geozarr.py
+++ b/open_climate_service/shared/geozarr.py
@@ -1,0 +1,112 @@
+"""GeoZarr ``spatial:`` convention attributes derived from a store's own grid.
+
+Both write paths (the streaming per-period appender and the batch downloader) declare the
+`spatial:` convention in ``zarr_conventions``, so both must describe the grid the same way.
+This module is the single source of that description, so the two can't drift.
+
+Two things matter to direct-Zarr clients, and both were wrong or missing before:
+
+* **Axis order is array order, ``(y, x)``.** ``spatial:dimensions`` and ``spatial:shape``
+  are read positionally — a client takes the second-to-last entry as the row (y) axis and
+  the last as the column (x) axis. Writing ``["x", "y"]`` / ``[width, height]`` transposes
+  the grid for anything that trusts the convention.
+* **The affine matters more than the bbox.** ``spatial:transform`` is what a client needs to
+  place a raster; without it, viewers fall back to guessing from the coordinate arrays, and
+  that guess is usually hardcoded to EPSG:4326 — which silently mislocates every projected
+  store. See CLIM-852.
+
+Everything here is derived from the store's *actual* cell-centre coordinates rather than the
+requested bbox: a source may deliver a smaller grid than was asked for (CHIRPS stops at 60°N,
+so a request up to 72.5°N yields a grid ending at 60°N), and describing the request instead
+of the data stretches the raster over ground it does not cover.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+# ``spatial:registration: "pixel"`` (what both write paths declare) puts the affine origin on
+# the outer *edge* of the first cell, not its centre — so a half-step is subtracted below.
+# This matches what topozarr writes for pyramid levels, keeping root and level-0 consistent.
+_PIXEL_REGISTRATION_HALF_STEP = 0.5
+
+
+def _as_floats(values: Any) -> list[float]:
+    """Coerce a coordinate array (numpy, xarray, list) to a plain list of floats."""
+    data = getattr(values, "values", values)
+    return [float(v) for v in data]
+
+
+def grid_geometry(
+    x_centres: Sequence[float] | Any,
+    y_centres: Sequence[float] | Any,
+) -> dict[str, Any] | None:
+    """Affine transform, shape and edge bbox for a regular grid, or None if undetermined.
+
+    ``x_centres`` / ``y_centres`` are the store's 1-D coordinate arrays, holding cell
+    *centres*. The step is taken from the first two cells and may be negative — a north-up
+    raster stores y descending, and the sign has to survive into the transform or the image
+    lands mirrored. At least two cells per axis are needed; a single-cell axis leaves the
+    cell size unknowable from coordinates alone, so the whole geometry is reported as
+    undetermined rather than guessed.
+    """
+    x = _as_floats(x_centres)
+    y = _as_floats(y_centres)
+    if len(x) < 2 or len(y) < 2:
+        return None
+
+    step_x = x[1] - x[0]
+    step_y = y[1] - y[0]
+    if step_x == 0.0 or step_y == 0.0:
+        return None
+
+    origin_x = x[0] - step_x * _PIXEL_REGISTRATION_HALF_STEP
+    origin_y = y[0] - step_y * _PIXEL_REGISTRATION_HALF_STEP
+    far_x = x[-1] + step_x * _PIXEL_REGISTRATION_HALF_STEP
+    far_y = y[-1] + step_y * _PIXEL_REGISTRATION_HALF_STEP
+
+    return {
+        # GeoZarr `spatial:transform`: [stepX, rotX, originX, rotY, stepY, originY].
+        "transform": [step_x, 0.0, origin_x, 0.0, step_y, origin_y],
+        # Array order, (rows, columns) == (y, x).
+        "shape": [len(y), len(x)],
+        # Outer edges, ordered [xmin, ymin, xmax, ymax] regardless of which way the axes run.
+        "bbox": [
+            min(origin_x, far_x),
+            min(origin_y, far_y),
+            max(origin_x, far_x),
+            max(origin_y, far_y),
+        ],
+    }
+
+
+def gdal_geotransform(transform: Sequence[float]) -> str:
+    """A GeoZarr ``spatial:transform`` as GDAL's ``GeoTransform`` string.
+
+    GDAL orders the same six coefficients differently — ``originX stepX rotX originY rotY
+    stepY`` — and stores them space-separated on the CF grid-mapping variable. Writing it
+    makes the store self-describing to GDAL/QGIS, and is what tells a viewer that a store is
+    a *projected* grid rather than degrees (zarr-viewer requires the GeoTransform before it
+    will route a store to its projected-grid renderer).
+    """
+    step_x, rot_x, origin_x, rot_y, step_y, origin_y = transform
+    return " ".join(repr(float(v)) for v in (origin_x, step_x, rot_x, origin_y, rot_y, step_y))
+
+
+def write_gdal_geotransform(root: Any, transform: Sequence[float]) -> None:
+    """Stamp the GDAL ``GeoTransform`` onto a store's CF ``spatial_ref`` grid-mapping array.
+
+    ``rio.write_crs`` writes ``crs_wkt`` and ``grid_mapping_name`` but not the transform —
+    ``rio.write_transform`` does that, and neither write path calls it, so whether a store
+    carries a GeoTransform currently depends on whether its *source* happened to have one
+    (GeoTIFF-backed CHIRPS does; NetCDF-backed seNorge does not). That makes the attribute
+    unreliable exactly where it matters most: it is the signal zarr-viewer uses to recognise
+    a projected grid, and its absence sends a UTM store down the degrees-assuming path.
+
+    A no-op when the store has no ``spatial_ref`` array (nothing to attach it to).
+    """
+    try:
+        spatial_ref = root["spatial_ref"]
+    except (KeyError, TypeError):
+        return
+    spatial_ref.attrs.update({"GeoTransform": gdal_geotransform(transform)})

--- a/open_climate_service/shared/raster_contract.py
+++ b/open_climate_service/shared/raster_contract.py
@@ -11,21 +11,36 @@ The contract:
 
 1. the temporal dimension is named ``t``
 2. spatial dims are named ``y`` / ``x`` and ordered ``(…, y, x)``
-3. for a geographic CRS, longitudes run −180…180 rather than 0…360
-4. the declared CRS matches the coordinates it describes
+3. ``y`` descends — array row 0 is the northernmost row
+4. for a geographic CRS, longitudes run −180…180 rather than 0…360
+5. the declared CRS matters and matches the coordinates it describes
 
-**Not** in the contract: the direction of ``y``. The ticket originally required ascending
-(south→north) because the map viewer's zarr-layer did; as of 0.6.1 it detects the direction
-from the ``y`` coordinate array instead (``detectedLatAscending = y1 > y0``), and OCS stores
-always take its "untiled" path, so either direction renders. Stores therefore keep the
-direction their source delivered — which for most rasters is north-up, matching GDAL's
-convention for the ``GeoTransform`` written alongside. A reader must honour the ``y``
-coordinate rather than assume a direction.
+Invariant 3 exists because real consumers assume a direction and never check. Two of them:
+
+* ``openeo/jobs.py`` renders result thumbnails with ``imshow(..., origin="upper")`` straight off
+  the array — row 0 is north, unconditionally.
+* OpenLayers' ``ol/source/GeoZarr``, the renderer STAC Browser uses, derives its tile grid
+  ``origin`` as ``[bbox[0], bbox[3]]`` (top-left) and computes
+  ``minRow = (origin[1] - tileExtent[3]) / resolution``, feeding that straight into the array
+  slice. There is no ``reverse``/``flip`` and no read of ``spatial:transform``'s y step anywhere
+  in that file, so an ascending store renders vertically mirrored with no signal it could use.
+
+Descending rather than ascending: OpenLayers requires it and cannot detect otherwise, GDAL's
+``GeoTransform`` convention for north-up is a negative y step, most sources are north-up already
+so the normalisation is usually a no-op — and carbonplan/zarr-layer, the one consumer that *does*
+detect the direction from the coordinate array, is satisfied either way and so does not constrain
+the choice.
 
 Axis order here is *array* order, ``(…, y, x)`` — NumPy row-major, CF's ``T,Z,Y,X``, and what
 xarray/rioxarray/GDAL/GeoZarr all assume. It does not conflict with GeoJSON's ``[x, y]``
 coordinate pairs and ``[west, south, east, north]`` bboxes, which stay as RFC 7946 requires:
 those describe coordinate tuples, not an N-D array. See docs/conventions.md.
+
+Invariants 3 and 4 reorder the array. Applying either to a period being appended to a store
+whose axes were written the other way round would put rows or columns under coordinates that no
+longer describe them — silent mirrored data, which is worse than stale metadata. So an append
+must first check the store it is appending to; see
+:func:`spatial_coords_match` and the orchestrator's use of it.
 """
 
 from __future__ import annotations
@@ -93,13 +108,33 @@ def normalize_dim_layout(
     return ds
 
 
+def normalize_y_direction(ds: "xr.Dataset", *, y_dim: str = "y") -> "xr.Dataset":
+    """Reverse the rows of a south-up dataset so ``y`` descends (row 0 = north).
+
+    Consumers assume this and do not check — see the module docstring for the two that would
+    otherwise render mirrored. Reverses the coordinate *and* the data together, so the value at
+    a given latitude does not move; only its row index does.
+
+    A no-op for the north-up rasters most sources deliver, so this usually costs one comparison.
+    """
+    if y_dim not in ds.coords or ds.sizes.get(y_dim, 0) < 2:
+        return ds
+    y = ds[y_dim].values
+    try:
+        already_descending = bool(y[1] < y[0])
+    except (IndexError, TypeError, ValueError):
+        return ds
+    if already_descending:
+        return ds
+    logger.info("Reversing %r so row 0 is the northernmost row (was south-up)", y_dim)
+    return ds.isel({y_dim: slice(None, None, -1)})
+
+
 def normalize_longitudes(ds: "xr.Dataset", *, x_dim: str = "x", crs: str | None = None) -> "xr.Dataset":
     """Roll a geographic x axis from 0…360 to −180…180 and sort it ascending.
 
     Only for a geographic CRS — an easting in a projected CRS is legitimately larger than 180
-    and must not be touched. This *does* change coordinate values and reorders the array, so
-    it belongs to a whole-store rewrite, not to a period being appended to a store whose x
-    axis is already fixed.
+    and must not be touched.
 
     A no-op when no longitude exceeds 180, which is the case for every source that already
     publishes on the −180…180 frame.
@@ -217,6 +252,37 @@ def resolve_store_crs(
     return from_data
 
 
+def spatial_coords_match(
+    stored: "Any",
+    incoming: "Any",
+    *,
+    axis: str,
+    tolerance: float = 1e-9,
+) -> bool:
+    """True when an incoming period's axis coordinates match the ones already in the store.
+
+    An append writes along the time axis only: the spatial coordinate arrays already committed
+    stay as they are. So if normalisation reorders a period's rows or columns relative to how the
+    store was written — a store created before invariant 3 or 4, or by a plugin that has since
+    changed orientation — the new data lands under coordinates that no longer describe it. That
+    is silently mirrored data, which is why this is checked rather than assumed.
+
+    Compares elementwise with a tolerance, since a coordinate can survive a float round trip
+    through Zarr with a last-bit difference.
+    """
+    import numpy as np
+
+    try:
+        a = np.asarray(getattr(stored, "values", stored), dtype="float64")
+        b = np.asarray(getattr(incoming, "values", incoming), dtype="float64")
+    except (TypeError, ValueError):
+        logger.debug("Could not compare %s coordinates; skipping the check", axis)
+        return True
+    if a.shape != b.shape:
+        return False
+    return bool(np.allclose(a, b, rtol=0.0, atol=tolerance, equal_nan=True))
+
+
 def published_contract_violations(
     ds: "xr.Dataset",
     *,
@@ -243,6 +309,13 @@ def published_contract_violations(
         var_dims = tuple(str(d) for d in var.dims)
         if y_dim in var_dims and x_dim in var_dims and var_dims[-2:] != (y_dim, x_dim):
             problems.append(f"variable {str(name)!r} has dims {var_dims}, not (…, {y_dim}, {x_dim})")
+    if y_dim in ds.coords and ds.sizes.get(y_dim, 0) >= 2:
+        y = ds[y_dim].values
+        try:
+            if bool(y[1] > y[0]):
+                problems.append(f"{y_dim!r} ascends — row 0 must be the northernmost row")
+        except (IndexError, TypeError, ValueError):
+            pass
     declared: Any = ds.attrs.get("proj:code")
     units = _axis_units(str(declared)) if declared else None
     if declared and units == "linear" and _looks_geographic(ds, x_dim=x_dim, y_dim=y_dim):

--- a/open_climate_service/shared/raster_contract.py
+++ b/open_climate_service/shared/raster_contract.py
@@ -1,0 +1,256 @@
+"""The layout contract every published store must satisfy, enforced at the write boundary.
+
+Dimension naming, axis order and CRS consistency are all *ingest-normalisation invariants*:
+properties of a published GeoZarr, not of any one source. Enforced per-plugin they get
+forgotten one plugin at a time — that is how datasets have shipped on a `time` dim the map
+viewer could not find, and with a projected CRS stamped over geographic coordinates. So they
+are enforced here instead, once, and plugins may return data in whatever orientation their
+source delivers (see CLIM-821).
+
+The contract:
+
+1. the temporal dimension is named ``t``
+2. spatial dims are named ``y`` / ``x`` and ordered ``(…, y, x)``
+3. for a geographic CRS, longitudes run −180…180 rather than 0…360
+4. the declared CRS matches the coordinates it describes
+
+**Not** in the contract: the direction of ``y``. The ticket originally required ascending
+(south→north) because the map viewer's zarr-layer did; as of 0.6.1 it detects the direction
+from the ``y`` coordinate array instead (``detectedLatAscending = y1 > y0``), and OCS stores
+always take its "untiled" path, so either direction renders. Stores therefore keep the
+direction their source delivered — which for most rasters is north-up, matching GDAL's
+convention for the ``GeoTransform`` written alongside. A reader must honour the ``y``
+coordinate rather than assume a direction.
+
+Axis order here is *array* order, ``(…, y, x)`` — NumPy row-major, CF's ``T,Z,Y,X``, and what
+xarray/rioxarray/GDAL/GeoZarr all assume. It does not conflict with GeoJSON's ``[x, y]``
+coordinate pairs and ``[west, south, east, north]`` bboxes, which stay as RFC 7946 requires:
+those describe coordinate tuples, not an N-D array. See docs/conventions.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# Source spellings for the temporal dimension, mapped onto the canonical ``t``. The map
+# viewer looks for `t`; a store that ships `time` renders without a time control.
+_TIME_ALIASES = ("time", "valid_time", "date", "time_counter")
+
+# Beyond this longitude a geographic x axis is on the 0…360 frame rather than −180…180.
+_LON_ROLL_THRESHOLD = 180.0
+
+
+def normalize_dim_layout(
+    ds: "xr.Dataset",
+    *,
+    time_dim: str = "t",
+    x_dim: str = "x",
+    y_dim: str = "y",
+) -> "xr.Dataset":
+    """Rename the temporal dimension to ``time_dim`` and order spatial dims ``(…, y, x)``.
+
+    Renames only coordinate/dimension *names* and axis order — no coordinate value changes —
+    so this is safe to apply to a single period being appended to an existing store as well
+    as to a whole-store rewrite. Longitude rolling, which does change values, is separate
+    (:func:`normalize_longitudes`).
+
+    A no-op when the dataset already conforms, so the common case costs one dims comparison
+    rather than a copy of the data.
+    """
+    if time_dim not in ds.dims:
+        for alias in _TIME_ALIASES:
+            if alias in ds.dims or alias in ds.coords:
+                ds = ds.rename({alias: time_dim})
+                logger.info("Renamed temporal dimension %r to %r", alias, time_dim)
+                break
+
+    if x_dim not in ds.dims or y_dim not in ds.dims:
+        # Nothing to order — the caller (orchestrator or downloader) raises a clearer error
+        # about the missing spatial dims than a transpose would.
+        return ds
+
+    for name, var in ds.data_vars.items():
+        dims = tuple(str(d) for d in var.dims)
+        if y_dim not in dims or x_dim not in dims:
+            continue  # a non-spatial variable, e.g. a scalar CRS holder
+        if dims[-2:] == (y_dim, x_dim):
+            continue
+        leading = [d for d in dims if d not in (y_dim, x_dim)]
+        ds[name] = var.transpose(*leading, y_dim, x_dim)
+        logger.info(
+            "Transposed %r from %s to (…, %s, %s) — array order is row-major",
+            str(name),
+            dims,
+            y_dim,
+            x_dim,
+        )
+    return ds
+
+
+def normalize_longitudes(ds: "xr.Dataset", *, x_dim: str = "x", crs: str | None = None) -> "xr.Dataset":
+    """Roll a geographic x axis from 0…360 to −180…180 and sort it ascending.
+
+    Only for a geographic CRS — an easting in a projected CRS is legitimately larger than 180
+    and must not be touched. This *does* change coordinate values and reorders the array, so
+    it belongs to a whole-store rewrite, not to a period being appended to a store whose x
+    axis is already fixed.
+
+    A no-op when no longitude exceeds 180, which is the case for every source that already
+    publishes on the −180…180 frame.
+    """
+    if x_dim not in ds.coords:
+        return ds
+    if crs is not None and _axis_units(crs) == "linear":
+        return ds
+
+    x = ds[x_dim]
+    try:
+        needs_roll = bool((x > _LON_ROLL_THRESHOLD).any())
+    except (TypeError, ValueError):
+        return ds
+    if not needs_roll:
+        return ds
+
+    logger.info("Rolling %r from the 0…360 frame to −180…180", x_dim)
+    rolled = ds.assign_coords({x_dim: ((ds[x_dim] + 180.0) % 360.0) - 180.0})
+    return rolled.sortby(x_dim)
+
+
+def _axis_units(crs: str | int) -> str | None:
+    """``"degrees"`` for a lon/lat CRS, ``"linear"`` for a projected one, ``None`` if unknown.
+
+    The three-way answer matters: a CRS that pyproj cannot resolve — a polluted host PROJ
+    database is a common developer-machine failure, see ``startup._ensure_proj_database`` — must
+    come back as *unknown* rather than being lumped in with projected. Treating an unresolvable
+    CRS as projected would let a perfectly good geographic one (ETRS89, say) be overridden with
+    EPSG:4326 purely because the database was unreadable.
+    """
+    from open_climate_service.shared.crs import canonical_crs_code
+
+    code = canonical_crs_code(crs)
+    if code == "EPSG:4326":
+        return "degrees"
+    try:
+        from pyproj import CRS
+
+        return "degrees" if CRS.from_user_input(code).is_geographic else "linear"
+    except Exception:  # noqa: BLE001 — unresolvable: report unknown, never guess "projected"
+        logger.debug("Could not resolve CRS %s to decide its axis units", code, exc_info=True)
+        return None
+
+
+def _looks_geographic(ds: "xr.Dataset", *, x_dim: str, y_dim: str) -> bool:
+    """True when the coordinate magnitudes can only be degrees.
+
+    Latitude carries the argument: it fits ±90, where a projected northing runs to millions
+    within a few hundred metres of the origin. Longitude is allowed up to 360 rather than 180
+    because a grid still on the 0…360 frame has not been rolled yet — testing it against 180
+    would make this return False for exactly the datasets that need rolling, and the roll needs
+    this answer to know the axis is a longitude at all.
+
+    Deliberately one-directional: this answers "these cannot be metres", never "these cannot be
+    degrees". A projected grid confined to a few hundred metres either side of its own origin
+    would pass, but no real dataset extent is that small.
+    """
+    try:
+        x = ds[x_dim].values
+        y = ds[y_dim].values
+        return bool(x.min() >= -180.0 and x.max() <= 360.0 and abs(y).max() <= 90.0)
+    except (KeyError, ValueError, TypeError):
+        return False
+
+
+def resolve_store_crs(
+    ds: "xr.Dataset",
+    declared: str | None = None,
+    *,
+    x_dim: str = "x",
+    y_dim: str = "y",
+) -> str:
+    """The CRS to write for *ds*, refusing a declared CRS its coordinates contradict.
+
+    ``declared`` is whatever the caller was going to write. When it is a projected CRS but the
+    coordinates can only be degrees, it is wrong — a projected code over geographic
+    coordinates puts the store at its projection's origin rather than on the map — so the
+    dataset's own CRS is preferred and the contradiction logged with both values.
+
+    Never consults the instance config CRS. That is how the contradiction arises in the first
+    place: an untagged cube picks up the instance's ``crs:`` (e.g. ``EPSG:32633`` for Norway)
+    regardless of where its coordinates actually are.
+    """
+    from open_climate_service.shared.crs import canonical_crs_code, dataset_crs
+
+    if declared is None:
+        return canonical_crs_code(dataset_crs(ds))
+
+    code = canonical_crs_code(declared)
+    # Override only on a definite contradiction: the declared CRS is known to be in linear
+    # units and the coordinates can only be degrees. An unresolvable CRS is left alone.
+    if _axis_units(code) != "linear" or not _looks_geographic(ds, x_dim=x_dim, y_dim=y_dim):
+        return code
+
+    from_data = canonical_crs_code(dataset_crs(ds))
+    logger.warning(
+        "Declared CRS %s is projected but the coordinates are within ±180/±90 "
+        "(x %.4f…%.4f, y %.4f…%.4f) — they can only be degrees. Using %s from the data "
+        "instead; a projected code over geographic coordinates puts the store off the map.",
+        code,
+        float(ds[x_dim].min()),
+        float(ds[x_dim].max()),
+        float(ds[y_dim].min()),
+        float(ds[y_dim].max()),
+        from_data,
+    )
+    if _axis_units(from_data) == "linear":
+        # The dataset's own CRS is projected too — a stale `proj:code` is copied forward on
+        # every rewrite, so both sources can be wrong at once (Norway's WorldPop store has
+        # EPSG:32633 at the root and EPSG:4326 on level 0). Neither agrees with the
+        # coordinates, so fall back to plain WGS84 rather than propagating a known-bad code.
+        logger.warning("Dataset CRS %s is also projected; falling back to EPSG:4326", from_data)
+        return "EPSG:4326"
+    return from_data
+
+
+def published_contract_violations(
+    ds: "xr.Dataset",
+    *,
+    time_dim: str = "t",
+    x_dim: str = "x",
+    y_dim: str = "y",
+) -> list[str]:
+    """Ways *ds* fails the published-store contract, as human-readable strings.
+
+    Used by the regression tests to assert the contract on a written store rather than
+    re-deriving it per test, and available to anyone debugging a store that renders oddly.
+    Empty list means conformant. The direction of ``y`` is deliberately not checked — see the
+    module docstring.
+    """
+    problems: list[str] = []
+    dims = set(str(d) for d in ds.dims)
+    if time_dim not in dims:
+        found = [a for a in _TIME_ALIASES if a in dims]
+        problems.append(f"temporal dimension is not named {time_dim!r}" + (f" (found {found[0]!r})" if found else ""))
+    for expected in (y_dim, x_dim):
+        if expected not in dims:
+            problems.append(f"spatial dimension {expected!r} is missing")
+    for name, var in ds.data_vars.items():
+        var_dims = tuple(str(d) for d in var.dims)
+        if y_dim in var_dims and x_dim in var_dims and var_dims[-2:] != (y_dim, x_dim):
+            problems.append(f"variable {str(name)!r} has dims {var_dims}, not (…, {y_dim}, {x_dim})")
+    declared: Any = ds.attrs.get("proj:code")
+    units = _axis_units(str(declared)) if declared else None
+    if declared and units == "linear" and _looks_geographic(ds, x_dim=x_dim, y_dim=y_dim):
+        problems.append(f"declared CRS {declared} is projected but the coordinates are degrees")
+    if declared and units == "degrees" and x_dim in ds.coords:
+        try:
+            if bool((ds[x_dim] > _LON_ROLL_THRESHOLD).any()):
+                problems.append(f"geographic {x_dim!r} exceeds 180 — still on the 0…360 frame")
+        except (TypeError, ValueError):
+            pass
+    return problems

--- a/open_climate_service/shared/raster_contract.py
+++ b/open_climate_service/shared/raster_contract.py
@@ -46,6 +46,8 @@ must first check the store it is appending to; see
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -59,6 +61,56 @@ _TIME_ALIASES = ("time", "valid_time", "date", "time_counter")
 
 # Beyond this longitude a geographic x axis is on the 0…360 frame rather than −180…180.
 _LON_ROLL_THRESHOLD = 180.0
+
+
+@dataclass(frozen=True)
+class PreparedCube:
+    """A cube normalised for publication, with the CRS that describes it."""
+
+    dataset: "xr.Dataset"
+    crs: str
+
+
+def prepare_for_publication(
+    ds: "xr.Dataset",
+    *,
+    fallback_crs: str | int | None = None,
+    time_dim: str = "t",
+    x_dim: str = "x",
+    y_dim: str = "y",
+) -> PreparedCube:
+    """Bring *ds* up to the published-store contract, and resolve the CRS that describes it.
+
+    **The entry point every write path should use.** The individual ``normalize_*`` steps below
+    are exported for focused testing, but composing them by hand at each call site is how the
+    two write paths came to run them in different orders with different CRS inputs — the drift
+    this module exists to prevent. The order here is not arbitrary:
+
+    * naming and axis order first, because everything after addresses axes by name;
+    * then the CRS, because whether the x axis is a longitude decides whether rolling it is
+      correct or destructive — an easting of 500000 rolled as a longitude becomes −40;
+    * then the coordinate reorderings, which need that answer.
+
+    ``fallback_crs`` is a *declaration* about a source that carries no CRS of its own (a
+    plugin's ``crs`` attribute, or an explicit argument); the data's own CRS still wins. See
+    :func:`resolve_store_crs`.
+    """
+    ds = normalize_dim_layout(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim)
+    crs = resolve_store_crs(ds, fallback_crs, x_dim=x_dim, y_dim=y_dim)
+    ds = normalize_longitudes(ds, x_dim=x_dim, crs=crs)
+    ds = normalize_y_direction(ds, y_dim=y_dim)
+
+    # Normalisation should leave nothing behind. If it did, something upstream is producing a
+    # shape this module does not understand, and the store is about to be published that way —
+    # so say so in the ingest's own logs rather than waiting for a client to render it oddly.
+    ds.attrs.setdefault("proj:code", crs)
+    remaining = published_contract_violations(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim)
+    if remaining:
+        logger.warning(
+            "Publishing a store that still violates the layout contract: %s",
+            "; ".join(str(violation) for violation in remaining),
+        )
+    return PreparedCube(dataset=ds, crs=crs)
 
 
 def normalize_dim_layout(
@@ -203,53 +255,53 @@ def _looks_geographic(ds: "xr.Dataset", *, x_dim: str, y_dim: str) -> bool:
 
 def resolve_store_crs(
     ds: "xr.Dataset",
-    declared: str | None = None,
+    fallback: str | int | None = None,
     *,
     x_dim: str = "x",
     y_dim: str = "y",
 ) -> str:
-    """The CRS to write for *ds*, refusing a declared CRS its coordinates contradict.
+    """The CRS to write for *ds*, in one decision.
 
-    ``declared`` is whatever the caller was going to write. When it is a projected CRS but the
-    coordinates can only be degrees, it is wrong — a projected code over geographic
-    coordinates puts the store at its projection's origin rather than on the map — so the
-    dataset's own CRS is preferred and the contradiction logged with both values.
+    Precedence, highest first:
 
-    Never consults the instance config CRS. That is how the contradiction arises in the first
-    place: an untagged cube picks up the instance's ``crs:`` (e.g. ``EPSG:32633`` for Norway)
-    regardless of where its coordinates actually are.
+    1. the dataset's own CRS — its ``proj:code`` attribute, else what rioxarray detects from
+       the CF grid mapping
+    2. ``fallback`` — how a plugin declares the projection of a source that carries none
+    3. ``EPSG:4326``
+
+    The data wins over a declaration because a declaration is a *guess about* the data, and
+    getting that precedence backwards is how a projected code ends up over lon/lat coordinates.
+
+    Whichever wins is then checked against the coordinates: a CRS in linear units over
+    coordinates that can only be degrees is wrong however it was arrived at, and is replaced by
+    plain WGS84 with the evidence logged. A stale ``proj:code`` is copied forward on every
+    rewrite, so *both* sources can be wrong at once — Norway's WorldPop store has EPSG:32633 at
+    the root and EPSG:4326 on level 0.
+
+    The instance config CRS is never consulted, at any step. Using it as a fallback is what
+    created the contradiction this function exists to catch.
     """
     from open_climate_service.shared.crs import canonical_crs_code, dataset_crs
 
-    if declared is None:
-        return canonical_crs_code(dataset_crs(ds))
+    default = canonical_crs_code(fallback) if fallback is not None else "EPSG:4326"
+    code = canonical_crs_code(dataset_crs(ds, default=default))
 
-    code = canonical_crs_code(declared)
-    # Override only on a definite contradiction: the declared CRS is known to be in linear
-    # units and the coordinates can only be degrees. An unresolvable CRS is left alone.
+    # Override only on a definite contradiction: the CRS is known to be in linear units and the
+    # coordinates can only be degrees. An unresolvable CRS is left alone rather than guessed at.
     if _axis_units(code) != "linear" or not _looks_geographic(ds, x_dim=x_dim, y_dim=y_dim):
         return code
 
-    from_data = canonical_crs_code(dataset_crs(ds))
     logger.warning(
-        "Declared CRS %s is projected but the coordinates are within ±180/±90 "
-        "(x %.4f…%.4f, y %.4f…%.4f) — they can only be degrees. Using %s from the data "
-        "instead; a projected code over geographic coordinates puts the store off the map.",
+        "CRS %s is projected but the coordinates are within ±180/±90 (x %.4f…%.4f, y %.4f…%.4f) "
+        "— they can only be degrees. Using EPSG:4326 instead; a projected code over geographic "
+        "coordinates puts the store at the projection's origin rather than on the map.",
         code,
         float(ds[x_dim].min()),
         float(ds[x_dim].max()),
         float(ds[y_dim].min()),
         float(ds[y_dim].max()),
-        from_data,
     )
-    if _axis_units(from_data) == "linear":
-        # The dataset's own CRS is projected too — a stale `proj:code` is copied forward on
-        # every rewrite, so both sources can be wrong at once (Norway's WorldPop store has
-        # EPSG:32633 at the root and EPSG:4326 on level 0). Neither agrees with the
-        # coordinates, so fall back to plain WGS84 rather than propagating a known-bad code.
-        logger.warning("Dataset CRS %s is also projected; falling back to EPSG:4326", from_data)
-        return "EPSG:4326"
-    return from_data
+    return "EPSG:4326"
 
 
 def spatial_coords_match(
@@ -283,47 +335,95 @@ def spatial_coords_match(
     return bool(np.allclose(a, b, rtol=0.0, atol=tolerance, equal_nan=True))
 
 
+class ContractViolation(StrEnum):
+    """A way a dataset fails the published-store contract."""
+
+    TEMPORAL_DIM_NAME = "temporal-dim-name"
+    MISSING_SPATIAL_DIM = "missing-spatial-dim"
+    AXIS_ORDER = "axis-order"
+    Y_ASCENDS = "y-ascends"
+    CRS_CONTRADICTS_COORDS = "crs-contradicts-coords"
+    LONGITUDE_FRAME = "longitude-frame"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One contract failure: a machine-checkable kind plus the detail behind it."""
+
+    kind: ContractViolation
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.kind.value}: {self.detail}"
+
+
 def published_contract_violations(
     ds: "xr.Dataset",
     *,
     time_dim: str = "t",
     x_dim: str = "x",
     y_dim: str = "y",
-) -> list[str]:
-    """Ways *ds* fails the published-store contract, as human-readable strings.
+) -> list[Violation]:
+    """Ways *ds* fails the published-store contract; empty means conformant.
 
-    Used by the regression tests to assert the contract on a written store rather than
-    re-deriving it per test, and available to anyone debugging a store that renders oddly.
-    Empty list means conformant. The direction of ``y`` is deliberately not checked — see the
-    module docstring.
+    Called at the write boundary so a regression shows up in the logs of a real ingest rather
+    than only in a test run, and available to anyone debugging a store that renders oddly.
+    Each violation carries a ``kind`` so callers can match on it without depending on wording.
     """
-    problems: list[str] = []
+    problems: list[Violation] = []
     dims = set(str(d) for d in ds.dims)
     if time_dim not in dims:
         found = [a for a in _TIME_ALIASES if a in dims]
-        problems.append(f"temporal dimension is not named {time_dim!r}" + (f" (found {found[0]!r})" if found else ""))
+        problems.append(
+            Violation(
+                ContractViolation.TEMPORAL_DIM_NAME,
+                f"temporal dimension is not named {time_dim!r}" + (f" (found {found[0]!r})" if found else ""),
+            )
+        )
     for expected in (y_dim, x_dim):
         if expected not in dims:
-            problems.append(f"spatial dimension {expected!r} is missing")
+            problems.append(
+                Violation(ContractViolation.MISSING_SPATIAL_DIM, f"spatial dimension {expected!r} is missing")
+            )
     for name, var in ds.data_vars.items():
         var_dims = tuple(str(d) for d in var.dims)
         if y_dim in var_dims and x_dim in var_dims and var_dims[-2:] != (y_dim, x_dim):
-            problems.append(f"variable {str(name)!r} has dims {var_dims}, not (…, {y_dim}, {x_dim})")
+            problems.append(
+                Violation(
+                    ContractViolation.AXIS_ORDER,
+                    f"variable {str(name)!r} has dims {var_dims}, not (…, {y_dim}, {x_dim})",
+                )
+            )
     if y_dim in ds.coords and ds.sizes.get(y_dim, 0) >= 2:
         y = ds[y_dim].values
         try:
             if bool(y[1] > y[0]):
-                problems.append(f"{y_dim!r} ascends — row 0 must be the northernmost row")
+                problems.append(
+                    Violation(
+                        ContractViolation.Y_ASCENDS,
+                        f"{y_dim!r} ascends — row 0 must be the northernmost row",
+                    )
+                )
         except (IndexError, TypeError, ValueError):
             pass
     declared: Any = ds.attrs.get("proj:code")
     units = _axis_units(str(declared)) if declared else None
     if declared and units == "linear" and _looks_geographic(ds, x_dim=x_dim, y_dim=y_dim):
-        problems.append(f"declared CRS {declared} is projected but the coordinates are degrees")
+        problems.append(
+            Violation(
+                ContractViolation.CRS_CONTRADICTS_COORDS,
+                f"declared CRS {declared} is projected but the coordinates are degrees",
+            )
+        )
     if declared and units == "degrees" and x_dim in ds.coords:
         try:
             if bool((ds[x_dim] > _LON_ROLL_THRESHOLD).any()):
-                problems.append(f"geographic {x_dim!r} exceeds 180 — still on the 0…360 frame")
+                problems.append(
+                    Violation(
+                        ContractViolation.LONGITUDE_FRAME,
+                        f"geographic {x_dim!r} exceeds 180 — still on the 0…360 frame",
+                    )
+                )
         except (TypeError, ValueError):
             pass
     return problems

--- a/open_climate_service/stac/media_types.py
+++ b/open_climate_service/stac/media_types.py
@@ -1,0 +1,123 @@
+"""The media type a STAC client is told for a published Zarr store.
+
+A *read* concern about an already-written store, and a *serving* one: it decides what the STAC
+collection and the openEO job result advertise, which is what gates whether a pyramid-only client
+will render the store at all. It lives here rather than beside the writer (``shared/geozarr.py``)
+because it runs per request against a store that may have been written long ago, and needs
+filesystem and Icechunk access the writer's pure geometry helpers do not.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# --- Media type: telling a STAC client whether the store is pyramided ---------------------#
+# STAC has no way to distinguish a flat store from a pyramided one through the plain Zarr
+# media type, and clients that only render pyramided stores therefore cannot decide whether an
+# asset is safe to open. The `profile` parameter closes that gap. It is a
+# STAC Zarr best-practices recommendation, which notes it is not (yet) part of the official
+# Zarr media type registration:
+#
+#     https://github.com/radiantearth/stac-best-practices/blob/main/best-practices-zarr.md
+#
+# Consumers match it as a literal, not by parsing parameters. stac-js holds
+# `wozMediaTypes = ['application/vnd.zarr; version=3; profile=multiscales']` and compares with
+# `allowedTypes.includes(type.toLowerCase())` — so case is forgiven but parameter order and
+# spacing are not. WEB_OPTIMIZED_ZARR_MEDIA_TYPE must stay byte-identical.
+
+ZARR_V3_MEDIA_TYPE = "application/vnd.zarr; version=3"
+"""Media type for a published Zarr v3 store with no resolution pyramid."""
+
+WEB_OPTIMIZED_ZARR_MEDIA_TYPE = f"{ZARR_V3_MEDIA_TYPE}; profile=multiscales"
+"""Media type for a pyramided ("web-optimized") Zarr v3 store.
+
+Byte-identical to the string web clients match on; do not reformat or reorder the parameters.
+"""
+
+MULTISCALES_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
+"""UUID of the Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)."""
+
+
+def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
+    """True when root group *attributes* describe a real multiscales pyramid.
+
+    Requires both the convention declared in ``zarr_conventions`` *and* a non-empty
+    ``multiscales.layout``. Those are the same two conditions pyramid-aware renderers check, so
+    the claim matches what a renderer can actually use. A store that declares the convention but
+    lists no levels is treated as flat — there is nothing extra for a client to read.
+    """
+    conventions = attributes.get("zarr_conventions")
+    if not isinstance(conventions, list):
+        return False
+    declared = any(
+        isinstance(convention, Mapping)
+        and (convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales")
+        for convention in conventions
+    )
+    if not declared:
+        return False
+    multiscales = attributes.get("multiscales")
+    if not isinstance(multiscales, Mapping):
+        return False
+    layout = multiscales.get("layout")
+    return isinstance(layout, list) and len(layout) > 0
+
+
+def read_root_attributes(store_path: str, *, icechunk: bool) -> Mapping[str, Any]:
+    """Root group attributes of a published store; empty mapping when unreadable.
+
+    Reads group metadata only, never chunk data. Deliberately the *root* group: the store
+    accessors descend into pyramid level ``0``, whose attributes do not carry the multiscales
+    layout, so this needs its own path.
+
+    Remote stores return empty rather than paying a network round trip — the caller degrades to
+    the flat media type.
+    """
+    if icechunk:
+        return _read_icechunk_root_attributes(store_path)
+    if "://" in store_path:
+        return {}
+    zarr_json = Path(store_path) / "zarr.json"
+    try:
+        payload = json.loads(zarr_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    attributes = payload.get("attributes")
+    return attributes if isinstance(attributes, Mapping) else {}
+
+
+def _read_icechunk_root_attributes(store_path: str) -> Mapping[str, Any]:
+    import icechunk
+    import zarr
+
+    if not Path(store_path).exists():
+        return {}
+    storage = icechunk.local_filesystem_storage(store_path)
+    repo = icechunk.Repository.open(storage)
+    session = repo.readonly_session("main")
+    group = zarr.open_group(session.store, mode="r")
+    return dict(group.attrs)
+
+
+def zarr_media_type(store_path: str, *, icechunk: bool) -> str:
+    """The media type to advertise for the store at *store_path*.
+
+    Falls back to the flat :data:`ZARR_V3_MEDIA_TYPE` whenever the pyramid cannot be confirmed.
+    The asymmetry is deliberate: understating is harmless — a client opens the store the ordinary
+    way — while overstating sends a renderer looking for levels that do not exist. A locked or
+    corrupt store must never take the STAC collection down with it.
+    """
+    try:
+        attributes = read_root_attributes(store_path, icechunk=icechunk)
+    except Exception:  # noqa: BLE001 — any read failure degrades to the flat type
+        logger.debug("Could not read root attributes of store %r", store_path, exc_info=True)
+        return ZARR_V3_MEDIA_TYPE
+    if attributes_declare_multiscales(attributes):
+        return WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+    return ZARR_V3_MEDIA_TYPE

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -20,6 +20,7 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
+from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import (
     parse_period_string_to_datetime,
     period_type_to_iso_step,
@@ -29,15 +30,24 @@ from open_climate_service.shared.time import (
 CATALOG_TITLE = "Open Climate Service"
 CATALOG_DESCRIPTION = "Published Open Climate Service GeoZarr datasets"
 STAC_VERSION = "1.1.0"
+CF_EXTENSION = "https://stac-extensions.github.io/cf/v1.0.0/schema.json"
 DATACUBE_EXTENSION = "https://stac-extensions.github.io/datacube/v2.3.0/schema.json"
 PROJECTION_EXTENSION = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
 RENDER_EXTENSION = "https://stac-extensions.github.io/render/v2.0.0/schema.json"
 ZARR_EXTENSION = "https://stac-extensions.github.io/zarr/v1.1.0/schema.json"
 DEFAULT_STAC_LICENSE = "various"
+# CF attributes surfaced from the store onto cube:variables, as `cf:`-prefixed STAC fields.
+# `cell_methods` is passed through as the CF string ("time: mean"); the CF extension also
+# defines a per-dimension array form, but permits the plain string for methods that span axes.
+_CF_VARIABLE_ATTRS = ("standard_name", "cell_methods")
 SPATIAL_STEP_DECIMALS = 8
 XSTAC_COLLECTION_CACHE_MAXSIZE = 128
 logger = logging.getLogger(__name__)
 _xstac_collection_cache: dict[str, dict[str, Any]] = {}
+# Media type per artifact id. Detecting it reads the store's root group, which the xstac cache
+# does not cover: the type is set on the collection template, which is built *before* — and so
+# on every request, even a cache hit. Same bound and same invalidation as the payload cache.
+_zarr_media_type_cache: dict[str, str] = {}
 
 
 def _get_catalog_id() -> str:
@@ -149,6 +159,8 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     # artifact's materialized coverage.
     _override_temporal_extent_from_artifact(collection_payload, artifact)
     _sanitize_variable_attrs(collection_payload)
+    # Last, because the cf: fields are only known after the variables are built and sanitized.
+    _declare_cf_extension_if_used(collection_payload)
     return collection_payload
 
 
@@ -206,7 +218,7 @@ def _build_collection_template(
         "zarr",
         pystac.Asset(
             href=zarr_href,
-            media_type="application/vnd.zarr; version=3",
+            media_type=_zarr_media_type(artifact),
             title="Zarr store",
             roles=["data"],
         ),
@@ -392,6 +404,31 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         ds.close()
 
 
+def _zarr_media_type(artifact: ArtifactRecord) -> str:
+    """Media type for the artifact's Zarr asset, advertising a pyramid only when there is one.
+
+    Lets pyramid-aware clients (STAC Browser via ``ol/source/GeoZarr``) tell a multiscales store
+    from a flat one, which the plain Zarr media type cannot express. Falls back to the flat type
+    whenever the store can't be inspected.
+
+    Cached per **artifact id**, not per store path. A re-ingest reuses the same path — and can
+    cross the pyramid threshold as the data grows — so a path-keyed cache would serve a stale
+    claim. A new write always means a new artifact record.
+    """
+    cached = _zarr_media_type_cache.get(artifact.artifact_id)
+    if cached is not None:
+        return cached
+    try:
+        store_path = _artifact_store_path(artifact)
+    except HTTPException:
+        return ZARR_V3_MEDIA_TYPE
+    media_type = zarr_media_type(store_path, icechunk=artifact.format == ArtifactFormat.ICECHUNK)
+    if len(_zarr_media_type_cache) >= XSTAC_COLLECTION_CACHE_MAXSIZE:
+        _zarr_media_type_cache.pop(next(iter(_zarr_media_type_cache)), None)
+    _zarr_media_type_cache[artifact.artifact_id] = media_type
+    return media_type
+
+
 def _cache_xstac_collection_payload(artifact_id: str, payload: dict[str, Any]) -> None:
     if artifact_id in _xstac_collection_cache:
         _xstac_collection_cache[artifact_id] = deepcopy(payload)
@@ -404,6 +441,7 @@ def _cache_xstac_collection_payload(artifact_id: str, payload: dict[str, Any]) -
 
 def _clear_xstac_collection_cache() -> None:
     _xstac_collection_cache.clear()
+    _zarr_media_type_cache.clear()
 
 
 def _link_to_dict(link: pystac.Link) -> dict[str, Any]:
@@ -545,12 +583,14 @@ def _build_cube_variables(ds: xr.Dataset) -> dict[str, Any]:
             "dimensions": [str(d) for d in var.dims],
             "unit": var.attrs.get("units"),
         }
-        # Surface the CF semantics we stamp onto the store so catalog clients can
-        # identify the quantity, not just its unit (#283).
-        for cf_key in ("standard_name", "cell_methods"):
+        # Surface the CF semantics stamped onto the store so catalog clients can identify the
+        # quantity, not just its unit (CLIM-828). Named per the STAC CF extension, which lists
+        # `cube:variables` among the places its fields may be used — an unprefixed
+        # `standard_name` here is not a field any STAC client is defined to understand.
+        for cf_key in _CF_VARIABLE_ATTRS:
             value = var.attrs.get(cf_key)
             if isinstance(value, str):
-                entry[cf_key] = value
+                entry[f"cf:{cf_key}"] = value
         result[str(name)] = entry
     return result
 
@@ -585,6 +625,26 @@ def _override_temporal_extent_from_artifact(collection: dict[str, Any], artifact
             return
 
 
+def _declare_cf_extension_if_used(collection: dict[str, Any]) -> None:
+    """Add the CF extension to ``stac_extensions`` when a ``cf:`` field was actually emitted.
+
+    Declared conditionally rather than always: a dataset whose store carries no CF attributes
+    emits no ``cf:`` field, and advertising an extension none of whose fields are present is
+    noise a client has to fetch and check for nothing.
+    """
+    variables = collection.get("cube:variables")
+    if not isinstance(variables, dict):
+        return
+    used = any(
+        isinstance(variable, dict) and any(key.startswith("cf:") for key in variable) for variable in variables.values()
+    )
+    if not used:
+        return
+    existing = collection.get("stac_extensions")
+    extensions = set(existing) if isinstance(existing, list) else set()
+    collection["stac_extensions"] = sorted({*extensions, CF_EXTENSION})
+
+
 def _sanitize_variable_attrs(collection: dict[str, Any]) -> None:
     variables = collection.get("cube:variables")
     if not isinstance(variables, dict):
@@ -603,13 +663,14 @@ def _sanitize_variable_attrs(collection: dict[str, Any]) -> None:
         if isinstance(units, str):
             kept_attrs["units"] = units
             variable["unit"] = units
-        # Surface the CF semantics we stamp onto the store as top-level cube:variable
-        # fields (and keep them in attrs) so catalog clients see the quantity (#283).
-        for cf_key in ("standard_name", "cell_methods"):
+        # Same CF semantics as _build_cube_variables, for the xstac-produced path. Prefixed at
+        # the cube:variable level (a defined STAC CF extension field); unprefixed inside
+        # `attrs`, which is a passthrough of the store's own CF attribute names.
+        for cf_key in _CF_VARIABLE_ATTRS:
             value = attrs.get(cf_key)
             if isinstance(value, str):
                 kept_attrs[cf_key] = value
-                variable[cf_key] = value
+                variable[f"cf:{cf_key}"] = value
         variable["attrs"] = kept_attrs
 
 

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -7,7 +7,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import pystac
 import xarray as xr
@@ -20,12 +20,12 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
-from open_climate_service.shared.geozarr import ZARR_V3_MEDIA_TYPE, zarr_media_type
 from open_climate_service.shared.time import (
     parse_period_string_to_datetime,
     period_type_to_iso_step,
     resolve_iso_period_step,
 )
+from open_climate_service.stac.media_types import ZARR_V3_MEDIA_TYPE, zarr_media_type
 
 CATALOG_TITLE = "Open Climate Service"
 CATALOG_DESCRIPTION = "Published Open Climate Service GeoZarr datasets"
@@ -41,13 +41,12 @@ DEFAULT_STAC_LICENSE = "various"
 # defines a per-dimension array form, but permits the plain string for methods that span axes.
 _CF_VARIABLE_ATTRS = ("standard_name", "cell_methods")
 SPATIAL_STEP_DECIMALS = 8
-XSTAC_COLLECTION_CACHE_MAXSIZE = 128
+ARTIFACT_CACHE_MAXSIZE = 128
 logger = logging.getLogger(__name__)
 _xstac_collection_cache: dict[str, dict[str, Any]] = {}
-# Media type per artifact id. Detecting it reads the store's root group, which the xstac cache
-# does not cover: the type is set on the collection template, which is built *before* — and so
-# on every request, even a cache hit. Same bound and same invalidation as the payload cache.
+# Media type per artifact id — see _zarr_media_type for why this needs its own cache.
 _zarr_media_type_cache: dict[str, str] = {}
+_V = TypeVar("_V")
 
 
 def _get_catalog_id() -> str:
@@ -411,9 +410,9 @@ def _zarr_media_type(artifact: ArtifactRecord) -> str:
     from a flat one, which the plain Zarr media type cannot express. Falls back to the flat type
     whenever the store can't be inspected.
 
-    Cached per **artifact id**, not per store path. A re-ingest reuses the same path — and can
-    cross the pyramid threshold as the data grows — so a path-keyed cache would serve a stale
-    claim. A new write always means a new artifact record.
+    Cached because detection reads the store's root group, and this is called from the collection
+    *template*, which is rebuilt on every request — so it sits outside the xstac payload cache.
+    See :func:`_cache_by_artifact` for why the key is the artifact id.
     """
     cached = _zarr_media_type_cache.get(artifact.artifact_id)
     if cached is not None:
@@ -423,20 +422,28 @@ def _zarr_media_type(artifact: ArtifactRecord) -> str:
     except HTTPException:
         return ZARR_V3_MEDIA_TYPE
     media_type = zarr_media_type(store_path, icechunk=artifact.format == ArtifactFormat.ICECHUNK)
-    if len(_zarr_media_type_cache) >= XSTAC_COLLECTION_CACHE_MAXSIZE:
-        _zarr_media_type_cache.pop(next(iter(_zarr_media_type_cache)), None)
-    _zarr_media_type_cache[artifact.artifact_id] = media_type
+    _cache_by_artifact(_zarr_media_type_cache, artifact.artifact_id, media_type)
     return media_type
 
 
-def _cache_xstac_collection_payload(artifact_id: str, payload: dict[str, Any]) -> None:
-    if artifact_id in _xstac_collection_cache:
-        _xstac_collection_cache[artifact_id] = deepcopy(payload)
+def _cache_by_artifact(cache: dict[str, _V], artifact_id: str, value: _V) -> None:
+    """Store *value* under *artifact_id*, evicting the oldest entry past the size bound.
+
+    Both per-artifact caches here are keyed on the artifact id rather than the store path: a
+    re-ingest reuses the path, so a path-keyed entry would go stale, while every write produces a
+    new artifact record. Refreshing an existing key keeps its insertion position, so a
+    frequently-rebuilt collection is not treated as newest and does not evict others.
+    """
+    if artifact_id in cache:
+        cache[artifact_id] = value
         return
-    if len(_xstac_collection_cache) >= XSTAC_COLLECTION_CACHE_MAXSIZE:
-        oldest_artifact_id = next(iter(_xstac_collection_cache))
-        _xstac_collection_cache.pop(oldest_artifact_id, None)
-    _xstac_collection_cache[artifact_id] = deepcopy(payload)
+    if len(cache) >= ARTIFACT_CACHE_MAXSIZE:
+        cache.pop(next(iter(cache)), None)
+    cache[artifact_id] = value
+
+
+def _cache_xstac_collection_payload(artifact_id: str, payload: dict[str, Any]) -> None:
+    _cache_by_artifact(_xstac_collection_cache, artifact_id, deepcopy(payload))
 
 
 def _clear_xstac_collection_cache() -> None:

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -27,6 +27,7 @@ from typing import Any, cast
 import xarray as xr
 
 from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
+from open_climate_service.shared.raster_contract import normalize_dim_layout
 from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
 from open_climate_service.streaming.store import (
     is_store_empty,
@@ -232,6 +233,12 @@ async def run_streaming_ingest(
             # open_dataset / remote HTTP) once it is written, so long backfills don't
             # leak file descriptors one period at a time.
             try:
+                # Enforce the naming/axis-order half of the published contract on every period,
+                # so a plugin can return data in its source's orientation (CLIM-821). Only the
+                # value-preserving half belongs here: rolling longitudes to −180…180 reorders
+                # the x axis, which would not match the x coordinates an existing store was
+                # created with, so that runs in the whole-store rewrite (write_to_icechunk_store).
+                ds = normalize_dim_layout(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim)
                 # Infer the grid from the first fetched period, before _strip_cf_encoding
                 # so the nodata sentinel survives into the spec.
                 if spec is None:

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -28,9 +28,7 @@ import xarray as xr
 
 from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
 from open_climate_service.shared.raster_contract import (
-    normalize_dim_layout,
-    normalize_longitudes,
-    normalize_y_direction,
+    prepare_for_publication,
     spatial_coords_match,
 )
 from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
@@ -76,40 +74,12 @@ def _strip_cf_encoding(ds: xr.Dataset, period_type: str, *, time_dim: str) -> No
         ds[time_dim].encoding.update({"units": units, "dtype": "int32"})
 
 
-def _infer_epsg(ds: xr.Dataset, fallback: int | str) -> int:
-    """Infer an EPSG code from a fetched dataset, falling back when unknown.
-
-    ``fallback`` may be an int or string CRS (e.g. the plugin's ``crs`` attribute);
-    it is normalized to an EPSG int.
-    """
-    from open_climate_service.streaming.protocol import to_epsg_int
-
-    code = ds.attrs.get("proj:code") or ds.attrs.get("proj:epsg")
-    if code:
-        try:
-            return to_epsg_int(code)
-        except (ValueError, TypeError):
-            pass
-    try:
-        import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates the .rio accessor
-
-        crs = ds.rio.crs
-        if crs is not None and crs.to_epsg():
-            return int(crs.to_epsg())
-    except Exception:  # noqa: BLE001 — CRS detection is best-effort
-        pass
-    return to_epsg_int(fallback)
-
-
-def _grid_spec_from_dataset(
-    ds: xr.Dataset, *, time_dim: str, x_dim: str, y_dim: str, fallback_crs: int | str = 4326
-) -> GridSpec:
+def _grid_spec_from_dataset(ds: xr.Dataset, *, time_dim: str, x_dim: str, y_dim: str, crs: str) -> GridSpec:
     """Infer the store `GridSpec` from the first fetched period.
 
-    Reads dtype/nodata before CF encoding is stripped, so the no-data sentinel
-    survives into the store's fill value. ``fallback_crs`` (the plugin's ``crs``
-    attribute) supplies the CRS when the fetched data carries none — how a
-    projected-grid plugin declares its projection.
+    Reads dtype/nodata before CF encoding is stripped, so the no-data sentinel survives into the
+    store's fill value. ``crs`` comes from :func:`prepare_for_publication`, which is the single
+    place a dataset's CRS is decided — a second inference here would be a second answer.
     """
     try:
         primary = next(iter(ds.data_vars))
@@ -126,7 +96,7 @@ def _grid_spec_from_dataset(
         ) from exc
     return GridSpec(
         shape=shape,
-        crs=_infer_epsg(ds, fallback_crs),
+        crs=crs,
         dtype=da.dtype,
         nodata=float(nodata) if nodata is not None else None,
         time_dim=time_dim,
@@ -278,15 +248,14 @@ async def run_streaming_ingest(
                 # data in whatever orientation its source delivers (CLIM-821). Deterministic, so
                 # every period of a run agrees; a store written before the contract can disagree,
                 # which _assert_appendable_axes catches below.
-                ds = normalize_dim_layout(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim)
-                ds = normalize_y_direction(ds, y_dim=y_dim)
-                ds = normalize_longitudes(ds, x_dim=x_dim, crs=getattr(plugin, "crs", None))
+                prepared = prepare_for_publication(
+                    ds, fallback_crs=fallback_crs, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim
+                )
+                ds = prepared.dataset
                 # Infer the grid from the first fetched period, before _strip_cf_encoding
                 # so the nodata sentinel survives into the spec.
                 if spec is None:
-                    spec = _grid_spec_from_dataset(
-                        ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim, fallback_crs=fallback_crs
-                    )
+                    spec = _grid_spec_from_dataset(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim, crs=prepared.crs)
                 _strip_cf_encoding(ds, period_type, time_dim=spec.time_dim)
                 apply_cf_metadata(ds, cf_attrs, overwrite=True)
                 try:

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -27,7 +27,12 @@ from typing import Any, cast
 import xarray as xr
 
 from open_climate_service.shared.cf import apply_cf_metadata, cf_attrs_from_template
-from open_climate_service.shared.raster_contract import normalize_dim_layout
+from open_climate_service.shared.raster_contract import (
+    normalize_dim_layout,
+    normalize_longitudes,
+    normalize_y_direction,
+    spatial_coords_match,
+)
 from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
 from open_climate_service.streaming.store import (
     is_store_empty,
@@ -130,6 +135,40 @@ def _grid_spec_from_dataset(
     )
 
 
+def _assert_appendable_axes(store_path: Path, ds: xr.Dataset, *, x_dim: str, y_dim: str) -> None:
+    """Refuse to append a period whose spatial axes disagree with the committed store.
+
+    Normalisation reorders rows (y descending) and columns (longitudes rolled to −180…180). An
+    append writes along the time axis only, so the committed coordinate arrays stay as they were:
+    a period normalised one way, appended to a store written the other, puts data under
+    coordinates that no longer describe it — a silently mirrored or half-shifted raster, which is
+    far worse than metadata being out of date.
+
+    That can only happen to a store written before the contract existed (or by a plugin whose
+    orientation has since changed), and the fix is a re-ingest rather than anything this function
+    can do safely, so it fails with an actionable message instead of guessing.
+    """
+    from open_climate_service.streaming.store import read_committed_spatial_coords
+
+    stored = read_committed_spatial_coords(store_path, x_dim=x_dim, y_dim=y_dim)
+    if stored is None:
+        return  # nothing committed to disagree with, or a store we cannot read
+    for axis in (y_dim, x_dim):
+        if axis not in ds.coords or axis not in stored:
+            continue
+        if spatial_coords_match(stored[axis], ds[axis], axis=axis):
+            continue
+        raise RuntimeError(
+            f"Cannot append to {store_path.name}: its committed {axis!r} coordinates do not match "
+            f"the normalised ones for this period "
+            f"(store {stored[axis][0]!r}…{stored[axis][-1]!r}, "
+            f"period {float(ds[axis].values[0])!r}…{float(ds[axis].values[-1])!r}). "
+            "The store predates the published-store layout contract (y descending, longitudes "
+            "−180…180); appending would write data under coordinates that no longer describe it. "
+            "Re-ingest this dataset from scratch to rebuild it under the current contract."
+        )
+
+
 async def run_streaming_ingest(
     *,
     plugin: IngestionPlugin,
@@ -196,6 +235,8 @@ async def run_streaming_ingest(
     # Icechunk transaction batching.
     commit_batch_size = max(1, int(getattr(plugin, "commit_batch_size", 1)))
     expected_spatial_shape: tuple[int, int] | None = None
+    # The append-axes check runs once per run, on the first period appended to an existing store.
+    axes_checked = False
     # CF attributes (units / standard_name / cell_methods) declared on the template,
     # stamped onto each written period so the store is CF-compliant on disk (#280).
     # The template is authoritative for the fields it declares, so we overwrite any
@@ -233,12 +274,13 @@ async def run_streaming_ingest(
             # open_dataset / remote HTTP) once it is written, so long backfills don't
             # leak file descriptors one period at a time.
             try:
-                # Enforce the naming/axis-order half of the published contract on every period,
-                # so a plugin can return data in its source's orientation (CLIM-821). Only the
-                # value-preserving half belongs here: rolling longitudes to −180…180 reorders
-                # the x axis, which would not match the x coordinates an existing store was
-                # created with, so that runs in the whole-store rewrite (write_to_icechunk_store).
+                # Enforce the published-store contract on every period, so a plugin can return
+                # data in whatever orientation its source delivers (CLIM-821). Deterministic, so
+                # every period of a run agrees; a store written before the contract can disagree,
+                # which _assert_appendable_axes catches below.
                 ds = normalize_dim_layout(ds, time_dim=time_dim, x_dim=x_dim, y_dim=y_dim)
+                ds = normalize_y_direction(ds, y_dim=y_dim)
+                ds = normalize_longitudes(ds, x_dim=x_dim, crs=getattr(plugin, "crs", None))
                 # Infer the grid from the first fetched period, before _strip_cf_encoding
                 # so the nodata sentinel survives into the spec.
                 if spec is None:
@@ -267,6 +309,9 @@ async def run_streaming_ingest(
                     ds.to_zarr(session.store, mode="w", zarr_format=3)
                     is_first_write = False
                 else:
+                    if not axes_checked:
+                        _assert_appendable_axes(store_path, ds, x_dim=x_dim, y_dim=y_dim)
+                        axes_checked = True
                     ds.to_zarr(session.store, append_dim=spec.time_dim, zarr_format=3)
                 # Root attrs are rewritten on every commit so later append sessions
                 # preserve GeoZarr metadata even if the underlying store layer only

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from geozarr_toolkit import create_geozarr_attrs
 
+from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
 from open_climate_service.streaming.protocol import GridSpec
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,25 @@ def is_store_empty(store_path: Path) -> bool:
         return False
 
 
+def _stored_grid_geometry(root: Any, spec: GridSpec) -> dict[str, Any] | None:
+    """Grid geometry read from the store's own coordinate arrays, or None if unavailable.
+
+    The coordinate arrays are the ground truth for where the data actually is. The requested
+    ``bbox`` is not: a source can return less than was asked for (CHIRPS ends at 60°N, so a
+    Norway request to 72.5°N yields a grid that stops at 60°N), and describing the request
+    would stretch the raster over ground it does not cover.
+
+    Returns None for a store whose coordinates aren't readable yet — the first-write path
+    calls this before any data exists, and a 1-cell axis has no derivable cell size.
+    """
+    try:
+        x_centres = root[spec.x_dim][:]
+        y_centres = root[spec.y_dim][:]
+    except (KeyError, TypeError):
+        return None
+    return grid_geometry(x_centres, y_centres)
+
+
 def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> None:
     """Write root metadata for a flat Zarr v3 store.
 
@@ -107,11 +127,17 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
     """
     import zarr
 
+    root = zarr.open_group(store, mode="r+")
+    geometry = _stored_grid_geometry(root, spec)
+
     attrs = create_geozarr_attrs(
-        dimensions=[spec.x_dim, spec.y_dim],
+        # Array order, (y, x) — `spatial:dimensions` and `spatial:shape` are read
+        # positionally, so naming them x-first transposes the grid for any client that
+        # trusts the convention.
+        dimensions=[spec.y_dim, spec.x_dim],
         crs=f"EPSG:{spec.crs}",
         bbox=bbox,
-        shape=(spec.shape[1], spec.shape[0]),
+        shape=spec.shape,
     )
     crs_code = f"EPSG:{spec.crs}"
     attrs["proj:code"] = crs_code
@@ -121,7 +147,15 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
     # coordinate arrays — no non-standard `proj4`/`bounds` attrs required. The STAC hints
     # (open_climate_service:proj4, proj:bbox) in stac/services.py serve the map viewer.
     attrs["spatial:bbox"] = bbox
+    if geometry is not None:
+        # The affine is what a client actually places the raster with. Without it, viewers
+        # fall back to inferring a grid from the coordinate arrays and assume EPSG:4326 while
+        # doing so, which puts every projected store (seNorge's UTM33 metres) off the map.
+        attrs["spatial:transform"] = geometry["transform"]
+        attrs["spatial:shape"] = geometry["shape"]
+        attrs["spatial:bbox"] = geometry["bbox"]
     attrs.update(spec.attrs)
 
-    root = zarr.open_group(store, mode="r+")
     root.attrs.update(attrs)
+    if geometry is not None:
+        write_gdal_geotransform(root, geometry["transform"])

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -100,6 +100,33 @@ def is_store_empty(store_path: Path) -> bool:
         return False
 
 
+def read_committed_spatial_coords(store_path: Path, *, x_dim: str = "x", y_dim: str = "y") -> Any:
+    """The spatial coordinate arrays already committed to a store, or None.
+
+    An append writes along the time axis only, leaving these as they are — so a period whose
+    rows or columns have been reordered by normalisation would land under coordinates that no
+    longer describe it. The orchestrator compares against these before its first append.
+
+    Returns None when there is nothing to compare against (new store, unreadable, no coords).
+    """
+    import xarray as xr
+
+    if not store_path.exists():
+        return None
+    try:
+        repo = open_or_create_repo(store_path)
+        ds = xr.open_zarr(repo.readonly_session("main").store)
+        try:
+            if x_dim not in ds.coords or y_dim not in ds.coords:
+                return None
+            return {x_dim: ds[x_dim].values, y_dim: ds[y_dim].values}
+        finally:
+            ds.close()
+    except Exception:  # noqa: BLE001 — best effort; a store we cannot read cannot be checked
+        logger.debug("Could not read committed spatial coordinates from %s", store_path, exc_info=True)
+        return None
+
+
 def _stored_grid_geometry(root: Any, spec: GridSpec) -> dict[str, Any] | None:
     """Grid geometry read from the store's own coordinate arrays, or None if unavailable.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -176,6 +176,38 @@ def test_get_dataset_zarr_store_file_reads_icechunk_metadata(tmp_path: Path, mon
     assert b'"node_type":"group"' in response.body
 
 
+def test_zarr_store_root_serves_group_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trailing slash addresses the store root, and must not look like a missing store.
+
+    No Zarr library requests the root — they treat the URL as a base and append keys — but a
+    person pasting the URL does, and FastAPI redirects the slashless form here too, so a 404
+    made the root of every store a dead end reachable by the most obvious route.
+    """
+    store_path = tmp_path / "root.icechunk"
+    repo = icechunk.Repository.create(icechunk.local_filesystem_storage(str(store_path)))
+    session = repo.writable_session("main")
+    ds = xr.Dataset(
+        {"precip": (("t", "y", "x"), [[[1.0]]])},
+        coords={"t": ["2026-01-01"], "x": [1.0], "y": [2.0]},
+        attrs={"proj:code": "EPSG:4326"},
+    )
+    ds.to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("seed metadata")
+    ds.close()
+
+    artifact = _artifact(artifact_id="a-root")
+    artifact.format = ArtifactFormat.ICECHUNK
+    artifact.path = str(store_path)
+    artifact.asset_paths = [str(store_path)]
+    monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: artifact)
+
+    # "" is what the route passes for both /zarr/{id} (after its redirect) and /zarr/{id}/.
+    response = services.get_dataset_zarr_store_file_or_404("chirps3_precipitation_daily", "")
+
+    assert isinstance(response, services.JSONResponse)
+    assert b'"node_type":"group"' in response.body
+
+
 def test_get_dataset_zarr_store_file_rejects_invalid_icechunk_relative_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_geozarr_grid_metadata.py
+++ b/tests/test_geozarr_grid_metadata.py
@@ -1,0 +1,278 @@
+"""GeoZarr grid metadata: axis order, the affine, and the extent actually stored.
+
+Direct-Zarr clients georeference from the store alone — no STAC, no catalog. Three things
+they read were wrong or missing (CLIM-852), and each has its own failure signature:
+
+* ``spatial:dimensions`` / ``spatial:shape`` are positional. A client takes the
+  second-to-last entry as the row (y) axis and the last as the column (x) axis. Writing
+  ``["x", "y"]`` / ``[width, height]`` transposes the grid.
+* ``spatial:transform`` was never written for flat stores. Without it, viewers infer the grid
+  from the coordinate arrays and assume EPSG:4326 while doing so — which puts a store in
+  projected metres nowhere near its real location.
+* ``spatial:bbox`` described the *requested* bbox. A source can return less than was asked
+  for, so the declared extent claimed ground the store does not cover.
+
+The affine assertions are pinned against CHIRPS' real numbers: the GeoTIFFs OCS ingests
+carry their own GDAL ``GeoTransform``, so deriving one from the stored coordinates has an
+independent right answer to match.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+pytest.importorskip("icechunk")
+pytest.importorskip("rioxarray")
+zarr = pytest.importorskip("zarr")
+
+from open_climate_service.shared.geozarr import (  # noqa: E402
+    gdal_geotransform,
+    grid_geometry,
+)
+from open_climate_service.streaming.protocol import GridSpec  # noqa: E402
+from open_climate_service.streaming.store import write_geozarr_attrs  # noqa: E402
+
+# The real CHIRPS-over-Norway grid: 0.05° cells, and the source GeoTIFF's own GeoTransform
+# is "2.9500027261674404 0.05000000074505806 0.0 60.0 0.0 -0.05000000074505806".
+CHIRPS_X0 = 2.9750027265399694
+CHIRPS_Y0 = 59.97499999962747
+CHIRPS_STEP = 0.05000000074505806
+CHIRPS_NX = 581
+CHIRPS_NY = 60
+# Norway asked for 72.5°N; CHIRPS stops at 60°N, so the store holds far less than the request.
+CHIRPS_REQUESTED_BBOX = [3.0, 57.0, 32.0, 72.5]
+
+
+def _chirps_coords() -> tuple[np.ndarray, np.ndarray]:
+    x = CHIRPS_X0 + np.arange(CHIRPS_NX) * CHIRPS_STEP
+    y = CHIRPS_Y0 - np.arange(CHIRPS_NY) * CHIRPS_STEP
+    return x, y
+
+
+def _cube(x: np.ndarray, y: np.ndarray, crs: str) -> Any:  # an xr.Dataset; xr is importorskip'd
+    import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio
+
+    ds = xr.Dataset(
+        {"precip": (("t", "y", "x"), np.ones((1, len(y), len(x)), dtype="float32"))},
+        coords={"t": np.array(["2026-01-01"], dtype="datetime64[ns]"), "y": y, "x": x},
+    )
+    return ds.rio.write_crs(crs)
+
+
+def test_grid_geometry_matches_the_sources_own_geotransform() -> None:
+    """The affine derived from stored cell centres reproduces CHIRPS' source GeoTransform."""
+    x, y = _chirps_coords()
+    geometry = grid_geometry(x, y)
+    assert geometry is not None
+
+    step_x, rot_x, origin_x, rot_y, step_y, origin_y = geometry["transform"]
+    assert (rot_x, rot_y) == (0.0, 0.0)  # north-up, unrotated
+    assert step_x == pytest.approx(CHIRPS_STEP)
+    assert step_y == pytest.approx(-CHIRPS_STEP)  # rows run north→south
+    # Pixel registration: the origin is the cell EDGE, half a step out from the first centre.
+    assert origin_x == pytest.approx(2.9500027261674404)
+    assert origin_y == pytest.approx(60.0)
+
+
+def test_grid_geometry_shape_is_array_order() -> None:
+    x, y = _chirps_coords()
+    geometry = grid_geometry(x, y)
+    assert geometry is not None
+    assert geometry["shape"] == [CHIRPS_NY, CHIRPS_NX]  # (rows, columns), not (x, y)
+
+
+def test_grid_geometry_bbox_covers_the_outer_cell_edges() -> None:
+    x, y = _chirps_coords()
+    geometry = grid_geometry(x, y)
+    assert geometry is not None
+    xmin, ymin, xmax, ymax = geometry["bbox"]
+    assert (xmin, ymax) == pytest.approx((2.9500027261674404, 60.0))
+    # Ordered [xmin, ymin, xmax, ymax] even though y descends through the array.
+    assert ymin < ymax and xmin < xmax
+    assert ymin == pytest.approx(60.0 - CHIRPS_NY * CHIRPS_STEP)
+
+
+def test_grid_geometry_handles_ascending_y() -> None:
+    """A south-up grid keeps its positive step — flipping the sign would mirror the image."""
+    geometry = grid_geometry(np.array([10.0, 11.0, 12.0]), np.array([50.0, 51.0, 52.0]))
+    assert geometry is not None
+    assert geometry["transform"][4] == pytest.approx(1.0)
+    assert geometry["transform"][5] == pytest.approx(49.5)
+    assert geometry["bbox"][1] == pytest.approx(49.5)
+    assert geometry["bbox"][3] == pytest.approx(52.5)
+
+
+@pytest.mark.parametrize(
+    "x,y",
+    [
+        ([1.0], [1.0, 2.0]),  # single column
+        ([1.0, 2.0], [1.0]),  # single row
+        ([], []),
+        ([1.0, 1.0], [1.0, 2.0]),  # duplicated coordinate → zero step
+    ],
+)
+def test_grid_geometry_refuses_to_guess_a_degenerate_grid(x: list[float], y: list[float]) -> None:
+    """One cell on an axis leaves the cell size unknowable, so claim nothing rather than guess."""
+    assert grid_geometry(np.array(x), np.array(y)) is None
+
+
+def test_gdal_geotransform_reorders_the_coefficients() -> None:
+    """GDAL wants originX stepX rotX originY rotY stepY — a different order to GeoZarr's."""
+    assert gdal_geotransform([0.05, 0.0, 2.95, 0.0, -0.05, 60.0]) == "2.95 0.05 0.0 60.0 0.0 -0.05"
+
+
+def _init_store(path: Path, ds: Any) -> str:
+    store = str(path / "s.zarr")
+    ds.to_zarr(store, mode="w", zarr_format=3, consolidated=False)
+    return store
+
+
+def test_streaming_store_declares_axes_in_array_order(tmp_path: Path) -> None:
+    x, y = _chirps_coords()
+    store = _init_store(tmp_path, _cube(x, y, "EPSG:4326"))
+    spec = GridSpec(shape=(CHIRPS_NY, CHIRPS_NX), crs=4326, dtype=np.dtype("float32"))
+
+    write_geozarr_attrs(store, spec=spec, bbox=CHIRPS_REQUESTED_BBOX)
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["spatial:dimensions"] == ["y", "x"]
+    assert attrs["spatial:shape"] == [CHIRPS_NY, CHIRPS_NX]
+
+
+def test_streaming_store_writes_the_affine(tmp_path: Path) -> None:
+    """Present at all, and matching the source's GeoTransform — this is what places a raster."""
+    x, y = _chirps_coords()
+    store = _init_store(tmp_path, _cube(x, y, "EPSG:4326"))
+    spec = GridSpec(shape=(CHIRPS_NY, CHIRPS_NX), crs=4326, dtype=np.dtype("float32"))
+
+    write_geozarr_attrs(store, spec=spec, bbox=CHIRPS_REQUESTED_BBOX)
+
+    transform = dict(zarr.open_group(store, mode="r").attrs)["spatial:transform"]
+    assert transform == pytest.approx([CHIRPS_STEP, 0.0, 2.9500027261674404, 0.0, -CHIRPS_STEP, 60.0])
+
+
+def test_streaming_store_extent_describes_the_data_not_the_request(tmp_path: Path) -> None:
+    """CHIRPS ends at 60°N; a store that claims 72.5°N stretches over 12° of missing ground."""
+    x, y = _chirps_coords()
+    store = _init_store(tmp_path, _cube(x, y, "EPSG:4326"))
+    spec = GridSpec(shape=(CHIRPS_NY, CHIRPS_NX), crs=4326, dtype=np.dtype("float32"))
+
+    write_geozarr_attrs(store, spec=spec, bbox=CHIRPS_REQUESTED_BBOX)
+
+    bbox = dict(zarr.open_group(store, mode="r").attrs)["spatial:bbox"]
+    assert bbox[3] == pytest.approx(60.0)
+    assert bbox[3] != CHIRPS_REQUESTED_BBOX[3]
+
+
+def test_streaming_store_falls_back_to_the_request_bbox_without_coordinates(tmp_path: Path) -> None:
+    """First write, or a degenerate grid: keep the old behaviour rather than fail the ingest."""
+    store = str(tmp_path / "empty.zarr")
+    zarr.open_group(store, mode="w", zarr_format=3)
+    spec = GridSpec(shape=(3, 3), crs=32633, dtype=np.dtype("float32"))
+
+    write_geozarr_attrs(store, spec=spec, bbox=[0.0, 0.0, 1.0, 1.0])
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["spatial:bbox"] == [0.0, 0.0, 1.0, 1.0]
+    assert "spatial:transform" not in attrs
+    assert attrs["spatial:dimensions"] == ["y", "x"]  # axis order doesn't need coordinates
+
+
+def test_streaming_store_stamps_the_gdal_geotransform(tmp_path: Path) -> None:
+    """``rio.write_crs`` writes crs_wkt but not the transform, so we add it.
+
+    Without it, whether a store carries a GeoTransform depends on whether its source
+    happened to have one, and that attribute is what identifies a projected grid.
+    """
+    x = -74500.0 + np.arange(4) * 1000.0
+    y = 7999500.0 - np.arange(3) * 1000.0
+    store = _init_store(tmp_path, _cube(x, y, "EPSG:32633"))
+    spec = GridSpec(shape=(3, 4), crs=32633, dtype=np.dtype("float32"))
+
+    write_geozarr_attrs(store, spec=spec, bbox=[0.0, 0.0, 1.0, 1.0])
+
+    root = zarr.open_group(store, mode="r")
+    assert dict(root["spatial_ref"].attrs)["GeoTransform"] == "-75000.0 1000.0 0.0 8000000.0 0.0 -1000.0"
+    assert dict(root["spatial_ref"].attrs)["grid_mapping_name"] == "transverse_mercator"
+
+
+def _write_icechunk(tmp_path: Path, ds: Any, name: str, crs: str) -> Any:
+    import icechunk
+
+    from open_climate_service.data_manager.services.downloader import write_to_icechunk_store
+
+    path = tmp_path / f"{name}.icechunk"
+    write_to_icechunk_store(ds, path, t_dim="t", crs=crs)
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(path)))
+    return zarr.open_group(repo.readonly_session("main").store, mode="r")
+
+
+def test_downloader_flat_store_grid_metadata(tmp_path: Path) -> None:
+    """The batch/openEO write path must describe its grid the same way the streaming one does."""
+    x, y = _chirps_coords()
+    root = _write_icechunk(tmp_path, _cube(x, y, "EPSG:4326"), "flat", "EPSG:4326")
+
+    attrs = dict(root.attrs)
+    assert attrs["spatial:dimensions"] == ["y", "x"]
+    assert attrs["spatial:shape"] == [CHIRPS_NY, CHIRPS_NX]
+    assert attrs["spatial:transform"] == pytest.approx([CHIRPS_STEP, 0.0, 2.9500027261674404, 0.0, -CHIRPS_STEP, 60.0])
+    assert attrs["spatial:bbox"][3] == pytest.approx(60.0)
+    assert "GeoTransform" in dict(root["spatial_ref"].attrs)
+
+
+def _pyramid_cube() -> Any:
+    # Past the 2048x2048 pyramid threshold, and deliberately non-square so a transposed
+    # shape would be visible rather than symmetric.
+    ny, nx = 2100, 2400
+    x = 28.8 + np.arange(nx) * 0.001
+    y = -1.0 - np.arange(ny) * 0.001
+    return _cube(x, y, "EPSG:4326")
+
+
+def test_pyramid_root_agrees_with_topozarrs_level_0(tmp_path: Path) -> None:
+    """We now write the root affine ourselves, overriding topozarr's — so it must match it.
+
+    Same formula (pixel registration, origin on the cell edge), so a mismatch here would mean
+    the root metadata contradicts the pyramid layout it sits next to.
+    """
+    root = _write_icechunk(tmp_path, _pyramid_cube(), "pyr", "EPSG:4326")
+    attrs = dict(root.attrs)
+
+    layout = attrs["multiscales"]["layout"]
+    assert attrs["spatial:transform"] == pytest.approx(layout[0]["spatial:transform"])
+    assert attrs["spatial:shape"] == list(layout[0]["spatial:shape"]) == [2100, 2400]
+    assert attrs["spatial:dimensions"] == ["y", "x"]
+
+
+def test_pyramid_levels_get_their_own_geotransform(tmp_path: Path) -> None:
+    """Each level halves the resolution; one GeoTransform copied from level 0 would place
+    every overview at twice its true size.
+
+    Checked against topozarr's own per-level ``multiscales.layout`` affine rather than against
+    the ``× 2**level`` rule we derive it from — otherwise this only restates our assumption.
+    """
+    root = _write_icechunk(tmp_path, _pyramid_cube(), "pyr", "EPSG:4326")
+    layout = {entry["asset"]: entry["spatial:transform"] for entry in dict(root.attrs)["multiscales"]["layout"]}
+
+    checked = 0
+    for key in root.keys():
+        group = root[key]
+        if not isinstance(group, zarr.Group) or not key.isdigit():
+            continue
+        origin_x, step_x, rot_x, origin_y, rot_y, step_y = (
+            float(v) for v in dict(group["spatial_ref"].attrs)["GeoTransform"].split()
+        )
+        expected_step_x, _, expected_origin_x, _, expected_step_y, expected_origin_y = layout[key]
+        assert step_x == pytest.approx(expected_step_x), f"level {key} x step"
+        assert step_y == pytest.approx(expected_step_y), f"level {key} y step"
+        assert origin_x == pytest.approx(expected_origin_x), f"level {key} x origin"
+        assert origin_y == pytest.approx(expected_origin_y), f"level {key} y origin"
+        assert (rot_x, rot_y) == (0.0, 0.0)
+        checked += 1
+
+    assert checked == len(layout) >= 2  # every level covered, and there is more than one

--- a/tests/test_geozarr_media_type.py
+++ b/tests/test_geozarr_media_type.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import pytest
 
-from open_climate_service.shared.geozarr import (
+from open_climate_service.stac.media_types import (
     MULTISCALES_CONVENTION_UUID,
     WEB_OPTIMIZED_ZARR_MEDIA_TYPE,
     ZARR_V3_MEDIA_TYPE,
@@ -127,7 +127,7 @@ class TestZarrMediaType:
         def _boom(*_args: object, **_kwargs: object) -> dict[str, Any]:
             raise RuntimeError("store is locked")
 
-        monkeypatch.setattr("open_climate_service.shared.geozarr.read_root_attributes", _boom)
+        monkeypatch.setattr("open_climate_service.stac.media_types.read_root_attributes", _boom)
         assert zarr_media_type("/tmp/whatever.icechunk", icechunk=True) == ZARR_V3_MEDIA_TYPE
 
 

--- a/tests/test_geozarr_media_type.py
+++ b/tests/test_geozarr_media_type.py
@@ -1,0 +1,189 @@
+"""Media type advertised for published GeoZarr stores (flat vs pyramided).
+
+The `profile=multiscales` parameter is what gates rendering in pyramid-only clients. It is
+matched as a literal — stac-js compares against
+`['application/vnd.zarr; version=3; profile=multiscales']` with
+`allowedTypes.includes(type.toLowerCase())` — so case is forgiven but parameter order and
+spacing are not, and any reformatting silently disables rendering everywhere (CLIM-853).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from open_climate_service.shared.geozarr import (
+    MULTISCALES_CONVENTION_UUID,
+    WEB_OPTIMIZED_ZARR_MEDIA_TYPE,
+    ZARR_V3_MEDIA_TYPE,
+    attributes_declare_multiscales,
+    read_root_attributes,
+    zarr_media_type,
+)
+
+
+def _multiscales_attrs(levels: int = 3) -> dict[str, Any]:
+    """Root attributes as geozarr_toolkit writes them for a pyramided store."""
+    return {
+        "zarr_conventions": [
+            {"name": "spatial:", "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"},
+            {"name": "proj:", "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f"},
+            {"name": "multiscales", "uuid": MULTISCALES_CONVENTION_UUID},
+        ],
+        "multiscales": {
+            "layout": [{"path": str(level)} for level in range(levels)],
+            "resampling_method": "mean",
+        },
+        "proj:code": "EPSG:4326",
+        "spatial:bbox": [0.0, 0.0, 1.0, 1.0],
+    }
+
+
+def _write_zarr_store(root: Path, attributes: dict[str, Any]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "zarr.json").write_text(
+        json.dumps({"zarr_format": 3, "node_type": "group", "attributes": attributes}),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_web_optimized_media_type_is_byte_identical_to_client_expectation() -> None:
+    # Consumers match this string literally (no media type parameter parsing),
+    # so any reformatting silently disables pyramid rendering everywhere.
+    assert WEB_OPTIMIZED_ZARR_MEDIA_TYPE == "application/vnd.zarr; version=3; profile=multiscales"
+    assert ZARR_V3_MEDIA_TYPE == "application/vnd.zarr; version=3"
+
+
+class TestAttributesDeclareMultiscales:
+    def test_true_for_declared_convention_with_levels(self) -> None:
+        assert attributes_declare_multiscales(_multiscales_attrs()) is True
+
+    def test_matches_convention_by_name_when_uuid_absent(self) -> None:
+        attrs = _multiscales_attrs()
+        attrs["zarr_conventions"] = [{"name": "multiscales"}]
+        assert attributes_declare_multiscales(attrs) is True
+
+    def test_false_for_flat_store(self) -> None:
+        assert attributes_declare_multiscales({"proj:code": "EPSG:4326"}) is False
+
+    def test_false_when_convention_declared_but_layout_empty(self) -> None:
+        # Nothing extra for a client to read — advertising a pyramid would lie.
+        attrs = _multiscales_attrs()
+        attrs["multiscales"]["layout"] = []
+        assert attributes_declare_multiscales(attrs) is False
+
+    def test_false_when_layout_missing(self) -> None:
+        attrs = _multiscales_attrs()
+        del attrs["multiscales"]["layout"]
+        assert attributes_declare_multiscales(attrs) is False
+
+    def test_false_when_convention_missing_but_layout_present(self) -> None:
+        attrs = _multiscales_attrs()
+        attrs["zarr_conventions"] = []
+        assert attributes_declare_multiscales(attrs) is False
+
+    @pytest.mark.parametrize("conventions", ["multiscales", 42, None])
+    def test_false_for_malformed_conventions(self, conventions: Any) -> None:
+        assert attributes_declare_multiscales({"zarr_conventions": conventions}) is False
+
+
+class TestReadRootAttributes:
+    def test_reads_plain_zarr_v3_root(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "store.zarr", _multiscales_attrs())
+        assert read_root_attributes(str(store), icechunk=False)["multiscales"]["resampling_method"] == "mean"
+
+    def test_empty_for_missing_store(self, tmp_path: Path) -> None:
+        assert read_root_attributes(str(tmp_path / "absent.zarr"), icechunk=False) == {}
+
+    def test_empty_for_unreadable_metadata(self, tmp_path: Path) -> None:
+        store = tmp_path / "broken.zarr"
+        store.mkdir()
+        (store / "zarr.json").write_text("{not json", encoding="utf-8")
+        assert read_root_attributes(str(store), icechunk=False) == {}
+
+    def test_empty_for_remote_store(self) -> None:
+        # Detection must not make a network round trip per STAC request.
+        assert read_root_attributes("s3://bucket/store.zarr", icechunk=False) == {}
+
+
+class TestZarrMediaType:
+    def test_pyramided_store_advertises_profile(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "pyramid.zarr", _multiscales_attrs())
+        assert zarr_media_type(str(store), icechunk=False) == WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+
+    def test_flat_store_advertises_plain_type(self, tmp_path: Path) -> None:
+        store = _write_zarr_store(tmp_path / "flat.zarr", {"proj:code": "EPSG:4326"})
+        assert zarr_media_type(str(store), icechunk=False) == ZARR_V3_MEDIA_TYPE
+
+    def test_falls_back_to_plain_type_when_store_absent(self, tmp_path: Path) -> None:
+        assert zarr_media_type(str(tmp_path / "absent.zarr"), icechunk=False) == ZARR_V3_MEDIA_TYPE
+
+    def test_falls_back_to_plain_type_when_detection_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A broken/locked store must never take the STAC collection down with it.
+        def _boom(*_args: object, **_kwargs: object) -> dict[str, Any]:
+            raise RuntimeError("store is locked")
+
+        monkeypatch.setattr("open_climate_service.shared.geozarr.read_root_attributes", _boom)
+        assert zarr_media_type("/tmp/whatever.icechunk", icechunk=True) == ZARR_V3_MEDIA_TYPE
+
+
+class TestIcechunkDetectionEndToEnd:
+    """The Icechunk path against a store written by the real pipeline.
+
+    The rest of this module builds root metadata by hand, which cannot catch a mismatch between
+    what OCS *writes* and what this module *looks for* — the two are on opposite sides of the
+    contract. These write real stores and read them back.
+    """
+
+    def _cube(self, ny: int, nx: int) -> Any:
+        xr = pytest.importorskip("xarray")
+        np = pytest.importorskip("numpy")
+        pytest.importorskip("rioxarray")
+        import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # activates .rio
+
+        ds = xr.Dataset(
+            {"v": (("t", "y", "x"), np.ones((1, ny, nx), dtype="float32"))},
+            coords={
+                "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+                "y": -1.0 - np.arange(ny) * 0.001,
+                "x": 28.8 + np.arange(nx) * 0.001,
+            },
+        )
+        return ds.rio.write_crs("EPSG:4326")
+
+    def _write(self, tmp_path: Path, ny: int, nx: int) -> str:
+        pytest.importorskip("icechunk")
+        from open_climate_service.data_manager.services.downloader import write_to_icechunk_store
+
+        store_path = tmp_path / f"{ny}x{nx}.icechunk"
+        write_to_icechunk_store(self._cube(ny, nx), store_path, t_dim="t", crs="EPSG:4326")
+        return str(store_path)
+
+    def test_a_pyramided_store_written_by_ocs_is_detected(self, tmp_path: Path) -> None:
+        # Past the 2048x2048 pyramid threshold, so the writer builds a multiscales layout.
+        store = self._write(tmp_path, 2100, 2400)
+        assert zarr_media_type(store, icechunk=True) == WEB_OPTIMIZED_ZARR_MEDIA_TYPE
+
+    def test_a_flat_store_written_by_ocs_is_not(self, tmp_path: Path) -> None:
+        store = self._write(tmp_path, 64, 64)
+        assert zarr_media_type(store, icechunk=True) == ZARR_V3_MEDIA_TYPE
+
+    def test_reads_the_root_group_not_pyramid_level_zero(self, tmp_path: Path) -> None:
+        """The store accessors descend into level 0, whose attrs carry no multiscales layout.
+
+        If detection ever read through those, every pyramided store would look flat — so pin
+        that the layout is genuinely absent one level down.
+        """
+        zarr = pytest.importorskip("zarr")
+        icechunk = pytest.importorskip("icechunk")
+
+        store = self._write(tmp_path, 2100, 2400)
+        repo = icechunk.Repository.open(icechunk.local_filesystem_storage(store))
+        root = zarr.open_group(repo.readonly_session("main").store, mode="r")
+
+        assert attributes_declare_multiscales(dict(root.attrs)) is True
+        assert attributes_declare_multiscales(dict(root["0"].attrs)) is False

--- a/tests/test_raster_contract.py
+++ b/tests/test_raster_contract.py
@@ -5,9 +5,8 @@ of any one source. Enforced per-plugin they get forgotten one plugin at a time �
 datasets shipped on a ``time`` dim the map viewer could not find, and how Norway's WorldPop
 store came to declare ``EPSG:32633`` over degree coordinates.
 
-Deliberately absent: any assertion about the *direction* of ``y``. See
-``shared/raster_contract`` for why, and ``docs/conventions.md`` for what readers must do
-instead.
+``y`` must descend (row 0 = north), because real consumers assume it and never check — the
+thumbnail renderer's ``imshow(origin="upper")`` and OpenLayers' GeoZarr tile grid among them.
 """
 
 from __future__ import annotations
@@ -26,8 +25,10 @@ from open_climate_service.shared.raster_contract import (  # noqa: E402
     _axis_units,
     normalize_dim_layout,
     normalize_longitudes,
+    normalize_y_direction,
     published_contract_violations,
     resolve_store_crs,
+    spatial_coords_match,
 )
 
 # Deciding that a CRS is projected needs a working PROJ database. When pyproj cannot read one
@@ -285,18 +286,92 @@ def test_a_normalised_dataset_has_no_violations() -> None:
     ds = ds.assign_coords(x=[0.0, 90.0, 270.0, 350.0], y=[1.0, 2.0, 3.0])
 
     ds = normalize_dim_layout(ds)
+    ds = normalize_y_direction(ds)
     ds = normalize_longitudes(ds, crs="EPSG:4326")
     ds.attrs["proj:code"] = resolve_store_crs(ds, "EPSG:4326")
 
     assert published_contract_violations(ds) == []
 
 
-def test_y_direction_is_not_a_violation() -> None:
-    """Both directions are valid; readers honour the coordinate. See docs/conventions.md."""
-    descending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
+# --- invariant 3: y descends (row 0 = north) ----------------------------------------------
+
+
+def test_south_up_rows_are_reversed() -> None:
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 3, "x": 2}, coords={"y": [58.0, 59.0, 60.0]})
+    out = normalize_y_direction(ds)
+    assert out["y"].values.tolist() == [60.0, 59.0, 58.0]
+
+
+def test_north_up_rows_are_left_alone() -> None:
+    """The common case: most sources are already north-up, so this must cost nothing."""
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 3, "x": 2}, coords={"y": [60.0, 59.0, 58.0]})
+    out = normalize_y_direction(ds)
+    assert out["y"].values.tolist() == [60.0, 59.0, 58.0]
+    assert out["v"].values is ds["v"].values
+
+
+def test_reversing_carries_the_data_with_the_coordinate() -> None:
+    """Reversing the coordinate without the data would mirror the raster — the exact bug this
+    invariant exists to prevent, so it must not be introduced while preventing it."""
+    values = np.array([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]], dtype="float32")
+    ds = xr.Dataset(
+        {"v": (("t", "y", "x"), values)},
+        coords={"t": [0], "y": [58.0, 59.0, 60.0], "x": [10.0, 11.0]},
+    )
+
+    out = normalize_y_direction(ds)
+
+    # The value at a given latitude is unchanged; only its row index moved.
+    assert out["v"].sel(y=58.0, x=10.0).item() == 1.0
+    assert out["v"].sel(y=60.0, x=10.0).item() == 5.0
+    # And row 0 now holds the northernmost row, which is what consumers assume.
+    assert out["v"].values[0, 0].tolist() == [5.0, 6.0]
+
+
+def test_an_ascending_y_is_a_contract_violation() -> None:
+    """OpenLayers' GeoZarr source maps array row 0 to the north edge and cannot detect otherwise,
+    so a south-up store renders mirrored with no signal available to it."""
     ascending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [59.0, 60.0]})
+    descending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
+
+    assert any("ascends" in problem for problem in published_contract_violations(ascending))
     assert published_contract_violations(descending) == []
-    assert published_contract_violations(ascending) == []
+
+
+def test_a_single_row_grid_has_no_direction_to_normalise() -> None:
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 1, "x": 2}, coords={"y": [60.0]})
+    assert normalize_y_direction(ds)["y"].values.tolist() == [60.0]
+    assert published_contract_violations(ds) == []
+
+
+# --- the append guard ----------------------------------------------------------------------
+
+
+def test_matching_coords_are_appendable() -> None:
+    stored = np.array([60.0, 59.0, 58.0])
+    assert spatial_coords_match(stored, np.array([60.0, 59.0, 58.0]), axis="y") is True
+
+
+def test_a_reversed_axis_is_not_appendable() -> None:
+    """The corruption case: same values, opposite order. Data would land mirrored."""
+    stored = np.array([58.0, 59.0, 60.0])  # a store written before the contract
+    assert spatial_coords_match(stored, np.array([60.0, 59.0, 58.0]), axis="y") is False
+
+
+def test_a_rolled_axis_is_not_appendable() -> None:
+    stored = np.array([0.0, 90.0, 270.0])  # 0…360 frame
+    assert spatial_coords_match(stored, np.array([-90.0, 0.0, 90.0]), axis="x") is False
+
+
+def test_a_float_round_trip_still_matches() -> None:
+    """A coordinate can lose a last bit through Zarr; that must not fail an ingest."""
+    stored = np.array([60.0, 59.95, 59.9])
+    incoming = stored + 1e-12
+    assert spatial_coords_match(stored, incoming, axis="y") is True
+
+
+def test_a_different_length_is_not_appendable() -> None:
+    assert spatial_coords_match(np.array([60.0, 59.0]), np.array([60.0, 59.0, 58.0]), axis="y") is False
 
 
 def test_written_store_satisfies_the_contract(tmp_path: Path) -> None:
@@ -328,3 +403,65 @@ def test_written_store_satisfies_the_contract(tmp_path: Path) -> None:
         assert written.attrs["proj:code"] == "EPSG:4326"
     finally:
         written.close()
+
+
+def test_ingest_refuses_to_append_to_a_pre_contract_store(tmp_path: Path) -> None:
+    """A store written south-up must not receive north-up periods.
+
+    An append writes along the time axis only, so the committed y coordinate stays ascending
+    while the new rows arrive descending — the data would be stored mirrored. Failing with an
+    actionable message beats silently corrupting the store, and the fix is a re-ingest.
+    """
+    pytest.importorskip("icechunk")
+    from open_climate_service.streaming.orchestrator import _assert_appendable_axes
+    from open_climate_service.streaming.store import open_or_create_repo
+
+    store_path = tmp_path / "south_up.icechunk"
+    ascending = xr.Dataset(
+        {"v": (("t", "y", "x"), np.ones((1, 3, 2), dtype="float32"))},
+        coords={
+            "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "y": [58.0, 59.0, 60.0],
+            "x": [10.0, 11.0],
+        },
+    )
+    repo = open_or_create_repo(store_path)
+    session = repo.writable_session("main")
+    ascending.to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("pre-contract store")
+
+    normalised = normalize_y_direction(ascending)
+    assert normalised["y"].values.tolist() == [60.0, 59.0, 58.0]
+
+    with pytest.raises(RuntimeError, match="Re-ingest this dataset"):
+        _assert_appendable_axes(store_path, normalised, x_dim="x", y_dim="y")
+
+
+def test_ingest_appends_happily_to_a_conforming_store(tmp_path: Path) -> None:
+    pytest.importorskip("icechunk")
+    from open_climate_service.streaming.orchestrator import _assert_appendable_axes
+    from open_climate_service.streaming.store import open_or_create_repo
+
+    store_path = tmp_path / "north_up.icechunk"
+    descending = xr.Dataset(
+        {"v": (("t", "y", "x"), np.ones((1, 3, 2), dtype="float32"))},
+        coords={
+            "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "y": [60.0, 59.0, 58.0],
+            "x": [10.0, 11.0],
+        },
+    )
+    repo = open_or_create_repo(store_path)
+    session = repo.writable_session("main")
+    descending.to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("conforming store")
+
+    _assert_appendable_axes(store_path, normalize_y_direction(descending), x_dim="x", y_dim="y")
+
+
+def test_a_missing_store_is_not_a_blocker(tmp_path: Path) -> None:
+    """Nothing committed yet means nothing to disagree with — the first write must not fail."""
+    from open_climate_service.streaming.orchestrator import _assert_appendable_axes
+
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
+    _assert_appendable_axes(tmp_path / "absent.icechunk", ds, x_dim="x", y_dim="y")

--- a/tests/test_raster_contract.py
+++ b/tests/test_raster_contract.py
@@ -22,10 +22,12 @@ xr = pytest.importorskip("xarray")
 zarr = pytest.importorskip("zarr")
 
 from open_climate_service.shared.raster_contract import (  # noqa: E402
+    ContractViolation,
     _axis_units,
     normalize_dim_layout,
     normalize_longitudes,
     normalize_y_direction,
+    prepare_for_publication,
     published_contract_violations,
     resolve_store_crs,
     spatial_coords_match,
@@ -191,9 +193,24 @@ def _degree_grid(declared: str | None = None) -> Any:
 
 
 @_needs_proj
-def test_projected_crs_over_degree_coordinates_is_refused(ocs_logs: Any) -> None:
-    """The reported failure: EPSG:32633 declared over lon/lat puts the store at the UTM origin."""
+def test_the_data_crs_wins_over_a_projected_declaration() -> None:
+    """A declaration is a guess *about* the data, so the data outranks it.
+
+    Getting this precedence backwards is how a projected code ended up over lon/lat coordinates:
+    the instance's `crs:` was consulted as though it knew better than the store.
+    """
     ds = _degree_grid(declared="EPSG:4326")
+    assert resolve_store_crs(ds, "EPSG:32633") == "EPSG:4326"
+
+
+@_needs_proj
+def test_a_projected_crs_over_degree_coordinates_is_refused(ocs_logs: Any) -> None:
+    """The reported failure: EPSG:32633 over lon/lat puts the store at the UTM origin.
+
+    Reached here with no CRS on the data at all, so the projected declaration is what wins the
+    precedence — and is then rejected by the coordinates it claims to describe.
+    """
+    ds = _degree_grid()
 
     resolved = resolve_store_crs(ds, "EPSG:32633")
 
@@ -236,17 +253,17 @@ def test_a_consistent_projected_crs_is_kept() -> None:
 
 
 @_needs_proj
-def test_a_sticky_wrong_crs_falls_back_to_wgs84(ocs_logs: Any) -> None:
+def test_a_sticky_wrong_crs_on_the_data_is_also_refused(ocs_logs: Any) -> None:
     """A wrong `proj:code` is copied forward on every rewrite, so the data's CRS can be wrong too.
 
     Norway's WorldPop store is in exactly this state: root says EPSG:32633, level 0 says
-    EPSG:4326. Neither source agreeing with the coordinates must not propagate the bad code.
+    EPSG:4326. Data-wins precedence must not turn a stale bad code into a licence to keep it.
     """
     ds = _degree_grid(declared="EPSG:32633")
 
     assert resolve_store_crs(ds, "EPSG:32633") == "EPSG:4326"
 
-    assert "also projected" in ocs_logs.text
+    assert "EPSG:32633 is projected" in ocs_logs.text
 
 
 def test_no_declared_crs_uses_the_datasets_own() -> None:
@@ -273,12 +290,12 @@ def test_violations_lists_every_problem_at_once() -> None:
     ds = ds.assign_coords(x=[0.0, 90.0, 270.0, 350.0], y=[1.0, 2.0, 3.0])
     ds.attrs["proj:code"] = "EPSG:32633"
 
-    problems = "\n".join(published_contract_violations(ds))
+    kinds = {violation.kind for violation in published_contract_violations(ds)}
 
-    assert "not named 't'" in problems
-    assert "not (…, y, x)" in problems
+    assert ContractViolation.TEMPORAL_DIM_NAME in kinds
+    assert ContractViolation.AXIS_ORDER in kinds
     if _CRS_RESOLVABLE:
-        assert "projected but the coordinates are degrees" in problems
+        assert ContractViolation.CRS_CONTRADICTS_COORDS in kinds
 
 
 def test_a_normalised_dataset_has_no_violations() -> None:
@@ -334,7 +351,7 @@ def test_an_ascending_y_is_a_contract_violation() -> None:
     ascending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [59.0, 60.0]})
     descending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
 
-    assert any("ascends" in problem for problem in published_contract_violations(ascending))
+    assert [v.kind for v in published_contract_violations(ascending)] == [ContractViolation.Y_ASCENDS]
     assert published_contract_violations(descending) == []
 
 
@@ -465,3 +482,71 @@ def test_a_missing_store_is_not_a_blocker(tmp_path: Path) -> None:
 
     ds = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
     _assert_appendable_axes(tmp_path / "absent.icechunk", ds, x_dim="x", y_dim="y")
+
+
+# --- the single entry point ----------------------------------------------------------------
+
+
+@_needs_proj
+def test_prepare_never_rolls_a_projected_axis(ocs_logs: Any) -> None:
+    """The defect this entry point exists to make unexpressible.
+
+    Composed by hand, the streaming path passed the plugin's `crs` *class attribute* into the
+    longitude roll while the resolved CRS sat unused a few lines away. With no attribute declared
+    that argument is None, the projected-CRS guard is skipped, and an easting of 500000 rolls to
+    ((500000 + 180) % 360) - 180 = -40 — the store silently destroyed. Going through
+    prepare_for_publication, the roll cannot be reached before the CRS is resolved.
+    """
+    ds = xr.Dataset(
+        {"v": (("t", "y", "x"), np.ones((1, 2, 3), dtype="float32"))},
+        coords={
+            "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "y": [7_000_000.0, 6_999_000.0],
+            "x": [400_000.0, 500_000.0, 600_000.0],
+        },
+    )
+    ds.attrs["proj:code"] = "EPSG:32633"
+
+    prepared = prepare_for_publication(ds)  # no fallback_crs — the data must carry the decision
+
+    assert prepared.crs == "EPSG:32633"
+    assert prepared.dataset["x"].values.tolist() == [400_000.0, 500_000.0, 600_000.0]
+    assert "Rolling" not in ocs_logs.text
+
+
+def test_prepare_applies_every_invariant_in_one_call() -> None:
+    """A cube violating all four at once comes out conforming."""
+    ds = xr.Dataset(
+        {"v": (("time", "x", "y"), np.ones((1, 4, 3), dtype="float32"))},
+        coords={
+            "time": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "x": [0.0, 10.0, 350.0, 355.0],
+            "y": [57.0, 58.0, 59.0],
+        },
+    )
+
+    prepared = prepare_for_publication(ds, fallback_crs="EPSG:32633")
+    out = prepared.dataset
+
+    assert published_contract_violations(out) == []
+    assert out["v"].dims == ("t", "y", "x")  # renamed and transposed
+    assert out["y"].values.tolist() == [59.0, 58.0, 57.0]  # north-up
+    assert out["x"].values.min() < 0  # rolled off 0…360
+    assert prepared.crs == "EPSG:4326"  # the projected declaration refused by the coordinates
+
+
+def test_prepare_leaves_a_conforming_cube_alone() -> None:
+    ds = xr.Dataset(
+        {"v": (("t", "y", "x"), np.ones((1, 2, 2), dtype="float32"))},
+        coords={
+            "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "y": [60.0, 59.0],
+            "x": [10.0, 11.0],
+        },
+    )
+    ds.attrs["proj:code"] = "EPSG:4326"
+
+    prepared = prepare_for_publication(ds)
+
+    assert prepared.crs == "EPSG:4326"
+    assert prepared.dataset["v"].values is ds["v"].values

--- a/tests/test_raster_contract.py
+++ b/tests/test_raster_contract.py
@@ -1,0 +1,330 @@
+"""The published-store layout contract, enforced at the write boundary (CLIM-821).
+
+Dimension naming, axis order and CRS consistency are properties of a published GeoZarr, not
+of any one source. Enforced per-plugin they get forgotten one plugin at a time — that is how
+datasets shipped on a ``time`` dim the map viewer could not find, and how Norway's WorldPop
+store came to declare ``EPSG:32633`` over degree coordinates.
+
+Deliberately absent: any assertion about the *direction* of ``y``. See
+``shared/raster_contract`` for why, and ``docs/conventions.md`` for what readers must do
+instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+zarr = pytest.importorskip("zarr")
+
+from open_climate_service.shared.raster_contract import (  # noqa: E402
+    _axis_units,
+    normalize_dim_layout,
+    normalize_longitudes,
+    published_contract_violations,
+    resolve_store_crs,
+)
+
+# Deciding that a CRS is projected needs a working PROJ database. When pyproj cannot read one
+# (a polluted host PROJ_DATA is a common developer-machine failure — see
+# `startup._ensure_proj_database`), `_axis_units` reports "unknown" and the CRS checks
+# deliberately stand down rather than guessing. Skip the assertions that need a real answer.
+_CRS_RESOLVABLE = _axis_units("EPSG:32633") == "linear"
+_needs_proj = pytest.mark.skipif(not _CRS_RESOLVABLE, reason="pyproj cannot resolve EPSG:32633 here")
+
+
+@pytest.fixture
+def ocs_logs(caplog: pytest.LogCaptureFixture) -> Any:
+    """Capture warnings from the OCS package logger.
+
+    ``startup.py`` sets ``propagate = False`` on it so the app owns its own handler, which
+    means caplog's root handler never sees the records. Re-enable propagation for the test.
+    """
+    package_logger = logging.getLogger("open_climate_service")
+    previous = package_logger.propagate
+    package_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="open_climate_service"):
+            yield caplog
+    finally:
+        package_logger.propagate = previous
+
+
+def _cube(*, dims: tuple[str, ...], sizes: dict[str, int], coords: dict[str, Any] | None = None) -> Any:
+    shape = tuple(sizes[d] for d in dims)
+    data = np.arange(int(np.prod(shape)), dtype="float32").reshape(shape)
+    return xr.Dataset({"v": (dims, data)}, coords=coords or {})
+
+
+# --- invariant 1: the temporal dimension is named `t` -------------------------------------
+
+
+@pytest.mark.parametrize("alias", ["time", "valid_time", "date", "time_counter"])
+def test_temporal_aliases_are_renamed_to_t(alias: str) -> None:
+    """The map viewer looks for `t`; a store shipping `time` renders with no time control."""
+    ds = _cube(dims=(alias, "y", "x"), sizes={alias: 2, "y": 3, "x": 4})
+    out = normalize_dim_layout(ds)
+    assert "t" in out.dims
+    assert alias not in out.dims
+
+
+def test_an_existing_t_dim_is_left_alone() -> None:
+    """A cube with both `t` and `time` must not have `time` collapsed onto it."""
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 2, "y": 3, "x": 4})
+    ds = ds.assign_coords(time=("t", np.array(["2026-01-01", "2026-01-02"], dtype="datetime64[ns]")))
+    out = normalize_dim_layout(ds)
+    assert "t" in out.dims
+    assert "time" in out.coords  # kept as an auxiliary coordinate, not renamed over `t`
+
+
+# --- invariant 2: spatial dims are (…, y, x) ----------------------------------------------
+
+
+def test_transposed_variable_is_reordered() -> None:
+    ds = _cube(dims=("t", "x", "y"), sizes={"t": 2, "x": 4, "y": 3})
+    out = normalize_dim_layout(ds)
+    assert out["v"].dims == ("t", "y", "x")
+
+
+def test_reordering_moves_data_not_just_labels() -> None:
+    """A transpose that relabelled without moving values would silently mirror the raster."""
+    values = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")  # (x=2, y=3)
+    ds = xr.Dataset({"v": (("x", "y"), values)}, coords={"x": [10.0, 11.0], "y": [50.0, 51.0, 52.0]})
+
+    out = normalize_dim_layout(ds)
+
+    assert out["v"].dims == ("y", "x")
+    np.testing.assert_array_equal(out["v"].values, values.T)
+    # The value at a given coordinate pair is unchanged — only its position in the array.
+    assert float(out["v"].sel(x=11.0, y=52.0)) == float(ds["v"].sel(x=11.0, y=52.0)) == 6.0
+
+
+def test_spatial_dims_end_up_last_even_with_several_leading_dims() -> None:
+    ds = _cube(dims=("y", "t", "x", "age"), sizes={"y": 3, "t": 2, "x": 4, "age": 5})
+    out = normalize_dim_layout(ds)
+    assert out["v"].dims[-2:] == ("y", "x")
+    assert set(out["v"].dims[:-2]) == {"t", "age"}
+
+
+def test_conformant_dataset_is_returned_untouched() -> None:
+    """The common case must not pay for a copy of the data."""
+    ds = _cube(dims=("t", "y", "x"), sizes={"t": 2, "y": 3, "x": 4})
+    out = normalize_dim_layout(ds)
+    assert out["v"].dims == ("t", "y", "x")
+    assert out["v"].values is ds["v"].values
+
+
+def test_non_spatial_variables_are_ignored() -> None:
+    """A scalar CRS holder has no y/x to order, and must survive normalisation."""
+    ds = _cube(dims=("t", "x", "y"), sizes={"t": 2, "x": 4, "y": 3})
+    ds["spatial_ref"] = xr.DataArray(0)
+    out = normalize_dim_layout(ds)
+    assert "spatial_ref" in out
+    assert out["v"].dims == ("t", "y", "x")
+
+
+def test_missing_spatial_dims_are_left_for_the_caller_to_report() -> None:
+    """The orchestrator raises a clearer error about missing y/x than a transpose would."""
+    ds = _cube(dims=("time", "station"), sizes={"time": 2, "station": 5})
+    out = normalize_dim_layout(ds)
+    assert "t" in out.dims  # the temporal rename still happens
+    assert out["v"].dims == ("t", "station")
+
+
+# --- invariant 3: geographic longitudes run -180…180 --------------------------------------
+
+
+def test_longitudes_are_rolled_off_the_0_360_frame() -> None:
+    ds = _cube(dims=("y", "x"), sizes={"y": 2, "x": 4}, coords={"y": [1.0, 2.0], "x": [0.0, 90.0, 270.0, 350.0]})
+    out = normalize_longitudes(ds, crs="EPSG:4326")
+    assert out["x"].values.tolist() == [-90.0, -10.0, 0.0, 90.0]  # rolled and re-sorted
+
+
+def test_rolling_carries_the_data_with_the_coordinates() -> None:
+    """Rolling without re-sorting the data would shift every value by half the globe."""
+    ds = xr.Dataset(
+        {"v": (("y", "x"), np.array([[1.0, 2.0, 3.0, 4.0]], dtype="float32"))},
+        coords={"y": [0.0], "x": [0.0, 90.0, 270.0, 350.0]},
+    )
+    out = normalize_longitudes(ds, crs="EPSG:4326")
+    assert out["v"].sel(x=-90.0, y=0.0).item() == 3.0  # was 270°
+    assert out["v"].sel(x=0.0, y=0.0).item() == 1.0
+
+
+def test_already_rolled_longitudes_are_untouched() -> None:
+    ds = _cube(dims=("y", "x"), sizes={"y": 2, "x": 3}, coords={"y": [1.0, 2.0], "x": [-10.0, 0.0, 10.0]})
+    out = normalize_longitudes(ds, crs="EPSG:4326")
+    assert out["x"].values.tolist() == [-10.0, 0.0, 10.0]
+
+
+@_needs_proj
+def test_projected_eastings_are_never_rolled() -> None:
+    """A UTM easting is legitimately far larger than 180 — rolling it would be destructive."""
+    ds = _cube(
+        dims=("y", "x"),
+        sizes={"y": 2, "x": 3},
+        coords={"y": [6450500.0, 6451500.0], "x": [-74500.0, 500000.0, 1119500.0]},
+    )
+    out = normalize_longitudes(ds, crs="EPSG:32633")
+    assert out["x"].values.tolist() == [-74500.0, 500000.0, 1119500.0]
+
+
+# --- invariant 4: the declared CRS matches the coordinates --------------------------------
+
+
+def _degree_grid(declared: str | None = None) -> Any:
+    # Norway's WorldPop extent, the store that reported this bug.
+    ds = _cube(
+        dims=("y", "x"),
+        sizes={"y": 2, "x": 2},
+        coords={"y": [71.1846, 57.9596], "x": [4.5037, 31.1679]},
+    )
+    if declared is not None:
+        ds.attrs["proj:code"] = declared
+    return ds
+
+
+@_needs_proj
+def test_projected_crs_over_degree_coordinates_is_refused(ocs_logs: Any) -> None:
+    """The reported failure: EPSG:32633 declared over lon/lat puts the store at the UTM origin."""
+    ds = _degree_grid(declared="EPSG:4326")
+
+    resolved = resolve_store_crs(ds, "EPSG:32633")
+
+    assert resolved == "EPSG:4326"
+    assert "EPSG:32633" in ocs_logs.text
+    assert "±180/±90" in ocs_logs.text  # the log names the evidence, not just the verdict
+
+
+@_needs_proj
+def test_a_grid_still_on_the_0_360_frame_is_recognised_as_geographic(ocs_logs: Any) -> None:
+    """Chicken-and-egg: the roll needs to know the axis is a longitude, but an unrolled axis
+    exceeds 180. Testing longitude against 180 would make every 0…360 dataset look projected,
+    so the check allows up to 360 and leans on latitude (±90) for the real evidence.
+    """
+    ds = _cube(
+        dims=("y", "x"),
+        sizes={"y": 2, "x": 3},
+        coords={"y": [60.0, 59.0], "x": [0.0, 180.0, 350.0]},
+    )
+    assert resolve_store_crs(ds, "EPSG:32633") == "EPSG:4326"
+    assert "EPSG:32633" in ocs_logs.text
+
+
+@_needs_proj
+def test_an_unresolvable_crs_is_left_as_declared() -> None:
+    """When we cannot tell whether a CRS is projected, stand down rather than guess."""
+    ds = _degree_grid()
+    assert resolve_store_crs(ds, "EPSG:999999") == "EPSG:999999"
+
+
+@_needs_proj
+def test_a_consistent_projected_crs_is_kept() -> None:
+    """Only a contradiction is overridden — a real projected grid must survive untouched."""
+    ds = _cube(
+        dims=("y", "x"),
+        sizes={"y": 2, "x": 2},
+        coords={"y": [6450500.0, 7999500.0], "x": [-74500.0, 1119500.0]},
+    )
+    assert resolve_store_crs(ds, "EPSG:32633") == "EPSG:32633"
+
+
+@_needs_proj
+def test_a_sticky_wrong_crs_falls_back_to_wgs84(ocs_logs: Any) -> None:
+    """A wrong `proj:code` is copied forward on every rewrite, so the data's CRS can be wrong too.
+
+    Norway's WorldPop store is in exactly this state: root says EPSG:32633, level 0 says
+    EPSG:4326. Neither source agreeing with the coordinates must not propagate the bad code.
+    """
+    ds = _degree_grid(declared="EPSG:32633")
+
+    assert resolve_store_crs(ds, "EPSG:32633") == "EPSG:4326"
+
+    assert "also projected" in ocs_logs.text
+
+
+def test_no_declared_crs_uses_the_datasets_own() -> None:
+    assert resolve_store_crs(_degree_grid(declared="EPSG:4326"), None) == "EPSG:4326"
+
+
+def test_crs84_aliases_are_canonicalised() -> None:
+    assert resolve_store_crs(_degree_grid(), "OGC:CRS84") == "EPSG:4326"
+
+
+def test_the_instance_config_crs_is_never_consulted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The config CRS as a fallback is what created the mismatch in the first place."""
+    from open_climate_service import config as api_config
+
+    monkeypatch.setattr(api_config, "get_crs", lambda: "EPSG:32633")
+    assert resolve_store_crs(_degree_grid(), None) == "EPSG:4326"
+
+
+# --- the contract as a whole ---------------------------------------------------------------
+
+
+def test_violations_lists_every_problem_at_once() -> None:
+    ds = _cube(dims=("time", "x", "y"), sizes={"time": 2, "x": 4, "y": 3})
+    ds = ds.assign_coords(x=[0.0, 90.0, 270.0, 350.0], y=[1.0, 2.0, 3.0])
+    ds.attrs["proj:code"] = "EPSG:32633"
+
+    problems = "\n".join(published_contract_violations(ds))
+
+    assert "not named 't'" in problems
+    assert "not (…, y, x)" in problems
+    if _CRS_RESOLVABLE:
+        assert "projected but the coordinates are degrees" in problems
+
+
+def test_a_normalised_dataset_has_no_violations() -> None:
+    ds = _cube(dims=("time", "x", "y"), sizes={"time": 2, "x": 4, "y": 3})
+    ds = ds.assign_coords(x=[0.0, 90.0, 270.0, 350.0], y=[1.0, 2.0, 3.0])
+
+    ds = normalize_dim_layout(ds)
+    ds = normalize_longitudes(ds, crs="EPSG:4326")
+    ds.attrs["proj:code"] = resolve_store_crs(ds, "EPSG:4326")
+
+    assert published_contract_violations(ds) == []
+
+
+def test_y_direction_is_not_a_violation() -> None:
+    """Both directions are valid; readers honour the coordinate. See docs/conventions.md."""
+    descending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [60.0, 59.0]})
+    ascending = _cube(dims=("t", "y", "x"), sizes={"t": 1, "y": 2, "x": 2}, coords={"y": [59.0, 60.0]})
+    assert published_contract_violations(descending) == []
+    assert published_contract_violations(ascending) == []
+
+
+def test_written_store_satisfies_the_contract(tmp_path: Path) -> None:
+    """End to end through the real write path, on a dataset that violates every invariant."""
+    import icechunk
+
+    pytest.importorskip("rioxarray")
+    from open_climate_service.data_manager.services.downloader import write_to_icechunk_store
+
+    # (time, x, y) order, a `time` dim, 0…360 longitudes, and a projected CRS over degrees.
+    ds = xr.Dataset(
+        {"v": (("time", "x", "y"), np.ones((1, 4, 3), dtype="float32"))},
+        coords={
+            "time": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "x": [0.0, 10.0, 350.0, 355.0],
+            "y": [60.0, 59.0, 58.0],
+        },
+    )
+
+    store_path = tmp_path / "contract.icechunk"
+    write_to_icechunk_store(ds, store_path, t_dim="time", crs="EPSG:32633")
+
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path)))
+    written = xr.open_zarr(repo.readonly_session("main").store, consolidated=False, zarr_format=3)
+    try:
+        assert published_contract_violations(written) == []
+        assert written["v"].dims == ("t", "y", "x")
+        assert written["x"].values.min() < 0  # rolled off the 0…360 frame
+        assert written.attrs["proj:code"] == "EPSG:4326"
+    finally:
+        written.close()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -133,9 +133,7 @@ def test_zarr_route_allows_the_hosted_geozarr_viewer_by_default(
         lambda _id, _path, range_header=None: {"zarr_format": 3, "node_type": "group", "attributes": {}},
     )
 
-    response = client.get(
-        "/zarr/dataset-1/zarr.json", headers={"Origin": "https://source-cooperative.github.io"}
-    )
+    response = client.get("/zarr/dataset-1/zarr.json", headers={"Origin": "https://source-cooperative.github.io"})
 
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "https://source-cooperative.github.io"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -118,6 +118,57 @@ def test_zarr_route_allows_private_network_preflight(client: TestClient, monkeyp
     assert response.headers["access-control-allow-private-network"] == "true"
 
 
+def test_zarr_route_allows_the_hosted_geozarr_viewer_by_default(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """source-cooperative/zarr-viewer must work without the operator configuring anything.
+
+    Left out of the default allowlist, its requests are blocked and it reports "your connection
+    looks slow or unstable" — a message that sends an operator to debug their network for what
+    is actually a cross-origin refusal (CLIM-852).
+    """
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_dataset_zarr_store_file_or_404",
+        lambda _id, _path, range_header=None: {"zarr_format": 3, "node_type": "group", "attributes": {}},
+    )
+
+    response = client.get(
+        "/zarr/dataset-1/zarr.json", headers={"Origin": "https://source-cooperative.github.io"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://source-cooperative.github.io"
+
+
+def test_zarr_route_answers_the_local_network_access_preflight(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Chrome renamed the opt-in from Private Network Access to Local Network Access.
+
+    Both spellings are answered, because which one a browser sends depends on its version and
+    getting it wrong looks identical to the server being unreachable.
+    """
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_dataset_zarr_store_file_or_404",
+        lambda _id, _path, range_header=None: {"zarr_format": 3, "node_type": "group", "attributes": {}},
+    )
+
+    response = client.options(
+        "/zarr/dataset-1/zarr.json",
+        headers={
+            "Origin": "https://source-cooperative.github.io",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Local-Network-Access": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-local-network-access"] == "true"
+    assert response.headers["access-control-allow-private-network"] == "true"
+
+
 def test_zarr_route_preserves_existing_vary_values(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         ingestion_services,

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -227,9 +227,12 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
     assert payload["cube:dimensions"]["t"]["extent"] == ["2026-01-01T00:00:00Z", "2026-01-10T00:00:00Z"]
     assert payload["cube:dimensions"]["t"]["step"] == "P1D"
     assert payload["cube:variables"]["precip"]["unit"] == "mm/day"
-    # CF semantics surfaced as top-level cube:variable fields (#283)
-    assert payload["cube:variables"]["precip"]["standard_name"] == "lwe_precipitation_rate"
-    assert payload["cube:variables"]["precip"]["cell_methods"] == "time: mean"
+    # CF semantics surfaced as cube:variable fields, named per the STAC CF extension
+    # (CLIM-828). Prefixed at this level because that is the defined STAC field; the raw CF
+    # spellings stay inside `attrs`, which passes the store's own attribute names through.
+    assert payload["cube:variables"]["precip"]["cf:standard_name"] == "lwe_precipitation_rate"
+    assert payload["cube:variables"]["precip"]["cf:cell_methods"] == "time: mean"
+    assert "standard_name" not in payload["cube:variables"]["precip"]
     assert payload["cube:variables"]["precip"]["attrs"] == {
         "long_name": "Precipitation",
         "units": "mm/day",
@@ -237,6 +240,8 @@ def test_collection_uses_xstac_and_adds_expected_fields(client: TestClient, monk
         "cell_methods": "time: mean",
     }
     assert "https://stac-extensions.github.io/projection/v2.0.0/schema.json" in payload["stac_extensions"]
+    # Declared because cf: fields were emitted.
+    assert "https://stac-extensions.github.io/cf/v1.0.0/schema.json" in payload["stac_extensions"]
 
 
 def test_stac_collection_compatibility_route_builds_collection(
@@ -907,3 +912,126 @@ def test_build_collection_crs_render_hints_use_store_wkt(tmp_path: Path) -> None
     proj4 = payload["open_climate_service:proj4"]
     assert "proj=utm" in proj4 and "zone=33" in proj4
     assert payload["proj:wkt2"].startswith("PROJCRS")
+
+
+def _stub_collection_build(monkeypatch: pytest.MonkeyPatch, artifact: ArtifactRecord) -> None:
+    """Stub out the store-reading parts of collection building, leaving the media type real."""
+    monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services, "_build_collection_with_xstac", lambda **_: _minimal_xstac_payload())
+    monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {})
+    monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
+
+
+def test_collection_advertises_the_detected_media_type(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whatever detection concludes must reach the payload — the `profile` parameter is what
+    gates rendering in pyramid-only clients (CLIM-853).
+
+    Detection itself is covered against real stores in test_geozarr_media_type.py; this is the
+    plumbing from there to the collection's zarr asset.
+    """
+    artifact = _artifact(artifact_id="pyr1")
+    _stub_collection_build(monkeypatch, artifact)
+    monkeypatch.setattr(
+        stac_services,
+        "zarr_media_type",
+        lambda *_a, **_k: "application/vnd.zarr; version=3; profile=multiscales",
+    )
+
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+
+    assert payload["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3; profile=multiscales"
+
+
+def test_collection_keeps_the_plain_media_type_for_a_flat_store(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Claiming a pyramid for a flat store sends a renderer looking for levels that don't exist."""
+    artifact = _artifact(artifact_id="flat1")
+    _stub_collection_build(monkeypatch, artifact)
+    monkeypatch.setattr(stac_services, "zarr_media_type", lambda *_a, **_k: "application/vnd.zarr; version=3")
+
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+
+    assert payload["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3"
+
+
+def test_media_type_detection_is_cached_per_request(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detection reads the store's root group; that must not happen on every STAC request.
+
+    The media type is set on the collection *template*, which is rebuilt per request — so it
+    sits outside the xstac payload cache and needs its own.
+    """
+    reads = 0
+
+    def counting_media_type(store_path: str, *, icechunk: bool) -> str:
+        nonlocal reads
+        reads += 1
+        return "application/vnd.zarr; version=3"
+
+    artifact = _artifact(artifact_id="cache1")
+    _stub_collection_build(monkeypatch, artifact)
+    monkeypatch.setattr(stac_services, "zarr_media_type", counting_media_type)
+
+    client.get("/stac/collections/chirps3_precipitation_daily")
+    client.get("/stac/collections/chirps3_precipitation_daily")
+
+    assert reads == 1
+
+
+def test_media_type_cache_is_keyed_by_artifact_not_store_path(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A re-ingest reuses the store path and can cross the pyramid threshold as data grows.
+
+    A path-keyed cache would keep serving the old claim; keying on the artifact id cannot, since
+    every write produces a new artifact record.
+    """
+    detections: list[str] = []
+
+    def growing_media_type(store_path: str, *, icechunk: bool) -> str:
+        detections.append(store_path)
+        return (
+            "application/vnd.zarr; version=3; profile=multiscales"
+            if len(detections) > 1
+            else "application/vnd.zarr; version=3"
+        )
+
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(stac_services, "_build_collection_with_xstac", lambda **_: _minimal_xstac_payload())
+    monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {})
+    monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
+    monkeypatch.setattr(stac_services, "zarr_media_type", growing_media_type)
+
+    same_path = "/tmp/chirps3_precipitation_daily.icechunk"
+    monkeypatch.setattr(
+        ingestion_services,
+        "list_artifacts",
+        lambda: SimpleNamespace(items=[_artifact(artifact_id="before", path=same_path)]),
+    )
+    first = client.get("/stac/collections/chirps3_precipitation_daily").json()
+
+    # Same store path, new artifact record — as a re-ingest produces.
+    monkeypatch.setattr(
+        ingestion_services,
+        "list_artifacts",
+        lambda: SimpleNamespace(items=[_artifact(artifact_id="after", path=same_path)]),
+    )
+    second = client.get("/stac/collections/chirps3_precipitation_daily").json()
+
+    assert first["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3"
+    assert second["assets"]["zarr"]["type"] == "application/vnd.zarr; version=3; profile=multiscales"
+    assert detections == [same_path, same_path]  # detected twice, despite the identical path
+
+
+def test_cf_extension_is_not_declared_when_no_cf_attrs_are_present(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store with no CF attributes emits no cf: field, so the extension is left undeclared."""
+    artifact = _artifact(artifact_id="nocf")
+    _stub_collection_build(monkeypatch, artifact)
+
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+
+    assert not any(key.startswith("cf:") for key in payload["cube:variables"]["precip"])
+    assert stac_services.CF_EXTENSION not in payload["stac_extensions"]

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -154,8 +154,11 @@ def test_orchestrator_uses_store_state_as_resume_truth(monkeypatch: pytest.Monke
 
     root = zarr.open_group(store_path, mode="r")
     assert root.attrs["proj:code"] == "EPSG:4326"
-    assert root.attrs["spatial:dimensions"] == ["x", "y"]
+    # Array order, (y, x) — see tests/test_geozarr_grid_metadata.py for why.
+    assert root.attrs["spatial:dimensions"] == ["y", "x"]
     assert root.attrs["spatial:shape"] == [1, 1]
+    # A 1x1 grid has no derivable cell size, so no affine is claimed for it.
+    assert "spatial:transform" not in root.attrs
 
     run_streaming_ingest_sync(
         plugin=_FakePlugin(),

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -15,7 +15,7 @@ from open_climate_service.streaming.orchestrator import _grid_spec_from_dataset,
 def test_grid_spec_from_dataset_raises_clear_error_for_missing_spatial_dims() -> None:
     ds = xr.Dataset({"v": (("t", "lat", "lon"), np.zeros((1, 1, 1), dtype=np.float32))})
     with pytest.raises(RuntimeError, match="missing the expected spatial dimensions 'y' and 'x'"):
-        _grid_spec_from_dataset(ds, time_dim="t", x_dim="x", y_dim="y")
+        _grid_spec_from_dataset(ds, time_dim="t", x_dim="x", y_dim="y", crs="EPSG:4326")
 
 
 class _FakePlugin:
@@ -264,9 +264,22 @@ def test_orchestrator_infers_grid_when_plugin_has_no_probe(monkeypatch: pytest.M
 
 
 class _ProjectedNoProbePlugin(_NoProbePlugin):
-    """No probe(), but declares a projected CRS via the `crs` class attribute."""
+    """No probe(), but declares a projected CRS via the `crs` class attribute.
+
+    Emits UTM33 metres rather than the base fixture's toy (1, 0). A declared projected CRS is
+    checked against the coordinates it claims to describe, so a store one metre from its own
+    origin would — correctly — be treated as degrees mislabelled as UTM.
+    """
 
     crs = 32633
+
+    def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
+        _ = bbox, params
+        value = float(period_id[-2:])
+        return xr.Dataset(
+            {"precip": (("t", "y", "x"), np.array([[[value]]], dtype=np.float32))},
+            coords={"t": [np.datetime64(period_id, "D")], "y": [6_650_000.0], "x": [500_000.0]},
+        )
 
 
 def test_orchestrator_uses_plugin_crs_attr_as_inference_fallback(


### PR DESCRIPTION
Implements [CLIM-852](https://dhis2.atlassian.net/browse/CLIM-852), [CLIM-821](https://dhis2.atlassian.net/browse/CLIM-821), [CLIM-853](https://dhis2.atlassian.net/browse/CLIM-853) and [CLIM-828](https://dhis2.atlassian.net/browse/CLIM-828).

Five parts, one subject: whether an external client can find our data and put it in the right place. CLIM-852 fixes *what the store's metadata says*, CLIM-821 fixes *what the store contains* and stops both classes of defect returning one plugin at a time, and CLIM-853/CLIM-828 fix *what the catalog tells a client about it*. Part 4 guarantees the `y` direction the first three assume. Part 5 fixes the HTTP surface all of it is served over — found by driving real hosted viewers against a running instance rather than reasoning about it.

---

# Part 1 — CLIM-852: the grid metadata direct-Zarr clients read

Checked OCS stores against [source-cooperative/zarr-viewer](https://github.com/source-cooperative/zarr-viewer), which reads the **store** and never looks at STAC — so it tests our GeoZarr metadata on its own terms. Three things it needs were wrong or missing.

Fixed in both write paths (the streaming per-period appender and the batch downloader) through one shared helper, [`shared/geozarr.py`](open_climate_service/shared/geozarr.py), so they can't drift apart again.

## What was wrong

**1. Axis order.** `spatial:dimensions` was written `["x","y"]` and `spatial:shape` as `[width, height]`. Both are read *positionally* — second-to-last entry is the row axis, last is the column axis — so this transposed the grid. Run through the viewer's own `parseMultiscaleLayout`, our pyramid root came out as:

```
BEFORE  layout.dims = ["x", "y"]      # it believed the rows were named "x"
AFTER   layout.dims = ["y", "x"]
```

Feeding the transposed shape into the viewer's `projectedBounds` moves the seNorge footprint's **east and south edges by ~355 km** of UTM.

**2. No affine on flat stores.** `spatial:transform` was never written at all, so every flat store fell through to the viewer's coordinate-array fallback — which hardcodes `EPSG:4326`:

```ts
// scalar-grid/profile.ts
} else {
  const syn = await synthesizeSpatialAttrs(...)
  projCode = "EPSG:4326";      // <- regardless of what the store says
}
```

seNorge is UTM33 metres, so its `x` ran from `-74500` as if that were a longitude. Not "slightly off" — off the planet.

**3. The declared extent was the request, not the data.** `spatial:bbox` came from the requested bbox. CHIRPS stops at 60°N, so the Norway store declared an extent reaching **72.5°N** — 12.5° of ground it holds no data for:

```
actual y coords:  59.975 … 57.025      (60 rows of 0.05°)
declared bbox:    [3.0, 57.0, 32.0, 72.5]
```

Everything is now derived from the store's own coordinate arrays.

## Also: the GDAL GeoTransform

`rio.write_crs` writes `crs_wkt` and `grid_mapping_name` but **not** the transform — `rio.write_transform` does that, and neither write path called it. So whether a store carried a `GeoTransform` depended on whether its *source* happened to have one:

| store | source | GeoTransform |
|---|---|---|
| `chirps3_precipitation_daily` | GeoTIFF | present (inherited) |
| `senorge_temperature_daily` | NetCDF | **absent** |

That attribute is what identifies a projected grid, so its absence is exactly what sent seNorge down the degrees-assuming path. It's now written from the same affine, and pyramid levels each get their own (scaled by `2**level`).

## Verification

I ran zarr-viewer's **own code**, not a reimplementation of it: a vitest file inside a checkout of the viewer, importing `parseMultiscaleLayout`, `readProjectedSpatialRef`, `geographicBounds`/`projectedBounds` and `detectConventions`, fed by attrs dumped from *both* revisions of OCS (a `git worktree` at `main` for the before) plus real Zarr v3 stores served over HTTP and opened with zarrita.

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Both before and after are asserted, so each finding is demonstrated rather than described:

```ts
// BEFORE: not detected as projected, so UTM metres get read as degrees
expect(await readProjectedSpatialRef(group, "")).toBeNull();

// AFTER: detected → hands off to the projected-grid profile
expect(projected!.gridMappingName).toBe("transverse_mercator");
expect(projected!.geoTransform).toEqual([-75000, 1000, 0, 8000000, 0, -1000]);
```

Two cross-checks worth keeping, because both had an independent right answer to hit:

- The affine derived from stored cell centres **reproduces CHIRPS' source GeoTIFF GeoTransform to the digit** — `2.9500027261674404 0.05000000074505806 0.0 60.0 0.0 -0.05000000074505806`. Half-step edge offset and step signs all confirmed by something other than my own arithmetic.
- The pyramid root affine we now write is **byte-identical to the one topozarr writes for level 0**, so overriding it changes nothing. Same for every per-level GeoTransform, checked against topozarr's `multiscales.layout` rather than against the `× 2**level` rule we derive it from.

## Confirmed in a real browser, on a real projected store

Everything above was verified through zarr-viewer's parsers and zarrita. This is the same thing
through the actual application, and it turned out to be the sharpest evidence in the PR — because
one seNorge store was re-ingested under this branch and three were not, giving an A/B on identical
source data where only the metadata differs.

**Re-ingested** (`senorge_precipitation_daily`) — renders correctly over Norway.

**Not re-ingested** (`senorge_temperature_daily`) — the console shows precisely the failure this
PR removes:

```
[zarr:profile] prepared "tg" float32 [13324,1550,1195] synthesized, metersPerPx=111319492
deck: TileLayer({id: 'raster-tile-layer-scalar-grid-tg-t=0'}): invalid latitude
```

`synthesized`, not `store-native`: with no `spatial:transform` and no GDAL `GeoTransform`, the
viewer falls back to inferring a grid from the coordinate arrays — and that fallback hardcodes
EPSG:4326. It therefore reads seNorge's 1000 **metre** step as 1000 **degrees**, giving
`metersPerPx = 111319492` (1000 x 111,319 m/deg), and deck.gl rejects the coordinates outright.

| | re-ingested | not re-ingested |
| --- | --- | --- |
| grid | store-native | `synthesized` |
| metres/px | 1 000 | 111 319 492 |
| result | renders over Norway | `invalid latitude`, nothing drawn |

Same source, same CRS, same viewer. The only difference is the two attributes this PR adds.

Worth noting for operators: seNorge is 1 km data, so the viewer's fetch-budget gate gives it
`minRenderZoom = 6` and it draws nothing at world view even when correct. That is the viewer
being sensible about chunk cost, not a fault in the store.

## The ticket's CORS blocker, as stated, doesn't exist

> **Superseded by part 5.** The header claim below is correct and still stands. The conclusion
> drawn from it — *"no OCS change needed"* — did not survive testing in a real browser: the
> origin allowlist and the network-access opt-in both needed fixing, and a 500 was masquerading
> as a CORS error. Read this section together with part 5.

CLIM-852 lists CORS as make-or-break, and says *"our `/zarr/` and `/stac` routers do not send `Access-Control-Allow-Origin` today"*. They do — `CORSMiddleware` is registered app-wide with `allow_origins=["*"]`, which covers every router. Against a running instance:

```
/zarr/senorge_temperature_daily/zarr.json  200  access-control-allow-origin: *
/stac                                      200  access-control-allow-origin: *
/icechunk/senorge_temperature_daily/...    404  access-control-allow-origin: *
```

The Icechunk endpoint is also discoverable: the viewer's first layout probe, `GET /icechunk/{id}/repo`, returns 200, so `hasIcechunkRepoConfig` succeeds without needing the `refs/branch.main/ref.json` fallback (which 404s — these are v2 repos with no `refs/` directory). No OCS change needed for either. Same note applies to the CORS dependency on CLIM-842 and CLIM-848.

## Existing stores

Attrs are rewritten on **every** streaming commit, so any dataset that syncs again picks up the corrected metadata with no migration. Batch/openEO artifacts are corrected on their next write. Stores that never sync again keep the old attrs.

## Tests

17 new, covering the shared helper (edge origin, sign of `stepY`, ascending-y grids, degenerate grids), both write paths, and the pyramid levels.

```
529 passed
make lint clean (ruff, format, mypy 81 files, pyright)
```

The 3 failures in `test_openeo_execution.py` are the pre-existing local PROJ database conflict, verified identical on `main`.

## Scope note

A degenerate grid (a single cell on an axis) has no derivable cell size, so no affine is claimed and the bbox falls back to the request rather than being guessed.

Not changed: `spatial:bbox` is now edge-based to match the `spatial:registration: "pixel"` we already declare, which shifts STAC's derived `proj:bbox` by half a cell. That's a correction, not a regression, but worth knowing it moves.

---

# Part 2 — CLIM-821: centralise the ingest contract

Dimension naming, axis order and CRS consistency are properties of a *published* GeoZarr, not of any one source. Enforced per-plugin they get forgotten one plugin at a time — that is how datasets shipped on a `time` dim the map viewer could not find. They now live in [`shared/raster_contract.py`](open_climate_service/shared/raster_contract.py):

1. the temporal dimension is named `t` (renamed from `time` / `valid_time` / `date` / `time_counter`)
2. spatial dims are `y` / `x`, ordered `(…, y, x)`
3. a geographic x axis runs −180…180, not 0…360
4. the declared CRS matches the coordinates it describes

Split across the two write paths by **what is safe where**: the streaming appender gets the name/order half, which changes no coordinate values and so is safe per period. The longitude roll reorders the x axis and would not match the coordinates an existing store was created with, so it runs only in the whole-store rewrite.

## The CRS bug, diagnosed

The ticket's comment asked which of two causes put `EPSG:32633` on Norway's WorldPop store, whose coordinates are degrees. Neither — it's the openEO path:

```python
openeo/jobs.py:569       crs = ds.attrs.get("proj:code") or api_config.get_crs()
openeo/execution.py:471  crs = ... or api_config.get_crs()
```

An untagged cube picks up the **instance** CRS — exactly what `downloader.py`'s own comment warns is fatal. `jobs.py` didn't even consult rioxarray first, so a cube carrying a perfectly good `spatial_ref` but no root `proj:code` got the config CRS written over it. Both now use `dataset_crs`, whose module docstring already promised the config CRS is *"deliberately never consulted"*.

Two things make it worse, both confirmed on the live store:

```
root    proj:code = EPSG:32633     <- wrong
level 0 proj:code = EPSG:4326      <- right; the store disagrees with itself
coords  x 4.50..31.17, y 57.96..71.18   (degrees)
```

A wrong `proj:code` is **sticky** — `dataset_crs` prefers it, and every `_maybe_build_pyramid` rewrite copies it forward. And nothing compared the declared CRS against the coordinates. `resolve_store_crs` now does, preferring the data's CRS on a contradiction and logging the evidence rather than just the verdict.

## y direction — superseded by part 4

This commit deliberately did *not* normalise the y direction, on the grounds that zarr-layer
detects it from the coordinate array. That held for the viewer we control but not for OpenLayers,
which STAC Browser uses. **Part 4 below reverses this** and guarantees y descending.

## Two bugs the tests caught

- **Longitude rolling ran before the CRS was validated**, so a lon/lat grid mislabelled as projected — precisely the case `resolve_store_crs` exists to correct — had its roll skipped. Resolution now comes first.
- **`_looks_geographic` tested longitude against 180**, which is false for any grid still on the 0…360 frame: the check needed to identify the datasets that need rolling returned `False` for exactly those. Latitude (±90) carries the argument now; longitude is allowed to 360.

`_axis_units` answers three ways rather than two. A CRS pyproj cannot resolve reports *unknown*, not *projected* — otherwise a polluted host PROJ database (see `startup._ensure_proj_database`) would let a good geographic CRS be overridden with EPSG:4326 just because the database was unreadable.

## Audit

Checked the places the two coordinate worlds meet, as the ticket asks:

| checked | result |
|---|---|
| bbox unpacking | `xmin, ymin, xmax, ymax` everywhere |
| `rasterio.from_bounds` | that order, then `width, height` — correct |
| `out_shape` for mask rasterisation | `(height, width)` — array order, correct |
| every `.transpose(...)` | targets `(…, y, x)` |

No further defects. Reporting that rather than inventing fixes.

## Docs

New [docs/conventions.md](docs/conventions.md) settles array order vs GeoJSON order (they describe different objects — an N-D array vs a coordinate tuple — so both stay as their own standard requires), states what the framework guarantees, and explains why y direction is not among the guarantees.

## Not done

The ~13 hand-rolled `if y[0] > y[-1]: isel(y=slice(None,None,-1))` flips in the Nepal/Malawi/Uganda instance plugins. They're separate repos, so out of this PR's reach — and with y left as delivered they're now harmless rather than required, so there's no rush.

## Combined test state

```
556 passed          (27 new here, 17 from part 1)
12 passed           zarr-viewer conformance, unchanged by part 2
make lint clean     ruff, format, mypy 82 files, pyright
```

The 3 `test_openeo_execution.py` failures are the pre-existing local PROJ database conflict, verified identical on `main`. Two of them cover `_ensure_crs`, which part 2 changes — I checked the failure is still `to_epsg()` returning `None` from the unreadable database, with the CRS itself correctly resolved to EPSG:4326.

---

# Part 3 — CLIM-853 + CLIM-828: what a STAC client is told

The catalog-side counterpart to parts 1 and 2: what a client is *told* about a store, rather than what the store contains.

## profile=multiscales (CLIM-853)

Pyramided stores now advertise `application/vnd.zarr; version=3; profile=multiscales`. That parameter is the entire gate for "Show on map" in STAC Browser — without it a store is recognised as Zarr (badge shown, download suppressed) but never offered for display.

Detection requires **both** the multiscales convention in the root `zarr_conventions` *and* a non-empty `multiscales.layout` — the same two conditions a renderer checks — and degrades to the flat type on any failure. Understating is harmless; overstating sends a renderer hunting for levels that don't exist.

### Two departures from the reference implementation on the closed #327 branch

**Cached, keyed by artifact id.** #327 set the media type in `_build_collection_template`, which is rebuilt on *every* STAC request and sits outside `_xstac_collection_cache` — so it opened an Icechunk repo per request even on a cache hit. It now has its own cache with the same bound and invalidation.

Keyed on artifact id, not store path, and that distinction is load-bearing:

```
re-ingest reuses  /data/downloads/worldpop_population_yearly.icechunk
                  and can cross the 2048² pyramid threshold as data grows
=> a path-keyed cache keeps serving "flat" forever
=> artifact-id-keyed cannot: every write produces a new artifact record
```

There's a test for exactly that scenario.

**Merged into the existing `shared/geozarr.py`** rather than a new module. The two halves are one contract: that file writes the `spatial:` attributes and now also reads them back to decide what to claim about them, so the claim and the thing being claimed can't drift.

## CF fields, prefixed (CLIM-828)

CLIM-828's scope said to emit a bare `standard_name` in `cube:variables` and *explicitly avoid* the STAC CF extension as "heavier". That's a false dichotomy — the CF extension lists among the places its fields may be used:

> - [x] Data Cube Extension (`cube:variables`, `cube:dimensions`)

and the STAC Zarr best-practices CF example does exactly that. So the fields are now `cf:standard_name` / `cf:cell_methods`: defined fields a client is *specified* to understand, where a bare `standard_name` at that level is not. Same cost, better outcome.

```json
"cube:variables": {
  "tg": {
    "unit": "degree_Celsius",
    "cf:standard_name": "air_temperature",
    "cf:cell_methods": "time: mean",
    "attrs": { "standard_name": "air_temperature", "units": "degree_Celsius", ... }
  }
}
```

The unprefixed spellings stay inside `attrs`, which passes the store's own CF attribute names through verbatim. The extension is declared in `stac_extensions` only when a `cf:` field was actually emitted — advertising an extension none of whose fields are present is just something for a client to fetch and check for nothing.

`cell_methods` passes through as the CF string (`"time: mean"`). The extension also defines a per-dimension array form, but permits the plain string, and converting would be guesswork.

**No `bands` array.** The best-practice example carries one alongside `cube:variables`, but OCS datasets are single-variable, so it would duplicate the same information for nothing.

## Verified by running the real gate

The chain is `ol-stac STAC.js:1195 → getDefaultGeoFile('geozarr', true, true)` → `stac-js stac.js:219 asset.isHTTP && asset.isType(wozMediaTypes)`. So calling `getDefaultGeoFile` with ol-stac's exact arguments **is** the gate — no reimplementation needed. Ran it with stac-js 0.5.4 against real collection documents served by a live instance:

```
PASS  worldpop_population_yearly
        advertised    application/vnd.zarr; version=3; profile=multiscales
        byte-identical to stac-js literal: true
        getDefaultGeoFile('geozarr',true,true) -> asset      (expected asset)
        asset.isHTTP: true
PASS  senorge_temperature_daily
        advertised    application/vnd.zarr; version=3
        getDefaultGeoFile('geozarr',true,true) -> undefined  (expected undefined)
```

Across all seven Norway stores, only the genuinely pyramided one changed — matching the ticket's predicted table exactly:

```
WOZ  worldpop_population_yearly                    ...; profile=multiscales
     chirps3_precipitation_daily                   application/vnd.zarr; version=3
     era5land_temperature_monthly                  application/vnd.zarr; version=3
     senorge_precipitation_daily                   application/vnd.zarr; version=3
     senorge_temperature_daily                     application/vnd.zarr; version=3
     senorge_temperature_daily_anomaly_1991_2020   application/vnd.zarr; version=3
     senorge_temperature_daily_normal_1991_2020    application/vnd.zarr; version=3
```

`asset.isHTTP` was worth checking rather than assuming: a `false` there drops the asset *before* the media type is consulted. Our `/zarr/{id}` href is relative, and it resolves correctly against the collection self link.

Also confirmed the store satisfies OpenLayers' own gate — all three `REQUIRED_ZARR_CONVENTIONS` UUIDs present and `'layout' in attributes.multiscales` — so OL takes its full multiscale path rather than bailing.

CF fields confirmed on three real collections (seNorge, CHIRPS3, ERA5-Land). WorldPop's store carries no CF attributes, so it emits none and the extension stays undeclared: the conditional working on real data.

## Two corrections to the ticket

- **The match is case-insensitive**, not case-sensitive as the ticket states. `isMediaType` lowercases both sides before `includes`. Parameter *order and spacing* are what must be exact.
- **The CRS blocker doesn't apply to the STAC path.** WorldPop's collection already reports `proj:code: EPSG:4326`, because collection building reads pyramid level 0 (correct) rather than the root (stale `EPSG:32633`). The mislocation risk is real but store-side — `ol/source/GeoZarr` reads the store's root — and it's what part 2 fixes. This particular existing store stays wrong until re-ingested.

## What stays unrenderable, and why

Six of Norway's seven datasets still won't render in STAC Browser no matter what we publish. `ol-stac` hardcodes optimized-only for GeoZarr while giving GeoTIFF an opt-in flag:

```js
const geotiff = data.getDefaultGeoFile('geotiff', true, !this.displayGeoTiffByDefault_);
const geozarr = data.getDefaultGeoFile('geozarr', true, true);   // hardcoded
```

`ol/source/GeoZarr` itself supports single-resolution stores. Two upstream issues are worth filing — an `ol-stac` `displayZarrByDefault` option mirroring the GeoTIFF one, and `stac-js` parsing media type parameters instead of matching a literal (it carries its own `@todo` admitting this). I haven't filed them; say the word and I will. Until the first lands, zarr-viewer (part 1) remains the better viewer for most of the catalog.

## Tests

- 21 in `test_geozarr_media_type.py`, three of which write **real Icechunk stores through the actual pipeline** — including one pinning that level 0's attrs carry no `multiscales.layout`. If detection ever read through those, every pyramided store would silently look flat.
- 5 in `test_stac.py`: the plumbing to the payload, the per-request cache, the artifact-id-vs-path keying, and the CF extension staying undeclared when there's nothing to declare.

```
582 passed
make lint clean (ruff, format, mypy 83 files, pyright)
```

---

# Part 4 — guarantee y descending (row 0 = north)

This reverses part 2's y-direction decision, and the reason is worth recording: part 2 checked
carbonplan/zarr-layer, which detects the direction from the coordinate array, and concluded the
direction was a free choice. That was the viewer we control. Two consumers assume a direction and
never check — and one of them isn't ours to fix.

## OpenLayers cannot detect it

`ol/source/GeoZarr` is the renderer STAC Browser uses, which part 3 just unlocked. It derives its
tile grid origin as the top-left corner and counts rows down from it:

```js
const origin = [extent[0], extent[3]];                                  // top-left
const minRow = Math.round((origin[1] - tileExtent[3]) / bandResolution);
... get(array, [slice(minRow, maxRow), colSlice])                        // straight into the array
```

No `reverse`, no `flip`, and no read of `spatial:transform`'s y step anywhere in that file. Array
row 0 is always painted at the north edge. Running its own arithmetic for a 3°-tall grid of 0.05°
rows:

```
OL asks for array row 0 to paint the northern tile (lat ~59.975)
  descending store: row 0 holds lat 59.975  -> CORRECT
  ascending  store: row 0 holds lat 57.025  -> WRONG, mirrored by 2.95 deg
```

**Result thumbnails** are the second: `imshow(..., origin="upper")` straight off the array. That's
a live bug today for the ~13 instance plugins that ship ascending — presumably unnoticed because
thumbnails are decorative.

## Why descending

| | descending | ascending |
|---|---|---|
| OpenLayers / STAC Browser | correct | mirrored, undetectably |
| zarr-layer (the `/map` viewer) | detects from the coordinate | detects from the coordinate |
| GDAL `GeoTransform` | negative y step — the north-up convention | positive — legal but unusual |
| cost for a typical source | none, already north-up | reverses every raster |

zarr-layer doesn't constrain the choice; OpenLayers does. Descending also keeps the GeoTransform
part 1 added pointing the way GDAL expects, and is a no-op for the built-ins.

## The one real hazard, guarded rather than noted

Reversing rows reorders the array, and an append writes along the time axis only — committed
coordinate arrays stay as they are. A normalised period appended to a store written the other way
would put rows under coordinates that no longer describe them: **silently mirrored data**,
categorically worse than the stale metadata elsewhere in this PR.

So an ingest compares the committed axes before its first append and fails with both ranges named:

```
Cannot append to senorge_temperature_daily.icechunk: its committed 'y' coordinates do not
match the normalised ones for this period (store 57.0…60.0, period 60.0…57.0). The store
predates the published-store layout contract (y descending, longitudes −180…180); appending
would write data under coordinates that no longer describe it. Re-ingest this dataset from
scratch to rebuild it under the current contract.
```

The same hazard applies to the longitude roll, so **that now runs in the streaming path too**,
behind the same guard. It was previously rewrite-only, which meant flat streaming stores — the ones
`_maybe_build_pyramid` skips — never got it. One guard, both value-changing invariants, both
paths: more coherent than what it replaces.

## Also

The thumbnail renderer now flips a south-up cube before drawing rather than trusting the
guarantee. Published stores can't reach it south-up, but an in-flight openEO result can, and the
check is two lines.

## Verified end to end

A south-up source through the real write path:

```
source  y[0]=57.00 (south),  row 0 marker = 111.0
stored  y[0]=58.95 (north), row 0 marker = 999.0
  y descends .......................... True
  row 0 holds the NORTH marker (999) .. True
  data followed: lat 57.00 still 111 .. True
  spatial:transform stepY negative .... True
  GeoTransform ........................ 9.975 0.05 0.0 58.975 0.0 -0.05
  contract violations ................. []
```

The value at a given latitude doesn't move — only its row index does. The 12 zarr-viewer
assertions and the STAC render gate both still pass unchanged.

## Tests

12 new: the reversal, the no-op on north-up input (asserting the array isn't copied), data moving
with the coordinate, the contract check, and the append guard against a **real pre-contract
Icechunk store** written south-up.

```
594 passed
make lint clean (ruff, format, mypy 83 files, pyright)
```

## Consequence for the instance repos

The ~13 hand-rolled `if y[0] > y[-1]: isel(y=slice(None,None,-1))` flips in the
Nepal/Malawi/Uganda plugins now flip *away* from the guarantee, and OCS flips them back. Net
correct, but wasted work and misleading comments — those flips can be deleted. Their existing
stores are ascending and will hit the append guard on next sync, needing one re-ingest each.

---

# Part 5 — the HTTP surface the viewers actually meet

Parts 1–4 concern what we *write*. This part concerns what we *serve*, and every item was found
the same way: by pointing real hosted viewers at a running instance instead of reasoning about
it. All four presented as something other than what they were.

## The hosted viewer wasn't allowed, and said so misleadingly

`source-cooperative.github.io` was not in the origin allowlist, so it got no
`Access-Control-Allow-Origin` on `/zarr` and no network-access opt-in. The viewer reported
*"your connection looks slow or unstable — check your network"*, sending an operator to debug a
network that is fine.

It is now a default alongside `inspect.geozarr.org`. CLIM-852 is *about* that viewer, so
requiring every operator to discover an environment variable before they could use it made the
feature undiscoverable.

## Chrome ships two spellings of the same opt-in

Private Network Access, and its successor Local Network Access. We answered only the former.
Which one a browser sends depends on its version, and guessing wrong is indistinguishable from
the server being unreachable. Both request headers are now recognised, and both response headers
sent.

**Not ours: the permission.** Current Chrome additionally requires a *user grant* to reach the
loopback address space:

```
blocked by CORS policy: Permission was denied for this request
to access the `loopback` address space
```

"Permission was denied", not a missing header — no server change fixes it. Documented in
`zarr_and_geozarr.md` with the three real options (grant it for the site, run the viewer from
localhost too, or expose the instance on a public HTTPS origin), plus the note that the viewer's
own error text misattributes this to the network.

## A 500 that presented as a CORS error

zarr-viewer probes an unknown store for `repo` and `refs/branch.main/ref.json` to decide whether
a URL is an Icechunk repository. Icechunk rejects those with `IcechunkError: invalid zarr key
format`, which `_icechunk_exists` did not catch — it handled only the `KeyError` raised for Zarr
v2 spellings (`.zgroup`, `.zarray`). The probe returned 500 instead of 404.

Worse than the wrong status: **an unhandled 500 is raised above the CORS middleware**, so it
reached the browser with no `Access-Control-Allow-Origin` and was reported as a CORS failure.
Nobody debugging that message would go looking for a missing-key bug. Both exceptions mean the
same thing — not here — so both now answer `False`.

## The most obvious URL 404'd

`/zarr/{id}/` returned `{"detail":"Not found"}` for every dataset, and `/zarr/{id}` redirects
straight into it — so the URL a person actually pastes made a perfectly good store look like a
missing one.

No Zarr library hit this: zarrita and friends treat the URL as a base and append keys, so they
request `.../zarr.json` and never the root. That is why the viewer worked while the same URL in
the address bar did not, which is a bad way to find out. The root now serves the group metadata
it stands for — the same document the appended request returns. `/icechunk/{id}/` has the same
shape, so the two endpoints stay consistent.

## Tests

Four added: the hosted viewer allowed with no configuration, an explicitly configured origin
still honoured, and the store root served for both spellings — the last against a real Icechunk
store rather than a stub, since the first attempt stubbed the very function under test.

```
645 passed
make lint clean (ruff, format, mypy 84 files, pyright)
```

The 3 `test_openeo_execution.py` failures noted in part 2 are confirmed environmental, and now
precisely: the local miniforge `proj.db` is `LAYOUT.VERSION.MINOR = 5` where GDAL wants ≥ 6. The
same WKT gives `pyproj.to_epsg() → 4326` but `rasterio.to_epsg() → None`, and `.rio.crs` is a
rasterio CRS. With an unpoisoned `PROJ_DATA` the full suite is 645 passed, 1 skipped, 0 failed.

## The shape of all four

**Works for the library, dead end for the human.** Each of these was invisible to programmatic
access — the Zarr clients never hit them — and fatal to anyone arriving with a browser. That is
the class of bug a conformance ticket like CLIM-852 exists to catch, and none of it would have
surfaced from reading code.


[CLIM-852]: https://dhis2.atlassian.net/browse/CLIM-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-821]: https://dhis2.atlassian.net/browse/CLIM-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-853]: https://dhis2.atlassian.net/browse/CLIM-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-828]: https://dhis2.atlassian.net/browse/CLIM-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

