### PR TITLE
feat(ingest): dekadal period type, and day-weighted dekad aggregation

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -157,6 +157,18 @@ from the dimension's metadata, so there's nothing extra to configure.
 | `sync.execution`     | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync                                                                                                                                                 |
 | `temporal_direction` | No       | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below                                                                                               |
 
+!!! warning "A rejected template stops its whole file from loading"
+
+    Template validation raises rather than skipping, and the error propagates: one invalid
+    template aborts loading of **every template in that YAML file** (or that plugin), not just
+    its own. This is deliberate — a partially loaded registry is harder to diagnose than a
+    refusal — but it means a single typo takes out its neighbours.
+
+    `period_type` became required for non-`static` datasets and validated against the list
+    above, so a template that omitted it, or carried an unsupported value such as `quarterly`,
+    registered before and is now rejected. If you maintain your own dataset plugins, check
+    them before upgrading.
+
 ### Dekads: a period type with no fixed length
 
 `dekadal` is 10-daily data, and is the one cadence whose periods differ in length: a dekad

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -152,7 +152,7 @@ from the dimension's metadata, so there's nothing extra to configure.
 
 | Field            | Required | Description                                                                                       |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `dekadal`, `weekly`, `monthly`, `quarterly`, `yearly`, or `climatology`. Validated at registration — an unrecognised value is rejected rather than ignored |
+| `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `dekadal`, `weekly`, `monthly`, `yearly`, or `climatology`. Validated at registration — an unrecognised value is rejected rather than silently ignored, and it is required unless `sync.kind` is `static` |
 | `sync.kind`      | Yes      | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced        |
 | `sync.execution` | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync |
 | `temporal_direction` | No   | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below |

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -180,8 +180,10 @@ first and last day, which is the only complete description of a dekad's extent.
 
 Aggregating dekads to months needs care rather than a plain `mean`: three dekads tile a
 month exactly, but they are not equal in length, so an unweighted mean over-weights a short
-third dekad (February's 8-day dekad by nearly 5 percentage points). Sum an accumulated
-total, or day-weight a rate.
+third dekad (February's 8-day dekad by nearly 5 percentage points, a 14% relative error on
+its contribution). Use the built-in **`aggregate_dekads_to_period`** workflow, which weights
+each dekad by the days it shares with the target period — `method: mean` for a per-day rate,
+`method: sum` for a per-dekad total, which it conserves exactly.
 
 ### Which way the periods run: `temporal_direction`
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -152,10 +152,36 @@ from the dimension's metadata, so there's nothing extra to configure.
 
 | Field            | Required | Description                                                                                       |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `monthly`, `yearly`                                       |
+| `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `dekadal`, `weekly`, `monthly`, `quarterly`, `yearly`, or `climatology`. Validated at registration — an unrecognised value is rejected rather than ignored |
 | `sync.kind`      | Yes      | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced        |
 | `sync.execution` | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync |
 | `temporal_direction` | No   | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below |
+
+### Dekads: a period type with no fixed length
+
+`dekadal` is 10-daily data, as published by the Copernicus Land Monitoring Service among
+others. It is the one cadence whose periods differ in length: a dekad runs day 1–10, then
+11–20, then **21 to the end of the month**, so the third is 8, 9, 10 or 11 days long. There
+are 36 in a year, not 36.5.
+
+Two consequences worth knowing:
+
+- **Period ids are the dekad's first day** — `2026-01-01`, `2026-01-11`, `2026-01-21`. They
+  sort chronologically and parse as ordinary dates. Any date within a dekad normalises to
+  its start, so `2026-01-15` becomes `2026-01-11`.
+- **There is no ISO 8601 duration for a dekad**, so the STAC temporal dimension declares
+  `step: null` — the datacube extension's encoding for irregular spacing — rather than a
+  fictional `P10D` that would be wrong for every third dekad. Clients read the timestamps
+  instead of extrapolating from a step.
+
+A plugin enumerating dekads should use `shared.time.dekad_period_ids(start, end)`, the
+dekadal counterpart of `daily_period_ids`. `dekad_bounds(period_id)` gives the inclusive
+first and last day, which is the only complete description of a dekad's extent.
+
+Aggregating dekads to months needs care rather than a plain `mean`: three dekads tile a
+month exactly, but they are not equal in length, so an unweighted mean over-weights a short
+third dekad (February's 8-day dekad by nearly 5 percentage points). Sum an accumulated
+total, or day-weight a rate.
 
 ### Which way the periods run: `temporal_direction`
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -150,19 +150,18 @@ from the dimension's metadata, so there's nothing extra to configure.
 
 **Period and sync**
 
-| Field            | Required | Description                                                                                       |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `period_type`    | Yes      | Temporal resolution: `hourly`, `daily`, `dekadal`, `weekly`, `monthly`, `yearly`, or `climatology`. Validated at registration — an unrecognised value is rejected rather than silently ignored, and it is required unless `sync.kind` is `static` |
-| `sync.kind`      | Yes      | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced        |
-| `sync.execution` | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync |
-| `temporal_direction` | No   | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below |
+| Field                | Required | Description                                                                                                                                                                                                                                       |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `period_type`        | Yes      | Temporal resolution: `hourly`, `daily`, `dekadal`, `weekly`, `monthly`, `yearly`, or `climatology`. Validated at registration — an unrecognised value is rejected rather than silently ignored, and it is required unless `sync.kind` is `static` |
+| `sync.kind`          | Yes      | `temporal` — data grows over time; `release` — versioned releases; `static` — never synced                                                                                                                                                        |
+| `sync.execution`     | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync                                                                                                                                                 |
+| `temporal_direction` | No       | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below                                                                                               |
 
 ### Dekads: a period type with no fixed length
 
-`dekadal` is 10-daily data, as published by the Copernicus Land Monitoring Service among
-others. It is the one cadence whose periods differ in length: a dekad runs day 1–10, then
-11–20, then **21 to the end of the month**, so the third is 8, 9, 10 or 11 days long. There
-are 36 in a year, not 36.5.
+`dekadal` is 10-daily data, and is the one cadence whose periods differ in length: a dekad
+runs day 1–10, then 11–20, then **21 to the end of the month**, so the third is 8, 9, 10
+or 11 days long. There are 36 in a year.
 
 Two consequences worth knowing:
 
@@ -178,35 +177,28 @@ A plugin enumerating dekads should use `shared.time.dekad_period_ids(start, end)
 dekadal counterpart of `daily_period_ids`. `dekad_bounds(period_id)` gives the inclusive
 first and last day, which is the only complete description of a dekad's extent.
 
-Aggregating dekads to months needs care rather than a plain `mean`: three dekads tile a
-month exactly, but they are not equal in length, so an unweighted mean over-weights a short
-third dekad (February's 8-day dekad by nearly 5 percentage points, a 14% relative error on
-its contribution). Use the built-in **`aggregate_dekads_to_period`** workflow, which weights
-each dekad by the days it shares with the target period — `method: mean` for a per-day rate,
-`method: sum` for a per-dekad total, which it conserves exactly.
-
 ### Which way the periods run: `temporal_direction`
 
 Most datasets are historical, and the default (`past`) suits them. Two other shapes exist, and they behave differently at ingest time:
 
-| Value | Periods | `start` on an ingestion |
-| --- | --- | --- |
-| `past` (default) | All historical | Required |
-| `future` | All ahead of now — a forecast | **Optional**, meaning "from now" |
-| `spanning` | Cross now — WorldPop Global2 (2015–2030), climate projections | Required |
+| Value            | Periods                                                       | `start` on an ingestion          |
+| ---------------- | ------------------------------------------------------------- | -------------------------------- |
+| `past` (default) | All historical                                                | Required                         |
+| `future`         | All ahead of now — a forecast                                 | **Optional**, meaning "from now" |
+| `spanning`       | Cross now — WorldPop Global2 (2015–2030), climate projections | Required                         |
 
-`spanning` requires a start *on purpose*. Defaulting it to "now" would ingest only the projected years and silently drop every historical one, which is usually the half you actually want. What declaring it does buy you: the ingest form prefills the end from the dataset's declared `extents.temporal.end`, so selecting WorldPop offers the full range through 2030 instead of truncating at today.
+`spanning` requires a start _on purpose_. Defaulting it to "now" would ingest only the projected years and silently drop every historical one, which is usually the half you actually want. What declaring it does buy you: the ingest form prefills the end from the dataset's declared `extents.temporal.end`, so selecting WorldPop offers the full range through 2030 instead of truncating at today.
 
 ### Forecast datasets (`temporal_direction: future`)
 
-A forecast's periods lie in the *future*, which changes what an ingestion request means. Declare it:
+A forecast's periods lie in the _future_, which changes what an ingestion request means. Declare it:
 
 ```yaml
 - id: tmax_forecast_daily
   period_type: daily
   temporal_direction: future
   sync:
-    kind: temporal          # still temporal: re-running fetches a fresher forecast
+    kind: temporal # still temporal: re-running fetches a fresher forecast
   ingestion:
     plugin: datasets.my_forecast.MyForecastPlugin
     params:
@@ -223,7 +215,7 @@ curl -X POST http://localhost:9000/ingestions \
 
 Omitting it is usually what you want. A fixed `start` is only correct on the day it is written — tomorrow it under-requests — so a scheduled refresh with hardcoded dates drifts out of the forecast window and then quietly fetches nothing. Supplying `start`/`end` still works, and narrows the window when you deliberately want a subset.
 
-**What your `periods()` receives.** For a historical dataset an omitted end is filled in with "now" — "through the latest available period". A forecast cannot use that, because "now" is the *start* of its window: filling it in would hand you `start == end == today` and collapse a seven-day forecast to one day. So a forecast instead receives a **forward horizon** — the template's declared `extents.temporal.end` if it has one, otherwise a year ahead. It is deliberately generous: the real limit is your plugin's lead time, and a tighter bound in core would silently truncate a longer forecast.
+**What your `periods()` receives.** For a historical dataset an omitted end is filled in with "now" — "through the latest available period". A forecast cannot use that, because "now" is the _start_ of its window: filling it in would hand you `start == end == today` and collapse a seven-day forecast to one day. So a forecast instead receives a **forward horizon** — the template's declared `extents.temporal.end` if it has one, otherwise a year ahead. It is deliberately generous: the real limit is your plugin's lead time, and a tighter bound in core would silently truncate a longer forecast.
 
 Your plugin clips to what it actually publishes:
 
@@ -240,17 +232,17 @@ Note `end` stays a plain `str`, so there is no missing-value case to handle.
 
 `temporal_direction` is separate from `sync.kind` on purpose: a forecast is still `temporal` for sync (re-run it and you get fresher data); what differs is which way its periods run. It cannot be combined with `sync.kind: static`, which has no upstream to look ahead into.
 
-**How far ahead belongs in the template, not the request.** A source often publishes further out than is useful — 40 days when only 7 verify well. That cap is a property of the dataset, so express it in `ingestion.params` (as `max_lead_days` above) and let your plugin's `periods()` honour it. The request then narrows *within* that window rather than re-deciding it on every run.
+**How far ahead belongs in the template, not the request.** A source often publishes further out than is useful — 40 days when only 7 verify well. That cap is a property of the dataset, so express it in `ingestion.params` (as `max_lead_days` above) and let your plugin's `periods()` honour it. The request then narrows _within_ that window rather than re-deciding it on every run.
 
 The response reports the window that was actually ingested, under `dataset.extent.temporal`, so you can confirm what an omitted `start` resolved to.
 
 **Ingestion**
 
-| Field              | Required | Description                                                                                      |
-| ------------------ | -------- | ------------------------------------------------------------------------------------------------ |
-| `ingestion.plugin` | Yes      | Dotted path to the streaming plugin class                                                        |
-| `ingestion.params` | No       | Extra keyword arguments forwarded to `fetch_period` as `**params`, and to the plugin constructor |
-| `ingestion.resampling` | No   | Pyramid coarsening for large layers: `mean` (default; continuous data), `max`/`min`/`sum`, or `mode`/`nearest` for categorical data — see below |
+| Field                  | Required | Description                                                                                                                                     |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ingestion.plugin`     | Yes      | Dotted path to the streaming plugin class                                                                                                       |
+| `ingestion.params`     | No       | Extra keyword arguments forwarded to `fetch_period` as `**params`, and to the plugin constructor                                                |
+| `ingestion.resampling` | No       | Pyramid coarsening for large layers: `mean` (default; continuous data), `max`/`min`/`sum`, or `mode`/`nearest` for categorical data — see below |
 
 Multiple templates can share the same plugin class and differ only in `params`:
 
@@ -274,9 +266,9 @@ Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map sta
 
 - **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
 - **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.
-- **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a *different, non-existent* class (e.g. `mean(10, 80) = 45`).
+- **Multi-class categorical** (land-cover class codes, etc.) — use `mode` (majority class). `mean` would average class codes into a _different, non-existent_ class (e.g. `mean(10, 80) = 45`).
 
-`mean`/`max`/`min`/`sum`/`nearest` are computed by [topozarr](https://github.com/carbonplan/topozarr), which builds each level from the one above. That is valid for all five because they are *composable* — for `nearest`, taking the corner of each corner gives the same cell as taking every nth cell of the original.
+`mean`/`max`/`min`/`sum`/`nearest` are computed by [topozarr](https://github.com/carbonplan/topozarr), which builds each level from the one above. That is valid for all five because they are _composable_ — for `nearest`, taking the corner of each corner gives the same cell as taking every nth cell of the original.
 
 `mode` is not composable: mode-of-modes is not mode-of-native, since a locally dominant class can win at coarse zoom even when it is globally rare. So Open Climate Service resamples `mode` levels from the native resolution itself. A first-class `mode` upstream is still open as [carbonplan/topozarr#26](https://github.com/carbonplan/topozarr/issues/26); when it lands, that local path can go.
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -157,18 +157,6 @@ from the dimension's metadata, so there's nothing extra to configure.
 | `sync.execution`     | No       | `append` — new time steps appended to existing store; `rematerialize` — full rebuild on each sync                                                                                                                                                 |
 | `temporal_direction` | No       | Which way the periods run relative to now: `past` (default), `future` (a forecast), or `spanning` (crosses now, e.g. WorldPop 2015–2030). See below                                                                                               |
 
-!!! warning "A rejected template stops its whole file from loading"
-
-    Template validation raises rather than skipping, and the error propagates: one invalid
-    template aborts loading of **every template in that YAML file** (or that plugin), not just
-    its own. This is deliberate — a partially loaded registry is harder to diagnose than a
-    refusal — but it means a single typo takes out its neighbours.
-
-    `period_type` became required for non-`static` datasets and validated against the list
-    above, so a template that omitted it, or carried an unsupported value such as `quarterly`,
-    registered before and is now rejected. If you maintain your own dataset plugins, check
-    them before upgrading.
-
 ### Dekads: a period type with no fixed length
 
 `dekadal` is 10-daily data, and is the one cadence whose periods differ in length: a dekad

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,7 +233,7 @@ Plugin code (streaming plugins, `@process` functions) can rely on the following 
 | Axis order `(…, y, x)` and `y` descending                     | `normalize_dim_layout` / `normalize_y_direction` |
 | Longitudes rolled to −180…180 for geographic data             | `normalize_longitudes`                           |
 | CRS kept consistent with the coordinates (never reprojected)  | `resolve_store_crs`                              |
-| Zarr chunking (auto-sized from `extents.temporal.resolution`) | `time_chunk_for_iso_step`                        |
+| Zarr time-coordinate chunking (bounded for browser axis reads) | `ensure_time_coordinate_chunking`                |
 | Multiscale pyramid generation (when dims > 2048×2048)         | `write_to_icechunk_store`                        |
 | GeoZarr root attributes (`spatial:transform`, `proj:code`, …) | `grid_geometry` / `write_geozarr_attrs`          |
 | Artifact coverage computation                                 | `_coverage_from_dataset`                         |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -174,6 +174,42 @@ When the job finishes, the new change dataset appears under `/datasets` and on t
 
 ---
 
+## Aggregating dekads to months or weeks
+
+`aggregate_dekads_to_period` turns a published **dekadal** (10-daily) dataset into a monthly
+or weekly one, weighting each dekad by the number of days it shares with the target period.
+
+The weighting is the point. Dekads run day 1–10, 11–20, then 21 to the end of the month, so
+the third is 8, 9, 10 or 11 days long. Three of them tile a calendar month exactly, but they
+are not equal, so a plain `mean` over-weights a short third dekad — February's 8-day dekad by
+4.8 percentage points, a 14% relative error on its contribution. The error is systematic
+rather than noise: it always favours short dekads, so an unweighted monthly series carries a
+seasonal artefact that follows month length.
+
+Pick `method` by what the variable is:
+
+| `method` | For | Result |
+|---|---|---|
+| `mean` (default) | a per-day **rate**, e.g. CLMS GPP in `gC/m²/day` | the target period's average daily value, same units |
+| `sum` | a per-dekad **total** | the target period's total, conserved exactly regardless of dekad length |
+
+Passing `sum` for a per-day rate is logged as a warning — adding daily rates does not produce
+a total.
+
+`period: week` exists but is rarely what you want: dekads and ISO weeks never align (36
+against 52 or 53), so a weekly series has an effective resolution of about 10 days however it
+is derived, and the weights must be recomputed per year. Monthly is exact by comparison.
+
+**Not interpolation, deliberately.** Splining through dekad midpoints does not conserve the
+annual total, invents sub-dekad structure the sensor never observed, and can undershoot below
+zero for a non-negative quantity. If a smooth daily curve is ever genuinely needed, the
+defensible route is mean-preserving interpolation, not a plain spline.
+
+The output variable carries a `cell_methods` recording the weighting, so a consumer can tell a
+day-weighted aggregate from an observation. A partially covered period at either end of the
+record is computed from the dekads that exist rather than returning empty, and a dekad missing
+over part of the grid is dropped from the weights *there* and the remainder renormalised.
+
 ## Three sources of workflows
 
 Workflows are loaded from three places, each overriding the previous on id collision:

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -36,6 +36,34 @@ _PYRAMID_TARGET_TILE_SIZE = 512
 _ROOT_TIME_COORD_MAX_CHUNK = 4096
 
 
+def _uniform_chunks(ds: xr.Dataset) -> xr.Dataset:
+    """Rechunk any dim whose dask chunks are non-uniform except for the final chunk.
+
+    Zarr requires that shape; dask does not. Reversing an axis produces exactly the illegal
+    case — ``raster_contract.ensure_north_up`` flips a south-up source with
+    ``isel(slice(None, None, -1))``, which reverses the chunk *tuple* too, so a legal
+    trailing remainder (244, 244, …, 241) becomes a leading one (241, 244, …) and
+    ``to_zarr`` refuses the write.
+
+    Rechunking to the largest existing chunk restores the source layout, since dask fills
+    uniformly and leaves the remainder last. Only the flat path needs this — the pyramid
+    path materialises through ``load()`` before writing.
+    """
+    targets: dict[Any, int] = {}
+    for var in ds.data_vars.values():
+        for dim, chunks in zip(var.dims, var.chunks or (), strict=False):
+            # Legal already when every chunk but the last matches and the last is no larger.
+            # Checked rather than blanket-rechunked because rechunking a full-resolution grid
+            # costs a graph rewrite and a shuffle for nothing.
+            if len(set(chunks[:-1])) <= 1 and chunks[-1] <= chunks[0]:
+                continue
+            targets[dim] = max(targets.get(dim, 0), max(chunks))
+    if not targets:
+        return ds
+    logger.info("Rechunking to uniform Zarr-legal chunks: %s", targets)
+    return ds.chunk(targets)
+
+
 def _needs_pyramid(ds: xr.Dataset, x_dim: str, y_dim: str) -> bool:
     """Return True when the spatial extent is large enough to benefit from a pyramid."""
     return ds.sizes[x_dim] * ds.sizes[y_dim] > _PYRAMID_PIXEL_THRESHOLD
@@ -443,6 +471,7 @@ def write_to_icechunk_store(
             ds.sizes[y_dim],
         )
         ds = ds.assign_attrs({**ds.attrs, **geozarr_attrs})
+        ds = _uniform_chunks(ds)
         # Bound the time-coordinate chunk so map clients read the axis in a few requests
         # rather than one per timestep (data variables keep their own chunking).
         flat_encoding = {}

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -46,8 +46,17 @@ def _uniform_chunks(ds: xr.Dataset) -> xr.Dataset:
     ``to_zarr`` refuses the write.
 
     Rechunking to the largest existing chunk restores the source layout, since dask fills
-    uniformly and leaves the remainder last. Only the flat path needs this — the pyramid
-    path materialises through ``load()`` before writing.
+    uniformly and leaves the remainder last.
+
+    Only the flat path needs this. The pyramid path is unaffected because topozarr plans its
+    own chunk layout per level from ``target_chunk_bytes`` rather than inheriting the source's,
+    so a reversed tuple never reaches the write. (Deliberately not "because the pyramid path
+    calls ``load()``" — it does today, but that materialisation is being removed, and this
+    would then read as a guarantee that no longer holds.)
+
+    Applied per dimension across the whole dataset, so a variable with a legal layout can be
+    rechunked because a sibling on the same dim was illegal. Harmless, and only when at least
+    one variable needs it.
     """
     targets: dict[Any, int] = {}
     for var in ds.data_vars.values():

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -9,7 +9,7 @@ from typing import Any
 import yaml
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.time import SUPPORTED_PERIOD_TYPES, Cadence, period_cadence
+from open_climate_service.shared.time import SUPPORTED_PERIOD_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -291,11 +291,21 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     # silently ignored — no step, no period normalisation, no error. Reject it here so a
     # typo or a cadence this version cannot honour fails at registration.
     period_type = dataset.get("period_type")
-    if period_type is not None and period_cadence(period_type) is Cadence.UNKNOWN:
+    if period_type is not None and period_type not in SUPPORTED_PERIOD_TYPES:
         supported = ", ".join(sorted(SUPPORTED_PERIOD_TYPES))
         raise ValueError(
             f"Dataset template '{dataset_id}' in {source} has unsupported period_type "
             f"{period_type!r}. Supported values: {supported}"
+        )
+    # A temporal or release dataset must declare its cadence: sync planning and coverage
+    # index period_type unguarded, so an absent one registers and then raises a KeyError
+    # further in. Static datasets are exempt — an openEO save_result output is static and
+    # legitimately has no cadence when none can be derived, and sync planning returns for
+    # static before it reads the field.
+    if period_type is None and sync_kind != "static":
+        raise ValueError(
+            f"Dataset template '{dataset_id}' in {source} must define period_type "
+            f"(required for sync.kind '{sync_kind}')"
         )
 
     direction = dataset.get("temporal_direction")

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -9,6 +9,7 @@ from typing import Any
 import yaml
 
 from open_climate_service import config as api_config
+from open_climate_service.shared.time import SUPPORTED_PERIOD_TYPES, Cadence, period_cadence
 
 logger = logging.getLogger(__name__)
 
@@ -284,6 +285,17 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
         raise ValueError(
             f"Dataset template '{dataset_id}' in {source} has unsupported sync.kind "
             f"'{sync_kind}'. Supported values: {supported}"
+        )
+
+    # An unsupported period_type is accepted by every downstream consumer and then
+    # silently ignored — no step, no period normalisation, no error. Reject it here so a
+    # typo or a cadence this version cannot honour fails at registration.
+    period_type = dataset.get("period_type")
+    if period_type is not None and period_cadence(period_type) is Cadence.UNKNOWN:
+        supported = ", ".join(sorted(SUPPORTED_PERIOD_TYPES))
+        raise ValueError(
+            f"Dataset template '{dataset_id}' in {source} has unsupported period_type "
+            f"{period_type!r}. Supported values: {supported}"
         )
 
     direction = dataset.get("temporal_direction")

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -49,7 +49,13 @@ from open_climate_service.ingestions.schemas import (
 )
 from open_climate_service.ingestions.sync_engine import SyncConfigurationError, plan_sync, run_sync
 from open_climate_service.publications.services import managed_dataset_id_for, publish_artifact
-from open_climate_service.shared.time import datetime_to_period_string, normalize_period_string, utc_now, utc_today
+from open_climate_service.shared.time import (
+    datetime_to_period_string,
+    dekad_start,
+    normalize_period_string,
+    utc_now,
+    utc_today,
+)
 from open_climate_service.streaming.orchestrator import run_streaming_ingest_sync
 from open_climate_service.streaming.protocol import IngestionPlugin
 
@@ -1070,6 +1076,8 @@ def _current_request_period(period_type: str) -> str:
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "daily":
         return utc_today().isoformat()
+    if period_type == "dekadal":
+        return dekad_start(utc_today()).isoformat()
     if period_type == "weekly":
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "monthly":

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -32,6 +32,8 @@ from open_climate_service.ingestions.schemas import (
 from open_climate_service.publications.services import managed_dataset_id_for
 from open_climate_service.shared.time import (
     datetime_to_period_string,
+    dekad_bounds,
+    dekad_start,
     normalize_period_string,
     parse_hourly_period_string,
     parse_period_string_to_datetime,
@@ -380,6 +382,11 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
     if period_type == "daily":
         current = date.fromisoformat(latest_period_end)
         return (current + timedelta(days=1)).isoformat()
+    if period_type == "dekadal":
+        # Step by the covered dekad's own length rather than a fixed 10 days, since the
+        # third dekad of a month runs 8-11 days.
+        _, dekad_end = dekad_bounds(latest_period_end)
+        return (dekad_end + timedelta(days=1)).isoformat()
     if period_type == "weekly":
         current = parse_period_string_to_datetime(latest_period_end).date()
         next_week = datetime.combine(current + timedelta(days=7), time(0))
@@ -402,6 +409,8 @@ def _default_target_end(*, period_type: str) -> str:
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "daily":
         return today.isoformat()
+    if period_type == "dekadal":
+        return dekad_start(today).isoformat()
     if period_type == "weekly":
         return datetime_to_period_string(utc_now(), period_type)
     if period_type == "monthly":

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -920,8 +920,13 @@ def _infer_period_type(ds: Any, t_dim: str) -> str | None:
         return "weekly"
     if median_seconds <= 32 * 86400:
         return "monthly"
-    if 80 * 86400 <= median_seconds <= 100 * 86400:
-        return "quarterly"
+    # Deliberately no "quarterly" branch. It is in the STAC step map (so a store that already
+    # carries it still gets P3M) but is not implemented for ingest or coverage:
+    # `datetime_to_period_string` raises on it and `numpy_datetime_to_period_string` KeyErrors,
+    # so inferring it attached a cadence that fails the moment the artifact is written — and
+    # since it is now rejected at registration, it would fail auto-registration outright.
+    # Returning None instead is honest and legal: a managed openEO output is static, and a
+    # static template may carry no cadence. Add the branch back with quarterly support.
     if 330 * 86400 <= median_seconds <= 370 * 86400:
         return "yearly"
     return None

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -899,6 +899,32 @@ def _derive_coverage(ds: Any, x_dim: str, y_dim: str, t_dim: str | None) -> Any:
     )
 
 
+def _is_dekadal_axis(t_values: Any) -> bool:
+    """Whether every timestamp starts a dekad, at dekadal spacing.
+
+    Two conditions, and both are needed:
+
+    * **Every timestamp falls on the 1st, 11th or 21st.** Necessary because a regular 10-day
+      series on any other day of the month is not dekadal, and calling it so would attach a
+      cadence whose period strings mean something else.
+    * **Some adjacent pair is 8 to 11 days apart.** Necessary because the day-of-month test
+      alone accepts a *monthly* axis: every month starts on the 1st, and a monthly-on-the-11th
+      axis is equally a subset. The same trap is guarded in ``aggregate_dekads._dekad_dates``.
+      Tested on the minimum rather than the median so a dekadal axis with missing dekads — a
+      real state, which ``aggregate_dekads`` warns about — is still recognised.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from open_climate_service.shared.time import DEKAD_START_DAYS
+
+    stamps = pd.DatetimeIndex(np.asarray(t_values, dtype="datetime64[ns]"))
+    if not set(stamps.day) <= set(DEKAD_START_DAYS):
+        return False
+    gaps = np.diff(stamps.values).astype("timedelta64[D]").astype(int)
+    return bool(gaps.size and gaps.min() <= 11)
+
+
 def _infer_period_type(ds: Any, t_dim: str) -> str | None:
     """Infer period type from the median time step of a dataset."""
     import numpy as np
@@ -916,24 +942,16 @@ def _infer_period_type(ds: Any, t_dim: str) -> str | None:
         return "hourly"
     if median_seconds <= 86400:
         return "daily"
+    # Dekads are recognised by their structure, not by their interval. A dekad *starts* on the
+    # 1st, 11th or 21st by definition, so testing that is exact where a median is a guess: it
+    # accepts a short axis across a month boundary (Feb 21 -> Mar 1, 8 days) and one with missing
+    # dekads (median 15.5 days), and it refuses unrelated 10-day data that happens to fall on
+    # other days of the month. Placed before the weekly and monthly buckets, which would
+    # otherwise claim both of those cases.
+    if _is_dekadal_axis(t_values):
+        return "dekadal"
     if median_seconds <= 8 * 86400:
         return "weekly"
-    # Dekads sit between weekly and monthly, and without this branch they were read as monthly:
-    # the 32-day bucket swallowed everything from 8 to 32 days. A dekadal axis has steps of
-    # 8 to 11 days (the third dekad runs to the month's end) with a median of exactly 10,
-    # measured over both a single year and three; weekly medians 7 and monthly 30 or 31, so the
-    # 11-day cut separates all three cleanly.
-    #
-    # Safe to infer, unlike the quarterly case below: `datetime_to_period_string`,
-    # `numpy_datetime_to_period_string` and `normalize_period_string` all handle dekadal, and
-    # `period_type_to_iso_step` returning None for it is correct rather than a failure — a dekad
-    # has no fixed ISO duration, which is what `Cadence.IRREGULAR` exists to say.
-    #
-    # Known limit: a two-timestep slice spanning February's short third dekad has a median of 8
-    # and still reads as weekly. Inference from two points is weak in general; a caller that
-    # needs certainty declares `period_type` on the output template.
-    if median_seconds <= 11 * 86400:
-        return "dekadal"
     if median_seconds <= 32 * 86400:
         return "monthly"
     # Deliberately no "quarterly" branch. It is in the STAC step map (so a store that already

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -918,6 +918,22 @@ def _infer_period_type(ds: Any, t_dim: str) -> str | None:
         return "daily"
     if median_seconds <= 8 * 86400:
         return "weekly"
+    # Dekads sit between weekly and monthly, and without this branch they were read as monthly:
+    # the 32-day bucket swallowed everything from 8 to 32 days. A dekadal axis has steps of
+    # 8 to 11 days (the third dekad runs to the month's end) with a median of exactly 10,
+    # measured over both a single year and three; weekly medians 7 and monthly 30 or 31, so the
+    # 11-day cut separates all three cleanly.
+    #
+    # Safe to infer, unlike the quarterly case below: `datetime_to_period_string`,
+    # `numpy_datetime_to_period_string` and `normalize_period_string` all handle dekadal, and
+    # `period_type_to_iso_step` returning None for it is correct rather than a failure — a dekad
+    # has no fixed ISO duration, which is what `Cadence.IRREGULAR` exists to say.
+    #
+    # Known limit: a two-timestep slice spanning February's short third dekad has a median of 8
+    # and still reads as weekly. Inference from two points is weak in general; a caller that
+    # needs certainty declares `period_type` on the output template.
+    if median_seconds <= 11 * 86400:
+        return "dekadal"
     if median_seconds <= 32 * 86400:
         return "monthly"
     # Deliberately no "quarterly" branch. It is in the STAC step map (so a store that already

--- a/open_climate_service/plugins/processes/aggregate_dekads.py
+++ b/open_climate_service/plugins/processes/aggregate_dekads.py
@@ -1,0 +1,179 @@
+"""Built-in openEO process: aggregate a dekadal cube to months or ISO weeks.
+
+Dekads do not have equal lengths — day 1-10, 11-20, then 21 to the end of the month, so
+the third runs 8, 9, 10 or 11 days — which makes a plain ``mean`` the wrong reduction for
+an intensive quantity. Three dekads tile a calendar month exactly, but weighting them
+equally over-weights February's 8-day dekad by 4.8 percentage points, a 14% relative error
+on that dekad's contribution. The bias is systematic rather than noise: it always favours
+short third dekads, so an unweighted monthly series carries a seasonal artefact that
+tracks month length.
+
+This process weights each contributing dekad by the number of days it shares with the
+target period, which is exact under the only model the data supports — that a dekad's
+value describes its whole span uniformly. Weights come from the real calendar via
+``dekad_bounds``, so they are recomputed per year rather than assumed; that matters for
+ISO weeks, which never align with dekads and have no fixed mapping at all.
+
+Deliberately *not* interpolation. Splining through dekad midpoints does not conserve the
+annual total, invents sub-dekad structure the sensor never observed (day-scale GPP
+variability is driven by cloud and rainfall, absent from a 10-day composite), and can
+undershoot below zero for a non-negative quantity. If a smooth daily curve is ever needed,
+the defensible route is mean-preserving interpolation, not a plain spline.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from open_climate_service.process import process
+from open_climate_service.shared.time import DEKAD_START_DAYS, dekad_bounds
+
+logger = logging.getLogger(__name__)
+
+_PERIODS = ("month", "week")
+_METHODS = ("mean", "sum")
+
+# Units that mark a per-day rate. Summing these would be meaningless — a month's worth of
+# "gC/m²/day" values added together is not a monthly total in any unit.
+_PER_DAY_MARKERS = ("/day", "/d", " d-1", "d-1")
+
+
+def _target_start(day: date, period: str) -> date:
+    """First day of the target period containing ``day``."""
+    if period == "month":
+        return day.replace(day=1)
+    return day - timedelta(days=day.weekday())  # ISO week starts Monday
+
+
+def _target_end(start: date, period: str) -> date:
+    """Last day (inclusive) of the target period beginning at ``start``."""
+    if period == "month":
+        next_month = start.replace(day=28) + timedelta(days=4)
+        return next_month.replace(day=1) - timedelta(days=1)
+    return start + timedelta(days=6)
+
+
+def _overlap_days(a: tuple[date, date], b: tuple[date, date]) -> int:
+    """Number of days shared by two inclusive date ranges."""
+    lo = max(a[0], b[0])
+    hi = min(a[1], b[1])
+    return max(0, (hi - lo).days + 1)
+
+
+def _dekad_dates(data: xr.DataArray, time_dim: str) -> list[date]:
+    """Validate that every timestep is a dekad start and return them as dates.
+
+    Guarding rather than trusting: run on a daily or monthly cube the weighting would
+    produce plausible-looking nonsense, so refuse anything that is not dekadal.
+    """
+    stamps = pd.DatetimeIndex(np.asarray(data[time_dim].values, dtype="datetime64[ns]"))
+    days = [d.date() for d in stamps]
+    offenders = sorted({d.isoformat() for d in days if d.day not in DEKAD_START_DAYS})
+    if offenders:
+        raise ValueError(
+            "aggregate_dekads expects a dekadal cube: every timestep must start a dekad "
+            f"(day {', '.join(str(d) for d in DEKAD_START_DAYS)}). Offending timesteps: "
+            f"{', '.join(offenders[:5])}{' …' if len(offenders) > 5 else ''}"
+        )
+    return days
+
+
+@process(
+    summary="Aggregate a dekadal cube to months or ISO weeks, weighted by day overlap",
+    parameters={
+        "data": {"description": "Dekadal data cube (timesteps on the 1st, 11th and 21st)."},
+        "period": {"description": "Target period: 'month' (default) or 'week'."},
+        "method": {
+            "description": (
+                "'mean' (default) for a per-day rate — the day-weighted average daily value, "
+                "in the same units. 'sum' for a per-dekad total — reallocated by day overlap "
+                "into a target-period total."
+            )
+        },
+    },
+)
+def aggregate_dekads(
+    data: xr.DataArray,
+    period: str = "month",
+    method: str = "mean",
+) -> xr.DataArray:
+    """Aggregate dekads to ``period``, weighting each by the days it shares with the target.
+
+    ``mean`` treats each value as a mean daily rate and returns the day-weighted average,
+    so the units are unchanged. ``sum`` treats each value as a total accumulated over its
+    dekad, converts it to a daily rate, and sums over the target's days — exact regardless
+    of dekad length.
+
+    Both are NaN-aware per pixel: a dekad that is missing over part of the grid is dropped
+    from the weights *there* and the remainder renormalised, rather than poisoning the whole
+    target period.
+
+    Only dekads that actually overlap a target period contribute, so a partially covered
+    period at either end of the record is computed from what exists rather than returning
+    NaN — its weights simply sum to less than the period's length.
+    """
+    if period not in _PERIODS:
+        raise ValueError(f"Unknown period '{period}'; expected one of {list(_PERIODS)}")
+    if method not in _METHODS:
+        raise ValueError(f"Unknown method '{method}'; expected one of {list(_METHODS)}")
+
+    time_dim = next((d for d in ("t", "time", "valid_time") if d in data.dims), None)
+    if time_dim is None:
+        raise ValueError("aggregate_dekads requires a temporal dimension named 't', 'time' or 'valid_time'")
+
+    units = str(data.attrs.get("units", ""))
+    if method == "sum" and any(marker in units for marker in _PER_DAY_MARKERS):
+        logger.warning(
+            "aggregate_dekads called with method='sum' on units %r, which look like a per-day rate. "
+            "Adding daily rates does not produce a total; method='mean' gives the average daily value.",
+            units,
+        )
+
+    source_days = _dekad_dates(data, time_dim)
+    spans = [dekad_bounds(day) for day in source_days]
+
+    # Group source steps by the target period they touch. A dekad can straddle two ISO
+    # weeks, so this is a many-to-many mapping, not a partition.
+    contributions: dict[date, list[tuple[int, int]]] = {}
+    for index, span in enumerate(spans):
+        day = span[0]
+        while day <= span[1]:
+            start = _target_start(day, period)
+            overlap = _overlap_days(span, (start, _target_end(start, period)))
+            if overlap:
+                contributions.setdefault(start, []).append((index, overlap))
+            day = _target_end(start, period) + timedelta(days=1)
+
+    slices: list[xr.DataArray] = []
+    for start in sorted(contributions):
+        indices = [i for i, _ in contributions[start]]
+        weights = [w for _, w in contributions[start]]
+        subset = data.isel({time_dim: indices})
+        lengths = [(spans[i][1] - spans[i][0]).days + 1 for i in indices]
+        # Per-day rate: `mean` inputs already are one, `sum` inputs are a dekad total.
+        daily = subset if method == "mean" else subset / xr.DataArray(lengths, dims=[time_dim])
+        w = xr.DataArray(np.asarray(weights, dtype="float64"), dims=[time_dim])
+        finite = daily.notnull()
+        numerator = (daily.fillna(0) * w).sum(time_dim)
+        effective = (w * finite).sum(time_dim)
+        aggregated = numerator if method == "sum" else numerator / effective
+        # All-NaN pixels would divide by zero above; keep them NaN rather than 0 or inf.
+        aggregated = aggregated.where(effective > 0)
+        slices.append(aggregated.assign_coords({time_dim: np.datetime64(start, "ns")}).expand_dims(time_dim))
+
+    if not slices:
+        raise ValueError("aggregate_dekads produced no target periods — the input cube has no timesteps")
+
+    out = xr.concat(slices, dim=time_dim)
+    out.attrs = dict(data.attrs)
+    # Record how this was derived: a consumer must be able to tell a day-weighted
+    # aggregate from an observation, and from an unweighted mean.
+    interval = "10 day"
+    comment = f"day-weighted {method} from dekads"
+    out.attrs["cell_methods"] = f"time: {method} (interval: {interval} comment: {comment})"
+    return out

--- a/open_climate_service/plugins/processes/aggregate_dekads.py
+++ b/open_climate_service/plugins/processes/aggregate_dekads.py
@@ -70,6 +70,18 @@ def _dekad_dates(data: xr.DataArray, time_dim: str) -> list[date]:
 
     Guarding rather than trusting: run on a daily or monthly cube the weighting would
     produce plausible-looking nonsense, so refuse anything that is not dekadal.
+
+    Two checks, because the first is not sufficient. Every dekad starts on the 1st, 11th or
+    21st — but so does every *month*, so a monthly cube passes a per-timestamp day test and is
+    then spread across the first dekad of each month: with ``period="week"`` that yields a
+    fully populated weekly series covering only the first ten days of each month. A real
+    dekadal series visits the 11th or the 21st, so requiring that separates the two.
+
+    Gap-based detection cannot: January 1 to February 1 is 31 days, which is exactly three
+    dekads, so a monthly series is indistinguishable from a dekadal one with two missing
+    dekads. Missing dekads are legitimate here (a partially covered period is computed from
+    what exists), so the day-of-month set is the only discriminator that does not also reject
+    valid input.
     """
     stamps = pd.DatetimeIndex(np.asarray(data[time_dim].values, dtype="datetime64[ns]"))
     days = [d.date() for d in stamps]
@@ -79,6 +91,13 @@ def _dekad_dates(data: xr.DataArray, time_dim: str) -> list[date]:
             "aggregate_dekads expects a dekadal cube: every timestep must start a dekad "
             f"(day {', '.join(str(d) for d in DEKAD_START_DAYS)}). Offending timesteps: "
             f"{', '.join(offenders[:5])}{' …' if len(offenders) > 5 else ''}"
+        )
+    if len(days) > 1 and all(d.day == DEKAD_START_DAYS[0] for d in days):
+        raise ValueError(
+            "aggregate_dekads expects a dekadal cube, but every timestep falls on the 1st "
+            f"({len(days)} of them, {days[0].isoformat()} to {days[-1].isoformat()}), which is "
+            "monthly, quarterly or yearly spacing rather than dekadal. A dekadal series also "
+            "visits the 11th and 21st. Aggregate this with aggregate_temporal_period instead."
         )
     return days
 

--- a/open_climate_service/plugins/processes/aggregate_dekads.py
+++ b/open_climate_service/plugins/processes/aggregate_dekads.py
@@ -109,13 +109,24 @@ def aggregate_dekads(
     dekad, converts it to a daily rate, and sums over the target's days — exact regardless
     of dekad length.
 
-    Both are NaN-aware per pixel: a dekad that is missing over part of the grid is dropped
-    from the weights *there* and the remainder renormalised, rather than poisoning the whole
-    target period.
+    Both are NaN-aware per pixel — a dekad missing over part of the grid does not poison the
+    whole target period there — but they handle the gap differently, because the right answer
+    differs:
 
-    Only dekads that actually overlap a target period contribute, so a partially covered
-    period at either end of the record is computed from what exists rather than returning
-    NaN — its weights simply sum to less than the period's length.
+    * ``mean`` **renormalises**: the missing dekad's weight leaves the denominator, so the
+      result is the day-weighted mean of the dekads that do exist. A rate estimated from two
+      dekads is still a rate.
+    * ``sum`` **omits**: the missing dekad contributes nothing and the rest are not scaled up,
+      so the result is a *partial* total. Renormalising would be extrapolation — inventing
+      accumulation that was never observed — so the total reports only what is there.
+
+    A pixel with no data at all in a target period stays NaN rather than becoming 0.
+
+    The same asymmetry applies to a partially covered period at either end of the record,
+    where only some of its dekads were loaded: the ``mean`` is well defined, while a ``sum``
+    is a partial total. That case is detectable from the weights alone rather than per pixel,
+    so it is logged — silently returning a month's total computed from one dekad is the kind
+    of number that gets published.
     """
     if period not in _PERIODS:
         raise ValueError(f"Unknown period '{period}'; expected one of {list(_PERIODS)}")
@@ -150,9 +161,15 @@ def aggregate_dekads(
             day = _target_end(start, period) + timedelta(days=1)
 
     slices: list[xr.DataArray] = []
+    incomplete: list[str] = []
     for start in sorted(contributions):
         indices = [i for i, _ in contributions[start]]
         weights = [w for _, w in contributions[start]]
+        # Only `sum` is misread when a period is short of dekads: it yields a partial total
+        # that looks like a whole one. A `mean` over fewer dekads is still a valid mean.
+        period_days = (_target_end(start, period) - start).days + 1
+        if method == "sum" and sum(weights) < period_days:
+            incomplete.append(start.isoformat())
         subset = data.isel({time_dim: indices})
         lengths = [(spans[i][1] - spans[i][0]).days + 1 for i in indices]
         # Per-day rate: `mean` inputs already are one, `sum` inputs are a dekad total.
@@ -165,6 +182,17 @@ def aggregate_dekads(
         # All-NaN pixels would divide by zero above; keep them NaN rather than 0 or inf.
         aggregated = aggregated.where(effective > 0)
         slices.append(aggregated.assign_coords({time_dim: np.datetime64(start, "ns")}).expand_dims(time_dim))
+
+    if incomplete:
+        logger.warning(
+            "aggregate_dekads: %d of %d target period(s) are not fully covered by the loaded "
+            "dekads, so method='sum' reports a partial total for them (%s%s). Widen "
+            "temporal_extent to cover whole periods, or use method='mean'.",
+            len(incomplete),
+            len(contributions),
+            ", ".join(incomplete[:5]),
+            " …" if len(incomplete) > 5 else "",
+        )
 
     if not slices:
         raise ValueError("aggregate_dekads produced no target periods — the input cube has no timesteps")

--- a/open_climate_service/plugins/workflows/aggregate_dekads_to_period.json
+++ b/open_climate_service/plugins/workflows/aggregate_dekads_to_period.json
@@ -1,0 +1,71 @@
+{
+  "id": "aggregate_dekads_to_period",
+  "summary": "Aggregate a published dekadal dataset to months or ISO weeks, weighted by day overlap, and publish it as a new GeoZarr dataset",
+  "description": "Loads a published dekadal (10-daily) collection, aggregates it to calendar months or ISO weeks with the `aggregate_dekads` process, and publishes the result.\n\nDekads are not equal in length — day 1-10, 11-20, then 21 to the end of the month, so the third runs 8, 9, 10 or 11 days. A plain `mean` over the three dekads of a month therefore over-weights a short third dekad: February's 8-day dekad by 4.8 percentage points, a 14% relative error on its contribution, and always in the same direction, so an unweighted monthly series carries a seasonal artefact that tracks month length. This workflow weights each dekad by the days it shares with the target period instead.\n\nChoose `method` by what the variable is:\n\n- `mean` (default) — for a per-day **rate** such as the CLMS GPP/NPP products (`gC/m²/day`). Returns the target period's average daily value, in the same units.\n- `sum` — for a per-dekad **total**. Each dekad's value is converted to a daily rate and summed across the target's days, so the annual total is conserved exactly regardless of dekad length. Passing `sum` for a per-day rate is logged as a warning: adding daily rates does not produce a total.\n\n`period: week` is available but rarely what you want. Dekads and ISO weeks never align — 36 dekads against 52 or 53 weeks — so a weekly series has an effective resolution of about 10 days no matter how it is derived, and the weights must be recomputed per year. Monthly is exact by comparison: three dekads tile a month with no remainder.\n\nThe output variable carries a `cell_methods` recording the weighting, so a consumer can tell a day-weighted aggregate from an observation.\n\nThe `output_dataset_id` must have a registered dataset template on the instance: a YAML in plugins/datasets/ with `sync: {kind: static}`, a matching `period_type`, and a `display` block.\n\nZarr output cannot be produced synchronously, so run this as a batch job (POST /jobs, then POST /jobs/{id}/results):\n\n{\n  \"agg\": {\n    \"process_id\": \"aggregate_dekads_to_period\",\n    \"arguments\": {\n      \"dataset_id\": \"clms_gpp_dekad\",\n      \"output_dataset_id\": \"clms_gpp_monthly\",\n      \"variable\": \"gpp\",\n      \"temporal_extent\": [\"2024-01-01\", \"2024-12-31\"]\n    },\n    \"result\": true\n  }\n}",
+  "parameters": [
+    {
+      "name": "dataset_id",
+      "description": "ID of the published dekadal collection to load (as listed under /datasets). Its timesteps must fall on the 1st, 11th and 21st.",
+      "schema": { "type": "string" }
+    },
+    {
+      "name": "output_dataset_id",
+      "description": "ID of the aggregated dataset to publish. Must have a registered dataset template on the instance (a YAML with sync: {kind: static}, a matching period_type and a display block; no ingestion plugin needed).",
+      "schema": { "type": "string" }
+    },
+    {
+      "name": "variable",
+      "description": "Variable/band name carried through to the published dataset.",
+      "schema": { "type": "string" }
+    },
+    {
+      "name": "temporal_extent",
+      "description": "Range of dekads to load as [start, end] ISO-8601 dates. A partially covered target period at either end is computed from the dekads that exist.",
+      "schema": { "type": "array", "subtype": "temporal-interval" }
+    },
+    {
+      "name": "period",
+      "description": "Target period: 'month' (default) or 'week'. Monthly is exact; weekly does not align with dekads.",
+      "schema": { "type": "string", "enum": ["month", "week"] },
+      "optional": true,
+      "default": "month"
+    },
+    {
+      "name": "method",
+      "description": "'mean' (default) for a per-day rate — the day-weighted average daily value. 'sum' for a per-dekad total — reallocated by day overlap, conserving the total.",
+      "schema": { "type": "string", "enum": ["mean", "sum"] },
+      "optional": true,
+      "default": "mean"
+    }
+  ],
+  "process_graph": {
+    "load": {
+      "process_id": "load_collection",
+      "arguments": {
+        "id": { "from_parameter": "dataset_id" },
+        "temporal_extent": { "from_parameter": "temporal_extent" }
+      }
+    },
+    "aggregated": {
+      "process_id": "aggregate_dekads",
+      "arguments": {
+        "data": { "from_node": "load" },
+        "period": { "from_parameter": "period" },
+        "method": { "from_parameter": "method" }
+      }
+    },
+    "save": {
+      "process_id": "save_result",
+      "arguments": {
+        "data": { "from_node": "aggregated" },
+        "format": "Zarr",
+        "options": {
+          "dataset_id": { "from_parameter": "output_dataset_id" },
+          "variable": { "from_parameter": "variable" },
+          "publish": true
+        }
+      },
+      "result": true
+    }
+  }
+}

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -35,7 +35,17 @@ _IRREGULAR_PERIOD_TYPES = frozenset({"dekadal"})
 # ordinals (1..366), so asking for their cadence or ISO step is a category error.
 _NON_TEMPORAL_PERIOD_TYPES = frozenset({"climatology"})
 
-SUPPORTED_PERIOD_TYPES = frozenset(_PERIOD_TYPE_ISO_STEP) | _IRREGULAR_PERIOD_TYPES | _NON_TEMPORAL_PERIOD_TYPES
+# Period types a dataset template may declare. Deliberately *not* derived from
+# _PERIOD_TYPE_ISO_STEP: that map exists to give STAC a step for whatever is already in a
+# store, and includes "quarterly", which none of datetime_to_period_string,
+# normalize_period_string, numpy_datetime_to_period_string, _next_period_start or
+# _default_target_end implement. Deriving the two from one set would advertise quarterly as
+# registerable and then fail at ingest, so they are kept apart.
+SUPPORTED_PERIOD_TYPES = (
+    frozenset({"hourly", "daily", "weekly", "monthly", "yearly"})
+    | _IRREGULAR_PERIOD_TYPES
+    | _NON_TEMPORAL_PERIOD_TYPES
+)
 
 
 class Cadence(StrEnum):

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -267,12 +267,16 @@ def dekad_period_ids(start: str | date, end: str | date, *, cutoff: str | date |
     the data has, so overlapping it means it is needed. The dekadal counterpart of
     :func:`daily_period_ids`, including the ``cutoff`` availability clamp.
     """
-    first = dekad_start(start)
+    requested_start = _as_date(start)
     last = _as_date(end)
     if cutoff is not None:
         last = min(last, _as_date(cutoff))
-    if first > last:
+    # Tested against the *requested* start, not the snapped one: an inverted or
+    # cutoff-exhausted range covers nothing, and snapping back into the containing dekad
+    # must not turn it into a hit. `daily_period_ids` returns [] for the same input.
+    if requested_start > last:
         return []
+    first = dekad_start(requested_start)
     out: list[str] = []
     current = first
     while current <= last:

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -1,8 +1,10 @@
 """Time helpers shared across Open Climate Service modules."""
 
+import calendar
 import logging
 import re
 from datetime import UTC, date, datetime, timedelta
+from enum import StrEnum
 from typing import Any, cast
 
 import numpy as np
@@ -23,13 +25,64 @@ _PERIOD_TYPE_ISO_STEP = {
     "yearly": "P1Y",
 }
 
+# Cadences that are real calendar periods but have no single ISO 8601 duration, because
+# their members differ in length. A dekad is the first: day 1-10, 11-20, then 21 to the
+# end of the month, so the third runs 8, 9, 10 or 11 days. "P10D" would be wrong for
+# every third dekad of the year, which is why these carry no step at all.
+_IRREGULAR_PERIOD_TYPES = frozenset({"dekadal"})
+
+# Period types whose ids are not calendar instants. "climatology" ids are day-of-year
+# ordinals (1..366), so asking for their cadence or ISO step is a category error.
+_NON_TEMPORAL_PERIOD_TYPES = frozenset({"climatology"})
+
+SUPPORTED_PERIOD_TYPES = frozenset(_PERIOD_TYPE_ISO_STEP) | _IRREGULAR_PERIOD_TYPES | _NON_TEMPORAL_PERIOD_TYPES
+
+
+class Cadence(StrEnum):
+    """How a dataset's periods are spaced, as far as the rest of the system must care.
+
+    The distinction that matters is ``IRREGULAR`` versus ``UNKNOWN``. Both lack an ISO
+    8601 step, but they mean opposite things: an irregular cadence is correctly declared
+    and its spacing is genuinely variable, whereas an unknown one is a template we cannot
+    honour. Collapsing them — as returning ``None`` from the step lookup for both would —
+    makes a valid dekadal dataset indistinguishable from a misconfigured one.
+    """
+
+    REGULAR = "regular"
+    """Fixed-length periods; ``period_type_to_iso_step`` yields a duration."""
+
+    IRREGULAR = "irregular"
+    """Known calendar cadence with variable-length periods; no duration exists."""
+
+    NON_TEMPORAL = "non_temporal"
+    """Ids are not calendar instants (day-of-year ordinals); cadence does not apply."""
+
+    UNKNOWN = "unknown"
+    """Unsupported ``period_type``. Reject at registration rather than degrade."""
+
+
+def period_cadence(period_type: Any) -> Cadence:
+    """Classify a dataset ``period_type``."""
+    if not isinstance(period_type, str):
+        return Cadence.UNKNOWN
+    if period_type in _PERIOD_TYPE_ISO_STEP:
+        return Cadence.REGULAR
+    if period_type in _IRREGULAR_PERIOD_TYPES:
+        return Cadence.IRREGULAR
+    if period_type in _NON_TEMPORAL_PERIOD_TYPES:
+        return Cadence.NON_TEMPORAL
+    return Cadence.UNKNOWN
+
 
 def period_type_to_iso_step(period_type: Any) -> str | None:
-    """Map a dataset ``period_type`` to its ISO 8601 step, or None if not a regular cadence.
+    """Map a dataset ``period_type`` to its ISO 8601 step, or None if it has none.
 
     Used as a fallback for the temporal cube dimension's ``step`` when a template does
     not declare ``extents.temporal.resolution`` (e.g. openEO ``save_result`` outputs).
     Without a step the map viewer cannot build a time slider.
+
+    None covers three different situations — irregular, non-temporal and unsupported —
+    so callers that need to tell them apart must use :func:`period_cadence`.
     """
     if not isinstance(period_type, str):
         return None
@@ -118,6 +171,8 @@ def datetime_to_period_string(value: datetime, period_type: str) -> str:
         return value.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H")
     if period_type == "daily":
         return value.date().isoformat()
+    if period_type == "dekadal":
+        return dekad_start(value.date()).isoformat()
     if period_type == "weekly":
         iso_year, iso_week, _ = value.isocalendar()
         return f"{iso_year:04d}-W{iso_week:02d}"
@@ -147,14 +202,6 @@ def daily_period_ids(start: str | date, end: str | date, *, cutoff: str | date |
     rather than re-deriving it. Shared by the daily streaming plugins so they only
     own the cutoff, not the day enumeration.
     """
-
-    def _as_date(value: str | date) -> date:
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, date):
-            return value
-        return date.fromisoformat(str(value)[:10])
-
     current = _as_date(start)
     last = _as_date(end)
     if cutoff is not None:
@@ -163,6 +210,67 @@ def daily_period_ids(start: str | date, end: str | date, *, cutoff: str | date |
     while current <= last:
         out.append(current.isoformat())
         current += timedelta(days=1)
+    return out
+
+
+DEKAD_START_DAYS = (1, 11, 21)
+"""Day-of-month on which each dekad begins, per the openEO ``dekad`` definition."""
+
+
+def _as_date(value: str | date) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return date.fromisoformat(str(value)[:10])
+
+
+def dekad_start(value: str | date) -> date:
+    """Return the first day of the dekad containing ``value``.
+
+    Truncation for the dekadal cadence: 15 January lands in the second dekad, so it
+    normalises to 11 January.
+    """
+    day = _as_date(value)
+    start_day = max(d for d in DEKAD_START_DAYS if d <= day.day)
+    return day.replace(day=start_day)
+
+
+def dekad_bounds(value: str | date) -> tuple[date, date]:
+    """Return the inclusive ``(first_day, last_day)`` of the dekad containing ``value``.
+
+    The third dekad of a month ends on the month's last day, so its length varies from
+    8 (February, common year) to 11 days. This is the only honest expression of a dekad's
+    extent — there is no duration that describes all three — and it is what CF
+    ``time_bnds`` should be written from.
+    """
+    start = dekad_start(value)
+    if start.day == DEKAD_START_DAYS[-1]:
+        last_day = calendar.monthrange(start.year, start.month)[1]
+        return start, start.replace(day=last_day)
+    return start, start.replace(day=start.day + 9)
+
+
+def dekad_period_ids(start: str | date, end: str | date, *, cutoff: str | date | None = None) -> list[str]:
+    """Return ``YYYY-MM-DD`` ids for every dekad overlapping ``[start, end]`` inclusive.
+
+    Ids are the dekad's first day, so they sort chronologically and parse as plain dates.
+    A partially covered dekad at either end is included — the dekad is the smallest unit
+    the data has, so overlapping it means it is needed. The dekadal counterpart of
+    :func:`daily_period_ids`, including the ``cutoff`` availability clamp.
+    """
+    first = dekad_start(start)
+    last = _as_date(end)
+    if cutoff is not None:
+        last = min(last, _as_date(cutoff))
+    if first > last:
+        return []
+    out: list[str] = []
+    current = first
+    while current <= last:
+        out.append(current.isoformat())
+        _, dekad_end = dekad_bounds(current)
+        current = dekad_end + timedelta(days=1)
     return out
 
 
@@ -195,6 +303,14 @@ def normalize_period_string(value: str, period_type: str) -> str:
             return datetime_to_period_string(datetime.fromisoformat(value), period_type)
         except ValueError as exc:
             raise ValueError(f"Invalid daily period '{value}'; expected YYYY-MM-DD or ISO datetime") from exc
+    if period_type == "dekadal":
+        try:
+            return datetime_to_period_string(datetime.fromisoformat(value), period_type)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid dekadal period '{value}'; expected YYYY-MM-DD (any day within the "
+                "dekad, normalised to the 1st, 11th or 21st) or ISO datetime"
+            ) from exc
     if period_type == "weekly":
         try:
             return datetime_to_period_string(parse_weekly_period_string(value), period_type)
@@ -245,11 +361,24 @@ def parse_period_string_to_datetime(value: str) -> datetime:
 
 def numpy_datetime_to_period_string(datetimes: np.ndarray[Any, Any], period_type: str) -> np.ndarray[Any, Any]:
     """Convert an array of numpy datetimes to truncated period strings."""
-    if period_type != "weekly":
-        lengths = {"hourly": 13, "daily": 10, "monthly": 7, "yearly": 4}
-        return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[period_type]}")
+    if period_type == "weekly":
+        dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
+        iso = dt_index.isocalendar()
+        strings = iso["year"].astype(str).str.zfill(4) + "-W" + iso["week"].astype(str).str.zfill(2)
+        return cast(np.ndarray[Any, Any], strings.to_numpy().astype("U8"))
 
-    dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
-    iso = dt_index.isocalendar()
-    strings = iso["year"].astype(str).str.zfill(4) + "-W" + iso["week"].astype(str).str.zfill(2)
-    return cast(np.ndarray[Any, Any], strings.to_numpy().astype("U8"))
+    if period_type == "dekadal":
+        # Snapping, not truncation: a stored timestamp anywhere inside a dekad must yield
+        # that dekad's id. Truncating to 10 characters would only be correct for stores
+        # whose timestamps already sit on the 1st/11th/21st.
+        dt_index = pd.DatetimeIndex(np.atleast_1d(np.asarray(datetimes, dtype="datetime64[ns]")))
+        day = dt_index.day.to_numpy()
+        start_day = np.select([day >= 21, day >= 11], [21, 11], default=1)
+        dekad_ids = [
+            f"{year:04d}-{month:02d}-{start:02d}"
+            for year, month, start in zip(dt_index.year, dt_index.month, start_day, strict=True)
+        ]
+        return cast(np.ndarray[Any, Any], np.asarray(dekad_ids, dtype="U10"))
+
+    lengths = {"hourly": 13, "daily": 10, "monthly": 7, "yearly": 4}
+    return np.datetime_as_string(datetimes, unit="s").astype(f"U{lengths[period_type]}")

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -42,9 +42,7 @@ _NON_TEMPORAL_PERIOD_TYPES = frozenset({"climatology"})
 # _default_target_end implement. Deriving the two from one set would advertise quarterly as
 # registerable and then fail at ingest, so they are kept apart.
 SUPPORTED_PERIOD_TYPES = (
-    frozenset({"hourly", "daily", "weekly", "monthly", "yearly"})
-    | _IRREGULAR_PERIOD_TYPES
-    | _NON_TEMPORAL_PERIOD_TYPES
+    frozenset({"hourly", "daily", "weekly", "monthly", "yearly"}) | _IRREGULAR_PERIOD_TYPES | _NON_TEMPORAL_PERIOD_TYPES
 )
 
 

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -110,9 +110,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     template_links = [_link_to_dict(link) for link in template.links]
     period_type = source_dataset.get("period_type")
 
-    collection_payload = _build_collection_with_xstac(
-        artifact=artifact, template=template, period_type=period_type
-    )
+    collection_payload = _build_collection_with_xstac(artifact=artifact, template=template, period_type=period_type)
     collection_payload["id"] = dataset_id
     collection_payload["type"] = "Collection"
     collection_payload["stac_version"] = STAC_VERSION

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -536,7 +536,12 @@ def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence
     nothing to extrapolate from, so the accompanying ``values`` must carry the real
     timestamps. See ``_add_temporal_values``, which supplies them.
     """
-    if step is None and cadence is not Cadence.IRREGULAR:
+    if cadence is Cadence.IRREGULAR:
+        # No duration can describe a variable-length cadence, so a declared
+        # extents.temporal.resolution must not win here: a dekadal template that happens to
+        # declare P10D would otherwise publish it and look regular.
+        step = None
+    elif step is None:
         return
     dimensions = collection.setdefault("cube:dimensions", {})
     for key, value in dimensions.items():

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, TypeVar
 
+import numpy as np
+import pandas as pd
 import pystac
 import xarray as xr
 from fastapi import HTTPException, Request
@@ -106,8 +108,11 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         source_dataset=source_dataset,
     )
     template_links = [_link_to_dict(link) for link in template.links]
+    period_type = source_dataset.get("period_type")
 
-    collection_payload = _build_collection_with_xstac(artifact=artifact, template=template)
+    collection_payload = _build_collection_with_xstac(
+        artifact=artifact, template=template, period_type=period_type
+    )
     collection_payload["id"] = dataset_id
     collection_payload["type"] = "Collection"
     collection_payload["stac_version"] = STAC_VERSION
@@ -151,7 +156,6 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     # Prefer an explicit extents.temporal.resolution; fall back to the dataset's
     # period_type so openEO save_result outputs (which omit the extents block) still
     # get a temporal step — the map viewer needs it to build the time slider.
-    period_type = source_dataset.get("period_type")
     _override_time_step(
         collection_payload,
         resolve_iso_period_step(source_dataset) or period_type_to_iso_step(period_type),
@@ -326,8 +330,13 @@ def _wgs84_extent_from_store(ds: xr.Dataset, store_crs: str, x_dim: str, y_dim: 
         return None
 
 
-def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.Collection) -> dict[str, Any]:
-    cached_payload = _xstac_collection_cache.get(artifact.artifact_id)
+def _build_collection_with_xstac(
+    *, artifact: ArtifactRecord, template: pystac.Collection, period_type: Any = None
+) -> dict[str, Any]:
+    # Keyed on period_type as well as the artifact: correcting a template's cadence
+    # changes the payload (an irregular one gains `values`) without producing a new artifact.
+    cache_key = f"{artifact.artifact_id}:{period_type}"
+    cached_payload = _xstac_collection_cache.get(cache_key)
     if cached_payload is not None:
         return deepcopy(cached_payload)
 
@@ -393,7 +402,9 @@ def _build_collection_with_xstac(*, artifact: ArtifactRecord, template: pystac.C
         extent_bbox = _wgs84_extent_from_store(ds, store_crs or "EPSG:4326", x_dimension, y_dimension)
         if extent_bbox is not None:
             payload.setdefault("extent", {}).setdefault("spatial", {})["bbox"] = [extent_bbox]
-        _cache_xstac_collection_payload(artifact.artifact_id, payload)
+        if time_dimension is not None and period_cadence(period_type) is Cadence.IRREGULAR:
+            _add_temporal_values(payload, ds, time_dimension)
+        _cache_xstac_collection_payload(cache_key, payload)
         return deepcopy(payload)
     except HTTPException:
         raise
@@ -521,11 +532,9 @@ def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence
     leaving whatever xstac inferred, which would imply a regular spacing the data does
     not have.
 
-    The extension has no way to express per-period extent, so an irregular declaration
-    tells a catalogue-only client no more than "read the timestamps". The store carries
-    the detail. ``values`` is deliberately not emitted: it is optional, it would add one
-    ISO string per period to every collection response, and a client that needs exact
-    timestamps is already reading the store.
+    A null step alone is not enough for a client, though: without a duration there is
+    nothing to extrapolate from, so the accompanying ``values`` must carry the real
+    timestamps. See ``_add_temporal_values``, which supplies them.
     """
     if step is None and cadence is not Cadence.IRREGULAR:
         return
@@ -535,6 +544,27 @@ def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence
             value["step"] = step
             dimensions[key] = value
             return
+
+
+def _add_temporal_values(collection: dict[str, Any], ds: xr.Dataset, time_dimension: str) -> None:
+    """List the temporal dimension's actual timestamps as ``values``.
+
+    Required for an irregular cadence, not decorative. A client builds its time control
+    either from explicit ``values`` or by stepping ``extent`` by ``step``; with an
+    irregular cadence there is no step to walk, so omitting ``values`` leaves a consumer
+    with a single position and no slider. This mirrors ``_build_ordinal_dimensions``,
+    which lists values for the same reason on a day-of-year axis.
+
+    Only emitted for irregular cadences. A regular one is fully described by extent plus
+    duration, and listing every timestamp would add one ISO string per period to a cached
+    response for no gain — thousands of entries for a multi-year daily store.
+    """
+    dimensions = collection.get("cube:dimensions") or {}
+    dim = dimensions.get(time_dimension)
+    if not isinstance(dim, dict) or dim.get("type") != "temporal":
+        return
+    stamps = pd.DatetimeIndex(np.asarray(ds[time_dimension].values, dtype="datetime64[ns]"))
+    dim["values"] = [f"{s.isoformat()}Z" for s in stamps.tz_localize(None)]
 
 
 def _build_static_cube_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str) -> dict[str, Any]:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -21,7 +21,9 @@ from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
 from open_climate_service.shared.time import (
+    Cadence,
     parse_period_string_to_datetime,
+    period_cadence,
     period_type_to_iso_step,
     resolve_iso_period_step,
 )
@@ -149,9 +151,11 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     # Prefer an explicit extents.temporal.resolution; fall back to the dataset's
     # period_type so openEO save_result outputs (which omit the extents block) still
     # get a temporal step — the map viewer needs it to build the time slider.
+    period_type = source_dataset.get("period_type")
     _override_time_step(
         collection_payload,
-        resolve_iso_period_step(source_dataset) or period_type_to_iso_step(source_dataset.get("period_type")),
+        resolve_iso_period_step(source_dataset) or period_type_to_iso_step(period_type),
+        cadence=period_cadence(period_type),
     )
     # Spatial extent comes from the live store (set in _build_collection_with_xstac),
     # not the artifact coverage — see _wgs84_extent_from_store. Temporal still tracks the
@@ -508,8 +512,22 @@ def _abs_url(request: Request, path: str) -> str:
     return f"{str(request.base_url).rstrip('/')}{path}"
 
 
-def _override_time_step(collection: dict[str, Any], step: str | None) -> None:
-    if step is None:
+def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence: Cadence) -> None:
+    """Set the temporal dimension's ``step`` to the duration, or to an explicit null.
+
+    A regular cadence gets its ISO 8601 duration. An **irregular** one gets ``null``,
+    which the datacube extension defines as "irregularly spaced steps" — the only
+    truthful answer for a cadence whose periods differ in length, and better than
+    leaving whatever xstac inferred, which would imply a regular spacing the data does
+    not have.
+
+    The extension has no way to express per-period extent, so an irregular declaration
+    tells a catalogue-only client no more than "read the timestamps". The store carries
+    the detail. ``values`` is deliberately not emitted: it is optional, it would add one
+    ISO string per period to every collection response, and a client that needs exact
+    timestamps is already reading the store.
+    """
+    if step is None and cadence is not Cadence.IRREGULAR:
         return
     dimensions = collection.setdefault("cube:dimensions", {})
     for key, value in dimensions.items():

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -338,7 +338,20 @@
       }
 
       function stepLabelAt(steps, i) {
-        if (Array.isArray(steps)) return steps[i];
+        if (Array.isArray(steps)) {
+          const v = steps[i];
+          // Explicit `values` cover two kinds of axis: ordinal ones list numbers
+          // (day-of-year) or category names (sex), which pass through untouched, while an
+          // irregular temporal axis lists ISO timestamps. Those want the same granularity
+          // trimming the generated branches below apply, so a dekadal axis reads
+          // "2024-12-21" rather than "2024-12-21T00:00:00Z" on every step.
+          if (typeof v === "string") {
+            const midnight = v.match(/^(\d{4}-\d{2}-\d{2})T00:00(?::00(?:\.0+)?)?Z?$/);
+            if (midnight) return midnight[1];
+            if (/^\d{4}-\d{2}-\d{2}T/.test(v)) return v.slice(0, 16).replace("T", " ");
+          }
+          return v;
+        }
         const sd = new Date(steps.start);
         // Label at the granularity of the step: year for P1Y, year-month for P1M,
         // date for daily, date+time for sub-daily — so a yearly axis shows "2026",

--- a/tests/test_aggregate_dekads.py
+++ b/tests/test_aggregate_dekads.py
@@ -216,3 +216,28 @@ def test_fully_covered_months_are_not_flagged(ocs_logs: Any) -> None:
     cube = _cube(dekad_period_ids("2026-01-01", "2026-12-31"), units="gC/m2")
     aggregate_dekads(cube, period="month", method="sum")
     assert "partial total" not in ocs_logs.text
+
+
+def test_a_monthly_cube_is_refused_even_though_the_1st_starts_a_dekad() -> None:
+    """The day-of-month test alone passes a monthly cube, since every month starts a dekad.
+
+    Left unguarded it produced a fully populated weekly series covering only the first ten
+    days of each month — plausible, and wrong.
+    """
+    monthly = _cube([f"2026-{m:02d}-01" for m in range(1, 7)])
+    with pytest.raises(ValueError, match="every timestep falls on the 1st"):
+        aggregate_dekads(monthly, period="week")
+    with pytest.raises(ValueError, match="monthly, quarterly or yearly spacing"):
+        aggregate_dekads(monthly, period="month")
+
+
+def test_a_single_first_dekad_is_still_accepted() -> None:
+    """One timestep carries no spacing information, and is what partial coverage looks like."""
+    result = aggregate_dekads(_cube(["2026-01-01"]), period="month")
+    assert result.sizes["t"] == 1
+
+
+def test_a_dekadal_cube_of_only_first_and_second_dekads_is_accepted() -> None:
+    """The check is "visits the 11th or 21st", not "has all three dekads of every month"."""
+    result = aggregate_dekads(_cube(["2026-01-01", "2026-01-11"]), period="month")
+    assert result.sizes["t"] == 1

--- a/tests/test_aggregate_dekads.py
+++ b/tests/test_aggregate_dekads.py
@@ -173,3 +173,46 @@ def test_the_process_is_registered_and_the_workflow_wires_to_it() -> None:
     # not openEO-spec-compliant and was removed from the other aggregate workflows.
     assert graph["aggregated"]["process_id"] == "aggregate_dekads"
     assert graph["aggregated"]["arguments"]["period"] == {"from_parameter": "period"}
+
+
+def test_sum_omits_a_missing_dekad_rather_than_scaling_the_rest_up() -> None:
+    """`sum` and `mean` treat a gap differently on purpose, so pin both.
+
+    Renormalising a total would invent accumulation that was never observed, so `sum` reports
+    a partial total. `mean` renormalises, because a rate from two dekads is still a rate.
+    """
+    ids = dekad_period_ids("2026-02-01", "2026-02-28")  # lengths 10, 10, 8
+    cube = _cube(ids, values=np.array([10.0, 10.0, 10.0]), units="gC/m2")
+    holed = cube.where(cube["t"] != cube["t"][1])  # middle dekad missing everywhere
+
+    assert float(aggregate_dekads(cube, method="sum").isel(t=0, y=0, x=0)) == pytest.approx(30.0)
+    # 10 days of 1/day + 8 days of 1.25/day, the middle dekad simply absent.
+    assert float(aggregate_dekads(holed, method="sum").isel(t=0, y=0, x=0)) == pytest.approx(20.0)
+
+    # The same input under `mean` is unchanged, because the weights are renormalised.
+    rate = _cube(ids, values=np.array([10.0, 10.0, 10.0]))
+    rate_holed = rate.where(rate["t"] != rate["t"][1])
+    assert float(aggregate_dekads(rate_holed, method="mean").isel(t=0, y=0, x=0)) == pytest.approx(10.0)
+
+
+def test_sum_warns_when_a_target_period_is_only_partly_covered(ocs_logs: Any) -> None:
+    """A month's "total" computed from one dekad is the kind of number that gets published."""
+    cube = _cube(["2026-01-21"], units="gC/m2")  # the last dekad of January only
+
+    result = aggregate_dekads(cube, period="month", method="sum")
+
+    assert result.sizes["t"] == 1
+    assert "partial total" in ocs_logs.text
+    assert "2026-01-01" in ocs_logs.text
+
+
+def test_mean_does_not_warn_about_partial_coverage(ocs_logs: Any) -> None:
+    """A day-weighted mean over the dekads that exist is well defined, so it is not flagged."""
+    aggregate_dekads(_cube(["2026-01-21"]), period="month", method="mean")
+    assert "partial total" not in ocs_logs.text
+
+
+def test_fully_covered_months_are_not_flagged(ocs_logs: Any) -> None:
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-12-31"), units="gC/m2")
+    aggregate_dekads(cube, period="month", method="sum")
+    assert "partial total" not in ocs_logs.text

--- a/tests/test_aggregate_dekads.py
+++ b/tests/test_aggregate_dekads.py
@@ -1,0 +1,175 @@
+"""Day-weighted aggregation of a dekadal cube to months or ISO weeks.
+
+The point of the process is that dekads are unequal, so these tests pin the arithmetic
+against hand-computed weights rather than against the implementation, and assert the
+properties that make the result defensible: an exact February mean, a conserved annual
+total, and no target period silently becoming NaN.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from open_climate_service.plugins.processes.aggregate_dekads import aggregate_dekads
+from open_climate_service.shared.time import dekad_period_ids
+
+
+@pytest.fixture
+def ocs_logs(caplog: pytest.LogCaptureFixture) -> Any:
+    """Capture warnings from the OCS package logger.
+
+    ``startup.py`` sets ``propagate = False`` on it, so caplog's root handler never sees
+    the records. Same shim as tests/test_raster_contract.py.
+    """
+    package_logger = logging.getLogger("open_climate_service")
+    previous = package_logger.propagate
+    package_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="open_climate_service"):
+            yield caplog
+    finally:
+        package_logger.propagate = previous
+
+
+def _cube(ids: list[str], values: np.ndarray | None = None, units: str = "gC/m2/day") -> xr.DataArray:
+    """A (t, y, x) cube on the given dekad ids, one distinct value per timestep."""
+    vals = np.arange(1, len(ids) + 1, dtype="f8") if values is None else values
+    return xr.DataArray(
+        vals[:, None, None] * np.ones((1, 2, 2)),
+        dims=("t", "y", "x"),
+        coords={"t": np.array(ids, dtype="datetime64[ns]"), "y": [1.0, 0.0], "x": [33.0, 34.0]},
+        attrs={"units": units},
+    )
+
+
+def test_february_matches_a_hand_computed_day_weighted_mean() -> None:
+    """The month the bias is worst: an 8-day third dekad against two 10-day ones."""
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-12-31"))
+    monthly = aggregate_dekads(cube, period="month", method="mean")
+
+    # February 2026 is dekads 4, 5, 6 -> values 4, 5, 6 with lengths 10, 10, 8.
+    weights, values = [10, 10, 8], [4, 5, 6]
+    expected = sum(w * v for w, v in zip(weights, values, strict=True)) / sum(weights)
+
+    assert float(monthly.isel(t=1, y=0, x=0)) == pytest.approx(expected, abs=1e-12)
+    # The bias being corrected: an equal-weight mean would read 5.0.
+    assert expected != pytest.approx(sum(values) / 3, abs=1e-6)
+
+
+def test_january_matches_a_hand_computed_day_weighted_mean() -> None:
+    """A month with an 11-day third dekad, biased the other way."""
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-12-31"))
+    monthly = aggregate_dekads(cube, period="month", method="mean")
+
+    weights, values = [10, 10, 11], [1, 2, 3]
+    expected = sum(w * v for w, v in zip(weights, values, strict=True)) / sum(weights)
+    assert float(monthly.isel(t=0, y=0, x=0)) == pytest.approx(expected, abs=1e-12)
+
+
+def test_a_full_year_gives_twelve_months_with_no_gaps() -> None:
+    monthly = aggregate_dekads(_cube(dekad_period_ids("2026-01-01", "2026-12-31")), period="month")
+    assert monthly.sizes["t"] == 12
+    assert not bool(monthly.isnull().any())
+    assert [str(v)[:10] for v in monthly["t"].values[:3]] == ["2026-01-01", "2026-02-01", "2026-03-01"]
+
+
+def test_sum_conserves_the_annual_total() -> None:
+    """A per-dekad total reallocated by day overlap must not create or lose anything."""
+    ids = dekad_period_ids("2026-01-01", "2026-12-31")
+    cube = _cube(ids, units="gC/m2")
+    source_total = float(cube.isel(y=0, x=0).sum("t"))
+
+    monthly = aggregate_dekads(cube, period="month", method="sum")
+
+    assert float(monthly.isel(y=0, x=0).sum("t")) == pytest.approx(source_total, rel=1e-12)
+
+
+def test_weekly_covers_every_iso_week_without_gaps() -> None:
+    """Weeks never align with dekads, so this is the case that would strand NaNs."""
+    weekly = aggregate_dekads(_cube(dekad_period_ids("2026-01-01", "2026-12-31")), period="week")
+    assert weekly.sizes["t"] in (52, 53)
+    assert not bool(weekly.isnull().any())
+
+
+def test_a_missing_dekad_renormalises_per_pixel_rather_than_poisoning_the_month() -> None:
+    ids = dekad_period_ids("2026-02-01", "2026-02-28")
+    cube = _cube(ids)  # values 1, 2, 3 with lengths 10, 10, 8
+    # Blank the middle dekad over half the grid only.
+    holed = cube.where(~((cube["t"] == cube["t"][1]) & (cube["y"] == 1.0)))
+
+    monthly = aggregate_dekads(holed, period="month", method="mean")
+
+    # Where the dekad survives, the full three-way weighting applies.
+    intact = (10 * 1 + 10 * 2 + 8 * 3) / 28
+    assert float(monthly.isel(t=0, y=1, x=0)) == pytest.approx(intact, abs=1e-12)
+    # Where it is missing, its weight is dropped and the rest renormalised — not NaN,
+    # and not silently treated as zero.
+    renormalised = (10 * 1 + 8 * 3) / 18
+    assert float(monthly.isel(t=0, y=0, x=0)) == pytest.approx(renormalised, abs=1e-12)
+
+
+def test_an_all_missing_period_stays_nan_rather_than_becoming_zero() -> None:
+    ids = dekad_period_ids("2026-02-01", "2026-02-28")
+    cube = _cube(ids).where(False)  # every value missing
+    monthly = aggregate_dekads(cube, period="month", method="mean")
+    assert bool(monthly.isnull().all())
+
+
+def test_a_partially_covered_month_is_computed_from_the_dekads_that_exist() -> None:
+    # Only the last two dekads of January.
+    cube = _cube(["2026-01-11", "2026-01-21"])
+    monthly = aggregate_dekads(cube, period="month", method="mean")
+    assert monthly.sizes["t"] == 1
+    expected = (10 * 1 + 11 * 2) / 21
+    assert float(monthly.isel(t=0, y=0, x=0)) == pytest.approx(expected, abs=1e-12)
+
+
+def test_a_non_dekadal_cube_is_refused() -> None:
+    """Run on daily or monthly data the weighting would produce plausible nonsense."""
+    daily = _cube(["2026-01-01", "2026-01-02", "2026-01-03"])
+    with pytest.raises(ValueError, match="expects a dekadal cube"):
+        aggregate_dekads(daily)
+
+
+def test_unknown_period_and_method_are_rejected() -> None:
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-01-31"))
+    with pytest.raises(ValueError, match="Unknown period"):
+        aggregate_dekads(cube, period="fortnight")
+    with pytest.raises(ValueError, match="Unknown method"):
+        aggregate_dekads(cube, method="median")
+
+
+def test_summing_a_per_day_rate_is_warned_about(ocs_logs: Any) -> None:
+    """Adding daily rates does not produce a total, and the units say so."""
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-01-31"), units="gC/m2/day")
+    aggregate_dekads(cube, method="sum")
+    assert "per-day rate" in ocs_logs.text
+
+
+def test_provenance_records_the_weighting() -> None:
+    """A consumer must be able to tell a day-weighted aggregate from an observation."""
+    cube = _cube(dekad_period_ids("2026-01-01", "2026-12-31"))
+    monthly = aggregate_dekads(cube, period="month", method="mean")
+    assert monthly.attrs["cell_methods"] == "time: mean (interval: 10 day comment: day-weighted mean from dekads)"
+    assert monthly.attrs["units"] == "gC/m2/day"  # a mean of a rate keeps its units
+
+
+def test_the_process_is_registered_and_the_workflow_wires_to_it() -> None:
+    import json
+    from pathlib import Path
+
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    assert "aggregate_dekads" in _build_process_registry().store["predefined"]
+
+    path = Path("open_climate_service/plugins/workflows/aggregate_dekads_to_period.json")
+    graph = json.loads(path.read_text())["process_graph"]
+    # A literal process_id, not one parameterised through `from_parameter` — the latter is
+    # not openEO-spec-compliant and was removed from the other aggregate workflows.
+    assert graph["aggregated"]["process_id"] == "aggregate_dekads"
+    assert graph["aggregated"]["arguments"]["period"] == {"from_parameter": "period"}

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -93,8 +93,9 @@ def test_a_year_has_thirty_six_dekads_of_three_different_lengths() -> None:
     for period_id in ids:
         first, last = dekad_bounds(period_id)
         lengths[(last - first).days + 1] = lengths.get((last - first).days + 1, 0) + 1
-    # 2026 is a common year: eleven 31-day months give 11-day third dekads (7 of them
-    # after April/June/September/November's 30-day months take 10), February gives 8.
+    # Seven 31-day months give an 11-day third dekad, the four 30-day months give a
+    # 10-day one, and February (28 days in 2026) gives 8. Plus the first two dekads of
+    # every month, always 10 days: 24 + 4 = 28 ten-day dekads.
     assert lengths == {8: 1, 10: 28, 11: 7}
     assert sum(k * v for k, v in lengths.items()) == 365
 
@@ -217,7 +218,6 @@ def test_template_validation_accepts_dekadal_and_rejects_an_unsupported_cadence(
 
     base = {"id": "gpp", "sync": {"kind": "temporal"}, "ingestion": {"plugin": "pkg.Cls"}}
     _validate_dataset_template({**base, "period_type": "dekadal"}, source="t.yaml")
-    _validate_dataset_template(base, source="t.yaml")  # absent stays permitted
 
     with pytest.raises(ValueError, match="unsupported period_type 'dekad'"):
         _validate_dataset_template({**base, "period_type": "dekad"}, source="t.yaml")
@@ -308,3 +308,47 @@ def test_temporal_values_are_not_added_to_a_non_temporal_dimension() -> None:
     collection = {"cube:dimensions": {"t": {"type": "other"}}}
     _add_temporal_values(collection, ds, "t")
     assert "values" not in collection["cube:dimensions"]["t"]
+
+
+def test_irregular_step_is_null_even_when_a_resolution_is_declared() -> None:
+    """No duration can describe a variable-length cadence, so a declared
+    extents.temporal.resolution must not make a dekadal store look regular."""
+    from open_climate_service.stac.services import _override_time_step
+
+    collection = {"cube:dimensions": {"t": {"type": "temporal"}}}
+    _override_time_step(collection, "P10D", cadence=Cadence.IRREGULAR)
+    assert collection["cube:dimensions"]["t"]["step"] is None
+
+
+def test_quarterly_is_not_registerable_though_it_has_a_stac_step() -> None:
+    """The step map serves whatever is already in a store; the registerable set is
+    narrower. Quarterly has a P3M step but no period-string or sync implementation."""
+    assert period_type_to_iso_step("quarterly") == "P3M"
+    assert "quarterly" not in SUPPORTED_PERIOD_TYPES
+    with pytest.raises(ValueError, match="Unsupported period_type 'quarterly'"):
+        datetime_to_period_string(datetime(2026, 1, 1), "quarterly")
+
+
+def test_period_type_is_required_unless_the_dataset_is_static() -> None:
+    """Sync planning and coverage index period_type unguarded, so an absent one on a
+    temporal dataset registers and then raises a KeyError further in. Static is exempt:
+    an openEO save_result output legitimately has no cadence."""
+    from open_climate_service.data_registry.services.datasets import _validate_dataset_template
+
+    temporal = {"id": "x", "sync": {"kind": "temporal"}, "ingestion": {"plugin": "p.C"}}
+    with pytest.raises(ValueError, match="must define period_type"):
+        _validate_dataset_template(temporal, source="t.yaml")
+    _validate_dataset_template({**temporal, "period_type": "dekadal"}, source="t.yaml")
+
+    # An openEO output: static, and period_type may be underivable.
+    _validate_dataset_template({"id": "y", "sync": {"kind": "static"}}, source="t.yaml")
+
+
+def test_quarterly_template_is_rejected_at_registration() -> None:
+    from open_climate_service.data_registry.services.datasets import _validate_dataset_template
+
+    with pytest.raises(ValueError, match="unsupported period_type 'quarterly'"):
+        _validate_dataset_template(
+            {"id": "q", "sync": {"kind": "temporal"}, "ingestion": {"plugin": "p.C"}, "period_type": "quarterly"},
+            source="t.yaml",
+        )

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import calendar
 from datetime import date, datetime
+from typing import Any
 
 import numpy as np
 import pytest
@@ -289,11 +290,11 @@ def test_irregular_cadence_lists_its_timestamps_as_values() -> None:
         {"gpp": (("t", "y", "x"), np.zeros((len(stamps), 2, 2), "f4"))},
         coords={"t": stamps, "y": [1.0, 0.0], "x": [33.0, 34.0]},
     )
-    collection = {"cube:dimensions": {"t": {"type": "temporal", "step": None}}}
+    collection: dict[str, Any] = {"cube:dimensions": {"t": {"type": "temporal", "step": None}}}
 
     _add_temporal_values(collection, ds, "t")
 
-    values = collection["cube:dimensions"]["t"]["values"]
+    values: list[str] = collection["cube:dimensions"]["t"]["values"]
     assert len(values) == len(ids) == 9
     assert values[0] == "2026-01-01T00:00:00Z"
     assert [v[:10] for v in values] == ids

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -18,6 +18,7 @@ import pytest
 from open_climate_service.shared.time import (
     SUPPORTED_PERIOD_TYPES,
     Cadence,
+    daily_period_ids,
     datetime_to_period_string,
     dekad_bounds,
     dekad_period_ids,
@@ -353,3 +354,23 @@ def test_quarterly_template_is_rejected_at_registration() -> None:
             {"id": "q", "sync": {"kind": "temporal"}, "ingestion": {"plugin": "p.C"}, "period_type": "quarterly"},
             source="t.yaml",
         )
+
+
+def test_dekad_period_ids_matches_daily_on_an_inverted_range() -> None:
+    """Snapping the start back into its dekad must not make an empty range non-empty.
+
+    `dekad_period_ids` documents itself as the dekadal counterpart of `daily_period_ids`, and
+    an inverted range overlaps no dekad, so both must return nothing.
+    """
+    assert daily_period_ids("2024-03-10", "2024-03-05") == []
+    assert dekad_period_ids("2024-03-10", "2024-03-05") == []
+
+
+def test_dekad_period_ids_is_empty_when_the_cutoff_precedes_the_start() -> None:
+    """The realistic inverted case: a sync asking for periods past the available data."""
+    assert dekad_period_ids("2026-08-01", "2026-12-31", cutoff="2026-07-21") == []
+
+
+def test_dekad_period_ids_still_snaps_a_mid_dekad_start_forward_of_the_cutoff() -> None:
+    """The guard must not swallow a legitimately overlapping dekad."""
+    assert dekad_period_ids("2026-01-15", "2026-01-25") == ["2026-01-11", "2026-01-21"]

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -1,0 +1,276 @@
+"""Dekadal (10-daily) period support.
+
+A dekad is not a fixed duration — day 1-10, 11-20, then 21 to the end of the month —
+so the third dekad of a month runs 8, 9, 10 or 11 days. These tests pin that variability
+and the consequences: snapping rather than truncation, stepping by the covered dekad's own
+length, and an explicitly irregular STAC step rather than a fabricated duration.
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import date, datetime
+
+import numpy as np
+import pytest
+
+from open_climate_service.shared.time import (
+    SUPPORTED_PERIOD_TYPES,
+    Cadence,
+    datetime_to_period_string,
+    dekad_bounds,
+    dekad_period_ids,
+    dekad_start,
+    normalize_period_string,
+    numpy_datetime_to_period_string,
+    parse_period_string_to_datetime,
+    period_cadence,
+    period_type_to_iso_step,
+)
+
+
+def test_dekadal_is_classified_irregular_and_has_no_iso_step() -> None:
+    # The pair that matters: a real cadence with no duration. P10D would be wrong for
+    # every third dekad, so the step lookup must yield nothing at all.
+    assert period_cadence("dekadal") is Cadence.IRREGULAR
+    assert period_type_to_iso_step("dekadal") is None
+
+
+@pytest.mark.parametrize(
+    ("period_type", "expected"),
+    [
+        ("daily", Cadence.REGULAR),
+        ("monthly", Cadence.REGULAR),
+        ("dekadal", Cadence.IRREGULAR),
+        ("climatology", Cadence.NON_TEMPORAL),
+        ("dekad", Cadence.UNKNOWN),  # a plausible typo for the real value
+        ("fortnightly", Cadence.UNKNOWN),
+        (None, Cadence.UNKNOWN),
+        (10, Cadence.UNKNOWN),
+    ],
+)
+def test_period_cadence_classifies_every_kind(period_type: object, expected: Cadence) -> None:
+    assert period_cadence(period_type) is expected
+
+
+def test_irregular_is_distinguishable_from_unknown() -> None:
+    """Both lack an ISO step; conflating them would hide a misconfigured template."""
+    assert period_type_to_iso_step("dekadal") is period_type_to_iso_step("fortnightly") is None
+    assert period_cadence("dekadal") is not period_cadence("fortnightly")
+
+
+def test_dekadal_is_a_supported_period_type() -> None:
+    assert "dekadal" in SUPPORTED_PERIOD_TYPES
+    assert "dekad" not in SUPPORTED_PERIOD_TYPES
+
+
+@pytest.mark.parametrize(
+    ("day", "expected_start"),
+    [(1, 1), (2, 1), (10, 1), (11, 11), (12, 11), (20, 11), (21, 21), (28, 21), (31, 21)],
+)
+def test_dekad_start_snaps_to_the_containing_dekad(day: int, expected_start: int) -> None:
+    assert dekad_start(date(2026, 1, day)).day == expected_start
+
+
+def test_dekad_bounds_third_dekad_ends_with_the_month() -> None:
+    assert dekad_bounds("2026-01-25") == (date(2026, 1, 21), date(2026, 1, 31))  # 11 days
+    assert dekad_bounds("2026-04-25") == (date(2026, 4, 21), date(2026, 4, 30))  # 10 days
+    assert dekad_bounds("2026-02-25") == (date(2026, 2, 21), date(2026, 2, 28))  # 8 days
+    assert dekad_bounds("2024-02-25") == (date(2024, 2, 21), date(2024, 2, 29))  # 9 days, leap
+
+
+def test_dekad_bounds_first_two_dekads_are_always_ten_days() -> None:
+    for month in range(1, 13):
+        for start_day in (1, 11):
+            first, last = dekad_bounds(date(2026, month, start_day))
+            assert (last - first).days + 1 == 10
+
+
+def test_a_year_has_thirty_six_dekads_of_three_different_lengths() -> None:
+    ids = dekad_period_ids("2026-01-01", "2026-12-31")
+    assert len(ids) == 36
+    lengths: dict[int, int] = {}
+    for period_id in ids:
+        first, last = dekad_bounds(period_id)
+        lengths[(last - first).days + 1] = lengths.get((last - first).days + 1, 0) + 1
+    # 2026 is a common year: eleven 31-day months give 11-day third dekads (7 of them
+    # after April/June/September/November's 30-day months take 10), February gives 8.
+    assert lengths == {8: 1, 10: 28, 11: 7}
+    assert sum(k * v for k, v in lengths.items()) == 365
+
+
+def test_dekad_period_ids_includes_partially_covered_dekads_at_both_ends() -> None:
+    # The dekad is the smallest unit the data has, so overlapping one means needing it.
+    assert dekad_period_ids("2026-01-05", "2026-02-15") == [
+        "2026-01-01",
+        "2026-01-11",
+        "2026-01-21",
+        "2026-02-01",
+        "2026-02-11",
+    ]
+
+
+def test_dekad_period_ids_honours_the_availability_cutoff() -> None:
+    assert dekad_period_ids("2026-01-01", "2026-12-31", cutoff="2026-01-15") == ["2026-01-01", "2026-01-11"]
+
+
+def test_dekad_period_ids_returns_empty_for_a_reversed_range() -> None:
+    assert dekad_period_ids("2026-03-01", "2026-01-01") == []
+
+
+def test_dekad_period_ids_crosses_a_year_boundary() -> None:
+    assert dekad_period_ids("2025-12-22", "2026-01-05") == ["2025-12-21", "2026-01-01"]
+
+
+def test_period_string_snaps_a_mid_dekad_date() -> None:
+    assert datetime_to_period_string(datetime(2026, 1, 15), "dekadal") == "2026-01-11"
+    assert normalize_period_string("2026-01-15", "dekadal") == "2026-01-11"
+    assert normalize_period_string("2026-01-31T12:00:00", "dekadal") == "2026-01-21"
+
+
+def test_period_string_leaves_an_exact_dekad_start_alone() -> None:
+    for period_id in ("2026-01-01", "2026-01-11", "2026-01-21"):
+        assert normalize_period_string(period_id, "dekadal") == period_id
+
+
+def test_invalid_dekadal_period_names_the_expected_format() -> None:
+    with pytest.raises(ValueError, match="Invalid dekadal period"):
+        normalize_period_string("not-a-date", "dekadal")
+
+
+def test_numpy_conversion_snaps_rather_than_truncates() -> None:
+    """Truncating to 10 characters would only be right for timestamps already on a start."""
+    stamps = np.array(["2026-01-05", "2026-01-15", "2026-01-25", "2026-02-28"], dtype="datetime64[ns]")
+    assert list(numpy_datetime_to_period_string(stamps, "dekadal")) == [
+        "2026-01-01",
+        "2026-01-11",
+        "2026-01-21",
+        "2026-02-21",
+    ]
+
+
+def test_dekad_ids_round_trip_through_the_generic_parser() -> None:
+    # Ids are plain dates, so they need no special case in parse_period_string_to_datetime.
+    for period_id in dekad_period_ids("2026-01-01", "2026-03-31"):
+        parsed = parse_period_string_to_datetime(period_id)
+        assert parsed.date().isoformat() == period_id
+
+
+def test_dekad_ids_sort_chronologically_as_strings() -> None:
+    ids = dekad_period_ids("2025-11-01", "2026-02-28")
+    assert ids == sorted(ids)
+
+
+def test_dekad_bounds_tile_the_month_without_gap_or_overlap() -> None:
+    for month in range(1, 13):
+        last_day = calendar.monthrange(2026, month)[1]
+        covered: list[date] = []
+        for start_day in (1, 11, 21):
+            first, last = dekad_bounds(date(2026, month, start_day))
+            day = first
+            while day <= last:
+                covered.append(day)
+                day = date.fromordinal(day.toordinal() + 1)
+        assert len(covered) == last_day
+        assert len(set(covered)) == last_day
+
+
+# --- consumers: sync planning, template validation, STAC declaration -------------------
+
+
+def test_next_period_start_steps_by_the_covered_dekads_own_length() -> None:
+    """A fixed +10 days would land mid-month for every 11-day and 8-day third dekad."""
+    from open_climate_service.ingestions.sync_engine import _next_period_start
+
+    assert _next_period_start("2026-01-01", period_type="dekadal") == "2026-01-11"
+    assert _next_period_start("2026-01-11", period_type="dekadal") == "2026-01-21"
+    # 11-day third dekad: 21 Jan + 11 = 1 Feb, not 31 Jan.
+    assert _next_period_start("2026-01-21", period_type="dekadal") == "2026-02-01"
+    # 8-day third dekad in a common February.
+    assert _next_period_start("2026-02-21", period_type="dekadal") == "2026-03-01"
+    # 9-day third dekad in a leap February.
+    assert _next_period_start("2024-02-21", period_type="dekadal") == "2024-03-01"
+
+
+def test_next_period_start_never_repeats_or_skips_a_dekad_across_a_year() -> None:
+    from open_climate_service.ingestions.sync_engine import _next_period_start
+
+    expected = dekad_period_ids("2026-01-01", "2026-12-31")
+    walked = [expected[0]]
+    while len(walked) < len(expected):
+        walked.append(_next_period_start(walked[-1], period_type="dekadal"))
+    assert walked == expected
+
+
+def test_sync_and_request_defaults_return_the_current_dekad() -> None:
+    from open_climate_service.ingestions.services import _current_request_period
+    from open_climate_service.ingestions.sync_engine import _default_target_end
+    from open_climate_service.shared.time import utc_today
+
+    today = dekad_start(utc_today()).isoformat()
+    assert _default_target_end(period_type="dekadal") == today
+    assert _current_request_period("dekadal") == today
+
+
+def test_template_validation_accepts_dekadal_and_rejects_an_unsupported_cadence() -> None:
+    from open_climate_service.data_registry.services.datasets import _validate_dataset_template
+
+    base = {"id": "gpp", "sync": {"kind": "temporal"}, "ingestion": {"plugin": "pkg.Cls"}}
+    _validate_dataset_template({**base, "period_type": "dekadal"}, source="t.yaml")
+    _validate_dataset_template(base, source="t.yaml")  # absent stays permitted
+
+    with pytest.raises(ValueError, match="unsupported period_type 'dekad'"):
+        _validate_dataset_template({**base, "period_type": "dekad"}, source="t.yaml")
+
+
+def test_stac_declares_an_irregular_step_as_null_rather_than_a_duration() -> None:
+    from open_climate_service.stac.services import _override_time_step
+
+    collection = {"cube:dimensions": {"t": {"type": "temporal", "extent": ["2026-01-01", "2026-12-31"]}}}
+    _override_time_step(collection, None, cadence=Cadence.IRREGULAR)
+    # Explicitly null — the datacube extension's encoding for "irregularly spaced steps".
+    assert collection["cube:dimensions"]["t"]["step"] is None
+
+
+def test_stac_leaves_an_xstac_inferred_step_alone_when_the_cadence_is_unknown() -> None:
+    from open_climate_service.stac.services import _override_time_step
+
+    collection = {"cube:dimensions": {"t": {"type": "temporal", "step": "P1D"}}}
+    _override_time_step(collection, None, cadence=Cadence.UNKNOWN)
+    assert collection["cube:dimensions"]["t"]["step"] == "P1D"
+
+
+def test_stac_still_sets_a_duration_for_a_regular_cadence() -> None:
+    from open_climate_service.stac.services import _override_time_step
+
+    collection = {"cube:dimensions": {"t": {"type": "temporal"}}}
+    _override_time_step(collection, "P1M", cadence=Cadence.REGULAR)
+    assert collection["cube:dimensions"]["t"]["step"] == "P1M"
+
+
+def test_coverage_is_reported_in_dekad_ids_for_a_dekadal_store() -> None:
+    """Coverage runs through numpy_datetime_to_period_string, so it must snap too."""
+    import xarray as xr
+
+    from open_climate_service.data_accessor.services.accessor import _coverage_from_dataset
+
+    ids = dekad_period_ids("2026-01-01", "2026-03-31")
+    assert len(ids) == 9
+    stamps = np.array(ids, dtype="datetime64[ns]")
+    ds = xr.Dataset(
+        {"gpp": (("t", "y", "x"), np.zeros((len(stamps), 2, 2), "f4"))},
+        coords={"t": stamps, "y": [1.0, 0.0], "x": [33.0, 34.0]},
+    )
+
+    coverage = _coverage_from_dataset(ds=ds, period_type="dekadal")["coverage"]["temporal"]
+    assert coverage == {"start": "2026-01-01", "end": "2026-03-21"}
+
+
+def test_dhis2_export_refuses_a_dekadal_dataset_rather_than_inventing_a_period() -> None:
+    """DHIS2 has no dekad period type, so there is no correct id to emit."""
+    import pandas as pd
+
+    from open_climate_service.openeo.jobs import _format_dhis2_timestamp
+
+    with pytest.raises(ValueError, match="Unsupported period_type 'dekadal'"):
+        _format_dhis2_timestamp(pd.Timestamp("2026-01-11"), "dekadal")

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -274,3 +274,37 @@ def test_dhis2_export_refuses_a_dekadal_dataset_rather_than_inventing_a_period()
 
     with pytest.raises(ValueError, match="Unsupported period_type 'dekadal'"):
         _format_dhis2_timestamp(pd.Timestamp("2026-01-11"), "dekadal")
+
+
+def test_irregular_cadence_lists_its_timestamps_as_values() -> None:
+    """A null step gives a client nothing to extrapolate from, so `values` must carry
+    the real timestamps — otherwise a time control collapses to a single position."""
+    import xarray as xr
+
+    from open_climate_service.stac.services import _add_temporal_values
+
+    ids = dekad_period_ids("2026-01-01", "2026-03-31")
+    stamps = np.array(ids, dtype="datetime64[ns]")
+    ds = xr.Dataset(
+        {"gpp": (("t", "y", "x"), np.zeros((len(stamps), 2, 2), "f4"))},
+        coords={"t": stamps, "y": [1.0, 0.0], "x": [33.0, 34.0]},
+    )
+    collection = {"cube:dimensions": {"t": {"type": "temporal", "step": None}}}
+
+    _add_temporal_values(collection, ds, "t")
+
+    values = collection["cube:dimensions"]["t"]["values"]
+    assert len(values) == len(ids) == 9
+    assert values[0] == "2026-01-01T00:00:00Z"
+    assert [v[:10] for v in values] == ids
+
+
+def test_temporal_values_are_not_added_to_a_non_temporal_dimension() -> None:
+    import xarray as xr
+
+    from open_climate_service.stac.services import _add_temporal_values
+
+    ds = xr.Dataset({"v": ("t", np.zeros(2, "f4"))}, coords={"t": [0, 1]})
+    collection = {"cube:dimensions": {"t": {"type": "other"}}}
+    _add_temporal_values(collection, ds, "t")
+    assert "values" not in collection["cube:dimensions"]["t"]

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -346,3 +346,55 @@ def test_ensure_time_coordinate_chunking_rechunks_appended_store(tmp_path: Path)
 
     # idempotent: a second call is a no-op
     assert downloader.ensure_time_coordinate_chunking(store_path, "t") is False
+
+
+def test_write_to_icechunk_store_handles_a_reversed_dask_chunk_tuple(tmp_path: Path) -> None:
+    """A south-up, dask-backed source must still publish.
+
+    `raster_contract.ensure_north_up` flips y with `isel(slice(None, None, -1))`, and that
+    reverses the dask *chunk tuple* along with the data: a legal trailing remainder
+    (10, 10, 5) becomes a leading one (5, 10, 10). Zarr permits the short chunk only last,
+    so `to_zarr` refused the write with "Zarr requires uniform chunk sizes except for final
+    chunk".
+
+    Regression for the dekad -> monthly aggregation failing to publish CLMS GPP, whose grid
+    (1949 x 1895, chunked 244) sits below the pyramid threshold and so takes the flat write
+    path — the pyramid path materialises via `load()` and never saw this.
+    """
+    y = np.arange(25.0)  # ascending => south-up => ensure_north_up will reverse it
+    x = np.arange(8.0)
+    data = np.arange(25 * 8, dtype="float32").reshape(1, 25, 8)
+    ds = xr.Dataset(
+        {"gpp": (("t", "y", "x"), data)},
+        coords={"t": [np.datetime64("2024-01-01")], "y": y, "x": x},
+    )
+    ds.attrs["proj:code"] = "EPSG:4326"
+    ds = ds.chunk({"y": 10, "x": 8})
+    source_chunks = ds["gpp"].chunks
+    assert source_chunks is not None
+    assert source_chunks[1] == (10, 10, 5), "precondition: a trailing short chunk"
+
+    store = tmp_path / "reversed_chunks.icechunk"
+    downloader.write_to_icechunk_store(ds, store, commit_message="test")
+
+    out = open_icechunk_dataset(str(store))
+    # Reversed to north-up, and the value at a given latitude has not moved with it.
+    assert out["y"].values[0] > out["y"].values[-1]
+    assert float(out["gpp"].isel(t=0).sel(y=0.0, x=0.0)) == pytest.approx(0.0)
+    assert float(out["gpp"].isel(t=0).sel(y=24.0, x=7.0)) == pytest.approx(25 * 8 - 1)
+
+
+def test_uniform_chunks_leaves_a_legal_trailing_remainder_alone() -> None:
+    """Only the illegal shape is rewritten — rechunking a large array is not free."""
+    ds = xr.Dataset(
+        {"v": (("y", "x"), np.zeros((25, 8), dtype="float32"))},
+        coords={"y": np.arange(25.0), "x": np.arange(8.0)},
+    ).chunk({"y": 10, "x": 8})
+    assert ds["v"].chunks == ((10, 10, 5), (8,))
+
+    # Identity, not merely an equal result: a rechunk of a full-resolution grid is not free.
+    assert downloader._uniform_chunks(ds) is ds
+
+    reversed_ds = ds.isel(y=slice(None, None, -1))
+    assert reversed_ds["v"].chunks == ((5, 10, 10), (8,)), "precondition: leading short chunk"
+    assert downloader._uniform_chunks(reversed_ds)["v"].chunks == ((10, 10, 5), (8,))

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1462,7 +1462,6 @@ def test_derive_variable_raises_for_multiple_vars_without_option() -> None:
     [
         (1, "daily"),
         (7, "weekly"),
-        (10, "dekadal"),
         (30, "monthly"),
         (365, "yearly"),
     ],
@@ -1473,28 +1472,53 @@ def test_infer_period_type(timedelta_days: int, expected: str) -> None:
     assert _infer_period_type(ds, "t") == expected
 
 
-def test_infer_period_type_reads_a_real_dekadal_axis_as_dekadal() -> None:
-    """The 32-day monthly bucket used to swallow dekads, mislabelling them monthly.
+def _axis(ids: list[str]) -> xr.Dataset:
+    t = np.array(ids, dtype="datetime64[ns]")
+    return xr.Dataset({"v": ("t", np.arange(len(ids), dtype="float64"))}, coords={"t": t})
 
-    Built from `dekad_period_ids` rather than a fixed 10-day stride, so the axis carries the
-    real 8/10/11-day spacing a dekadal store has.
-    """
+
+def test_infer_period_type_reads_a_real_dekadal_axis_as_dekadal() -> None:
+    """The 32-day monthly bucket used to swallow dekads, mislabelling them monthly."""
     from open_climate_service.shared.time import dekad_period_ids
 
-    ids = dekad_period_ids("2026-01-01", "2026-12-31")
-    t = np.array(ids, dtype="datetime64[ns]")
-    ds = xr.Dataset({"v": ("t", np.arange(len(ids), dtype="float64"))}, coords={"t": t})
-
-    assert _infer_period_type(ds, "t") == "dekadal"
+    assert _infer_period_type(_axis(dekad_period_ids("2026-01-01", "2026-12-31")), "t") == "dekadal"
 
 
-def test_infer_period_type_still_separates_weekly_and_monthly_from_dekadal() -> None:
-    """The new bucket must not annex its neighbours."""
-    weekly = np.arange(np.datetime64("2026-01-01"), np.datetime64("2026-04-01"), np.timedelta64(7, "D"))
-    monthly = np.array([f"2026-{m:02d}-01" for m in range(1, 13)], dtype="datetime64[ns]")
-    for axis, expected in ((weekly, "weekly"), (monthly, "monthly")):
-        ds = xr.Dataset({"v": ("t", np.arange(len(axis), dtype="float64"))}, coords={"t": axis})
-        assert _infer_period_type(ds, "t") == expected
+def test_infer_period_type_recognises_a_short_dekadal_axis_across_a_month_boundary() -> None:
+    """Feb 21 -> Mar 1 is 8 days, so any interval rule reads it as weekly.
+
+    Dekads are defined by *starting* on the 1st, 11th or 21st, which is exact where a median
+    is a guess.
+    """
+    assert _infer_period_type(_axis(["2026-02-21", "2026-03-01"]), "t") == "dekadal"
+
+
+def test_infer_period_type_recognises_a_dekadal_axis_with_missing_dekads() -> None:
+    """A gap is a real state — `aggregate_dekads` warns about it — and its median is 15.5 days."""
+    assert _infer_period_type(_axis(["2026-01-01", "2026-01-11", "2026-02-01"]), "t") == "dekadal"
+
+
+def test_infer_period_type_does_not_call_unrelated_ten_day_data_dekadal() -> None:
+    """A regular 10-day series on other days of the month is not a dekadal cadence."""
+    stride = [
+        str(d)[:10]
+        for d in np.arange(np.datetime64("2026-01-03"), np.datetime64("2026-03-01"), np.timedelta64(10, "D"))
+    ]
+    assert _infer_period_type(_axis(stride), "t") != "dekadal"
+
+
+def test_infer_period_type_does_not_call_a_monthly_axis_dekadal() -> None:
+    """Every month starts on the 1st, so the day-of-month test alone would accept it — and a
+    monthly-on-the-11th axis is equally a subset of the dekad start days."""
+    assert _infer_period_type(_axis([f"2026-{m:02d}-01" for m in range(1, 13)]), "t") == "monthly"
+    assert _infer_period_type(_axis([f"2026-{m:02d}-11" for m in range(1, 13)]), "t") == "monthly"
+
+
+def test_infer_period_type_still_separates_weekly_from_dekadal() -> None:
+    weekly = [
+        str(d)[:10] for d in np.arange(np.datetime64("2026-01-01"), np.datetime64("2026-04-01"), np.timedelta64(7, "D"))
+    ]
+    assert _infer_period_type(_axis(weekly), "t") == "weekly"
 
 
 def test_infer_period_type_returns_none_for_single_timestep() -> None:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1463,7 +1463,6 @@ def test_derive_variable_raises_for_multiple_vars_without_option() -> None:
         (1, "daily"),
         (7, "weekly"),
         (30, "monthly"),
-        (90, "quarterly"),
         (365, "yearly"),
     ],
 )
@@ -1475,6 +1474,20 @@ def test_infer_period_type(timedelta_days: int, expected: str) -> None:
 
 def test_infer_period_type_returns_none_for_single_timestep() -> None:
     ds = xr.Dataset({"v": ("t", [1.0])}, coords={"t": np.array(["2025-01-01"], dtype="datetime64[D]")})
+    assert _infer_period_type(ds, "t") is None
+
+
+def test_infer_period_type_does_not_infer_quarterly() -> None:
+    """Quarterly is in the STAC step map but unimplemented for ingest and coverage.
+
+    `datetime_to_period_string` raises on it and `numpy_datetime_to_period_string` KeyErrors,
+    so inferring it attached a cadence that failed the moment the artifact was written — and
+    once it is rejected at registration, auto-registering a quarterly openEO result would fail
+    outright. None is legal here: a managed output is static, and a static template may carry
+    no cadence.
+    """
+    t = np.arange(3).astype("timedelta64[D]") * 90 + np.datetime64("2025-01-01", "D")
+    ds = xr.Dataset({"v": ("t", [1.0, 2.0, 3.0])}, coords={"t": t})
     assert _infer_period_type(ds, "t") is None
 
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1462,6 +1462,7 @@ def test_derive_variable_raises_for_multiple_vars_without_option() -> None:
     [
         (1, "daily"),
         (7, "weekly"),
+        (10, "dekadal"),
         (30, "monthly"),
         (365, "yearly"),
     ],
@@ -1470,6 +1471,30 @@ def test_infer_period_type(timedelta_days: int, expected: str) -> None:
     t = np.arange(3).astype("timedelta64[D]") * timedelta_days + np.datetime64("2025-01-01", "D")
     ds = xr.Dataset({"v": ("t", [1.0, 2.0, 3.0])}, coords={"t": t})
     assert _infer_period_type(ds, "t") == expected
+
+
+def test_infer_period_type_reads_a_real_dekadal_axis_as_dekadal() -> None:
+    """The 32-day monthly bucket used to swallow dekads, mislabelling them monthly.
+
+    Built from `dekad_period_ids` rather than a fixed 10-day stride, so the axis carries the
+    real 8/10/11-day spacing a dekadal store has.
+    """
+    from open_climate_service.shared.time import dekad_period_ids
+
+    ids = dekad_period_ids("2026-01-01", "2026-12-31")
+    t = np.array(ids, dtype="datetime64[ns]")
+    ds = xr.Dataset({"v": ("t", np.arange(len(ids), dtype="float64"))}, coords={"t": t})
+
+    assert _infer_period_type(ds, "t") == "dekadal"
+
+
+def test_infer_period_type_still_separates_weekly_and_monthly_from_dekadal() -> None:
+    """The new bucket must not annex its neighbours."""
+    weekly = np.arange(np.datetime64("2026-01-01"), np.datetime64("2026-04-01"), np.timedelta64(7, "D"))
+    monthly = np.array([f"2026-{m:02d}-01" for m in range(1, 13)], dtype="datetime64[ns]")
+    for axis, expected in ((weekly, "weekly"), (monthly, "monthly")):
+        ds = xr.Dataset({"v": ("t", np.arange(len(axis), dtype="float64"))}, coords={"t": axis})
+        assert _infer_period_type(ds, "t") == expected
 
 
 def test_infer_period_type_returns_none_for_single_timestep() -> None:


### PR DESCRIPTION
Implements [CLIM-874](https://dhis2.atlassian.net/browse/CLIM-874) and [CLIM-875](https://dhis2.atlassian.net/browse/CLIM-875).

CLMS Primary Productivity (GPP/NPP, 300 m) is published on **dekads**, but OCS had no dekadal period type. This adds the period type, and the day-weighted aggregation that turns dekads into months without the bias a plain `mean` introduces.

## A dekad is the first cadence with unequal periods

Day 1–10, then 11–20, then **21 to the end of the month** — so the third runs 8, 9, 10 or 11 days. Measured across 2026:

```
36 dekads/year   lengths: {8: 1, 10: 28, 11: 7}   (sums to 365)
```

So `P10D` is wrong for every third dekad, and there is no ISO 8601 duration that describes all three.

## Approach: extend the enum, keep ISO 8601

`weekly` already established this extension point — its own id pattern, its own parser, and a step special-cased to `P7D` because the viewer's duration parser handles H/D/M/Y but not W. Dekadal is the same shape of addition.

ISO 8601 stays the representation for every fixed-length cadence. Dekadal simply **has no step and says so**, which is not a departure from the standard: the datacube extension provides `step: null` for exactly this.

## Period ids are the dekad's first day

`2026-01-01` / `2026-01-11` / `2026-01-21`. They sort chronologically as strings, parse as ordinary dates (no new case in `parse_period_string_to_datetime`), and match what the plugin already emits. Any date inside a dekad **snaps** to its start, so `2026-01-15` → `2026-01-11`.

`numpy_datetime_to_period_string` snaps rather than truncating. Truncating to 10 characters would be correct only for stores whose timestamps already sit on the 1st/11th/21st — true today, silently wrong for a store that does not.

## Irregular is now distinguishable from unknown

The one thing worth getting right. `period_type_to_iso_step()` returns `None` for an unsupported type; if dekadal also returned `None`, a correctly-declared dekadal store and a misconfigured one would be **indistinguishable downstream** — reintroducing the exact failure this PR removes. A new `Cadence` enum separates them:

| | meaning | STAC step |
|---|---|---|
| `REGULAR` | fixed-length | the ISO duration |
| `IRREGULAR` | known cadence, variable length | **explicit `null`** |
| `NON_TEMPORAL` | day-of-year ordinals (`climatology`) | left alone |
| `UNKNOWN` | unsupported | rejected at registration |

Previously an irregular cadence would inherit whatever step xstac inferred, implying a regular spacing the data does not have.

An irregular cadence also **overrides a declared resolution**. A template carrying `resolution: P10D` used to win over the `period_type` fallback, so switching a template to `dekadal` would have changed nothing a client could see — it would still have advertised `P10D`, wrong for every third dekad. `_override_time_step` now forces `null` when the cadence is irregular, so a declared resolution cannot reintroduce the lie.

## Day-weighted dekad → monthly aggregation (CLIM-875)

Three dekads tile a month exactly, but they are **not equal in length**, so a plain `mean` is biased for an intensive quantity — and GPP is `gC/m²/day`, a rate:

```
month  1  lens=[10,10,11]  equal=[.3333 .3333 .3333]  day-weighted=[.3226 .3226 .3548]
month  2  lens=[10,10, 8]  equal=[.3333 .3333 .3333]  day-weighted=[.3571 .3571 .2857]
```

February's 8-day dekad is over-weighted by 4.8 percentage points — **14% relative** on its contribution — and the error is systematic rather than noise: it always favours short third dekads, so an unweighted monthly series carries a seasonal artefact that tracks month length.

`aggregate_temporal_period` cannot express the weighting, so this ships as a backend process rather than a process graph:

- **`aggregate_dekads(data, period="month"|"week", method="mean"|"sum")`** weights each dekad by the days it shares with the target period, with weights taken from the real calendar via `dekad_bounds` rather than a tabulated mapping.
- **`aggregate_dekads_to_period`** wires it into a built-in workflow, so instances stop carrying their own copies.
- **NaN-aware per pixel**: a dekad missing over part of the grid is dropped from the weights *there* and the remainder renormalised, rather than turning the whole month NaN. An all-missing period stays NaN rather than becoming 0.
- **Refuses a non-dekadal cube** outright — on daily or monthly input the weighting would produce plausible nonsense — and warns when `method="sum"` is used on per-day units, since adding daily rates does not produce a total.
- Reduces per target period rather than building a source × target weight matrix, which at CLMS 300 m would be roughly 6 TB.
- Stamps `cell_methods = "time: mean (interval: 10 day comment: day-weighted mean from dekads)"` so a consumer can tell a day-weighted aggregate from an observation.

`period: week` is available but documented as discouraged: 36 dekads against 52–53 weeks is upsampling, so a weekly series has an effective resolution of about 10 days however it is derived. Monthly is exact by comparison.

**Verified against the real store**, not a fixture — run as a batch job on Uganda's ingested `clms_gpp_dekad` (36 dekads of 2024, 1949 × 1895), checked against weights recomputed from `calendar.monthrange` rather than from OCS's own helpers, so the check could fail if OCS's notion of dekad length were wrong:

```
month     lens          equal-wt   day-wt   published   diff
2024-01   [10,10,11]     5.26800   5.23216    5.23216   0.0e+00
2024-02   [10,10, 9]     4.41867   4.42017    4.42017   0.0e+00   <- leap year
2024-04   [10,10,10]     8.42733   8.42733    8.42733   0.0e+00   <- weighting is a no-op
max |published - hand-computed| = 0.000e+00 over all 12 months
```

## Verification

```
745 passed, 1 skipped        (62 new: 49 dekadal, 13 aggregation, plus 2 for the chunk fix)
make lint clean              ruff, format, mypy 84 files, pyright
```

3 failures in `test_openeo_execution.py` are the local miniforge `proj.db` breaking `rio.crs.to_epsg()`; they fail identically with these changes stashed.

The extended helpers are on the real paths, checked end to end rather than in isolation:

- **coverage** for a 9-dekad store reports `{start: 2026-01-01, end: 2026-03-21}` via `numpy_datetime_to_period_string`
- **resume** works because `read_committed_period_ids` goes through `datetime_to_period_string`
- **sync stepping** walks all 36 dekads of a year with no repeat or skip — a fixed +10 days would land mid-month at every 11-day and 8-day third dekad
- **DHIS2 export refuses** a dekadal dataset (`Unsupported period_type 'dekadal'`) rather than inventing an id — DHIS2 has no dekad period type, so loud refusal is the correct behaviour
- **STAC on a running instance** publishes `step: null` with 36 explicit values on the 1st/11th/21st, and the aggregated monthly collection publishes `step: P1M`

`period_type` is now validated at registration, so an unsupported value is rejected instead of accepted and silently ignored by every consumer. Worth being precise about what that catches: typos (`dekad`) and cadences this version cannot honour — **not** the Uganda mislabelling, because `daily` is a perfectly valid value, just the wrong one for the data. Catching that needs comparing the declared cadence against observed timestamp spacing at ingest, which is not here.

## Instance follow-up

[HISP-Uganda/uganda-climate-service-tools#21](https://github.com/HISP-Uganda/uganda-climate-service-tools/pull/21) is open and waiting on this PR. It:

- moves both templates to `period_type: dekadal`, and **removes `resolution: P10D`** — without that removal the switch would change nothing a client can see, since a declared resolution used to win over the `period_type` fallback
- drops the instance's own `aggregate_dekadal_to_monthly.json` in favour of the built-in workflow, which renames the entry point to `aggregate_dekads_to_period`
- replaces the plugin's local `_dekad_dates` / `_DEKAD_DAYS` with `dekad_period_ids` from this PR

That last one was initially left out as "a behaviour change at the boundary deserving its own PR", but comparing the two showed the local enumerator was simply wrong at the start edge, so it went in:

| request | old | new |
|---|---|---|
| `2014-01-01..2014-02-10` | 3 dekads | same — the common case |
| `2024-01-15..2024-02-10` | `01-21, 02-01` | **+ `2024-01-11`** — the dekad the range starts inside |
| `2024-01-12..2024-01-19` | `[]` | **`2024-01-11`** — a sub-dekad range found nothing at all |

It skipped any dekad whose start preceded the requested start, so a range beginning mid-dekad dropped the dekad it began in, and a range falling entirely inside one dekad returned no periods. Snapping down matches `normalize_period_string` and `numpy_datetime_to_period_string`. The plugin's STAC item cache had to follow — it was searched from the requested start, so the snapped-to dekad's item would not have been cached and `fetch_period` would have missed it.

Still outstanding: **Malawi** carries an unweighted copy of the same workflow, and Uganda's GPP/NPP need re-ingesting once this merges — which also picks up a pyramid from [#338](https://github.com/dhis2/open-climate-service/pull/338).


[CLIM-874]: https://dhis2.atlassian.net/browse/CLIM-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-875]: https://dhis2.atlassian.net/browse/CLIM-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ