### PR TITLE
fix(publish): lower the pyramid threshold, build it lazily, and make appends pyramid-aware

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -242,7 +242,7 @@ Multiple templates can share the same plugin class and differ only in `params`:
 
 #### Pyramid resampling for categorical layers
 
-Layers larger than ~2048×2048 are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels are aggregated from the full-resolution data, and `ingestion.resampling` controls how:
+Layers whose grid exceeds 1024×1024 cells (about 1.05 megapixels, counted as `nx × ny` rather than per axis) are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels sit beside the full-resolution level 0, which analytics keeps reading, so the cost is roughly +33% storage and nothing else. They are aggregated from the full-resolution data, and `ingestion.resampling` controls how:
 
 - **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
 - **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -242,7 +242,11 @@ Multiple templates can share the same plugin class and differ only in `params`:
 
 #### Pyramid resampling for categorical layers
 
-Layers whose grid exceeds 1024×1024 cells (about 1.05 megapixels, counted as `nx × ny` rather than per axis) are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels sit beside the full-resolution level 0, which analytics keeps reading, so the cost is roughly +33% storage and nothing else. They are aggregated from the full-resolution data, and `ingestion.resampling` controls how:
+Layers whose grid exceeds 1024×1024 cells (about 1.05 megapixels, counted as `nx × ny` rather than per axis) are stored as a multiscale pyramid so the map stays fast when zoomed out. Coarser levels sit beside the full-resolution level 0, which analytics keeps reading, so **analysis results do not change** and the persistent cost is roughly +33% storage.
+
+Building one is not free, though. Level 0 is rewritten rather than kept as-is — the pyramid writer re-chunks it to its own target chunk size — the rebuild goes to a sibling store and is swapped in, so it needs transient disk for a second copy, and it takes longer than a flat write (measured at roughly 2.4× on a 2 GB store, in exchange for around 6× less peak memory).
+
+Levels are aggregated from the full-resolution data, and `ingestion.resampling` controls how:
 
 - **Continuous data** (temperature, precipitation, NDVI, …) — leave the default `mean`.
 - **Binary masks** (0/1 presence) — use `max` ("present anywhere in the block"). Averaging turns a mask into meaningless fractions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,7 +234,7 @@ Plugin code (streaming plugins, `@process` functions) can rely on the following 
 | Longitudes rolled to −180…180 for geographic data             | `normalize_longitudes`                           |
 | CRS kept consistent with the coordinates (never reprojected)  | `resolve_store_crs`                              |
 | Zarr chunking (auto-sized from `extents.temporal.resolution`) | `time_chunk_for_iso_step`                        |
-| Multiscale pyramid generation (when dims > 2048×2048)         | `write_to_icechunk_store`                        |
+| Multiscale pyramid generation (when nx × ny > 1024×1024)      | `write_to_icechunk_store`                        |
 | GeoZarr root attributes (`spatial:transform`, `proj:code`, …) | `grid_geometry` / `write_geozarr_attrs`          |
 | Artifact coverage computation                                 | `_coverage_from_dataset`                         |
 | Artifact record persistence                                   | `_store_artifact_record`                         |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -150,7 +150,7 @@ Published Zarr-backed managed datasets appear there as one STAC Collection per d
 
 Current STAC details:
 
-- pyramid Zarr stores (detected by the presence of a `0/` level on disk) expose `/zarr/{dataset_id}/0` as the canonical asset href
+- the Zarr asset href is `/zarr/{dataset_id}` — the store root — for flat and pyramided stores alike. A pyramided root has no data variables of its own: it carries `multiscales` (with the levels under `0/`, `1/`, …) plus the time coordinate and `spatial_ref`, and its media type gains `profile=multiscales`, which is how a client knows to resolve a level rather than expecting arrays at the root. Python readers do that descent for you via `open_icechunk_dataset` / `open_zarr_dataset`, which always land on level 0
 - temporal extents are normalized to RFC 3339 in both STAC and Datacube temporal extent fields
 - STAC collection `license` currently defaults to `various`
 - spatial `step` values are rounded for readability while preserving axis direction

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -30,10 +30,23 @@ def _resolve_download_dir() -> Path:
 DOWNLOAD_DIR = _resolve_download_dir()
 
 
-_PYRAMID_PIXEL_THRESHOLD = 2048 * 2048
+# A grid larger than this gets overviews. Compared against the *grid* (nx * ny), not the
+# chunk shape — a pyramid appends coarser levels beside level 0 and costs ~+33% storage
+# (1 + 1/4 + 1/16), so the only question is whether a map client would benefit.
+#
+# 1024x1024 rather than 2048x2048: at 2048² a 1949 x 1895 store (Uganda's CLMS GPP, 3.69 Mpx)
+# fell 0.88x short of the bar and rendered flat, making every frame at every zoom read the
+# full grid — 32 chunk requests and 14.8 MB per timestep to fill a few hundred screen pixels.
+# 1024² catches that while still skipping grids small enough to send whole.
+_PYRAMID_PIXEL_THRESHOLD = 1024 * 1024
 _PYRAMID_MAX_LEVELS = 8
 _PYRAMID_TARGET_TILE_SIZE = 512
 _ROOT_TIME_COORD_MAX_CHUNK = 4096
+# Memory budget per streamed level-0 region. topozarr writes region by region from a *lazy*
+# source, so this — not the store size — bounds the pyramid build. Its own default is 256 MB;
+# 64 MB keeps peak well within a small on-prem box, since peak is roughly
+# `max_workers * 5 * region_bytes`.
+_PYRAMID_MAX_REGION_BYTES = 64 * 1024 * 1024
 
 
 def _needs_pyramid(ds: xr.Dataset, x_dim: str, y_dim: str) -> bool:
@@ -361,8 +374,11 @@ def write_to_icechunk_store(
             ds.sizes[y_dim],
         )
 
-        # topozarr.create_pyramid requires fully materialised numpy arrays.
-        ds = ds.load()
+        # Deliberately *not* `ds.load()`. topozarr streams level 0 region by region and sizes
+        # those regions from `max_region_bytes`, so a lazy source is what bounds peak memory —
+        # its own docs say "for bounded memory on large stores, open the source lazily".
+        # Materialising first defeated that: Uganda's GPP store is 3.47 GB and growing ~0.6 GB
+        # per year of dekads, which is what made a lower threshold risky on a small box.
         # Validate/normalize here too, so a direct caller passing e.g. "MAX" or a mistyped
         # value never reaches topozarr as an invalid CoarseningMethod (falls back to mean).
         pyramid_method = _normalize_resampling_method(pyramid_method)
@@ -389,7 +405,7 @@ def write_to_icechunk_store(
             if var_da.dtype.kind != "f" and pyramid.fill_values.get(str(var_name)) is None:
                 pyramid.fill_values[str(var_name)] = 0
 
-        pyramid.write(session.store, mode="w")
+        pyramid.write(session.store, mode="w", max_region_bytes=_PYRAMID_MAX_REGION_BYTES)
 
         if native_resample:
             # Categorical data: recompute the coarsened levels from native so class codes /

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -422,15 +422,51 @@ def _create_streaming_artifact(
         lock.release()
 
 
+def _retired_path(target: Path) -> Path:
+    return target.with_name(f"{target.name}.retired")
+
+
+def recover_interrupted_swap(target: Path) -> bool:
+    """Restore a store left behind by a swap that was killed between its two renames.
+
+    ``_swap_store`` moves the published store aside before moving the rebuilt one in. An
+    exception between the two is handled there, but a SIGKILL or a host restart is not: the
+    published path then does not exist and the data sits at ``<name>.retired``, which no
+    reader looks for. Called before the store is opened, so the next sync heals it rather
+    than reporting an unreadable dataset.
+
+    Returns True when a recovery was performed.
+    """
+    retired = _retired_path(target)
+    if target.exists() or not retired.is_dir():
+        return False
+    retired.rename(target)
+    logger.warning(
+        "Recovered '%s' from '%s': a previous store swap was interrupted between its two "
+        "renames, leaving the published path missing.",
+        target.name,
+        retired.name,
+    )
+    return True
+
+
 def _swap_store(staging: Path, target: Path) -> None:
     """Move ``staging`` into ``target``'s place, keeping the original until the swap lands.
 
-    Two directory renames on one filesystem rather than a copy. Not a single atomic
-    operation, but the failure windows are narrow and each one is recoverable: if the second
-    rename fails the original is put back, and a leftover ``.retired`` directory is only
-    wasted space, never a half-written store — Icechunk itself is commit-or-nothing.
+    Two directory renames on one filesystem rather than a copy, so the cost is metadata
+    rather than bytes. Two caveats, both real:
+
+    * **The target does not exist between the renames.** A reader that opens the store in that
+      window fails. The window is two metadata operations wide, but it is not zero.
+    * **Only an exception is rolled back here.** A process kill or host restart between the
+      renames leaves the published path missing, which :func:`recover_interrupted_swap`
+      repairs on the next sync.
+
+    Neither is fixable by reordering: POSIX has no atomic directory exchange that Python
+    exposes portably. The durable answer is to publish through a pointer that can be switched
+    atomically, which is CLIM-880 — this keeps the window small and recoverable meanwhile.
     """
-    retired = target.with_name(f"{target.name}.retired")
+    retired = _retired_path(target)
     shutil.rmtree(retired, ignore_errors=True)
     target.rename(retired)
     try:
@@ -463,6 +499,10 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
     registered.
     """
     from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
+
+    # Before the open, not after: a swap interrupted by a kill leaves the published path
+    # missing, so without this the open below would fail and the dataset would stay broken.
+    recover_interrupted_swap(store_path)
 
     try:
         ds = open_icechunk_dataset(store_path)

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -341,6 +341,13 @@ def _create_streaming_artifact(
             detail=f"An ingest or sync is already running for dataset '{dataset['id']}'. Wait for it to finish.",
         )
     try:
+        # First thing under the lock, before anything looks at the store. A swap killed between
+        # its two renames leaves the published path missing and the data at `.retired`; ingest
+        # would read that as a brand-new store and write only the requested delta into a fresh
+        # one, after which recovery finds the target present and strands the whole history in
+        # `.retired`. Healing before any inspection makes the next sync an ordinary append.
+        recover_interrupted_swap(store_path)
+
         if overwrite and store_path.exists():
             if store_path.is_dir():
                 shutil.rmtree(store_path)
@@ -500,8 +507,9 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
     """
     from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
 
-    # Before the open, not after: a swap interrupted by a kill leaves the published path
-    # missing, so without this the open below would fail and the dataset would stay broken.
+    # Belt and braces: `_create_streaming_artifact` already heals this under the lock before
+    # ingest, which is the call that matters. Kept because this function is also entered
+    # directly, and because it is idempotent — a present target makes it a no-op.
     recover_interrupted_swap(store_path)
 
     try:
@@ -536,14 +544,21 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
         # GPP) to transient disk (one extra copy, reclaimed on success).
         staging = store_path.with_name(f"{store_path.name}.rebuild")
         shutil.rmtree(staging, ignore_errors=True)
-        downloader.write_to_icechunk_store(
-            ds,
-            staging,
-            pyramid_method=downloader.resampling_method_from_template(dataset),
-            commit_message="Applied GeoZarr conventions",
-        )
-        ds.close()  # drop the read session before the directory moves under it
-        _swap_store(staging, store_path)
+        try:
+            downloader.write_to_icechunk_store(
+                ds,
+                staging,
+                pyramid_method=downloader.resampling_method_from_template(dataset),
+                commit_message="Applied GeoZarr conventions",
+            )
+            ds.close()  # drop the read session before the directory moves under it
+            _swap_store(staging, store_path)
+        finally:
+            # A failed build leaves a partial copy of the whole store behind. That matters most
+            # when the failure *was* disk exhaustion: the flat-store fallback below would
+            # otherwise run with the transient copy still occupying the space. A successful
+            # swap has already moved `staging` away, so this is a no-op then.
+            shutil.rmtree(staging, ignore_errors=True)
     except Exception:
         logger.error(
             "GeoZarr/pyramid write failed for '%s'; flat Icechunk artifact will be used as-is",

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -422,6 +422,25 @@ def _create_streaming_artifact(
         lock.release()
 
 
+def _swap_store(staging: Path, target: Path) -> None:
+    """Move ``staging`` into ``target``'s place, keeping the original until the swap lands.
+
+    Two directory renames on one filesystem rather than a copy. Not a single atomic
+    operation, but the failure windows are narrow and each one is recoverable: if the second
+    rename fails the original is put back, and a leftover ``.retired`` directory is only
+    wasted space, never a half-written store — Icechunk itself is commit-or-nothing.
+    """
+    retired = target.with_name(f"{target.name}.retired")
+    shutil.rmtree(retired, ignore_errors=True)
+    target.rename(retired)
+    try:
+        staging.rename(target)
+    except Exception:
+        retired.rename(target)  # leave the store exactly as it was
+        raise
+    shutil.rmtree(retired, ignore_errors=True)
+
+
 def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
     """Apply GeoZarr conventions and a multiscale pyramid to the committed Icechunk store.
 
@@ -430,14 +449,15 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
     ``write_to_icechunk_store`` to add them, so every Icechunk store follows the
     same GeoZarr layout regardless of size.
 
-    The rewrite must materialise the whole store in memory first, because
-    ``write_to_icechunk_store`` overwrites the very store it is reading from. That
-    is unavoidable on the initial ingest and whenever a pyramid must be rebuilt,
-    but a *temporal append* to an already-normalised flat store produces nothing
-    new: ``spatial_ref`` is a scalar that survives the append and streaming
-    refreshes the root attrs on every commit. We detect that case and skip the
-    read-rewrite, avoiding both the full in-memory load and the write
-    amplification of re-emitting the entire store on every sync.
+    ``write_to_icechunk_store`` would overwrite the very store it is reading from, so the
+    rewrite goes to a sibling store which is then swapped in. That keeps the source readable
+    while topozarr streams the pyramid out of it, which is what lets the build stay lazy
+    instead of materialising the whole store in RAM.
+
+    A *temporal append* to an already-normalised flat store produces nothing new, though:
+    ``spatial_ref`` is a scalar that survives the append and streaming refreshes the root
+    attrs on every commit. We detect that case and skip the read-rewrite entirely, avoiding
+    the write amplification of re-emitting the whole store on every sync.
 
     Errors are logged and swallowed so that the plain flat artifact is still
     registered.
@@ -469,12 +489,21 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
                 store_path.name,
             )
             return
+        # `ds` reads lazily from `store_path`, and the rewrite overwrites that same store —
+        # the aliasing is why this used to materialise everything first. Build into a sibling
+        # store and swap it in, so the source stays readable while topozarr streams the
+        # pyramid out of it. The cost moves from RAM (the whole store: 3.47 GB for Uganda's
+        # GPP) to transient disk (one extra copy, reclaimed on success).
+        staging = store_path.with_name(f"{store_path.name}.rebuild")
+        shutil.rmtree(staging, ignore_errors=True)
         downloader.write_to_icechunk_store(
-            ds.load(),
-            store_path,
+            ds,
+            staging,
             pyramid_method=downloader.resampling_method_from_template(dataset),
             commit_message="Applied GeoZarr conventions",
         )
+        ds.close()  # drop the read session before the directory moves under it
+        _swap_store(staging, store_path)
     except Exception:
         logger.error(
             "GeoZarr/pyramid write failed for '%s'; flat Icechunk artifact will be used as-is",

--- a/open_climate_service/stac/media_types.py
+++ b/open_climate_service/stac/media_types.py
@@ -44,6 +44,17 @@ MULTISCALES_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
 """UUID of the Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)."""
 
 
+def is_multiscales_convention(convention: Any) -> bool:
+    """True for one ``zarr_conventions`` entry declaring the multiscales convention.
+
+    Shared with the streaming writer, which has to carry this entry across an append rather
+    than let a flat store's convention list replace it.
+    """
+    return isinstance(convention, Mapping) and (
+        convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales"
+    )
+
+
 def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
     """True when root group *attributes* describe a real multiscales pyramid.
 
@@ -55,12 +66,7 @@ def attributes_declare_multiscales(attributes: Mapping[str, Any]) -> bool:
     conventions = attributes.get("zarr_conventions")
     if not isinstance(conventions, list):
         return False
-    declared = any(
-        isinstance(convention, Mapping)
-        and (convention.get("uuid") == MULTISCALES_CONVENTION_UUID or convention.get("name") == "multiscales")
-        for convention in conventions
-    )
-    if not declared:
+    if not any(is_multiscales_convention(convention) for convention in conventions):
         return False
     multiscales = attributes.get("multiscales")
     if not isinstance(multiscales, Mapping):

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -33,6 +33,7 @@ from open_climate_service.shared.raster_contract import (
 )
 from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
 from open_climate_service.streaming.store import (
+    committed_data_group,
     is_store_empty,
     open_or_create_repo,
     read_committed_period_ids,
@@ -207,6 +208,8 @@ async def run_streaming_ingest(
     expected_spatial_shape: tuple[int, int] | None = None
     # The append-axes check runs once per run, on the first period appended to an existing store.
     axes_checked = False
+    # Group to append into: None for a flat store, "0" for a pyramided one.
+    append_group: str | None = None
     # CF attributes (units / standard_name / cell_methods) declared on the template,
     # stamped onto each written period so the store is CF-compliant on disk (#280).
     # The template is authoritative for the fields it declares, so we overwrite any
@@ -280,8 +283,19 @@ async def run_streaming_ingest(
                 else:
                     if not axes_checked:
                         _assert_appendable_axes(store_path, ds, x_dim=x_dim, y_dim=y_dim)
+                        # Where the data actually lives. A store promoted to a pyramid by an
+                        # earlier sync keeps its variables in level groups, and appending at the
+                        # root would create a second one-timestep array beside the pyramid,
+                        # leaving the store unopenable. Resolved once per sync, since promotion
+                        # only happens between syncs.
+                        append_group = committed_data_group(store_path)
                         axes_checked = True
-                    ds.to_zarr(session.store, append_dim=spec.time_dim, zarr_format=3)
+                    ds.to_zarr(
+                        session.store,
+                        group=append_group,
+                        append_dim=spec.time_dim,
+                        zarr_format=3,
+                    )
                 # Root attrs are rewritten on every commit so later append sessions
                 # preserve GeoZarr metadata even if the underlying store layer only
                 # touches array content for the new period.

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -35,6 +35,50 @@ def open_or_create_repo(store_path: Path) -> Any:
     return icechunk.Repository.create(storage)
 
 
+def committed_data_group(store_path: Path) -> str | None:
+    """Return the group holding the committed data variables: ``"0"``, or ``None`` for the root.
+
+    A pyramided store keeps its data in level groups and leaves the root with only the time
+    coordinate and ``spatial_ref``, so every reader and the *appender* have to descend. Getting
+    this wrong is not a degraded read: appending at the root of a pyramided store creates a
+    second, one-timestep ``gpp`` beside the pyramid, after which the root no longer opens at
+    all — ``conflicting sizes for dimension 't'`` — and nothing can repair it in place.
+
+    Returns None for a missing or unreadable store, which callers already treat as "nothing
+    committed to compare against".
+    """
+    import xarray as xr
+
+    if not store_path.exists():
+        return None
+    try:
+        repo = open_or_create_repo(store_path)
+        store = repo.readonly_session("main").store
+        ds = xr.open_zarr(store)
+        try:
+            if ds.data_vars:
+                return None
+        finally:
+            ds.close()
+        # Confirm the level exists rather than assuming the layout.
+        level0 = xr.open_zarr(store, group="0")
+        level0.close()
+        return "0"
+    except Exception:
+        logger.debug("Could not determine the committed data group for %s", store_path, exc_info=True)
+        return None
+
+
+def _open_committed(store_path: Path) -> Any:
+    """Open the committed store at whichever group actually holds the data."""
+    import xarray as xr
+
+    repo = open_or_create_repo(store_path)
+    store = repo.readonly_session("main").store
+    group = committed_data_group(store_path)
+    return xr.open_zarr(store) if group is None else xr.open_zarr(store, group=group)
+
+
 def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: str = "t") -> set[str]:
     """Return period ids already committed in the store, or an empty set.
 
@@ -43,7 +87,6 @@ def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: s
     a persisted cursor is stale or missing.
     """
     import pandas as pd
-    import xarray as xr
 
     from open_climate_service.shared.time import datetime_to_period_string
 
@@ -51,9 +94,10 @@ def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: s
         return set()
 
     try:
-        repo = open_or_create_repo(store_path)
-        session = repo.readonly_session("main")
-        ds = xr.open_zarr(session.store)
+        # Level 0 rather than the root: the root time coordinate of a pyramided store is
+        # rebuilt at the end of a sync, so mid-sync it lags the data and resume would
+        # re-append periods that are already committed.
+        ds = _open_committed(store_path)
         try:
             if time_dim not in ds.coords:
                 return set()
@@ -108,14 +152,15 @@ def read_committed_spatial_coords(store_path: Path, *, x_dim: str = "x", y_dim: 
     longer describe it. The orchestrator compares against these before its first append.
 
     Returns None when there is nothing to compare against (new store, unreadable, no coords).
-    """
-    import xarray as xr
 
+    Reads level 0 for a pyramided store. The root there carries only the time coordinate and
+    ``spatial_ref``, so reading the root returned None and silently disabled the check — on
+    exactly the large stores where a mirrored raster is hardest to spot by eye.
+    """
     if not store_path.exists():
         return None
     try:
-        repo = open_or_create_repo(store_path)
-        ds = xr.open_zarr(repo.readonly_session("main").store)
+        ds = _open_committed(store_path)
         try:
             if x_dim not in ds.coords or y_dim not in ds.coords:
                 return None

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -19,6 +19,7 @@ from typing import Any
 from geozarr_toolkit import create_geozarr_attrs
 
 from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
+from open_climate_service.stac.media_types import is_multiscales_convention
 from open_climate_service.streaming.protocol import GridSpec
 
 logger = logging.getLogger(__name__)
@@ -227,6 +228,18 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
         attrs["spatial:shape"] = geometry["shape"]
         attrs["spatial:bbox"] = geometry["bbox"]
     attrs.update(spec.attrs)
+
+    # An append to a pyramided store must not un-declare its pyramid. `create_geozarr_attrs`
+    # builds `zarr_conventions` for a *flat* store, and the `update` below replaces the list
+    # wholesale — dropping the multiscales entry while the data still lives under `0/`, so the
+    # store would advertise itself as flat while having no root data variables at all. That
+    # then persists if the run aborts before the end-of-sync pyramid rebuild.
+    existing_conventions = root.attrs.get("zarr_conventions")
+    if isinstance(existing_conventions, list):
+        preserved = [c for c in existing_conventions if is_multiscales_convention(c)]
+        if preserved:
+            declared = attrs.get("zarr_conventions")
+            attrs["zarr_conventions"] = ([*declared] if isinstance(declared, list) else []) + preserved
 
     root.attrs.update(attrs)
     if geometry is not None:

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1139,13 +1139,19 @@ def test_maybe_build_pyramid_calls_write_to_icechunk_store(tmp_path: Path, monke
 
     def fake_write(ds_arg: xr.Dataset, path: Path, *a: object, **kw: object) -> None:
         written.append((ds_arg, path))
+        path.mkdir(parents=True, exist_ok=True)  # a real write leaves a store behind
 
     monkeypatch.setattr(downloader, "write_to_icechunk_store", fake_write)
 
     _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "precip"})
 
     assert len(written) == 1
-    assert written[0][1] == icechunk_path
+    # The rewrite cannot target the store it is reading from, so it goes to a sibling and is
+    # swapped in. What matters to callers is where it ends up, and that nothing is left over.
+    assert written[0][1] == icechunk_path.with_name(f"{icechunk_path.name}.rebuild")
+    assert icechunk_path.is_dir()
+    assert not written[0][1].exists()
+    assert not icechunk_path.with_name(f"{icechunk_path.name}.retired").exists()
 
 
 def test_maybe_build_pyramid_skips_rewrite_for_normalized_flat_store(
@@ -1235,3 +1241,37 @@ def test_plan_sync_append_for_icechunk_artifact(
     )
 
     assert result.action == SyncAction.APPEND
+
+
+def test_swap_store_replaces_the_target_and_cleans_up(tmp_path: Path) -> None:
+    from open_climate_service.ingestions.services import _swap_store
+
+    target = tmp_path / "ds.icechunk"
+    target.mkdir()
+    (target / "old.txt").write_text("old", encoding="utf-8")
+    staging = tmp_path / "ds.icechunk.rebuild"
+    staging.mkdir()
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+
+    _swap_store(staging, target)
+
+    assert (target / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not (target / "old.txt").exists()
+    assert not staging.exists()
+    assert not (tmp_path / "ds.icechunk.retired").exists()
+
+
+def test_swap_store_puts_the_original_back_when_the_swap_fails(tmp_path: Path) -> None:
+    """A failed swap must not leave the dataset without a store."""
+    from open_climate_service.ingestions.services import _swap_store
+
+    target = tmp_path / "ds.icechunk"
+    target.mkdir()
+    (target / "old.txt").write_text("old", encoding="utf-8")
+    missing_staging = tmp_path / "ds.icechunk.rebuild"  # never created -> rename raises
+
+    with pytest.raises(OSError):
+        _swap_store(missing_staging, target)
+
+    # The original survived, contents intact.
+    assert (target / "old.txt").read_text(encoding="utf-8") == "old"

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1396,7 +1396,7 @@ def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
         country_code=None,
         overwrite=False,
         publish=False,
-        request_scope=ArtifactRequestScope(start="2026-01-01", end="2026-01-03", bbox=[0.0, 0.0, 1.0, 1.0]),
+        request_scope=ArtifactRequestScope(start="2026-01-01", end="2026-01-03", bbox=(0.0, 0.0, 1.0, 1.0)),
     )
 
     # The point of the test: the ingest ran against the recovered store, not a bare path.

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1316,3 +1316,92 @@ def test_recover_interrupted_swap_is_a_no_op_for_a_brand_new_dataset(tmp_path: P
     from open_climate_service.ingestions.services import recover_interrupted_swap
 
     assert recover_interrupted_swap(tmp_path / "never-existed.icechunk") is False
+
+
+def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery has to happen before anything inspects the store, not after ingest.
+
+    A swap killed between its two renames leaves the published path missing and the whole
+    history at `.retired`. If recovery runs after the ingest — as it did when it lived only in
+    `_maybe_build_pyramid` — the sequence is:
+
+    1. ingest sees no store, treats it as new, and writes *only* the requested delta;
+    2. recovery then finds the target present and does nothing;
+    3. the entire history stays stranded in `.retired`, unreferenced.
+
+    Nothing errors, and the dataset silently loses everything before the interruption. So this
+    asserts on what the ingest *sees*: the store must already be there, carrying its history.
+    """
+    from types import SimpleNamespace
+
+    from open_climate_service.data_manager.services import downloader
+    from open_climate_service.ingestions import services as ingestion_services
+    from open_climate_service.ingestions.schemas import ArtifactRequestScope
+
+    target = tmp_path / "ds.icechunk"
+    retired = tmp_path / "ds.icechunk.retired"
+    # The state a killed swap leaves: no published store, the history under `.retired`.
+    retired.mkdir()
+    (retired / "history").write_text("2026-01-01,2026-01-02", encoding="utf-8")
+
+    seen: dict[str, object] = {}
+
+    def fake_ingest(**kwargs: object) -> object:
+        store_path = kwargs["store_path"]
+        assert isinstance(store_path, Path)
+        seen["store_existed"] = store_path.exists()
+        history = store_path / "history"
+        seen["history"] = history.read_text(encoding="utf-8") if history.exists() else None
+        # Append the new period the way a real sync would, onto whatever is there.
+        if history.exists():
+            history.write_text(history.read_text(encoding="utf-8") + ",2026-01-03", encoding="utf-8")
+        else:
+            store_path.mkdir(parents=True, exist_ok=True)
+            history.write_text("2026-01-03", encoding="utf-8")
+        return SimpleNamespace(periods_written=1)
+
+    monkeypatch.setattr(downloader, "get_icechunk_path", lambda _dataset: target)
+    monkeypatch.setattr(ingestion_services, "run_streaming_ingest_sync", fake_ingest)
+    monkeypatch.setattr(ingestion_services, "_load_streaming_plugin", lambda *a, **k: object())
+    monkeypatch.setattr(ingestion_services, "_maybe_build_pyramid", lambda *a, **k: None)
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_data_coverage_for_paths",
+        lambda *a, **k: {
+            "has_data": True,
+            "forecast_reference": None,
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0},
+                "spatial_wgs84": None,
+            },
+        },
+    )
+    monkeypatch.setattr(ingestion_services, "_upsert_artifact_record", lambda record, **k: record)
+
+    ingestion_services._create_streaming_artifact(
+        dataset={
+            "id": "ds1",
+            "name": "DS1",
+            "variable": "precip",
+            "period_type": "daily",
+            "ingestion": {"plugin": "example.Plugin"},
+        },
+        plugin_path="example.Plugin",
+        start="2026-01-01",
+        end="2026-01-03",
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+        request_scope=ArtifactRequestScope(start="2026-01-01", end="2026-01-03", bbox=[0.0, 0.0, 1.0, 1.0]),
+    )
+
+    # The point of the test: the ingest ran against the recovered store, not a bare path.
+    assert seen["store_existed"] is True
+    assert seen["history"] == "2026-01-01,2026-01-02"
+    # And the delta landed on top of the history rather than replacing it.
+    assert (target / "history").read_text(encoding="utf-8") == "2026-01-01,2026-01-02,2026-01-03"
+    assert not retired.exists()

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1275,3 +1275,44 @@ def test_swap_store_puts_the_original_back_when_the_swap_fails(tmp_path: Path) -
 
     # The original survived, contents intact.
     assert (target / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_recover_interrupted_swap_restores_a_store_killed_between_renames(tmp_path: Path) -> None:
+    """A SIGKILL between the two renames leaves the published path missing and the data at
+    `.retired`, which no reader looks for. The exception handler cannot cover that case.
+    """
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    target = tmp_path / "ds.icechunk"
+    retired = tmp_path / "ds.icechunk.retired"
+    retired.mkdir()
+    (retired / "data").write_text("published", encoding="utf-8")
+    assert not target.exists()  # the state a killed swap leaves behind
+
+    assert recover_interrupted_swap(target) is True
+    assert (target / "data").read_text(encoding="utf-8") == "published"
+    assert not retired.exists()
+
+
+def test_recover_interrupted_swap_leaves_a_healthy_store_alone(tmp_path: Path) -> None:
+    """A `.retired` directory alongside a live store is leftover space, not a pending recovery.
+
+    Restoring over a healthy store would roll back a completed swap.
+    """
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    target = tmp_path / "ds.icechunk"
+    target.mkdir()
+    (target / "data").write_text("current", encoding="utf-8")
+    retired = tmp_path / "ds.icechunk.retired"
+    retired.mkdir()
+    (retired / "data").write_text("stale", encoding="utf-8")
+
+    assert recover_interrupted_swap(target) is False
+    assert (target / "data").read_text(encoding="utf-8") == "current"
+
+
+def test_recover_interrupted_swap_is_a_no_op_for_a_brand_new_dataset(tmp_path: Path) -> None:
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    assert recover_interrupted_swap(tmp_path / "never-existed.icechunk") is False

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -28,7 +28,7 @@ from open_climate_service.data_manager.services.downloader import (  # noqa: E40
 
 
 def _pyramid_sized_cube():
-    # Larger than the 2048x2048 pyramid threshold; integer var exercises the
+    # Larger than the pyramid threshold; integer var exercises the
     # no-data fill_value handling that used to be pinned via pyramid.encoding.
     ny = nx = 2100
     data = np.ones((1, ny, nx), dtype="uint8")
@@ -183,3 +183,65 @@ def test_write_to_icechunk_store_mode_keeps_class_codes(tmp_path: Path) -> None:
     with xr.open_zarr(store, group="1", consolidated=False, zarr_format=3) as lvl1:
         values = np.unique(lvl1["landcover"].values)
     assert set(int(v) for v in values) <= codes
+
+
+def _uganda_gpp_shaped_cube(nt: int = 2):
+    """A cube on the grid that motivated lowering the threshold: CLMS GPP over Uganda."""
+    ny, nx = 1949, 1895
+    return xr.Dataset(
+        {"gpp": (("t", "y", "x"), np.zeros((nt, ny, nx), dtype="float32"))},
+        coords={
+            "t": np.array(["2024-01-01", "2024-01-11"], dtype="datetime64[ns]")[:nt],
+            "y": np.linspace(4.29, -1.50, ny),
+            "x": np.linspace(29.47, 35.11, nx),
+        },
+    )
+
+
+def test_threshold_catches_the_grid_that_used_to_render_flat() -> None:
+    """1949 x 1895 = 3.69 Mpx sat at 0.88x of the old 2048^2 bar, so no pyramid was built.
+
+    Every frame then read the full grid at every zoom — 32 chunk requests and 14.8 MB per
+    timestep to fill a few hundred screen pixels. Pinned to the real geometry rather than a
+    round number so the constant cannot drift back above it unnoticed.
+    """
+    assert needs_pyramid(_uganda_gpp_shaped_cube())
+
+
+def test_threshold_still_skips_a_grid_small_enough_to_send_whole() -> None:
+    """A pyramid on a small grid is pure overhead: more metadata, no fewer bytes to draw."""
+    ny = nx = 700  # 0.49 Mpx
+    small = xr.Dataset(
+        {"v": (("y", "x"), np.zeros((ny, nx), dtype="float32"))},
+        coords={"y": np.linspace(1.0, 0.0, ny), "x": np.linspace(0.0, 1.0, nx)},
+    )
+    assert not needs_pyramid(small)
+
+
+def test_pyramid_build_never_materialises_the_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """topozarr streams level 0 region by region, so the source must stay lazy.
+
+    Loading it first defeated that and made peak memory scale with the store: measured on a
+    2.13 GB cube, 7.50 GB peak loaded versus 1.19 GB streamed. Asserted by making `.load()`
+    fail outright, which is the only way to prove it is not called somewhere in the path.
+    """
+
+    def explode(self: object, **kwargs: object) -> None:
+        raise AssertionError("write_to_icechunk_store must not materialise the source")
+
+    monkeypatch.setattr(xr.Dataset, "load", explode)
+    monkeypatch.setattr(xr.DataArray, "load", explode)
+
+    ds = _uganda_gpp_shaped_cube().chunk({"t": 1, "y": 244, "x": 474})
+    assert ds["gpp"].chunks is not None
+    assert needs_pyramid(ds)
+
+    store_path = tmp_path / "streamed.icechunk"
+    write_to_icechunk_store(ds, store_path, crs="EPSG:4326")
+
+    import icechunk
+
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path)))
+    root = zarr.open_group(repo.readonly_session("main").store, mode="r")
+    assert "multiscales" in dict(root.attrs)
+    assert {"0", "1"} <= {k for k, _ in root.groups()}

--- a/tests/test_streaming_pyramided_store.py
+++ b/tests/test_streaming_pyramided_store.py
@@ -129,3 +129,70 @@ def test_spatial_guard_is_active_on_a_pyramided_store(tmp_path: Path) -> None:
     assert stored is not None
     assert stored["y"][0] > stored["y"][-1]  # north-up, per the publication contract
     assert len(stored["x"]) == 1200
+
+
+def test_appending_does_not_un_declare_the_pyramid(tmp_path: Path) -> None:
+    """`write_geozarr_attrs` runs on every commit and rebuilds `zarr_conventions` for a flat
+    store, which used to drop the multiscales entry — leaving a store that advertised itself as
+    flat while having no data variables at the root at all. If the run then aborted before the
+    end-of-sync rebuild, that is how it stayed.
+    """
+    from open_climate_service.stac.media_types import attributes_declare_multiscales
+    from open_climate_service.streaming.protocol import GridSpec
+    from open_climate_service.streaming.store import write_geozarr_attrs
+
+    store_path, repo = _pyramided_store(tmp_path)
+
+    def declared() -> bool:
+        attrs = dict(zarr.open_group(repo.readonly_session("main").store, mode="r").attrs)
+        return attributes_declare_multiscales(attrs)
+
+    assert declared(), "precondition: the built pyramid declares the convention"
+
+    spec = GridSpec(
+        shape=(1500, 1200),
+        crs=4326,
+        dtype=np.dtype("float32"),
+        nodata=None,
+        time_dim="t",
+        x_dim="x",
+        y_dim="y",
+    )
+    session = repo.writable_session("main")
+    _period(3).to_zarr(session.store, group=committed_data_group(store_path), append_dim="t", zarr_format=3)
+    write_geozarr_attrs(session.store, spec=spec, bbox=[29.0, -1.0, 35.0, 4.0])
+    session.commit("append + attrs")
+
+    assert declared(), "the pyramid must still be declared after an append"
+    attrs = dict(zarr.open_group(repo.readonly_session("main").store, mode="r").attrs)
+    names = [c.get("name") for c in attrs["zarr_conventions"] if isinstance(c, dict)]
+    assert names.count("multiscales") == 1, f"declared once, not duplicated per commit: {names}"
+
+
+def test_a_flat_store_does_not_gain_a_multiscales_declaration(tmp_path: Path) -> None:
+    """The preservation must be conditional — a flat store claiming a pyramid is worse."""
+    from open_climate_service.stac.media_types import attributes_declare_multiscales
+    from open_climate_service.streaming.protocol import GridSpec
+    from open_climate_service.streaming.store import write_geozarr_attrs
+
+    flat = tmp_path / "flat.icechunk"
+    repo = icechunk.Repository.open_or_create(icechunk.local_filesystem_storage(str(flat)))
+    session = repo.writable_session("main")
+    _period(1, ny=64, nx=64).to_zarr(session.store, mode="w", zarr_format=3)
+    write_geozarr_attrs(
+        session.store,
+        spec=GridSpec(
+            shape=(64, 64),
+            crs=4326,
+            dtype=np.dtype("float32"),
+            nodata=None,
+            time_dim="t",
+            x_dim="x",
+            y_dim="y",
+        ),
+        bbox=[29.0, -1.0, 35.0, 4.0],
+    )
+    session.commit("flat")
+
+    attrs = dict(zarr.open_group(repo.readonly_session("main").store, mode="r").attrs)
+    assert not attributes_declare_multiscales(attrs)

--- a/tests/test_streaming_pyramided_store.py
+++ b/tests/test_streaming_pyramided_store.py
@@ -1,0 +1,131 @@
+"""Appending to a store that an earlier sync promoted to a pyramid.
+
+A pyramided store keeps its data variables in level groups and leaves the root with only the
+time coordinate and ``spatial_ref``. Appending at the root therefore does not extend level 0 —
+it creates a second, one-timestep variable beside the pyramid, after which the root cannot be
+opened at all (``conflicting sizes for dimension 't'``) and nothing can repair it in place.
+
+Latent until the pyramid threshold dropped to 1024^2: every store above the old 2048^2 bar was
+`sync: kind: release` or `static`, so none of them appended. Uganda's dekadal GPP and Norway's
+seNorge dailies do.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+icechunk = pytest.importorskip("icechunk")
+pytest.importorskip("topozarr")
+pytest.importorskip("rioxarray")
+zarr = pytest.importorskip("zarr")
+
+from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset  # noqa: E402
+from open_climate_service.data_manager.services import downloader  # noqa: E402
+from open_climate_service.streaming.store import (  # noqa: E402
+    committed_data_group,
+    read_committed_period_ids,
+    read_committed_spatial_coords,
+)
+
+
+def _period(day: int, ny: int = 1500, nx: int = 1200):  # noqa: ANN202 — `xr` is an importorskip variable
+    """One period on a grid over the 1024^2 threshold, so it gets a pyramid."""
+    return xr.Dataset(
+        {"gpp": (("t", "y", "x"), np.full((1, ny, nx), float(day), dtype="float32"))},
+        coords={
+            "t": np.array([f"2024-01-{day:02d}"], dtype="datetime64[ns]"),
+            "y": np.linspace(4.0, -1.0, ny),
+            "x": np.linspace(29.0, 35.0, nx),
+        },
+    )
+
+
+def _pyramided_store(tmp_path: Path) -> tuple[Path, Any]:
+    """A store with two committed periods, promoted to a pyramid as a sync would leave it."""
+    store_path = tmp_path / "gpp.icechunk"
+    repo = icechunk.Repository.open_or_create(icechunk.local_filesystem_storage(str(store_path)))
+    session = repo.writable_session("main")
+    _period(1).to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("p1")
+    session = repo.writable_session("main")
+    _period(2).to_zarr(session.store, append_dim="t", zarr_format=3)
+    session.commit("p2")
+    downloader.write_to_icechunk_store(
+        open_icechunk_dataset(store_path), store_path, crs="EPSG:4326", commit_message="promote"
+    )
+    return store_path, repo
+
+
+def test_committed_data_group_distinguishes_flat_from_pyramided(tmp_path: Path) -> None:
+    flat = tmp_path / "flat.icechunk"
+    repo = icechunk.Repository.open_or_create(icechunk.local_filesystem_storage(str(flat)))
+    session = repo.writable_session("main")
+    _period(1, ny=64, nx=64).to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("p1")
+    assert committed_data_group(flat) is None
+
+    pyramided, _ = _pyramided_store(tmp_path)
+    assert committed_data_group(pyramided) == "0"
+
+
+def test_appending_into_the_committed_group_keeps_the_store_readable(tmp_path: Path) -> None:
+    """The regression: appending at the root instead left the store unopenable."""
+    store_path, repo = _pyramided_store(tmp_path)
+
+    session = repo.writable_session("main")
+    _period(3).to_zarr(session.store, group=committed_data_group(store_path), append_dim="t", zarr_format=3)
+    session.commit("p3")
+
+    ds = open_icechunk_dataset(store_path)
+    try:
+        assert ds.sizes["t"] == 3
+        assert [float(v) for v in ds["gpp"][:, 0, 0].values] == [1.0, 2.0, 3.0]
+    finally:
+        ds.close()
+
+
+def test_appending_at_the_root_of_a_pyramided_store_would_break_it(tmp_path: Path) -> None:
+    """Pins why `committed_data_group` exists, so the guard is not removed as redundant."""
+    store_path, repo = _pyramided_store(tmp_path)
+
+    session = repo.writable_session("main")
+    _period(3).to_zarr(session.store, append_dim="t", zarr_format=3)  # no group= -> the root
+    session.commit("bad append")
+
+    with pytest.raises(ValueError, match="conflicting sizes for dimension"):
+        open_icechunk_dataset(store_path)
+
+
+def test_committed_periods_come_from_level_zero(tmp_path: Path) -> None:
+    """The root time coordinate is only rebuilt at the end of a sync, so it lags mid-sync.
+
+    Reading it would make resume re-append periods that are already committed.
+    """
+    store_path, repo = _pyramided_store(tmp_path)
+    session = repo.writable_session("main")
+    _period(3).to_zarr(session.store, group=committed_data_group(store_path), append_dim="t", zarr_format=3)
+    session.commit("p3")
+
+    root_t = zarr.open_group(repo.readonly_session("main").store, mode="r")["t"].shape[0]
+    assert root_t == 2, "precondition: the root coordinate is stale until the rebuild"
+    assert read_committed_period_ids(store_path, "daily") == {
+        "2024-01-01",
+        "2024-01-02",
+        "2024-01-03",
+    }
+
+
+def test_spatial_guard_is_active_on_a_pyramided_store(tmp_path: Path) -> None:
+    """Reading the root returned None here, silently disabling the mirrored-raster check."""
+    store_path, _ = _pyramided_store(tmp_path)
+
+    stored = read_committed_spatial_coords(store_path)
+
+    assert stored is not None
+    assert stored["y"][0] > stored["y"][-1]  # north-up, per the publication contract
+    assert len(stored["x"]) == 1200


### PR DESCRIPTION
Implements [CLIM-877](https://dhis2.atlassian.net/browse/CLIM-877). Uganda's CLMS GPP rendered flat because 1949 × 1895 = 3.69 Mpx sat at 0.88× of the `2048²` pyramid threshold, so every frame read the full grid at every zoom.

Three coupled changes: lower the threshold, build the pyramid lazily, and make appends pyramid-aware.

### Threshold → `1024²`

Checked against all 31 published stores across the five local instances: **7 gain a pyramid**, each with ≥ 2 levels. No borderline cases — largest still-flat is 0.42 Mpx, smallest newly-pyramided 1.85 Mpx. Two were unnoticed: Nepal's `clms_ndvi_dekadal` and Norway's four seNorge dailies.

### Lazy build

The build called `ds.load()`, so a lower threshold would have turned a render problem into a sync OOM. Both calls are gone: topozarr streams level 0 region by region (bounded by `max_region_bytes`, pinned to 64 MB), and `_maybe_build_pyramid` now builds into a sibling store and swaps it in, since it reads lazily from the store it overwrites.

| timesteps | store | lazy peak RSS | `.load()` peak RSS |
|---|---|---|---|
| 36 | 0.53 GB | **0.77 GB** | 2.22 GB |
| 144 | 2.13 GB | **1.19 GB** | 7.50 GB |

Lazy peak stays flat as the store grows; `.load()` grows at ~3.5× store size. For the live 235-dekad store that is ~1.3 GB versus ~12 GB. Build is ~2.4× slower — the intended trade.

### Appends must target level 0

A pyramided store keeps its variables under `0/` and leaves the root with only the time coordinate. Appending at the root creates a second one-timestep variable beside the pyramid, after which the store cannot be opened (`conflicting sizes for dimension 't'`) and cannot be repaired in place.

Latent on `main` because every store above the old bar is `release` or `static`; this PR promotes appending datasets, so `committed_data_group()` now resolves where the data lives, used by the append, by resume (`read_committed_period_ids`), and by the spatial guard — which had been silently disabled for every pyramided store. `write_geozarr_attrs` also preserves the multiscales declaration, and an interrupted store swap is recovered on the next sync.

### Tested on the Norway instance

seNorge is the target case: 1.85 Mpx, `temporal/append`, UTM33 projected grid. Real config, venv and installable plugin; scratch `data_dir`.

```
ingest 5 days   -> levels ['0','1'], profile=multiscales, proj:code EPSG:32633
                   level 0 (5, 1550, 1195) chunks (1, 388, 299)
                   level 1 (5,  775,  597) chunks (1, 259, 299)
sync 5 more     -> action: append; opens OK, 10 contiguous steps, no stray root
                   variable, both levels grew, root 't'=10, multiscales intact,
                   spatial guard active
re-sync         -> up_to_date / no_op  (resume reads level 0, not the stale root)
render          -> level 1 chunk 121 KB vs level 0 987 KB  (8.2x fewer bytes)
```

0 errors, 0 tracebacks. Browser rendering is still unverified: the asset href points at the store root, and zarr-layer's multiscales support is documented as experimental.

### Verification

696 passed (3 pre-existing local PROJ failures); ruff, format, mypy, pyright, mkdocs clean. `test_pyramid_build_never_materialises_the_source` makes `.load()` raise to prove nothing loads; `test_appending_at_the_root_of_a_pyramided_store_would_break_it` pins the old failure so the guard cannot be dropped.

### Not included

A data-variable chunk policy: topozarr 0.1.4 forces a time chunk of 1 in every level regardless of input, so a larger time chunk needs upstream support or a post-write rechunk of every level — which would reintroduce the whole-store rewrite this PR removes. [CLIM-879](https://dhis2.atlassian.net/browse/CLIM-879).

### Follow-up

- Re-ingest Uganda GPP/NPP once this and #337 land, then benchmark a frame.
- [CLIM-880](https://dhis2.atlassian.net/browse/CLIM-880) — separate the ingest store from the published pyramid, removing the swap window and the append awareness above.


[CLIM-877]: https://dhis2.atlassian.net/browse/CLIM-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-879]: https://dhis2.atlassian.net/browse/CLIM-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ