### PR TITLE
fix(openeo): stop advertising xclim indicators that return several cubes

### DIFF
--- a/open_climate_service/openeo/xclim_processes.py
+++ b/open_climate_service/openeo/xclim_processes.py
@@ -96,6 +96,19 @@ def _collect() -> list[Any]:
                 continue
             seen.add(indicator_id)
 
+            # Every spec below declares a single datacube return, so an indicator producing
+            # several cubes cannot be honoured: a client composing a graph from GET /processes
+            # would feed a tuple into save_result or a reducer and get a confusing failure
+            # rather than "not supported". Three of xclim 0.61's registered indicators are
+            # multi-output — cffwis (6), rain_season (3), jetstream_metric_woollings (2) — and
+            # no OCS workflow uses them, so advertising 176 processes we honour beats 179 where
+            # three lie (CLIM-860). Registering one process per named output is the richer
+            # alternative, worth doing if someone asks for these specifically.
+            outputs = _declared_output_count(obj)
+            if outputs > 1:
+                logger.debug("Skipping multi-output xclim indicator '%s' (%d outputs)", indicator_id, outputs)
+                continue
+
             params: list[dict[str, Any]] = []
             for name, p in obj.parameters.items():
                 if p.kind in _SKIP_KINDS:
@@ -127,6 +140,20 @@ def _collect() -> list[Any]:
             funcs.append(_make_callable(obj, meta))
 
     return funcs
+
+
+def _declared_output_count(indicator: Any) -> int:
+    """How many cubes an xclim indicator returns, per its own CF metadata.
+
+    ``cf_attrs`` carries one entry per output, so its length is the indicator's arity.
+    Anything unreadable counts as one: a wrong guess here would silently drop a
+    single-output indicator, and losing a process is worse than the mismatch this guards.
+    """
+    try:
+        return len(indicator.cf_attrs)
+    except Exception:  # noqa: BLE001 — metadata shape is xclim's business, not ours
+        logger.debug("Could not read cf_attrs for %r; assuming single output", indicator, exc_info=True)
+        return 1
 
 
 def _make_callable(indicator: Any, meta: dict[str, Any]) -> Any:

--- a/tests/test_xclim_process_registration.py
+++ b/tests/test_xclim_process_registration.py
@@ -1,0 +1,61 @@
+"""What the auto-registered xclim indicator processes promise, and whether they can keep it.
+
+`_collect()` declares the same `returns` schema — a single datacube — for every indicator it
+registers. Three of xclim 0.61's indicators return a tuple of cubes instead, so advertising them
+published a contract the process could not honour: a client composing a graph from
+`GET /processes` would feed a tuple into save_result or a reducer and get a confusing failure
+rather than a clear "not supported" (CLIM-860).
+
+The general assertion matters more than the three names. A future xclim release can add
+multi-output indicators, and this catches that at test time instead of in someone's process graph.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from open_climate_service.openeo import xclim_processes
+from open_climate_service.process import get_process_metadata
+
+pytest.importorskip("xclim")
+
+_MULTI_OUTPUT_IN_XCLIM_061 = {"cffwis", "rain_season", "jetstream_metric_woollings"}
+
+
+def _registered() -> dict[str, dict]:
+    metas = {}
+    for func in xclim_processes.scan():
+        meta = get_process_metadata(func)
+        assert meta is not None
+        metas[meta["id"]] = meta
+    return metas
+
+
+def test_every_registered_indicator_returns_exactly_one_cube() -> None:
+    """The declared `returns` must match what the indicator actually produces."""
+    import xclim.indicators.atmos as atmos
+    import xclim.indicators.land as land
+    import xclim.indicators.seaIce as seaice
+
+    by_id = {}
+    for mod in (atmos, land, seaice):
+        for obj in vars(mod).values():
+            if hasattr(obj, "identifier") and hasattr(obj, "cf_attrs"):
+                by_id.setdefault(obj.identifier, len(obj.cf_attrs))
+
+    offenders = {name: by_id[name] for name in _registered() if by_id.get(name, 1) > 1}
+    assert offenders == {}, f"registered indicators that return multiple cubes: {offenders}"
+
+
+@pytest.mark.parametrize("indicator_id", sorted(_MULTI_OUTPUT_IN_XCLIM_061))
+def test_known_multi_output_indicators_are_not_advertised(indicator_id: str) -> None:
+    assert indicator_id not in _registered()
+
+
+def test_single_output_indicators_are_still_registered() -> None:
+    """The skip must not thin the catalogue beyond the three that cannot be honoured."""
+    registered = _registered()
+
+    assert len(registered) >= 170
+    assert "tx_max" in registered
+    assert registered["tx_max"]["returns"]["schema"]["subtype"] == "datacube"


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-860

`_collect()` declares the same `returns` schema — one datacube — for all 179 xclim indicators it registers. Three of them return a tuple instead:

| Indicator | Outputs |
|---|---|
| `cffwis` | 6 |
| `rain_season` | 3 |
| `jetstream_metric_woollings` | 2 |

So `GET /processes` published a contract those three cannot honour. A client composing a graph from the catalogue — the openEO Web Editor, a generated client — feeds a tuple into `save_result` or a reducer and gets a confusing failure rather than a clear "not supported".

They are now skipped at registration: **176 processes we honour instead of 179 where three lie.** No OCS workflow uses them. Registering one process per named output is the richer alternative, worth doing if someone asks for these specifically.

An indicator whose `cf_attrs` cannot be read counts as single-output — dropping a working process would be worse than the mismatch this guards against.

**Tests** — the durable one asserts that *every* registered indicator's declared `returns` matches what it actually produces, so a future xclim release adding multi-output indicators fails here rather than in someone's process graph. Plus the three names, and a check that the catalogue is not thinned further (≥170 registered, `tx_max` still present). Four of the five fail on `main`.

Verified against the live instance before and after: all three were advertised among 342 total processes; now none are.

942 passed; the 3 `test_openeo_execution.py` CRS failures are pre-existing (local `proj.db` clash).
