### PR TITLE
fix(ingestions): persist artifact store paths relative to the data root

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,8 @@ Multiple artifacts can exist for the same dataset template if data was ingested 
 
 Artifacts are stored in `{data_dir}/artifacts/records.json`, where `data_dir` is the path configured in `climate-service.yaml`. This is an internal implementation detail — consumers should never depend on artifact IDs or artifact paths directly.
 
+Store paths are persisted relative to `data_dir` (`downloads/foo.icechunk`) and resolved to absolute paths when records are loaded, so the data directory stays portable: it can be moved, copied to another host, or written in a container at `/app/data` and read from the host. Records written before this convention hold absolute paths and are re-rooted onto the current `data_dir` on read, then rewritten in relative form on the next update. Stores kept outside `data_dir`, and remote URIs such as `s3://`, are recorded as-is.
+
 ### Managed dataset
 
 A **managed dataset** is the public-facing view of the most recent artifact for a given template. It is what `/datasets`, `/zarr`, and `/stac` expose. When an operator ingests or syncs a dataset, the managed dataset view updates to reflect the new artifact — the public ID stays stable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ Multiple artifacts can exist for the same dataset template if data was ingested 
 
 Artifacts are stored in `{data_dir}/artifacts/records.json`, where `data_dir` is the path configured in `climate-service.yaml`. This is an internal implementation detail — consumers should never depend on artifact IDs or artifact paths directly.
 
-Store paths are persisted relative to `data_dir` (`downloads/foo.icechunk`) and resolved to absolute paths when records are loaded, so the data directory stays portable: it can be moved, copied to another host, or written in a container at `/app/data` and read from the host. Records written before this convention hold absolute paths and are re-rooted onto the current `data_dir` on read, then rewritten in relative form on the next update. Stores kept outside `data_dir`, and remote URIs such as `s3://`, are recorded as-is.
+Store paths are persisted relative to `data_dir` (`downloads/foo.icechunk`) and resolved to absolute paths when records are loaded, so the data directory stays portable: it can be moved, copied to another host, or written in a container at `/app/data` and read from the host. Records written before this convention hold absolute paths and are re-rooted onto the current `data_dir` on read, then rewritten in relative form on the next update. Stores kept outside `data_dir` are recorded as absolute paths.
 
 ### Managed dataset
 

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -62,6 +62,7 @@ def _load_config() -> dict[str, Any]:
 DEFAULT_CRS = "EPSG:4326"
 DEFAULT_NAME = "Open Climate Service"
 DEFAULT_ID = "open-climate-service"  # operators should always set id: in climate-service.yaml
+DOWNLOAD_SUBDIR = "downloads"
 
 
 def get_id() -> str:
@@ -157,6 +158,11 @@ def get_data_root() -> Path:
         return data_dir
     xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     return xdg_data / "climate-service"
+
+
+def get_download_root() -> Path:
+    """Return the directory holding managed artifact stores."""
+    return get_data_root() / DOWNLOAD_SUBDIR
 
 
 def get_utc_offset_hours() -> float:

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -145,6 +145,20 @@ def get_data_dir() -> Path | None:
     return (config_path.parent / raw).resolve()
 
 
+def get_data_root() -> Path:
+    """Return the effective root for instance data, falling back to XDG when unconfigured.
+
+    ``get_data_dir`` returns None when no config file is present. Every consumer that
+    needs a concrete directory then repeats the same XDG fallback, so it lives here
+    instead. Subdirectories (``downloads``, ``artifacts``, ``jobs``) hang off this root.
+    """
+    data_dir = get_data_dir()
+    if data_dir is not None:
+        return data_dir
+    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return xdg_data / "climate-service"
+
+
 def get_utc_offset_hours() -> float:
     """Return the UTC offset in hours for daily period boundaries, defaulting to 0 (UTC).
 

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_download_dir() -> Path:
-    return api_config.get_data_root() / "downloads"
+    return api_config.get_download_root()
 
 
 DOWNLOAD_DIR = _resolve_download_dir()

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -1,7 +1,6 @@
 """Write raster datasets to Icechunk stores with GeoZarr conventions."""
 
 import logging
-import os
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,11 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_download_dir() -> Path:
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return data_dir / "downloads"
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return xdg_data / "climate-service" / "downloads"
+    return api_config.get_data_root() / "downloads"
 
 
 DOWNLOAD_DIR = _resolve_download_dir()

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -18,6 +18,7 @@ from open_climate_service import config as api_config
 
 _PATH_FIELD = "path"
 _PATH_LIST_FIELD = "asset_paths"
+_STORE_DIR = "downloads"
 
 
 def to_portable(raw: str) -> str:
@@ -58,19 +59,17 @@ def to_absolute(raw: str) -> str:
 def _rebase_legacy(candidate: Path, root: Path) -> Path:
     """Re-root a legacy absolute path onto root, preferring the longest matching suffix.
 
-    A store under the current data root always wins over the recorded location, even
-    when the recorded one still exists. Deferring to an existing recorded path would
-    break a *copied* data directory: the copy carries the original's absolute paths,
-    both roots are present, and the copy would silently read the original's stores and
-    never heal. Only ``data_dir/downloads`` is a trusted root for managed stores
-    (see ``sync_engine._artifact_storage_roots``), so a path elsewhere is not a case
-    worth preserving over one here.
+    Managed stores always live at ``{data_root}/downloads/<name>`` (``downloader.DOWNLOAD_DIR``,
+    the sole trusted root in ``sync_engine._artifact_storage_roots``), so only a suffix
+    starting at a ``downloads`` component is considered - a longer suffix would otherwise
+    bind the record to a lookalike elsewhere under the root, and the rebased path would be
+    persisted in a form sync rejects as untrusted.
 
-    Only a suffix that actually exists is accepted, and it must keep at least two
-    components, so a match has to agree on the containing directory as well as the
-    store name - a bare basename would otherwise bind a record to any same-named
-    store anywhere under the root. When nothing matches, the recorded path is kept
-    so errors name what was originally written.
+    A store under the current data root always wins over the recorded location, even when
+    the recorded one still exists: a copied data directory carries the original's absolute
+    paths, and deferring to them would make the copy read the original's stores. Only a
+    suffix that actually exists is accepted; when nothing matches, the recorded path is
+    kept so errors name what was originally written.
     """
     resolved_root = root.resolve(strict=False)
     try:
@@ -80,7 +79,9 @@ def _rebase_legacy(candidate: Path, root: Path) -> Path:
     else:
         return candidate
     parts = candidate.parts
-    for index in range(1, max(len(parts) - 1, 1)):
+    for index in range(1, len(parts) - 1):
+        if parts[index] != _STORE_DIR:
+            continue
         rebased = resolved_root.joinpath(*parts[index:])
         if rebased.exists():
             return rebased

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -58,12 +58,19 @@ def to_absolute(raw: str) -> str:
 def _rebase_legacy(candidate: Path, root: Path) -> Path:
     """Re-root a legacy absolute path onto root, preferring the longest matching suffix.
 
-    Only a suffix that actually exists is accepted, so a store intentionally held
-    outside the data directory keeps its recorded path rather than being silently
-    redirected at a lookalike inside it. The suffix must keep at least two components,
-    so a match has to agree on the containing directory as well as the store name -
-    a bare basename would otherwise bind a record to any same-named store anywhere
-    under the root.
+    A store under the current data root always wins over the recorded location, even
+    when the recorded one still exists. Deferring to an existing recorded path would
+    break a *copied* data directory: the copy carries the original's absolute paths,
+    both roots are present, and the copy would silently read the original's stores and
+    never heal. Only ``data_dir/downloads`` is a trusted root for managed stores
+    (see ``sync_engine._artifact_storage_roots``), so a path elsewhere is not a case
+    worth preserving over one here.
+
+    Only a suffix that actually exists is accepted, and it must keep at least two
+    components, so a match has to agree on the containing directory as well as the
+    store name - a bare basename would otherwise bind a record to any same-named
+    store anywhere under the root. When nothing matches, the recorded path is kept
+    so errors name what was originally written.
     """
     resolved_root = root.resolve(strict=False)
     try:
@@ -71,8 +78,6 @@ def _rebase_legacy(candidate: Path, root: Path) -> Path:
     except ValueError:
         pass
     else:
-        return candidate
-    if candidate.exists():
         return candidate
     parts = candidate.parts
     for index in range(1, max(len(parts) - 1, 1)):

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -1,0 +1,115 @@
+"""Portable on-disk representation for artifact store paths.
+
+Artifact records are persisted to ``{data_dir}/artifacts/records.json``, which lives
+inside the very directory the paths point into. Storing absolute paths there pins the
+data directory to the machine and mount point that produced it: a directory ingested in
+a container at ``/app/data`` is unreadable from the host, from a restored backup, or
+from any deployment that mounts it elsewhere.
+
+Records are therefore written relative to the data root and resolved back to absolute
+when loaded, so everything downstream of :func:`decode_record_paths` keeps seeing the
+absolute paths it always did.
+"""
+
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from open_climate_service import config as api_config
+
+_URI_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
+
+_PATH_FIELD = "path"
+_PATH_LIST_FIELD = "asset_paths"
+
+
+def _is_windows_absolute(raw: str) -> bool:
+    """Return whether raw is a drive-letter path, which urlparse misreads as a URI scheme."""
+    return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
+
+
+def _is_remote(raw: str) -> bool:
+    """Return whether raw addresses a remote store rather than a local filesystem path."""
+    if _is_windows_absolute(raw):
+        return False
+    return bool(_URI_SCHEME.match(raw)) and not raw.startswith("file://")
+
+
+def to_portable(raw: str) -> str:
+    """Return raw relative to the data root when it points inside it.
+
+    Anything else - a remote URI, an already-relative path, or a store deliberately
+    kept outside the data directory - is returned untouched.
+    """
+    if not raw or _is_remote(raw):
+        return raw
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        return raw
+    root = api_config.get_data_root()
+    try:
+        relative = candidate.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return raw
+    return relative.as_posix()
+
+
+def to_absolute(raw: str) -> str:
+    """Return raw as an absolute path against the current data root.
+
+    Relative paths are the portable form and are simply rejoined. Absolute paths are
+    legacy records written before this module existed; they are re-rooted onto the
+    current data root when the original no longer resolves but a re-rooted suffix does.
+    """
+    if not raw or _is_remote(raw):
+        return raw
+    root = api_config.get_data_root()
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        return str((root / PurePosixPath(raw)).resolve(strict=False))
+    return str(_rebase_legacy(candidate, root))
+
+
+def _rebase_legacy(candidate: Path, root: Path) -> Path:
+    """Re-root a legacy absolute path onto root, preferring the longest matching suffix.
+
+    Only a suffix that actually exists is accepted, so a store intentionally held
+    outside the data directory keeps its recorded path rather than being silently
+    redirected at a lookalike inside it.
+    """
+    resolved_root = root.resolve(strict=False)
+    try:
+        candidate.resolve(strict=False).relative_to(resolved_root)
+    except ValueError:
+        pass
+    else:
+        return candidate
+    if candidate.exists():
+        return candidate
+    parts = candidate.parts
+    for index in range(1, len(parts)):
+        rebased = resolved_root.joinpath(*parts[index:])
+        if rebased.exists():
+            return rebased
+    return candidate
+
+
+def _map_record_paths(item: dict[str, Any], convert: Any) -> dict[str, Any]:
+    """Apply convert to every path-bearing field of a serialized artifact record."""
+    value = item.get(_PATH_FIELD)
+    if isinstance(value, str):
+        item[_PATH_FIELD] = convert(value)
+    assets = item.get(_PATH_LIST_FIELD)
+    if isinstance(assets, list):
+        item[_PATH_LIST_FIELD] = [convert(entry) if isinstance(entry, str) else entry for entry in assets]
+    return item
+
+
+def decode_record_paths(item: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a record's stored paths to absolute, in place."""
+    return _map_record_paths(item, to_absolute)
+
+
+def encode_record_paths(item: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite a record's paths into their portable form, in place."""
+    return _map_record_paths(item, to_portable)

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -60,7 +60,10 @@ def _rebase_legacy(candidate: Path, root: Path) -> Path:
 
     Only a suffix that actually exists is accepted, so a store intentionally held
     outside the data directory keeps its recorded path rather than being silently
-    redirected at a lookalike inside it.
+    redirected at a lookalike inside it. The suffix must keep at least two components,
+    so a match has to agree on the containing directory as well as the store name -
+    a bare basename would otherwise bind a record to any same-named store anywhere
+    under the root.
     """
     resolved_root = root.resolve(strict=False)
     try:
@@ -72,7 +75,7 @@ def _rebase_legacy(candidate: Path, root: Path) -> Path:
     if candidate.exists():
         return candidate
     parts = candidate.parts
-    for index in range(1, len(parts)):
+    for index in range(1, max(len(parts) - 1, 1)):
         rebased = resolved_root.joinpath(*parts[index:])
         if rebased.exists():
             return rebased

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -11,37 +11,22 @@ when loaded, so everything downstream of :func:`decode_record_paths` keeps seein
 absolute paths it always did.
 """
 
-import re
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 from open_climate_service import config as api_config
 
-_URI_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
-
 _PATH_FIELD = "path"
 _PATH_LIST_FIELD = "asset_paths"
-
-
-def _is_windows_absolute(raw: str) -> bool:
-    """Return whether raw is a drive-letter path, which urlparse misreads as a URI scheme."""
-    return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
-
-
-def _is_remote(raw: str) -> bool:
-    """Return whether raw addresses a remote store rather than a local filesystem path."""
-    if _is_windows_absolute(raw):
-        return False
-    return bool(_URI_SCHEME.match(raw)) and not raw.startswith("file://")
 
 
 def to_portable(raw: str) -> str:
     """Return raw relative to the data root when it points inside it.
 
-    Anything else - a remote URI, an already-relative path, or a store deliberately
-    kept outside the data directory - is returned untouched.
+    An already-relative path, or a store deliberately kept outside the data
+    directory, is returned untouched.
     """
-    if not raw or _is_remote(raw):
+    if not raw:
         return raw
     candidate = Path(raw)
     if not candidate.is_absolute():
@@ -61,7 +46,7 @@ def to_absolute(raw: str) -> str:
     legacy records written before this module existed; they are re-rooted onto the
     current data root when the original no longer resolves but a re-rooted suffix does.
     """
-    if not raw or _is_remote(raw):
+    if not raw:
         return raw
     root = api_config.get_data_root()
     candidate = Path(raw)

--- a/open_climate_service/ingestions/artifact_paths.py
+++ b/open_climate_service/ingestions/artifact_paths.py
@@ -11,14 +11,16 @@ when loaded, so everything downstream of :func:`decode_record_paths` keeps seein
 absolute paths it always did.
 """
 
+import logging
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 from open_climate_service import config as api_config
 
+logger = logging.getLogger(__name__)
+
 _PATH_FIELD = "path"
 _PATH_LIST_FIELD = "asset_paths"
-_STORE_DIR = "downloads"
 
 
 def to_portable(raw: str) -> str:
@@ -80,10 +82,17 @@ def _rebase_legacy(candidate: Path, root: Path) -> Path:
         return candidate
     parts = candidate.parts
     for index in range(1, len(parts) - 1):
-        if parts[index] != _STORE_DIR:
+        if parts[index] != api_config.DOWNLOAD_SUBDIR:
             continue
         rebased = resolved_root.joinpath(*parts[index:])
         if rebased.exists():
+            if candidate.exists():
+                logger.warning(
+                    "Artifact store recorded at %s also exists at %s under the current data root; using %s",
+                    candidate,
+                    rebased,
+                    rebased,
+                )
             return rebased
     return candidate
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -26,6 +26,7 @@ from open_climate_service.data_accessor.services.accessor import get_data_covera
 from open_climate_service.data_manager.services import downloader
 from open_climate_service.data_registry.services import datasets as registry_datasets
 from open_climate_service.extents.services import get_extent
+from open_climate_service.ingestions.artifact_paths import decode_record_paths, encode_record_paths
 from open_climate_service.ingestions.schemas import (
     ArtifactCoverage,
     ArtifactFormat,
@@ -112,12 +113,7 @@ class _IcechunkSession:
 
 
 def _resolve_artifacts_dir() -> Path:
-
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return data_dir / "artifacts"
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return xdg_data / "climate-service" / "artifacts"
+    return api_config.get_data_root() / "artifacts"
 
 
 ARTIFACTS_DIR = _resolve_artifacts_dir()
@@ -967,16 +963,26 @@ def _get_icechunk_store_path_or_404(
     raise HTTPException(status_code=404, detail=f"Zarr path '{relative_path}' not found")
 
 
+def _decode_record(item: dict[str, object]) -> ArtifactRecord:
+    """Rebuild a record from its stored form, applying schema and path migrations."""
+    return ArtifactRecord.model_validate(decode_record_paths(_upgrade_legacy_record(item)))
+
+
+def _encode_records(records: list[ArtifactRecord]) -> str:
+    """Serialize records for disk, with store paths in their data-root-relative form."""
+    payload = [encode_record_paths(record.model_dump(mode="json")) for record in records]
+    return f"{json.dumps(payload, indent=2)}\n"
+
+
 def _load_records() -> list[ArtifactRecord]:
     ensure_store()
     raw = json.loads(ARTIFACTS_INDEX_PATH.read_text(encoding="utf-8"))
-    return [ArtifactRecord.model_validate(_upgrade_legacy_record(item)) for item in raw]
+    return [_decode_record(item) for item in raw]
 
 
 def _save_records(records: list[ArtifactRecord]) -> None:
     ensure_store()
-    payload = [record.model_dump(mode="json") for record in records]
-    ARTIFACTS_INDEX_PATH.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+    ARTIFACTS_INDEX_PATH.write_text(_encode_records(records), encoding="utf-8")
 
 
 def _store_artifact_record(
@@ -1046,12 +1052,11 @@ def _mutate_records(mutation: Callable[[list[ArtifactRecord]], ArtifactRecord]) 
         portalocker.lock(handle, portalocker.LOCK_EX)
         handle.seek(0)
         raw = handle.read()
-        records = [ArtifactRecord.model_validate(_upgrade_legacy_record(item)) for item in json.loads(raw or "[]")]
+        records = [_decode_record(item) for item in json.loads(raw or "[]")]
         result = mutation(records)
-        payload = [record.model_dump(mode="json") for record in records]
         handle.seek(0)
         handle.truncate()
-        handle.write(f"{json.dumps(payload, indent=2)}\n")
+        handle.write(_encode_records(records))
         handle.flush()
         os.fsync(handle.fileno())
         portalocker.unlock(handle)

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
@@ -451,11 +450,7 @@ def _is_plugin_backed(source_dataset: dict[str, Any]) -> bool:
 
 def _artifact_storage_roots() -> tuple[Path, ...]:
     """Return the trusted local roots that may contain managed artifact stores."""
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return ((data_dir / "downloads").resolve(),)
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return ((xdg_data / "climate-service" / "downloads").resolve(),)
+    return ((api_config.get_data_root() / "downloads").resolve(),)
 
 
 def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str | None]:

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -450,7 +450,7 @@ def _is_plugin_backed(source_dataset: dict[str, Any]) -> bool:
 
 def _artifact_storage_roots() -> tuple[Path, ...]:
     """Return the trusted local roots that may contain managed artifact stores."""
-    return ((api_config.get_data_root() / "downloads").resolve(),)
+    return (api_config.get_download_root().resolve(),)
 
 
 def _resolve_local_artifact_path(raw_path: str | None) -> tuple[Path | None, str | None]:

--- a/open_climate_service/jobs/store.py
+++ b/open_climate_service/jobs/store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -14,11 +13,7 @@ from open_climate_service.jobs.models import JobRecord
 
 
 def _resolve_jobs_dir() -> Path:
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return data_dir / "jobs"
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return xdg_data / "climate-service" / "jobs"
+    return api_config.get_data_root() / "jobs"
 
 
 JOBS_DIR = _resolve_jobs_dir()

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import threading
 from collections.abc import Callable
@@ -40,11 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_openeo_jobs_dir() -> Path:
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return data_dir / "openeo_jobs"
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return xdg_data / "climate-service" / "openeo_jobs"
+    return api_config.get_data_root() / "openeo_jobs"
 
 
 _JOBS_DIR = _resolve_openeo_jobs_dir()

--- a/open_climate_service/openeo/workflows.py
+++ b/open_climate_service/openeo/workflows.py
@@ -20,13 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_workflow_dir() -> Path:
-    data_dir = api_config.get_data_dir()
-    if data_dir is not None:
-        return data_dir / "process_graphs"
-    import os
-
-    xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return xdg_data / "climate-service" / "process_graphs"
+    return api_config.get_data_root() / "process_graphs"
 
 
 WORKFLOW_DIR = _resolve_workflow_dir()

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -142,6 +142,27 @@ def test_copied_data_dir_does_not_read_the_original(monkeypatch: pytest.MonkeyPa
     assert on_disk[0]["path"] == "downloads/chirps3.icechunk"  # and it heals
 
 
+def test_to_absolute_ignores_a_lookalike_outside_downloads(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A deeper suffix match loses to the managed store at data_dir/downloads."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    managed = data_dir / "downloads" / "chirps3.icechunk"
+    managed.mkdir(parents=True)
+    lookalike = data_dir / "data" / "downloads" / "chirps3.icechunk"
+    lookalike.mkdir(parents=True)
+
+    assert to_absolute("/old/data/downloads/chirps3.icechunk") == str(managed)
+    assert to_portable(to_absolute("/old/data/downloads/chirps3.icechunk")) == "downloads/chirps3.icechunk"
+
+
+def test_to_absolute_will_not_rebase_onto_a_lookalike_alone(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With only a match outside downloads, the recorded path is kept rather than bound to it."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    (data_dir / "data" / "downloads" / "chirps3.icechunk").mkdir(parents=True)
+    legacy = "/old/data/downloads/chirps3.icechunk"
+
+    assert to_absolute(legacy) == legacy
+
+
 def test_to_absolute_will_not_rebase_on_a_bare_basename(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A match must agree on the containing directory, not just the store name."""
     data_dir = _use_data_dir(monkeypatch, tmp_path / "data")

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -1,0 +1,143 @@
+"""Portability of the artifact index across data directories (CLIM-916)."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from open_climate_service import config as api_config
+from open_climate_service.ingestions import services
+from open_climate_service.ingestions.artifact_paths import to_absolute, to_portable
+from open_climate_service.ingestions.schemas import (
+    ArtifactCoverage,
+    ArtifactFormat,
+    ArtifactPublication,
+    ArtifactRecord,
+    ArtifactRequestScope,
+    CoverageSpatial,
+    CoverageTemporal,
+    PublicationStatus,
+)
+
+
+def _use_data_dir(monkeypatch: pytest.MonkeyPatch, data_dir: Path) -> Path:
+    """Point the instance config at data_dir and return it."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    config_file = data_dir.parent / "climate-service.yaml"
+    config_file.write_text(
+        f"data_dir: {data_dir}\nextent:\n  id: test\n  bbox: [0, 0, 1, 1]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLIMATE_SERVICE_CONFIG", str(config_file))
+    api_config._cache = None
+    return data_dir
+
+
+def _artifact(path: str) -> ArtifactRecord:
+    return ArtifactRecord(
+        artifact_id="a1",
+        dataset_id="chirps3_precipitation_daily",
+        dataset_name="CHIRPS3 precipitation",
+        variable="precip",
+        format=ArtifactFormat.ICECHUNK,
+        path=path,
+        asset_paths=[path],
+        variables=["precip"],
+        request_scope=ArtifactRequestScope(start="2026-01-01", end="2026-01-10", bbox=(1.0, 2.0, 3.0, 4.0)),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-01-01", end="2026-01-10"),
+            spatial=CoverageSpatial(xmin=1.0, ymin=2.0, xmax=3.0, ymax=4.0),
+        ),
+        created_at=datetime(2026, 1, 10, tzinfo=UTC),
+        publication=ArtifactPublication(status=PublicationStatus.PUBLISHED, collection_id="chirps3"),
+    )
+
+
+def test_to_portable_strips_the_data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+
+    assert to_portable(str(data_dir / "downloads" / "chirps3.icechunk")) == "downloads/chirps3.icechunk"
+
+
+def test_to_portable_keeps_paths_outside_the_data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _use_data_dir(monkeypatch, tmp_path / "data")
+    external = str(tmp_path / "elsewhere" / "chirps3.icechunk")
+
+    assert to_portable(external) == external
+
+
+@pytest.mark.parametrize("uri", ["s3://bucket/chirps3.icechunk", "https://example.org/chirps3.icechunk"])
+def test_to_portable_keeps_remote_uris(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, uri: str) -> None:
+    _use_data_dir(monkeypatch, tmp_path / "data")
+
+    assert to_portable(uri) == uri
+    assert to_absolute(uri) == uri
+
+
+def test_to_absolute_resolves_against_the_current_data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+
+    assert to_absolute("downloads/chirps3.icechunk") == str(data_dir / "downloads" / "chirps3.icechunk")
+
+
+def test_to_absolute_rebases_a_legacy_container_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A record written inside Docker at /app/data resolves against the host data dir."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    store = data_dir / "downloads" / "chirps3.icechunk"
+    store.mkdir(parents=True)
+
+    assert to_absolute("/app/data/downloads/chirps3.icechunk") == str(store)
+
+
+def test_to_absolute_keeps_an_existing_external_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A store deliberately held outside the data dir is not redirected at a lookalike."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    (data_dir / "downloads" / "chirps3.icechunk").mkdir(parents=True)
+    external = tmp_path / "mnt" / "downloads" / "chirps3.icechunk"
+    external.mkdir(parents=True)
+
+    assert to_absolute(str(external)) == str(external)
+
+
+def test_to_absolute_keeps_an_unresolvable_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With nothing to rebase onto, the recorded path survives so errors name it."""
+    _use_data_dir(monkeypatch, tmp_path / "data")
+
+    assert to_absolute("/app/data/downloads/missing.icechunk") == "/app/data/downloads/missing.icechunk"
+
+
+def test_records_are_persisted_relative_and_loaded_absolute(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    index_path = data_dir / "artifacts" / "records.json"
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", index_path.parent)
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", index_path)
+    store = data_dir / "downloads" / "chirps3.icechunk"
+
+    services._save_records([_artifact(str(store))])
+
+    on_disk = json.loads(index_path.read_text(encoding="utf-8"))
+    assert on_disk[0]["path"] == "downloads/chirps3.icechunk"
+    assert on_disk[0]["asset_paths"] == ["downloads/chirps3.icechunk"]
+
+    loaded = services._load_records()
+    assert loaded[0].path == str(store)
+    assert loaded[0].asset_paths == [str(store)]
+
+
+def test_data_dir_survives_being_moved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The whole point: an index written under one root reads correctly under another."""
+    origin = _use_data_dir(monkeypatch, tmp_path / "origin" / "data")
+    index_path = origin / "artifacts" / "records.json"
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", index_path.parent)
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", index_path)
+    services._save_records([_artifact(str(origin / "downloads" / "chirps3.icechunk"))])
+
+    moved = tmp_path / "moved" / "data"
+    moved.parent.mkdir(parents=True, exist_ok=True)
+    origin.rename(moved)
+    _use_data_dir(monkeypatch, moved)  # data_dir already exists; the helper only rewrites config
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", moved / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", moved / "artifacts" / "records.json")
+
+    assert services._load_records()[0].path == str(moved / "downloads" / "chirps3.icechunk")

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -92,6 +92,15 @@ def test_to_absolute_keeps_an_existing_external_store(monkeypatch: pytest.Monkey
     assert to_absolute(str(external)) == str(external)
 
 
+def test_to_absolute_will_not_rebase_on_a_bare_basename(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A match must agree on the containing directory, not just the store name."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    (data_dir / "chirps3.icechunk").mkdir(parents=True)
+    archived = "/app/data/downloads/v1/chirps3.icechunk"
+
+    assert to_absolute(archived) == archived
+
+
 def test_to_absolute_keeps_an_unresolvable_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """With nothing to rebase onto, the recorded path survives so errors name it."""
     _use_data_dir(monkeypatch, tmp_path / "data")

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -1,6 +1,7 @@
 """Portability of the artifact index across data directories (CLIM-916)."""
 
 import json
+import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -82,14 +83,63 @@ def test_to_absolute_rebases_a_legacy_container_path(monkeypatch: pytest.MonkeyP
     assert to_absolute("/app/data/downloads/chirps3.icechunk") == str(store)
 
 
-def test_to_absolute_keeps_an_existing_external_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """A store deliberately held outside the data dir is not redirected at a lookalike."""
+def test_to_absolute_prefers_a_store_under_the_current_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The current root wins even when the recorded location still exists.
+
+    Only data_dir/downloads is a trusted root for managed stores, so a path elsewhere
+    is not worth preserving over one here - and deferring to it breaks copied data
+    directories (see test_copied_data_dir_does_not_read_the_original).
+    """
     data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
-    (data_dir / "downloads" / "chirps3.icechunk").mkdir(parents=True)
+    local = data_dir / "downloads" / "chirps3.icechunk"
+    local.mkdir(parents=True)
     external = tmp_path / "mnt" / "downloads" / "chirps3.icechunk"
     external.mkdir(parents=True)
 
+    assert to_absolute(str(external)) == str(local)
+
+
+def test_to_absolute_keeps_an_external_store_with_no_counterpart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With nothing matching under the root, the recorded path is left alone."""
+    _use_data_dir(monkeypatch, tmp_path / "data")
+    external = tmp_path / "mnt" / "downloads" / "era5.icechunk"
+    external.mkdir(parents=True)
+
     assert to_absolute(str(external)) == str(external)
+
+
+def test_copied_data_dir_does_not_read_the_original(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A copied data dir resolves against its own root while the original still exists."""
+    origin = _use_data_dir(monkeypatch, tmp_path / "instance-a" / "data")
+    (origin / "downloads" / "chirps3.icechunk").mkdir(parents=True)
+    index_path = origin / "artifacts" / "records.json"
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", index_path.parent)
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", index_path)
+    services._save_records([_artifact(str(origin / "downloads" / "chirps3.icechunk"))])
+    # legacy state: the index carries absolute paths rather than the portable form
+    index_path.write_text(
+        index_path.read_text(encoding="utf-8").replace(
+            '"downloads/chirps3.icechunk"', f'"{origin / "downloads" / "chirps3.icechunk"}"'
+        ),
+        encoding="utf-8",
+    )
+
+    copy = tmp_path / "instance-b" / "data"
+    copy.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(origin, copy)
+    assert (origin / "downloads" / "chirps3.icechunk").exists()  # the original is still there
+    _use_data_dir(monkeypatch, copy)
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", copy / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", copy / "artifacts" / "records.json")
+
+    loaded = services._load_records()
+    assert loaded[0].path == str(copy / "downloads" / "chirps3.icechunk")
+
+    services._save_records(loaded)
+    on_disk = json.loads((copy / "artifacts" / "records.json").read_text(encoding="utf-8"))
+    assert on_disk[0]["path"] == "downloads/chirps3.icechunk"  # and it heals
 
 
 def test_to_absolute_will_not_rebase_on_a_bare_basename(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -67,14 +67,6 @@ def test_to_portable_keeps_paths_outside_the_data_root(monkeypatch: pytest.Monke
     assert to_portable(external) == external
 
 
-@pytest.mark.parametrize("uri", ["s3://bucket/chirps3.icechunk", "https://example.org/chirps3.icechunk"])
-def test_to_portable_keeps_remote_uris(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, uri: str) -> None:
-    _use_data_dir(monkeypatch, tmp_path / "data")
-
-    assert to_portable(uri) == uri
-    assert to_absolute(uri) == uri
-
-
 def test_to_absolute_resolves_against_the_current_data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
 

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -1,6 +1,7 @@
 """Portability of the artifact index across data directories (CLIM-916)."""
 
 import json
+import logging
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
@@ -140,6 +141,23 @@ def test_copied_data_dir_does_not_read_the_original(monkeypatch: pytest.MonkeyPa
     services._save_records(loaded)
     on_disk = json.loads((copy / "artifacts" / "records.json").read_text(encoding="utf-8"))
     assert on_disk[0]["path"] == "downloads/chirps3.icechunk"  # and it heals
+
+
+def test_shadowing_an_existing_recorded_store_is_logged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Preferring the current root over a store that still exists is not silent."""
+    data_dir = _use_data_dir(monkeypatch, tmp_path / "data")
+    (data_dir / "downloads" / "chirps3.icechunk").mkdir(parents=True)
+    external = tmp_path / "mnt" / "downloads" / "chirps3.icechunk"
+    external.mkdir(parents=True)
+    # startup.py detaches the package logger from the root handler caplog installs
+    monkeypatch.setattr(logging.getLogger("open_climate_service"), "propagate", True)
+
+    with caplog.at_level("WARNING"):
+        to_absolute(str(external))
+
+    assert str(external) in caplog.text
 
 
 def test_to_absolute_ignores_a_lookalike_outside_downloads(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`records.json` recorded the absolute path of every managed store, in both `path` and `asset_paths`. That pins the data directory to the machine and mount point that produced it — it cannot be moved, copied to another host, or written in a container and read from the host.

This is visible in `nepal-climate-service-demo`, whose `compose.yml` bind-mounts `./data` to `/app/data`:

```json
"path": "/app/data/downloads/worldpop_population_global2_R2025A_100m.icechunk",
"asset_paths": ["/app/data/downloads/worldpop_population_global2_R2025A_100m.icechunk"]
```

The stores are right there on the host, but nothing can find them.

The failure is silent, and worse than it first looks. `_materialized_records` drops any record whose backing storage is missing, and it checks the recorded path — so on the host **every** artifact in the demo is filtered as stale, not just old ones. Sync degrades the same way: `sync_engine._resolve_local_artifact_path` validates against the trusted root `data_dir/downloads`, so a path from a different root is rejected and planning falls back instead of raising. Confirmed against the demo's real index on `main`:

```
_resolve_local_artifact_path("/app/data/downloads/worldpop_...icechunk")
  -> (None, 'untrusted local path')
```

STAC asset resolution and openEO execution read the same fields and simply do not find the store.

## Fix

Make the on-disk representation portable while keeping the in-memory representation absolute, so nothing downstream changes.

- **Write** paths relative to the data root (`downloads/foo.icechunk`) when the store lives inside it.
- **Read** them back to absolute against the *current* data root. Every consumer of `ArtifactRecord.path` is untouched.
- **Migrate** legacy absolute records on read by re-rooting them onto the current data root.

Both serialization points already funnelled through `_upgrade_legacy_record`, so this hooks into the existing migration seam rather than adding one. Rewriting is whole-file, so one ordinary write (any ingest, sync, or publish) heals every healable row at once — there is no separate migration step.

The change also collapses five copies of the "`data_dir`, else XDG fallback" lookup into `config.get_data_root()`, and the three copies of the `downloads` store-directory name into `config.DOWNLOAD_SUBDIR` / `config.get_download_root()`. That is not just tidying: the relative form and the directories files are actually written to must agree, and independent copies of those rules could drift.

## How a legacy path is re-rooted

`_rebase_legacy` resolves a recorded absolute path in this order:

1. Already under the current data root — keep it.
2. Otherwise, the longest suffix that **starts at a `downloads` component** and exists under the current root.
3. Otherwise, keep the recorded path, so errors name what was originally written.

Two constraints are worth calling out, both from review on this PR:

**The current root wins over the recorded location, even when the recorded one still exists.** Deferring to an existing recorded path breaks a *copied* data directory: the copy carries the original's absolute paths, both roots are present, so the copy silently reads the original's stores and — because the path stays absolute — never heals. There is no way to distinguish a copied data directory from a deliberately external store; both are absolute paths under a foreign root. The copied case is the one the system must support, so it wins.

The cost is that a store deliberately kept outside the data directory *is* shadowed by a same-named store under `{data_root}/downloads`. That is no longer silent — it logs a warning naming both paths. It is also a case the system already refuses to operate on: `_artifact_storage_roots()` returns only `data_dir/downloads`, so `_resolve_local_artifact_path(<external>)` returns `(None, 'untrusted local path')`, and both record-creation sites (`ingestions/services.py`, `openeo/jobs.py`) write under that same directory.

**Only suffixes rooted at `downloads` are considered.** Trying every suffix longest-first meant `/old/data/downloads/foo.icechunk` rebased onto `{root}/data/downloads/foo.icechunk` in preference to the canonical `{root}/downloads/foo.icechunk`, whenever that lookalike existed. The mis-rebase then persisted as the relative `data/downloads/foo.icechunk`, which is never re-examined and which sync rejects as untrusted — converting a healable row into a permanently broken one. Restricting candidates to `downloads` also subsumes the earlier "at least two components" guard.

## Known limitation

A historical record whose store has since been deleted cannot be re-rooted — there is nothing on disk to confirm the rebase against — so those rows keep their original absolute path. They are already inert: `_materialized_records` excludes them from every API surface, and sync deduplication matches on `dataset_id` + `request_scope` rather than on path. The stale string is provenance only.

Relatedly, the relative form is anchored to the data root, so moving `downloads/` *within* the data dir still breaks a record. Relocating the root as a unit — the case this fixes — is safe.

## Verification

Against the demo's real, unmodified `records.json`, with this branch:

```
worldpop_population_global2_R2025A_100m    exists=True  sync=OK
clms_gpp_dekadal                           exists=True  sync=OK
```

and the file that the next write produces:

```json
"path": "downloads/worldpop_population_global2_R2025A_100m.icechunk"
```

Existing demo data needs no manual migration — it self-heals on read.

14 tests in `tests/test_artifact_paths.py` cover the round trip, the legacy container-path rebase, the copied-data-directory case with both roots present, the lookalike collision, the shadowing warning, and an end-to-end "data dir gets moved" test. Full suite: 1099 passed, 1 skipped. `make lint` clean (ruff, mypy, pyright).

Resolves [CLIM-916](https://dhis2.atlassian.net/browse/CLIM-916).


[CLIM-916]: https://dhis2.atlassian.net/browse/CLIM-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
