### PR TITLE
feat(jobs): persist dataset update outcomes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,13 @@ POST /sync/{dataset_id} + Prefer: respond-async → 202 + Location: /ingestions/
 
 A job is the operational state of one async execution. The same job runtime is shared between async ingestion, async sync, and openEO batch jobs (the latter tracked at `/jobs/{id}`; native ingestion/sync jobs tracked at `/ingestions/jobs/{id}`).
 
+Successful native jobs may also contain domain events in their `events` field. These events are
+persisted in the same update that marks the job successful, so consumers never observe an event
+for failed work. An async sync that actually appends or rematerializes data records one
+`dataset.updated` event with the dataset, artifact, executed action, and previous/current coverage.
+An up-to-date sync records no event. The event is a durable completion outcome; dispatching
+downstream workflows or external notifications is a separate concern.
+
 Jobs provide:
 
 - status tracking

--- a/open_climate_service/ingestions/processes.py
+++ b/open_climate_service/ingestions/processes.py
@@ -10,7 +10,8 @@ from fastapi import HTTPException
 from open_climate_service.data_registry.services import datasets as registry_datasets
 from open_climate_service.extents.services import get_extent_or_404
 from open_climate_service.ingestions import services
-from open_climate_service.ingestions.schemas import IngestionResponse, SyncResponse
+from open_climate_service.ingestions.schemas import IngestionResponse, SyncAction
+from open_climate_service.jobs.models import JobEventDraft, JobExecutionResult
 
 
 def execute_ingestion(
@@ -50,10 +51,35 @@ def execute_sync(
     dataset_id: str,
     end: str | None = None,
     publish: bool = True,
-) -> SyncResponse:
-    """Execute one managed-dataset sync from existing artifact state."""
-    return services.sync_dataset(
+) -> JobExecutionResult:
+    """Execute one sync and describe any resulting dataset update."""
+    response = services.sync_dataset(
         dataset_id=dataset_id,
         end=end,
         publish=publish,
     )
+    events: list[JobEventDraft] = []
+    detail = response.sync_detail
+    if (
+        response.status == "completed"
+        and detail is not None
+        and detail.action
+        in {
+            SyncAction.APPEND,
+            SyncAction.REMATERIALIZE,
+        }
+    ):
+        events.append(
+            JobEventDraft(
+                type="dataset.updated",
+                source=f"/datasets/{dataset_id}",
+                data={
+                    "dataset_id": dataset_id,
+                    "artifact_id": response.sync_id,
+                    "action": detail.action.value,
+                    "previous_end": detail.current_end,
+                    "current_end": detail.target_end,
+                },
+            )
+        )
+    return JobExecutionResult(result=response, events=events)

--- a/open_climate_service/jobs/models.py
+++ b/open_climate_service/jobs/models.py
@@ -54,6 +54,30 @@ class JobError(BaseModel):
     message: str
 
 
+class JobEventDraft(BaseModel):
+    """Domain event returned by a job before completion metadata is assigned."""
+
+    type: str
+    source: str
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class JobExecutionResult(BaseModel):
+    """A callable result accompanied by domain events created on success."""
+
+    result: Any = None
+    events: list[JobEventDraft] = Field(default_factory=list)
+
+
+class JobEvent(JobEventDraft):
+    """Domain event persisted atomically with a successful native job."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    event_id: str = Field(validation_alias="eventID", serialization_alias="eventID")
+    time: datetime
+
+
 class JobRecord(BaseModel):
     """Persisted native job record."""
 
@@ -72,6 +96,7 @@ class JobRecord(BaseModel):
     request: dict[str, Any] = Field(default_factory=dict)
     progress: JobProgress = Field(default_factory=JobProgress)
     result: Any | None = None
+    events: list[JobEvent] = Field(default_factory=list)
     error: JobError | None = None
     cancel_requested: bool = Field(
         default=False,

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -16,6 +16,8 @@ from open_climate_service.jobs import store
 from open_climate_service.jobs.models import (
     JobCancelledError,
     JobError,
+    JobEvent,
+    JobExecutionResult,
     JobLink,
     JobListResponse,
     JobProgress,
@@ -343,14 +345,29 @@ class JobService:
             )
 
             try:
-                result = self._invoke_process(started)
+                execution_result = self._invoke_process(started)
+                completed_at = utc_now()
+                if isinstance(execution_result, JobExecutionResult):
+                    result = execution_result.result
+                    events = [
+                        JobEvent(
+                            event_id=f"{job_id}:{index}",
+                            time=completed_at,
+                            **event.model_dump(),
+                        )
+                        for index, event in enumerate(execution_result.events)
+                    ]
+                else:
+                    result = execution_result
+                    events = []
                 store.mutate_job_record(
                     job_id,
                     lambda current: current.model_copy(
                         update={
                             "status": JobStatus.SUCCESSFUL,
-                            "finished_at": utc_now(),
+                            "finished_at": completed_at,
                             "result": result,
+                            "events": events,
                             "progress": JobProgress(
                                 done=current.progress.done,
                                 total=current.progress.total,

--- a/tests/test_ingestion_async.py
+++ b/tests/test_ingestion_async.py
@@ -1,5 +1,6 @@
 """Tests for async ingestion and sync via Prefer: respond-async."""
 
+from collections.abc import Callable
 from typing import NoReturn
 from unittest.mock import MagicMock
 
@@ -7,7 +8,15 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from open_climate_service.jobs.models import JobProgress, JobRecord, JobStatus
+from open_climate_service.ingestions import processes
+from open_climate_service.ingestions.schemas import SyncAction, SyncDetail, SyncKind, SyncResponse
+from open_climate_service.jobs.models import (
+    JobEventDraft,
+    JobExecutionResult,
+    JobProgress,
+    JobRecord,
+    JobStatus,
+)
 from open_climate_service.jobs.service import JobService
 
 
@@ -28,6 +37,33 @@ def _make_job(job_id: str = "job-123") -> JobRecord:
 
 def _fake_job_callable() -> dict[str, object]:
     return {"ok": True}
+
+
+def _fake_event_job_callable() -> JobExecutionResult:
+    return JobExecutionResult(
+        result={"ok": True},
+        events=[JobEventDraft(type="dataset.updated", source="/datasets/example", data={"action": "append"})],
+    )
+
+
+def _sync_response(action: SyncAction, *, status: str = "completed") -> SyncResponse:
+    return SyncResponse(
+        sync_id="artifact-2" if status == "completed" else None,
+        status=status,
+        message="test",
+        dataset=None,
+        sync_detail=SyncDetail(
+            source_dataset_id="source",
+            sync_kind=SyncKind.TEMPORAL,
+            action=action,
+            reason="test",
+            message="test",
+            current_start="2026-01-01",
+            current_end="2026-01-02",
+            target_end="2026-01-03",
+            target_end_source="request",
+        ),
+    )
 
 
 def test_post_ingestion_respond_async_returns_202_with_location(
@@ -256,3 +292,66 @@ def test_submit_callable_job_normalizes_custom_jobs_base(monkeypatch: pytest.Mon
     )
 
     assert [link.href for link in record.links] == [f"/ingestions/jobs/{record.job_id}"]
+
+
+def test_successful_job_persists_result_and_events_atomically(monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted: dict[str, JobRecord] = {}
+
+    monkeypatch.setattr("open_climate_service.jobs.service.JobService._enqueue_job", lambda self, job_id: None)
+    monkeypatch.setattr(
+        "open_climate_service.jobs.store.create_job_record",
+        lambda record: persisted.setdefault(record.job_id, record),
+    )
+    monkeypatch.setattr("open_climate_service.jobs.store.get_job_record", lambda job_id: persisted.get(job_id))
+
+    def mutate(job_id: str, mutation: Callable[[JobRecord], JobRecord]) -> JobRecord:
+        updated = mutation(persisted[job_id])
+        persisted[job_id] = updated
+        return updated
+
+    monkeypatch.setattr("open_climate_service.jobs.store.mutate_job_record", mutate)
+    service = JobService()
+    submitted = service.submit_callable_job(func=_fake_event_job_callable, label="sync", request={})
+
+    service._execute_job(submitted.job_id)
+
+    completed = persisted[submitted.job_id]
+    assert completed.status == JobStatus.SUCCESSFUL
+    assert completed.result == {"ok": True}
+    assert len(completed.events) == 1
+    assert completed.events[0].event_id == f"{submitted.job_id}:0"
+    assert completed.events[0].type == "dataset.updated"
+    assert completed.events[0].time == completed.finished_at
+
+
+@pytest.mark.parametrize("action", [SyncAction.APPEND, SyncAction.REMATERIALIZE])
+def test_execute_sync_returns_dataset_updated_after_completed_change(
+    action: SyncAction, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(processes.services, "sync_dataset", lambda **_: _sync_response(action))
+
+    outcome = processes.execute_sync(dataset_id="managed-dataset")
+
+    assert isinstance(outcome.result, SyncResponse)
+    assert len(outcome.events) == 1
+    assert outcome.events[0].type == "dataset.updated"
+    assert outcome.events[0].source == "/datasets/managed-dataset"
+    assert outcome.events[0].data == {
+        "dataset_id": "managed-dataset",
+        "artifact_id": "artifact-2",
+        "action": action.value,
+        "previous_end": "2026-01-02",
+        "current_end": "2026-01-03",
+    }
+
+
+def test_execute_sync_does_not_emit_dataset_updated_for_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        processes.services,
+        "sync_dataset",
+        lambda **_: _sync_response(SyncAction.NO_OP, status="up_to_date"),
+    )
+
+    outcome = processes.execute_sync(dataset_id="managed-dataset")
+
+    assert outcome.events == []


### PR DESCRIPTION
## Summary

Implements Phase 2 of [CLIM-849](https://dhis2.atlassian.net/browse/CLIM-849): a reliable post-execution outcome for dataset updates.

- lets native job callables return their normal result with typed domain events
- persists events in the same job-record mutation that marks a job successful
- records dataset.updated only after a sync actually appends or rematerializes data
- includes the managed dataset, resulting artifact, executed action, and coverage transition
- assigns deterministic event IDs derived from the native job
- emits no event for NO_OP, unsupported, failed, or cancelled syncs

## Why

The scheduler pre-check describes intended work, not its result. A sync can fail or produce a different outcome after submission, so downstream automation must use the completed sync response. Keeping the event on the durable native job record provides a post-success handoff without adding a workflow dispatcher yet.

## Scope

This PR defines and persists the completion outcome. It does not consume events, configure workflow triggers, or submit openEO workflows. Those remain Phase 3 of CLIM-849.

This branch is independent of the Phase 1 scheduler PR (#343) and targets main.

[CLIM-849]: https://dhis2.atlassian.net/browse/CLIM-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ