### PR TITLE
fix(openeo): scrub unencodable attrs before netCDF and Zarr export

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -1117,6 +1117,16 @@ def _write_raster(ds: Any, results_dir: Any, fmt: str) -> str | None:
 
     ext, _ = _RASTER_FORMATS.get(fmt, (".zarr", "application/vnd+zarr"))
 
+    if ext in {".zarr", ".nc"}:
+        # `reduce_dimension` (openeo-processes-dask) stamps dict-valued bookkeeping attrs such
+        # as `reduced_dimensions_min_values={'t': numpy.datetime64(...)}`, which neither writer
+        # can encode — netCDF rejects the dict outright and Zarr rejects it as non-JSON. The
+        # managed-publish path already scrubs these; the file export paths did not, so a graph
+        # ending in reduce_dimension failed at write time (CLIM-825). Temporal extent is
+        # recovered from these attrs elsewhere, before this point, so dropping them here
+        # loses nothing the output needed.
+        ds = _strip_non_serializable_attrs(ds)
+
     if ext == ".zarr":
         path = str(results_dir / "result.zarr")
         ds.to_zarr(path, mode="w")

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import numbers
 import os
 import re
 import threading
@@ -491,6 +492,51 @@ def _strip_non_serializable_attrs(ds: Any) -> Any:
             except (TypeError, ValueError):
                 pass
         return out
+
+    ds = ds.copy()
+    ds.attrs = _safe(ds.attrs)
+    for name in list(ds.data_vars) + list(ds.coords):
+        if ds[name].attrs:
+            ds[name].attrs = _safe(ds[name].attrs)
+    return ds
+
+
+def _netcdf_safe_attrs(ds: Any) -> Any:
+    """Return a copy of ds keeping only attrs netCDF can encode.
+
+    JSON-serializability is Zarr's contract, not netCDF's, and the two disagree in both
+    directions — measured against ``to_netcdf`` rather than inferred:
+
+    | attr value            | JSON | netCDF |
+    |-----------------------|------|--------|
+    | ``{'t': '2025-01-01'}`` | ok   | fails  |
+    | ``[{'a': 1}]``          | ok   | fails  |
+    | ``None``                | ok   | fails  |
+    | ``True``                | ok   | fails  |
+    | ``np.array([1., 2.])``  | fails| ok     |
+    | ``np.float32(0.5)``     | fails| ok     |
+
+    So a JSON scrub both misses dict attrs whose contents happen to be JSON-safe and throws
+    away arrays and numpy scalars that netCDF writes happily. This keeps str, bytes, numbers
+    (excluding bool, which netCDF has no type for), numpy arrays and scalars, and sequences of
+    those.
+    """
+
+    def _encodable(value: Any) -> bool:
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, (str, bytes, numbers.Number)):
+            return True
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            return True
+        if isinstance(value, (list, tuple)):
+            return all(not isinstance(item, bool) and isinstance(item, (str, numbers.Number)) for item in value)
+        return False
+
+    def _safe(attrs: dict[str, Any]) -> dict[str, Any]:
+        return {key: value for key, value in attrs.items() if _encodable(value)}
 
     ds = ds.copy()
     ds.attrs = _safe(ds.attrs)
@@ -1117,24 +1163,23 @@ def _write_raster(ds: Any, results_dir: Any, fmt: str) -> str | None:
 
     ext, _ = _RASTER_FORMATS.get(fmt, (".zarr", "application/vnd+zarr"))
 
-    if ext in {".zarr", ".nc"}:
-        # `reduce_dimension` (openeo-processes-dask) stamps dict-valued bookkeeping attrs such
-        # as `reduced_dimensions_min_values={'t': numpy.datetime64(...)}`, which neither writer
-        # can encode — netCDF rejects the dict outright and Zarr rejects it as non-JSON. The
-        # managed-publish path already scrubs these; the file export paths did not, so a graph
-        # ending in reduce_dimension failed at write time (CLIM-825). Temporal extent is
-        # recovered from these attrs elsewhere, before this point, so dropping them here
-        # loses nothing the output needed.
-        ds = _strip_non_serializable_attrs(ds)
-
+    # `reduce_dimension` (openeo-processes-dask) stamps dict-valued bookkeeping attrs such as
+    # `reduced_dimensions_min_values={'t': numpy.datetime64(...)}`, which neither writer can
+    # encode. The managed-publish path already scrubbed these; the file export paths did not,
+    # so a graph ending in reduce_dimension failed at write time (CLIM-825). Temporal extent is
+    # recovered from these attrs earlier, so dropping them here loses nothing the output needed.
+    #
+    # Each format is filtered against its own contract: JSON for Zarr, netCDF's attr types for
+    # netCDF. They disagree in both directions, so using one rule for both would still fail on
+    # a JSON-safe dict and would discard arrays netCDF can write.
     if ext == ".zarr":
         path = str(results_dir / "result.zarr")
-        ds.to_zarr(path, mode="w")
+        _strip_non_serializable_attrs(ds).to_zarr(path, mode="w")
         return path
 
     if ext == ".nc":
         path = str(results_dir / "result.nc")
-        ds.to_netcdf(path)
+        _netcdf_safe_attrs(ds).to_netcdf(path)
         return path
 
     if ext == ".tif":

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1629,6 +1629,7 @@ def test_write_raster_keeps_attrs_the_writer_can_encode(tmp_path: Path) -> None:
     from open_climate_service.openeo.jobs import _write_raster
 
     output = _write_raster(_reduced_dataset(), tmp_path, "NETCDF")
+    assert output is not None
 
     reopened = xr.open_dataset(output)
     try:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1624,6 +1624,79 @@ def test_write_raster_scrubs_attrs_no_writer_can_encode(tmp_path: Path, fmt: str
     assert Path(output).exists()
 
 
+# JSON-serializability is Zarr's contract, not netCDF's, and they disagree both ways. Each case
+# below records what `to_netcdf` actually does, so the filter is measured rather than assumed.
+_NETCDF_ATTR_CASES = [
+    ("dict_of_datetime64", {"t": np.datetime64("2025-01-01")}, False),
+    ("dict_of_str", {"t": "2025-01-01"}, False),
+    ("list_of_dict", [{"a": 1}], False),
+    ("none", None, False),
+    ("bool", True, False),
+    ("ndarray", np.array([1.0, 2.0], dtype="float32"), True),
+    ("numpy_scalar", np.float32(0.5), True),
+    ("str", "mm/d", True),
+    ("int", 3, True),
+    ("list_of_str", ["a", "b"], True),
+]
+
+
+@pytest.mark.parametrize(("label", "value", "netcdf_can_encode"), _NETCDF_ATTR_CASES)
+def test_netcdf_attr_filter_matches_what_the_writer_accepts(
+    tmp_path: Path, label: str, value: object, netcdf_can_encode: bool
+) -> None:
+    """The filter must keep exactly what netCDF can write — no more, no less."""
+    from open_climate_service.openeo.jobs import _netcdf_safe_attrs
+
+    ds = xr.Dataset({"v": xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=["y", "x"])})
+    ds.attrs["probe"] = value
+
+    kept = "probe" in _netcdf_safe_attrs(ds).attrs
+    assert kept == netcdf_can_encode, f"{label}: filter kept={kept}, writer accepts={netcdf_can_encode}"
+
+    # And the writer agrees, so this table cannot drift from reality unnoticed.
+    if netcdf_can_encode:
+        _netcdf_safe_attrs(ds).to_netcdf(tmp_path / f"{label}.nc")
+    else:
+        with pytest.raises(TypeError):
+            ds.to_netcdf(tmp_path / f"{label}-raw.nc")
+
+
+def test_write_raster_netcdf_drops_a_json_safe_dict_attr(tmp_path: Path) -> None:
+    """A dict of plain strings survives a JSON scrub but still breaks to_netcdf."""
+    from open_climate_service.openeo.jobs import _write_raster
+
+    ds = _reduced_dataset()
+    ds.attrs["json_safe_dict"] = {"t": "2025-01-01"}
+
+    output = _write_raster(ds, tmp_path, "NETCDF")
+
+    assert output is not None
+    reopened = xr.open_dataset(output)
+    try:
+        assert "json_safe_dict" not in reopened.attrs
+    finally:
+        reopened.close()
+
+
+def test_write_raster_netcdf_keeps_array_attrs_a_json_scrub_would_drop(tmp_path: Path) -> None:
+    """netCDF writes arrays and numpy scalars happily; the JSON scrub would discard them."""
+    from open_climate_service.openeo.jobs import _write_raster
+
+    ds = _reduced_dataset()
+    ds.attrs["valid_range"] = np.array([0.0, 100.0], dtype="float32")
+    ds.attrs["scale_factor"] = np.float32(0.1)
+
+    output = _write_raster(ds, tmp_path, "NETCDF")
+
+    assert output is not None
+    reopened = xr.open_dataset(output)
+    try:
+        assert list(reopened.attrs["valid_range"]) == [0.0, 100.0]
+        assert reopened.attrs["scale_factor"] == pytest.approx(0.1)
+    finally:
+        reopened.close()
+
+
 def test_write_raster_keeps_attrs_the_writer_can_encode(tmp_path: Path) -> None:
     """The scrub must drop only what cannot be written, not all metadata."""
     from open_climate_service.openeo.jobs import _write_raster

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1599,3 +1599,57 @@ def test_derive_coverage_returns_spatial_and_temporal_from_dataset() -> None:
     assert coverage.spatial.ymax == pytest.approx(30.0)
     assert coverage.temporal.start == "2025-01-01"
     assert coverage.temporal.end == "2025-01-03"
+
+
+def _reduced_dataset() -> Any:
+    """A dataset shaped like `reduce_dimension` output: dict-valued bookkeeping attrs."""
+    ds = xr.Dataset(
+        {"precip": xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=["y", "x"])},
+        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    ds.attrs["reduced_dimensions_min_values"] = {"t": np.datetime64("2025-01-01")}
+    ds.attrs["units"] = "mm/d"
+    ds["precip"].attrs["reduced_dimensions_max_values"] = {"t": np.datetime64("2025-02-01")}
+    return ds
+
+
+@pytest.mark.parametrize("fmt", ["NETCDF", "ZARR"])
+def test_write_raster_scrubs_attrs_no_writer_can_encode(tmp_path: Path, fmt: str) -> None:
+    """netCDF rejects a dict attr outright; Zarr rejects it as non-JSON (CLIM-825)."""
+    from open_climate_service.openeo.jobs import _write_raster
+
+    output = _write_raster(_reduced_dataset(), tmp_path, fmt)
+
+    assert output is not None
+    assert Path(output).exists()
+
+
+def test_write_raster_keeps_attrs_the_writer_can_encode(tmp_path: Path) -> None:
+    """The scrub must drop only what cannot be written, not all metadata."""
+    from open_climate_service.openeo.jobs import _write_raster
+
+    output = _write_raster(_reduced_dataset(), tmp_path, "NETCDF")
+
+    reopened = xr.open_dataset(output)
+    try:
+        assert reopened.attrs["units"] == "mm/d"
+        assert "reduced_dimensions_min_values" not in reopened.attrs
+        assert "reduced_dimensions_max_values" not in reopened["precip"].attrs
+    finally:
+        reopened.close()
+
+
+def test_result_route_serves_netcdf_after_reduce_dimension(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reported symptom: a graph ending in reduce_dimension, exported as NETCDF, 500d."""
+    monkeypatch.setattr(
+        "open_climate_service.openeo.execution.run_process_graph",
+        lambda process, request=None: SaveResultEnvelope(_reduced_dataset(), "NETCDF"),
+    )
+
+    response = client.post(
+        "/result",
+        json={"process_graph": {"result": {"process_id": "save_result", "result": True}}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.content


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-825

`reduce_dimension` (openeo-processes-dask) stamps dict-valued bookkeeping attrs onto its result:

```
reduced_dimensions_min_values = {'t': numpy.datetime64('2025-01-01')}
```

Neither writer can encode that — netCDF rejects the dict outright, Zarr rejects it as non-JSON — so a graph ending in `reduce_dimension` failed at write time. The managed-publish path already calls `_strip_non_serializable_attrs`; the file export paths did not. They do now.

Temporal extent is recovered from these attrs earlier in the pipeline, so dropping them at write time loses nothing the output needed, and attrs the writer *can* encode are kept.

**One correction to the ticket.** It records this as NETCDF-only, with GTIFF and ZARR succeeding. ZARR only looks unaffected through `POST /result`, which refuses it with 400 before reaching the write. Calling `_write_raster` directly:

```
NETCDF  -> TypeError: Invalid value for attr 'reduced_dimensions_min_values'
ZARR    -> TypeError: Invalid attribute in Dataset.attrs.
GTIFF   -> ok
```

So a **batch job** exporting ZARR after `reduce_dimension` hit the same failure. Both branches are scrubbed rather than just netCDF.

**Tests** — netCDF and Zarr both write from a reduce-shaped dataset; a legitimate `units` attr survives while both offenders are gone; and the reported route symptom (`POST /result` with NETCDF) returns 200. All four fail on `main`.

941 passed; the 3 `test_openeo_execution.py` CRS failures are pre-existing (local `proj.db` clash).
