### PR TITLE
fix(registry): parse built-in and plugin templates once per process

### DIFF
--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -5,6 +5,7 @@ import functools
 import importlib.resources
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +21,16 @@ logger = logging.getLogger(__name__)
 CONFIGS_DIR: Path | None = None
 
 # Template issues already logged this process, so a re-read path cannot repeat them.
+# Guarded by its own lock: FastAPI runs sync endpoints in worker threads, so the
+# check-then-add would otherwise let two threads both decide a warning is new.
 _WARNED_TEMPLATE_ISSUES: set[tuple[str, str, str]] = set()
+_WARNED_LOCK = threading.Lock()
+
+# Serialises cache population. `lru_cache` protects its own state but calls the wrapped
+# function outside that lock, so concurrent cold calls would each parse every template.
+# Only contended on a cold cache; the warm path takes it and returns immediately.
+# Lock order is one-way — a parse takes this and then `_WARNED_LOCK` while validating.
+_PARSE_LOCK = threading.Lock()
 
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
@@ -209,9 +219,11 @@ def reset_template_caches() -> None:
     change without a restart, and an instance's ``plugins_dir`` is not cached. It exists so
     tests that install a fake entry point, or patch package data, do not leak state.
     """
-    _parse_builtin_datasets.cache_clear()
-    _parse_entry_point_datasets.cache_clear()
-    _WARNED_TEMPLATE_ISSUES.clear()
+    with _PARSE_LOCK:
+        _parse_builtin_datasets.cache_clear()
+        _parse_entry_point_datasets.cache_clear()
+    with _WARNED_LOCK:
+        _WARNED_TEMPLATE_ISSUES.clear()
 
 
 def _load_builtin_datasets() -> list[dict[str, Any]]:
@@ -227,7 +239,9 @@ def _load_builtin_datasets() -> list[dict[str, Any]]:
     isolating callers from each other costs almost nothing next to what caching saves,
     and a mutation of a returned template cannot poison every later request.
     """
-    return copy.deepcopy(_parse_builtin_datasets())
+    with _PARSE_LOCK:
+        parsed = _parse_builtin_datasets()
+    return copy.deepcopy(parsed)
 
 
 @functools.lru_cache(maxsize=1)
@@ -264,7 +278,9 @@ def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
     Cached and copied for the same reasons as :func:`_load_builtin_datasets`: an installed
     package's templates cannot change without a reinstall, which needs a restart anyway.
     """
-    return copy.deepcopy(_parse_entry_point_datasets())
+    with _PARSE_LOCK:
+        parsed = _parse_entry_point_datasets()
+    return copy.deepcopy(parsed)
 
 
 @functools.lru_cache(maxsize=1)
@@ -410,6 +426,8 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
             # request, so without this a questionable unit there would log on every request
             # exactly as the built-ins used to (CLIM-904).
             key = (dataset_id, source, message)
-            if key not in _WARNED_TEMPLATE_ISSUES:
+            with _WARNED_LOCK:
+                first_time = key not in _WARNED_TEMPLATE_ISSUES
                 _WARNED_TEMPLATE_ISSUES.add(key)
+            if first_time:
                 logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -1,5 +1,7 @@
 """Dataset registry backed by YAML config files."""
 
+import copy
+import functools
 import importlib.resources
 import logging
 import sys
@@ -16,6 +18,9 @@ logger = logging.getLogger(__name__)
 # Overridden in tests via monkeypatch to point to a temporary directory.
 # When set, only this directory is loaded (no built-ins, no config override).
 CONFIGS_DIR: Path | None = None
+
+# Template issues already logged this process, so a re-read path cannot repeat them.
+_WARNED_TEMPLATE_ISSUES: set[tuple[str, str, str]] = set()
 
 SUPPORTED_SYNC_KINDS = {"temporal", "release", "static"}
 SUPPORTED_SYNC_EXECUTIONS = {"append", "rematerialize"}
@@ -189,8 +194,37 @@ def write_dataset_template(dataset: dict[str, Any], *, overwrite: bool = False) 
     return destination
 
 
+def reset_template_caches() -> None:
+    """Forget the parsed built-in and plugin templates, and which warnings were logged.
+
+    Nothing in a running service needs this: both cached stages read files that cannot
+    change without a restart, and an instance's ``plugins_dir`` is not cached. It exists so
+    tests that install a fake entry point, or patch package data, do not leak state.
+    """
+    _parse_builtin_datasets.cache_clear()
+    _parse_entry_point_datasets.cache_clear()
+    _WARNED_TEMPLATE_ISSUES.clear()
+
+
 def _load_builtin_datasets() -> list[dict[str, Any]]:
-    """Load built-in dataset templates from package data via importlib.resources.
+    """Built-in dataset templates, parsed once per process.
+
+    Package data cannot change while the process runs, but this was re-reading and
+    re-validating every built-in YAML on each call — 13.5 ms per call, on a path some
+    requests take twice — and re-emitting the same validation warnings each time, which
+    is what filled deployment logs (CLIM-904). Under ``--reload`` the process restarts,
+    so edits during development are still picked up.
+
+    Callers get a deep copy: the cached parse is 13.5 ms and the copy 0.17 ms, so
+    isolating callers from each other costs almost nothing next to what caching saves,
+    and a mutation of a returned template cannot poison every later request.
+    """
+    return copy.deepcopy(_parse_builtin_datasets())
+
+
+@functools.lru_cache(maxsize=1)
+def _parse_builtin_datasets() -> list[dict[str, Any]]:
+    """Read and validate the built-in templates from package data.
 
     Using importlib.resources instead of __file__-relative path arithmetic ensures
     this works correctly in both editable installs and wheel installs, where the
@@ -217,7 +251,17 @@ def _load_builtin_datasets() -> list[dict[str, Any]]:
 
 
 def _load_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
-    """Load dataset templates contributed by installed plugin packages (#118).
+    """Dataset templates from installed plugin packages, parsed once per process.
+
+    Cached and copied for the same reasons as :func:`_load_builtin_datasets`: an installed
+    package's templates cannot change without a reinstall, which needs a restart anyway.
+    """
+    return copy.deepcopy(_parse_entry_point_datasets())
+
+
+@functools.lru_cache(maxsize=1)
+def _parse_entry_point_datasets() -> list[tuple[str, dict[str, Any]]]:
+    """Read and validate dataset templates contributed by installed plugin packages (#118).
 
     A plugin's ``datasets/*.yaml`` templates are loaded here; the package's Python —
     the ``ingestion.plugin`` class — is importable by dotted path because the package
@@ -353,4 +397,11 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
 
         message = validate_units(units)
         if message:
-            logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)
+            # Once per (template, source, message) per process. Built-in templates are now
+            # parsed once, but an instance's plugins_dir is deliberately re-read on every
+            # request, so without this a questionable unit there would log on every request
+            # exactly as the built-ins used to (CLIM-904).
+            key = (dataset_id, source, message)
+            if key not in _WARNED_TEMPLATE_ISSUES:
+                _WARNED_TEMPLATE_ISSUES.add(key)
+                logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -386,3 +386,57 @@ def test_plugins_dir_of_the_wrong_type_still_raises(
 
     with pytest.raises(ValueError, match="must be a path string"):
         datasets.list_datasets()
+
+
+def test_concurrent_cold_calls_parse_the_templates_once() -> None:
+    """FastAPI runs sync endpoints in worker threads, so a cold cache is hit concurrently.
+
+    ``lru_cache`` calls the wrapped function outside its own lock, so without serialising
+    population every thread arriving on a cold cache parses every template.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    datasets.reset_template_caches()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = [f.result() for f in [pool.submit(datasets._load_builtin_datasets) for _ in range(8)]]
+
+    assert datasets._parse_builtin_datasets.cache_info().misses == 1
+    assert all([d["id"] for d in r] == [d["id"] for d in results[0]] for r in results)
+
+
+def test_concurrent_validation_warns_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent validation of one template yields one warning.
+
+    A smoke test, not a race guard: it also passes without the lock in `_validate_dataset_template`,
+    because the check-then-add window is a few bytecodes and the GIL rarely interleaves there. The
+    lock is still worth having — it makes "once" true rather than merely probable — but this test
+    cannot demonstrate its absence, unlike the parse test above (8 misses instead of 1).
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    datasets.reset_template_caches()
+    warnings: list[str] = []
+    warn_lock = __import__("threading").Lock()
+
+    def record(msg: str, *args: object) -> None:
+        with warn_lock:  # the assertion is about datasets.py's locking, not this list's
+            warnings.append(msg % args if args else msg)
+
+    monkeypatch.setattr(datasets.logger, "warning", record)
+    template = {
+        "id": "counts",
+        "name": "Counts",
+        "variable": "n",
+        "sync": {"kind": "static"},
+        "units": "people",
+    }
+    # Warm xclim outside the threads so import timing does not shape the result.
+    datasets._validate_dataset_template(template, source="warmup.yaml")
+    datasets.reset_template_caches()
+    warnings.clear()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for f in [pool.submit(datasets._validate_dataset_template, template, source="counts.yaml") for _ in range(8)]:
+            f.result()
+
+    assert len(warnings) == 1

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -297,3 +297,51 @@ def test_plugins_dir_overrides_entry_point_plugin(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(api_config, "get_config_path", lambda: tmp_path / "climate-service.yaml")
     result = {d["id"]: d for d in datasets.list_datasets()}
     assert result["x"]["name"] == "plugins_dir"
+
+
+def test_builtin_templates_are_parsed_once_per_process() -> None:
+    """The YAML parse is 13.5 ms; it used to run on every call, twice for some requests."""
+    datasets.reset_template_caches()
+    first = datasets._load_builtin_datasets()
+    second = datasets._load_builtin_datasets()
+
+    info = datasets._parse_builtin_datasets.cache_info()
+    assert (info.misses, info.hits) == (1, 1)
+    assert [d["id"] for d in first] == [d["id"] for d in second]
+
+
+def test_returned_templates_are_isolated_from_the_cache() -> None:
+    """A caller mutating a template must not poison every later request."""
+    datasets.reset_template_caches()
+    mutated = datasets._load_builtin_datasets()
+    mutated[0]["name"] = "clobbered"
+    mutated[0].setdefault("display", {})["colormap"] = "clobbered"
+
+    fresh = datasets._load_builtin_datasets()
+    assert fresh[0]["name"] != "clobbered"
+    assert fresh[0].get("display", {}).get("colormap") != "clobbered"
+
+
+def test_unrecognised_units_warn_once_per_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An instance's plugins_dir is re-read per request, so the warning must not repeat.
+
+    Counting calls on the module logger rather than using ``caplog``: validating units imports
+    xclim, which pulls in pint, and that import reshuffles root logging handlers so records
+    emitted afterwards can escape capture. The assertion here is the intent anyway — warn once.
+    """
+    datasets.reset_template_caches()
+    warnings: list[str] = []
+    monkeypatch.setattr(datasets.logger, "warning", lambda msg, *args: warnings.append(msg % args if args else msg))
+    template = {
+        "id": "counts",
+        "name": "Counts",
+        "variable": "n",
+        "sync": {"kind": "static"},
+        "units": "people",
+    }
+
+    for _ in range(3):
+        datasets._validate_dataset_template(template, source="counts.yaml")
+
+    assert len(warnings) == 1
+    assert "not a recognised CF/udunits unit" in warnings[0]


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-904

`list_datasets()` re-read and re-validated every built-in template YAML on each call, and re-emitted the same validation warnings each time. Some requests take that path twice, which is why deployments log three `units 'people' is not a recognised CF/udunits unit` lines per request indefinitely.

Package data and installed plugin packages cannot change while the process runs, so both stages are now cached. The instance `plugins_dir` stage is deliberately left hot — it is re-read per request so template edits are picked up without a restart.

Callers get a deep copy of the cached parse. The copy is 0.17 ms against the 13.5 ms it replaces, so isolating callers costs almost nothing and a caller mutating a returned template cannot poison every later request.

Template warnings are deduplicated per (template, source, message), because the still-hot `plugins_dir` path would otherwise spam exactly as the built-ins did.

**Measured**

| | before | after |
|---|---|---|
| `list_datasets()` | 18.09 ms | 0.17 ms |
| units warnings, running server | 3 per template-loading call | 3 once per process |

**Tests** — the parse happens once (`cache_info`), a returned template cannot mutate the cache, and the warning fires once across repeated validation. All three fail on `main`.

`reset_template_caches()` exists for tests that install fake entry points; nothing in a running service needs it.

938 passed, in both ordered and randomised runs, so nothing leaks between tests. The 3 `test_openeo_execution.py` failures are pre-existing (local `proj.db` clash).
