### PR TITLE
fix(compose): track :main tag and always pull

### DIFF
--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -1,6 +1,7 @@
 services:
   api:
-    image: ghcr.io/dhis2/open-climate-service:latest
+    image: ghcr.io/dhis2/open-climate-service:main
+    pull_policy: always
     env_file: .env
     ports:
       - "${PORT:-9000}:${PORT:-9000}"


### PR DESCRIPTION
## Problem

`compose.ghcr.yml` referenced `ghcr.io/dhis2/open-climate-service:latest`, a tag the publish workflow has never pushed. Following the documented deploy path fails outright:

```
$ docker compose -f compose.ghcr.yml pull
Error: failed to resolve reference "ghcr.io/dhis2/open-climate-service:latest": not found
```

The registry tag list holds only `main` plus attestation `sha256-*` tags. `docker/metadata-action` emits `type=ref,event=branch` by default, so `main` is the only moving tag; the hand-rolled matrix build replaced in #336 carried the same default, so this predates the arm64 work.

## Change

Point the service at `:main` and add `pull_policy: always`, so a deployment tracking main picks up each merge without a manual `compose pull`.

## Follow-up

Once versioned releases exist, `meta-tags` on the `docker/github-builder` call should add `type=semver` plus `latest` on the default branch. At that point compose goes back to a pinned tag and `pull_policy: always` becomes wasted work — both revert together.

## Verification

Ran against the current `main` image (rev `ffbb584`) on an arm64 host:

- `docker compose -f compose.ghcr.yml pull` resolves and pulls.
- Manifest is a proper OCI index: `linux/arm64` + `linux/amd64`, each with a signed attestation manifest (702 MB / 722 MB compressed, 13 layers each).
- arm64 container runs native `aarch64` as non-root `ocs`, reaches Docker `healthy`, registers 342 processes.
- Native-extension deps import clean on arm64, including `eccodes` 2.47.3, which dlopens the system library rather than bundling it.
- Synchronous compute matches across both architectures: `add(21,21)` -> `42`, `mean([1,2,3,4,5.5])` -> `3.1`.