### PR TITLE
fix(openeo): refuse formats a raster cube cannot produce

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -1115,7 +1115,20 @@ def _write_raster(ds: Any, results_dir: Any, fmt: str) -> str | None:
         except Exception:
             logger.debug("geometry→GeoDataFrame conversion failed", exc_info=True)
 
-    ext, _ = _RASTER_FORMATS.get(fmt, (".zarr", "application/vnd+zarr"))
+    if fmt not in _RASTER_FORMATS:
+        # Defaulting an unwritable format to Zarr wrote a `result.zarr` directory and called it
+        # the requested format. Synchronously that surfaced as a 500 — `IsADirectoryError` when
+        # the route read the "file" back — and in a batch job as a job that succeeded while
+        # advertising output it had not produced (CLIM-909).
+        if fmt in _VECTOR_FORMATS:
+            raise ValueError(
+                f"Format '{fmt}' describes vector features, but this result is a raster datacube "
+                "with no geometry dimension. Aggregate to geometries first (e.g. aggregate_spatial), "
+                "or request a raster format: " + ", ".join(sorted(_RASTER_FORMATS))
+            )
+        raise ValueError(f"Unsupported output format '{fmt}'. Supported: " + ", ".join(sorted(_RASTER_FORMATS)))
+
+    ext, _ = _RASTER_FORMATS[fmt]
 
     if ext == ".zarr":
         path = str(results_dir / "result.zarr")

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1660,3 +1660,38 @@ def test_derive_coverage_returns_spatial_and_temporal_from_dataset() -> None:
     assert coverage.spatial.ymax == pytest.approx(30.0)
     assert coverage.temporal.start == "2025-01-01"
     assert coverage.temporal.end == "2025-01-03"
+
+
+def test_batch_job_with_unwritable_format_errors_without_a_result_asset(
+    job_service: OpenEOJobService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The batch half of CLIM-909: the job must fail, not finish with mislabelled output.
+
+    Before the fix `_write_raster` fell back to Zarr, so the job wrote `result.zarr`, was marked
+    FINISHED, and advertised it as the requested format — quieter than the synchronous 500 and
+    harder to notice.
+    """
+    ds = xr.Dataset(
+        {"temperature": xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=["y", "x"])},
+        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        lambda process: SaveResultEnvelope(ds, "GEOJSON"),
+    )
+
+    record = job_service.create_job(
+        OpenEOJobCreate(
+            process={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+        )
+    )
+    job_service._execute(record.id)
+
+    failed = job_service.get_job_or_404(record.id)
+    assert failed.status == OpenEOJobStatus.ERROR
+    assert "describes vector features" in (failed.error_message or "")
+    assert not (failed.usage or {}).get("output_path")
+
+    with pytest.raises(HTTPException) as exc_info:
+        job_service.get_results(record.id)
+    assert exc_info.value.status_code == 424

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -620,6 +620,67 @@ def test_result_route_rejects_synchronous_zarr_datacube(client: TestClient, monk
     assert "do not support ZARR output" in response.json()["detail"]
 
 
+@pytest.mark.parametrize(
+    ("fmt", "expected_fragment"),
+    [
+        ("GEOJSON", "describes vector features"),
+        ("PARQUET", "describes vector features"),
+        ("JSON", "Unsupported output format"),
+    ],
+)
+def test_result_route_rejects_formats_a_raster_cube_cannot_produce(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fmt: str,
+    expected_fragment: str,
+) -> None:
+    """A raster cube asked for a vector or unknown format must 4xx, not 500.
+
+    These used to fall through to the Zarr default, writing a `result.zarr` directory that the
+    route then tried to read as a file: `IsADirectoryError`, surfaced as 500 (CLIM-909).
+    """
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        lambda process, request=None: SaveResultEnvelope(
+            xr.Dataset({"temperature": xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=["y", "x"])}),
+            fmt,
+        ),
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 400
+    assert expected_fragment in response.json()["detail"]
+
+
+@pytest.mark.parametrize("fmt", ["NETCDF", "GTIFF", "CSV"])
+def test_result_route_still_serves_raster_formats(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fmt: str,
+) -> None:
+    """The refusal above must not catch formats a raster cube genuinely produces."""
+    ds = xr.Dataset(
+        {"temperature": xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=["y", "x"])},
+        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        lambda process, request=None: SaveResultEnvelope(ds, fmt),
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.content
+
+
 def test_result_route_returns_geojson_payload_for_synchronous_vector_result(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-909

`_write_raster` defaulted any unrecognised format to Zarr:

```python
ext, _ = _RASTER_FORMATS.get(fmt, (".zarr", "application/vnd+zarr"))
```

So a raster datacube asked for GEOJSON, PARQUET or an unknown format wrote a `result.zarr` **directory** and called it the requested format. Synchronously the route read that "file" back and raised `IsADirectoryError` → 500. In a batch job it was quieter and worse: the job succeeded while advertising output it had not produced.

Unwritable formats now raise `ValueError`, which the sync route already converts to 400 — the same clean refusal ZARR gets — and which fails a batch job with a message rather than writing something mislabelled. A vector format gets a specific message pointing at `aggregate_spatial`, since asking for GEOJSON is a reasonable thing to want and only the missing geometry dimension makes it impossible here.

Unchanged: the geometry-dimension path, so `aggregate_spatial` output still converts to a GeoDataFrame and writes GEOJSON, PARQUET or CSV.

**Tests** — GEOJSON, PARQUET and JSON on a raster cube return 400 (all three fail on `main`), and NETCDF, GTIFF and CSV still return 200, so the refusal cannot swallow formats a raster genuinely produces.

943 passed; the 3 `test_openeo_execution.py` CRS failures are pre-existing (local `proj.db` clash).

Scope: the refusal half of CLIM-909 only. Making GEOJSON genuinely work for vector results is #341.
