### PR TITLE
fix(plugins): serve built-in templates when plugins_dir is absent

### DIFF
--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -108,7 +108,15 @@ def list_datasets() -> list[dict[str, Any]]:
         base = config_path.parent if config_path else Path()
         root = (base / config_plugins_dir).resolve()
         if not root.is_dir():
-            raise ValueError(f"plugins_dir '{root}' does not exist or is not a directory")
+            # Startup already warns about this (plugins_diagnostics.log_plugin_loading) and lets the
+            # service run, so raising here made the two disagree: the instance reported healthy and
+            # served /datasets, /collections and /processes while /dataset-templates/ returned 500 —
+            # the one route the ingest form needs. A configured-but-absent plugins_dir is a
+            # deployment slip, not a reason to refuse service, so degrade to the built-in and
+            # entry-point templates instead. Debug rather than warning because startup has already
+            # said it loudly, once, and this runs per request.
+            logger.debug("plugins_dir '%s' does not exist; serving built-in and plugin templates only", root)
+            return list(merged.values())
         root_str = str(root)
         if root_str not in sys.path:
             sys.path.append(root_str)

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -297,3 +297,44 @@ def test_plugins_dir_overrides_entry_point_plugin(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
     result = {d["id"]: d for d in datasets.list_datasets()}
     assert result["x"]["name"] == "plugins_dir"
+
+
+def test_missing_plugins_dir_serves_built_ins_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A configured plugins_dir that does not exist must not break template listing.
+
+    Startup warns and keeps serving, so raising here left the instance reporting healthy with
+    /dataset-templates/ returning 500 — the one route the ingest form needs (CLIM-910).
+    """
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
+    monkeypatch.setattr(
+        datasets, "_load_builtin_datasets", lambda: [{"id": "built_in", "name": "b", "sync": {"kind": "static"}}]
+    )
+    monkeypatch.setattr(
+        datasets,
+        "_load_entry_point_datasets",
+        lambda: [("p", {"id": "from_plugin", "name": "p", "sync": {"kind": "static"}})],
+    )
+    absent = tmp_path / "not-created"
+    monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": str(absent)})
+    monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
+
+    assert not absent.exists()
+    assert {d["id"] for d in datasets.list_datasets()} == {"built_in", "from_plugin"}
+
+
+def test_plugins_dir_of_the_wrong_type_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A misconfigured type is a config error, not a missing directory — keep failing loudly."""
+    monkeypatch.setattr(datasets, "CONFIGS_DIR", None)
+    monkeypatch.setattr(datasets, "_load_builtin_datasets", lambda: [])
+    monkeypatch.setattr(datasets, "_load_entry_point_datasets", lambda: [])
+    monkeypatch.setattr(api_config, "get_config", lambda: {"plugins_dir": ["a", "list"]})
+    monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
+
+    with pytest.raises(ValueError, match="must be a path string"):
+        datasets.list_datasets()


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-910

Startup warns about a configured-but-missing `plugins_dir` and lets the service run (`plugins_diagnostics.py:56`), but `list_datasets()` raised `ValueError` for the same condition. So the instance reported healthy and served `/datasets`, `/collections`, `/processes` and `/stac` while `/dataset-templates/` returned 500 — the one route the ingest form needs. The healthcheck agreed with the lenient half, so nothing surfaced it.

The read path now degrades to built-in and entry-point templates, which is what startup already promises. Two behaviours deliberately unchanged: a `plugins_dir` of the wrong *type* still raises, since that is a config error rather than a deployment slip; and the write path (`get_instance_datasets_dir`) still raises, since a template cannot be persisted into a directory that does not exist.

**Verified end to end** with an absent `plugins_dir`: `/dataset-templates/` returns 200 with all 17 built-ins, `/health` is healthy, and startup warns exactly once.

Tests: the degrade case (fails on `main`), plus the wrong-type case to pin what should still raise.

937 passed; the 3 `test_openeo_execution.py` failures are pre-existing (local `proj.db` clash).
