### PR TITLE
ci(docker): publish linux/arm64 alongside linux/amd64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,127 +4,21 @@ on:
   push:
     branches: [main]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: dhis2/open-climate-service
-
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Set platform slug
-        env:
-          PLATFORM: ${{ matrix.platform }}
-        run: echo "PLATFORM_SLUG=${PLATFORM//\//-}" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # Push untagged, addressed by digest only. The merge job collects the
-      # per-architecture digests into a single tagged manifest list.
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_SLUG }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
       id-token: write
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/dhis2/open-climate-service
+      set-meta-labels: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Create and push manifest list
-        working-directory: /tmp/digests
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.target["docker.metadata"].tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(for d in *; do printf '%s@sha256:%s ' "$IMAGE" "$d"; done)
-
-      - name: Inspect manifest list
-        id: inspect
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-        run: |
-          docker buildx imagetools inspect "$IMAGE"
-          digest=$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
-          push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,14 +9,25 @@ env:
   IMAGE_NAME: dhis2/open-climate-service
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
     steps:
+      - name: Set platform slug
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_SLUG=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
@@ -29,25 +40,91 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push
-        id: push
+      # Push untagged, addressed by digest only. The merge job collects the
+      # per-architecture digests into a single tagged manifest list.
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_SLUG }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.target["docker.metadata"].tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(for d in *; do printf '%s@sha256:%s ' "$IMAGE" "$d"; done)
+
+      - name: Inspect manifest list
+        id: inspect
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE"
+          digest=$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Publishes `ghcr.io/dhis2/open-climate-service` as a multi-arch image covering `linux/amd64` and `linux/arm64`.

## Approach

Uses the Docker-maintained [`docker/github-builder`](https://github.com/docker/github-builder) `build.yml` reusable workflow (as suggested in review), which replaces the hand-rolled matrix/digest/merge pipeline from earlier revisions of this PR. The entire workflow is now a single job call:

- `platforms: linux/amd64,linux/arm64` with the default `distribute: true` fans the build out across **native runners** — arm64 lands on `ubuntu-24.04-arm`, no QEMU. The repo is public, so arm runners are free; emulation would have cost roughly 5-10x the build time for no benefit. The two builds run in parallel, so wall-clock stays close to where it is today.
- The reusable workflow owns Buildx setup, per-arch digest pushes, manifest-list assembly, and tagging internally.
- Provenance is signed by the workflow itself (`sign: auto` default, cosign-based) rather than `actions/attest-build-provenance`, and covers the manifest list — previously only a single amd64 image digest was attested.

## Notes

- **No source builds on arm64.** Every binary dependency in `uv.lock` ships a `manylinux...aarch64` wheel — only `pywin32` lacks one, and that's Windows-only. The `uv` base image is already a multi-arch index including `linux/arm64`.
- **Tags are unchanged.** Same `docker/metadata-action` defaults (via `meta-images`), so `ghcr.io/dhis2/open-climate-service:latest` (referenced by `compose.ghcr.yml`) keeps resolving — now to a multi-arch index. `set-meta-labels: true` preserves the OCI labels the old workflow applied.
- **Pinned to `@v1`** (currently v1.16.0). The workflow is young; if anything misbehaves, the previous hand-rolled buildx pattern in this PR's history is a known-good fallback.
- **No build cache added.** The workflow supports `cache: true` (GHA backend), but this image is large and two architectures would likely thrash the 10 GB per-repo cache limit. Worth revisiting separately if build times become a problem.

## Follow-up, not included here

`Dockerfile:11-21` installs `build-essential`, `cython3`, `libgeos-dev`, and `libproj-dev`, justified by a comment about cartopy needing to compile from source on aarch64. **cartopy is no longer a dependency** — the comment and probably the packages are stale (shapely/pyproj/rasterio all vendor their own GEOS/PROJ/GDAL in wheels). Only `libeccodes-dev` is still genuinely needed, since the `eccodes` wheel dlopens the system library. Dropping the rest would cut a few hundred MB per architecture, but it deserves its own PR with a verified local build.

## Verification

The YAML parses (actionlint clean) and the inputs/secrets match the reusable workflow's `workflow_call` definition at `v1`. The workflow only triggers on push to `main`, so merging is the test — the first main build's GHCR output (tags, index, signed attestation) should be checked after merge.
