### PR TITLE
fix(ingest): treat a never-written store as empty so retries work

### DIFF
--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -194,7 +194,10 @@ async def run_streaming_ingest(
         is_first_write = True
     else:
         raise RuntimeError(
-            f"Existing store at {store_path} is not empty, but committed periods could not be determined safely"
+            f"Existing store at {store_path} holds data whose committed periods could not be read, so it is "
+            "neither safe to append to nor safe to overwrite. Inspect the store, or remove it to re-ingest "
+            "from scratch. A store that was created but never written to is not this case and is handled as "
+            "a first write."
         )
 
     repo = open_or_create_repo(store_path)

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -131,14 +131,20 @@ def is_store_empty(store_path: Path) -> bool:
     `mode="w"` rewrite of data that may already exist.
 
     A repository created but never written to is the one inspection failure that means
-    the opposite. Ingest creates the repo before fetching, so any failure before the
-    first period commits leaves a repo whose branch tip holds only the initial snapshot
-    and no zarr hierarchy at all — `zarr.open_group` raises `GroupNotFoundError` there.
-    Reading that as "cannot inspect, assume data" made the emptiest possible store look
-    occupied, and the orchestrator's first-write guard then refused every retry until
-    the directory was deleted by hand (CLIM-898). No group is not an unknown state: it
-    is an empty one, and there is nothing for a `mode="w"` write to destroy.
+    the opposite. Ingest creates the repo before fetching, so any failure before the first
+    period commits leaves a repo holding nothing but its initial snapshot. Reading that as
+    "cannot inspect, assume data" made the emptiest possible store look occupied, and the
+    orchestrator's first-write guard then refused every retry until the directory was
+    deleted by hand (CLIM-898). Nothing committed is not an unknown state: it is an empty
+    one, and there is nothing for a `mode="w"` write to destroy.
+
+    That case is decided from Icechunk's own history rather than from how `zarr.open_group`
+    reports a missing hierarchy, which varies by version. The `GroupNotFoundError` branch
+    below then only covers a repo that has commits but no group, and cannot be the sole
+    signal for a never-written store.
     """
+    import itertools
+
     import zarr
     from zarr.errors import GroupNotFoundError
 
@@ -147,6 +153,11 @@ def is_store_empty(store_path: Path) -> bool:
 
     try:
         repo = open_or_create_repo(store_path)
+        # Two is enough to answer "more than the initial snapshot?" — ancestry is lazy, so
+        # this does not walk the history of a store with thousands of commits.
+        if len(list(itertools.islice(repo.ancestry(branch="main"), 2))) < 2:
+            logger.debug("%s has no commits beyond initialization; treating as empty", store_path)
+            return True
         session = repo.readonly_session("main")
         try:
             root = zarr.open_group(session.store, mode="r")

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -129,8 +129,18 @@ def is_store_empty(store_path: Path) -> bool:
     This is a conservative safety check for first-write detection. If the store
     cannot be inspected, we treat it as non-empty to avoid a destructive
     `mode="w"` rewrite of data that may already exist.
+
+    A repository created but never written to is the one inspection failure that means
+    the opposite. Ingest creates the repo before fetching, so any failure before the
+    first period commits leaves a repo whose branch tip holds only the initial snapshot
+    and no zarr hierarchy at all — `zarr.open_group` raises `GroupNotFoundError` there.
+    Reading that as "cannot inspect, assume data" made the emptiest possible store look
+    occupied, and the orchestrator's first-write guard then refused every retry until
+    the directory was deleted by hand (CLIM-898). No group is not an unknown state: it
+    is an empty one, and there is nothing for a `mode="w"` write to destroy.
     """
     import zarr
+    from zarr.errors import GroupNotFoundError
 
     if not store_path.exists():
         return True
@@ -138,7 +148,11 @@ def is_store_empty(store_path: Path) -> bool:
     try:
         repo = open_or_create_repo(store_path)
         session = repo.readonly_session("main")
-        root = zarr.open_group(session.store, mode="r")
+        try:
+            root = zarr.open_group(session.store, mode="r")
+        except GroupNotFoundError:
+            logger.debug("%s holds no zarr group; treating as empty", store_path)
+            return True
         return not list(root.array_keys()) and not list(root.group_keys()) and not bool(root.attrs.asdict())
     except Exception:
         logger.debug("Could not determine whether %s is empty", store_path, exc_info=True)

--- a/tests/test_streaming_orchestrator.py
+++ b/tests/test_streaming_orchestrator.py
@@ -380,7 +380,7 @@ def test_orchestrator_refuses_destructive_first_write_when_existing_store_is_not
     )
     monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: False)
 
-    with pytest.raises(RuntimeError, match="committed periods could not be determined safely"):
+    with pytest.raises(RuntimeError, match="committed periods could not be read"):
         run_streaming_ingest_sync(
             plugin=_FakePlugin(),
             params={},

--- a/tests/test_streaming_store_emptiness.py
+++ b/tests/test_streaming_store_emptiness.py
@@ -7,9 +7,9 @@ refuses to touch a store it cannot classify, and an operator has no supported wa
 (CLIM-898), so a false "not empty" here wedges the dataset until someone removes the directory on
 the host.
 
-The pair of assertions matters more than either alone. Reading "no group" as empty must not widen
-into reading "cannot inspect" as empty, because the value returned here decides whether ingest is
-allowed to write with ``mode="w"``.
+The negative cases matter as much as the positive ones: "nothing committed" must not widen into
+"cannot inspect", because the value returned here decides whether ingest may write with
+``mode="w"``.
 """
 
 from __future__ import annotations
@@ -21,9 +21,9 @@ import numpy as np
 import pytest
 
 xr = pytest.importorskip("xarray")
-icechunk = pytest.importorskip("icechunk")
 zarr = pytest.importorskip("zarr")
 zarr_errors = pytest.importorskip("zarr.errors")
+pytest.importorskip("icechunk")  # required by the store helpers, not referenced here
 
 from open_climate_service.streaming.orchestrator import run_streaming_ingest_sync  # noqa: E402
 from open_climate_service.streaming.store import is_store_empty, open_or_create_repo  # noqa: E402
@@ -113,3 +113,23 @@ def test_repo_with_only_root_attrs_is_not_empty(tmp_path: Path) -> None:
     session.commit("root attrs only")
 
     assert is_store_empty(store_path) is False
+
+
+def test_never_written_repo_is_empty_even_if_group_probing_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The decision comes from Icechunk history, not from how zarr reports a missing group.
+
+    How ``zarr.open_group`` signals "no hierarchy here" varies by version, so a fix that
+    depended on catching one exception type would be one upgrade away from wedging again.
+    """
+
+    def explode(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("some other zarr version's idea of a missing group")
+
+    store_path = tmp_path / "never-written.icechunk"
+    open_or_create_repo(store_path)
+    monkeypatch.setattr(zarr, "open_group", explode)
+
+    assert is_store_empty(store_path) is True

--- a/tests/test_streaming_store_emptiness.py
+++ b/tests/test_streaming_store_emptiness.py
@@ -1,0 +1,115 @@
+"""First-write detection on a store that was created but never written to.
+
+Ingest creates the Icechunk repository before it fetches anything, so any failure before the
+first period commits leaves a repo whose branch tip holds only the initial snapshot and no zarr
+hierarchy at all. ``is_store_empty`` has to call that empty: the orchestrator's first-write guard
+refuses to touch a store it cannot classify, and an operator has no supported way to delete one
+(CLIM-898), so a false "not empty" here wedges the dataset until someone removes the directory on
+the host.
+
+The pair of assertions matters more than either alone. Reading "no group" as empty must not widen
+into reading "cannot inspect" as empty, because the value returned here decides whether ingest is
+allowed to write with ``mode="w"``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+icechunk = pytest.importorskip("icechunk")
+zarr = pytest.importorskip("zarr")
+zarr_errors = pytest.importorskip("zarr.errors")
+
+from open_climate_service.streaming.orchestrator import run_streaming_ingest_sync  # noqa: E402
+from open_climate_service.streaming.store import is_store_empty, open_or_create_repo  # noqa: E402
+
+
+class _OnePeriodPlugin:
+    """Minimal plugin, enough to drive a first write."""
+
+    max_concurrency = 1
+    commit_batch_size = 1
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        _ = start, end
+        return ["2026-01-01"]
+
+    async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> Any:
+        _ = bbox, params
+        return xr.Dataset(
+            {"precip": (("t", "y", "x"), np.array([[[1.0]]], dtype=np.float32))},
+            coords={"t": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
+        )
+
+
+def test_repo_created_but_never_written_is_empty(tmp_path: Path) -> None:
+    """The state a failed first ingest leaves behind: initial snapshot, no zarr group."""
+    store_path = tmp_path / "never-written.icechunk"
+    open_or_create_repo(store_path)
+
+    assert store_path.exists(), "repo directory should exist even with nothing committed"
+    with pytest.raises(zarr_errors.GroupNotFoundError):
+        # The condition being classified: the branch tip has no hierarchy to open.
+        repo = open_or_create_repo(store_path)
+        zarr.open_group(repo.readonly_session("main").store, mode="r")
+
+    assert is_store_empty(store_path) is True
+
+
+def test_repo_with_committed_data_is_not_empty(tmp_path: Path) -> None:
+    """The guard still protects real data — otherwise the fix above enables a destructive write."""
+    store_path = tmp_path / "has-data.icechunk"
+    repo = open_or_create_repo(store_path)
+    session = repo.writable_session("main")
+    xr.Dataset(
+        {"precip": (("t", "y", "x"), np.zeros((1, 2, 2), dtype="float32"))},
+        coords={
+            "t": np.array(["2026-01-01"], dtype="datetime64[ns]"),
+            "y": [1.0, 0.0],
+            "x": [0.0, 1.0],
+        },
+    ).to_zarr(session.store, mode="w", zarr_format=3)
+    session.commit("one period")
+
+    assert is_store_empty(store_path) is False
+
+
+def test_ingest_recovers_from_a_repo_left_behind_by_a_failed_first_attempt(tmp_path: Path) -> None:
+    """The whole point: a retry after a failed first ingest succeeds, with no manual cleanup.
+
+    Nothing is monkeypatched here — this is the path that raised
+    ``RuntimeError: ... is not empty, but committed periods could not be determined safely``
+    on every attempt until the directory was deleted on the host.
+    """
+    store_path = tmp_path / "wedged.icechunk"
+    open_or_create_repo(store_path)  # the failed attempt's leftovers
+
+    result = run_streaming_ingest_sync(
+        plugin=_OnePeriodPlugin(),
+        params={},
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        start="2026-01-01",
+        end="2026-01-01",
+        store_path=store_path,
+        period_type="daily",
+    )
+
+    assert result.periods_written == 1
+    assert is_store_empty(store_path) is False
+
+
+def test_repo_with_only_root_attrs_is_not_empty(tmp_path: Path) -> None:
+    """Attrs without arrays still count as content, as they did before."""
+    store_path = tmp_path / "attrs-only.icechunk"
+    repo = open_or_create_repo(store_path)
+    session = repo.writable_session("main")
+    root = zarr.open_group(session.store, mode="w")
+    root.attrs["title"] = "written by something"
+    session.commit("root attrs only")
+
+    assert is_store_empty(store_path) is False


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-898

A store created but never written to has no zarr group, so `zarr.open_group` raises `GroupNotFoundError`. `is_store_empty` caught that with its "cannot inspect, assume data" handler and returned `False` — the emptiest possible store classified as occupied. The first-write guard then refused every retry, recoverable only by `rm -rf` on the host since no API can delete a store (CLIM-871).

Ingest creates the repo before it fetches, so any failure before the first commit leaves this state. Reached on two instances from three unrelated first failures, and separately via `overwrite=True`.

`GroupNotFoundError` now means empty — there is nothing for a `mode="w"` write to destroy. Every other inspection failure stays conservative, so a store holding genuinely unreadable data is still refused, with a message that says what to do about it.

**Tests** — first real coverage of `is_store_empty`; existing orchestrator tests all monkeypatch it. The leftover repo is empty, and an ingest into it succeeds with nothing mocked. A repo with data, and one with only root attrs, are both still not empty — those pin the boundary so this cannot later widen into authorising a destructive write. Both new assertions fail on `main`.

939 passed; the 3 `test_openeo_execution.py` failures are pre-existing (local `proj.db` clash).

Scope: the recovery half only. Making `overwrite=True` replace-on-success is the rest of CLIM-898.
