### PR TITLE
feat(automation): trigger workflows after dataset updates (CLIM-849)

### DIFF
--- a/climate-service.yaml.example
+++ b/climate-service.yaml.example
@@ -12,6 +12,19 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
+# Event-driven workflows are instance-specific bindings. Event references are resolved from
+# the successful dataset sync outcome; literal argument values are passed through unchanged.
+# automation:
+#   workflow_triggers:
+#     - id: chirps-to-chap
+#       on_update_of: chirps3_precipitation_daily
+#       workflow_id: aggregate_to_chap_csv
+#       arguments:
+#         dataset_id: $event.dataset_id
+#         temporal_extent: [$event.previous_end, $event.current_end]
+#         geometries: {type: FeatureCollection, features: []}
+#         period_type: day
+
 # plugins_dir: ./plugins/   # optional — plugin root: YAML templates in plugins/datasets/, Python modules importable by dotted path
 # crs: EPSG:4326             # optional — CRS for stored GeoZarr files (default: EPSG:4326); use e.g. EPSG:25833 for UTM33
 # utc_offset_hours: 0        # optional — UTC offset in hours for local-day aggregation in daily_from_hourly datasets (default: 0 = UTC)

--- a/climate-service.yaml.example
+++ b/climate-service.yaml.example
@@ -12,8 +12,29 @@ extent:
 
 data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr stores
 
-# Event-driven workflows are instance-specific bindings. Event references are resolved from
-# the successful dataset sync outcome; literal argument values are passed through unchanged.
+# Operator-managed recurring checks. Each previously ingested dataset may appear once, with its
+# own cadence. Due checks enter the same native job queue; stagger times where practical.
+# scheduler:
+#   enabled: true
+#   timezone: UTC
+#   dataset_sync:
+#     - dataset_id: chirps3_precipitation_daily
+#       cron: "0 6 * * *"       # every day at 06:00 UTC
+#       publish: true
+#       max_attempts: 3
+#
+#     - dataset_id: era5land_temperature_monthly
+#       cron: "30 6 * * *"      # check daily at 06:30 UTC
+#       publish: true
+#       max_attempts: 3
+#
+#     - dataset_id: worldpop_population_global2_R2025A_100m
+#       cron: "0 7 1 * *"       # first day of each month at 07:00 UTC
+#       publish: true
+#       max_attempts: 3
+
+# Event-driven workflows are separate from cron schedules. Every trigger whose `on_update_of`
+# matches a successful dataset update creates an independent openEO workflow job.
 # automation:
 #   workflow_triggers:
 #     - id: chirps-to-chap
@@ -24,16 +45,17 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 #         temporal_extent: [$event.previous_end, $event.current_end]
 #         geometries: {type: FeatureCollection, features: []}
 #         period_type: day
+#
+#     - id: chirps-to-dhis2-json
+#       on_update_of: chirps3_precipitation_daily
+#       workflow_id: aggregate_to_dhis2_json
+#       arguments:
+#         dataset_id: $event.dataset_id
+#         temporal_extent: [$event.previous_end, $event.current_end]
+#         geometries: {type: FeatureCollection, features: []}
+#         data_element_id: BXgDHhPdFVU
+#         period_type: day
 
 # plugins_dir: ./plugins/   # optional — plugin root: YAML templates in plugins/datasets/, Python modules importable by dotted path
 # crs: EPSG:4326             # optional — CRS for stored GeoZarr files (default: EPSG:4326); use e.g. EPSG:25833 for UTM33
 # utc_offset_hours: 0        # optional — UTC offset in hours for local-day aggregation in daily_from_hourly datasets (default: 0 = UTC)
-
-# scheduler:                 # optional — operator-managed recurring dataset syncs
-#   enabled: true
-#   timezone: UTC
-#   dataset_sync:
-#     - dataset_id: chirps3_precipitation_daily
-#       cron: "0 6 * * *"
-#       publish: true
-#       max_attempts: 3

--- a/climate-service.yaml.example
+++ b/climate-service.yaml.example
@@ -45,6 +45,7 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 #         temporal_extent: [$event.previous_end, $event.current_end]
 #         geometries: {type: FeatureCollection, features: []}
 #         period_type: day
+#       replay_existing: false  # default: do not backfill events predating this trigger
 #
 #     - id: chirps-to-dhis2-json
 #       on_update_of: chirps3_precipitation_daily

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,8 +135,9 @@ Successful native jobs may also contain domain events in their `events` field. T
 persisted in the same update that marks the job successful, so consumers never observe an event
 for failed work. An async sync that actually appends or rematerializes data records one
 `dataset.updated` event with the dataset, artifact, executed action, and previous/current coverage.
-An up-to-date sync records no event. The event is a durable completion outcome; dispatching
-downstream workflows or external notifications is a separate concern.
+An up-to-date sync records no event. Instance-configured workflow triggers consume these durable
+outcomes and submit existing openEO workflows. A deterministic job ID makes replay after restart
+idempotent. External notification remains a separate concern.
 
 Jobs provide:
 

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -140,6 +140,7 @@ plugins_dir: ./plugins/
 | `plugins_dir` | No | Directory containing `datasets/`, `processes/`, and `workflows/` plugin subdirectories |
 | `read_only` | No | Set `true` to refuse all state-changing requests — see [Read-only instances](#read-only-instances). Defaults to `false` |
 | `scheduler` | No | Instance-level scheduled dataset-sync configuration. See [Scheduled dataset synchronization](scheduled_sync.md) |
+| `automation` | No | Event-driven workflow bindings for successful dataset updates. See [Dataset-update workflow automation](workflow_automation.md) |
 
 To find the bounding box for a region, [bboxfinder.com](http://bboxfinder.com) is a useful tool.
 

--- a/docs/scheduled_sync.md
+++ b/docs/scheduled_sync.md
@@ -64,5 +64,7 @@ with an error, without preventing unrelated API routes from starting. Refreshing
 requires replacing an overlapping forward window, not merely appending periods after the
 latest stored timestamp.
 
-Event-driven derived workflows, cross-service orchestration, schedule mutation APIs,
-distributed leader election, and forecast-window refresh are later automation phases.
+Successful update events can drive openEO workflows through instance-owned bindings; see
+[Dataset-update workflow automation](workflow_automation.md). Cross-service orchestration,
+schedule mutation APIs, distributed leader election, and forecast-window refresh remain later
+automation phases.

--- a/docs/workflow_automation.md
+++ b/docs/workflow_automation.md
@@ -1,0 +1,60 @@
+# Dataset-update workflow automation
+
+An OCS instance can run an existing openEO workflow after a successful dataset sync changes
+stored data. This is event-driven: it does not guess that a sync has finished by scheduling a
+second cron expression.
+
+## Configure a trigger
+
+Triggers are instance-owned bindings in `climate-service.yaml`:
+
+```yaml
+automation:
+  workflow_triggers:
+    - id: chirps-to-chap
+      on_update_of: chirps3_precipitation_daily
+      workflow_id: aggregate_to_chap_csv
+      arguments:
+        dataset_id: $event.dataset_id
+        temporal_extent: [$event.previous_end, $event.current_end]
+        geometries:
+          type: FeatureCollection
+          features: []
+        method: mean
+        period_type: day
+```
+
+`on_update_of` names the managed source dataset and `workflow_id` names a workflow already
+available through `GET /process_graphs`. Trigger IDs must be unique within an instance.
+
+Arguments are the parameters passed to the workflow. Literal YAML values are preserved. These
+exact event references can be used at any nesting level:
+
+- `$event.dataset_id`
+- `$event.artifact_id`
+- `$event.action`
+- `$event.previous_end`
+- `$event.current_end`
+
+The workflow definition remains reusable and deployment-independent. Operational bindings such
+as output dataset IDs, geometries, and DHIS2 identifiers remain in instance configuration.
+
+## Delivery behavior
+
+A workflow is considered only after the native sync job has successfully persisted a
+`dataset.updated` event. Failed and no-op syncs do not trigger workflows. Manual and scheduled
+syncs use the same path.
+
+Each event and trigger pair produces a deterministic openEO job ID. OCS replays persisted events
+at startup, but an already created, queued, running, or completed job is not duplicated. If OCS
+stopped after creating a job but before queueing it, startup queues that existing job.
+
+Workflow execution and status remain owned by the openEO batch-job service and are visible under
+`GET /jobs`. Workflows may also be submitted directly without a preceding dataset sync.
+
+## Current boundary
+
+This mechanism dispatches workflows owned by the same OCS instance. It does not provide workflow
+dependency graphs, cross-service retries, webhooks, or distributed event consumption. Exactly
+one writable OCS process should perform automation until the stores and leadership model become
+shared and transactional.

--- a/docs/workflow_automation.md
+++ b/docs/workflow_automation.md
@@ -49,8 +49,20 @@ Each event and trigger pair produces a deterministic openEO job ID. OCS replays 
 at startup, but an already created, queued, running, or completed job is not duplicated. If OCS
 stopped after creating a job but before queueing it, startup queues that existing job.
 
+A trigger is activated the first time OCS starts with it configured. By default
+(`replay_existing: false`), startup replay ignores events that predate the trigger's activation, so
+adding a new trigger does not backfill the workflow over every historical update. Set
+`replay_existing: true` to opt into replaying all persisted events for that trigger. Newly
+persisted events are always dispatched immediately, regardless of this flag.
+
 Workflow execution and status remain owned by the openEO batch-job service and are visible under
 `GET /jobs`. Workflows may also be submitted directly without a preceding dataset sync.
+
+Triggered jobs share the existing openEO job pool with manually submitted jobs — there is no
+separate automation queue or concurrency limit. A fan-out of several triggers therefore runs
+independently in that pool. Bounding total workflow concurrency is a general resource-policy
+concern deferred to CLIM-845; until then the per-store lock remains the write-safety boundary for
+workflows that publish managed datasets.
 
 ## Current boundary
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Climate indices: climate_indices.md
       - Workflows: workflows.md
       - Scheduled dataset synchronization: scheduled_sync.md
+      - Dataset-update workflow automation: workflow_automation.md
       - Import to DHIS2 and Chap: importing_to_dhis2.md
       - GeoLibre plugin: geolibre_plugin.md
       - Adding custom datasets: adding_custom_datasets.md

--- a/open_climate_service/automation/__init__.py
+++ b/open_climate_service/automation/__init__.py
@@ -1,0 +1,1 @@
+"""Event-driven workflow automation."""

--- a/open_climate_service/automation/config.py
+++ b/open_climate_service/automation/config.py
@@ -18,6 +18,7 @@ class WorkflowTrigger(BaseModel):
     on_update_of: str = Field(min_length=1)
     workflow_id: str = Field(min_length=1)
     arguments: dict[str, Any] = Field(default_factory=dict)
+    replay_existing: bool = False
 
 
 class AutomationConfig(BaseModel):

--- a/open_climate_service/automation/config.py
+++ b/open_climate_service/automation/config.py
@@ -1,0 +1,44 @@
+"""Validated instance configuration for event-driven workflow triggers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from open_climate_service import config as api_config
+
+
+class WorkflowTrigger(BaseModel):
+    """Bind one dataset update to an existing openEO workflow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    on_update_of: str = Field(min_length=1)
+    workflow_id: str = Field(min_length=1)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class AutomationConfig(BaseModel):
+    """Workflow automation owned by this OCS instance."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_triggers: list[WorkflowTrigger] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_unique_ids(self) -> "AutomationConfig":
+        ids = [trigger.id for trigger in self.workflow_triggers]
+        duplicates = sorted({trigger_id for trigger_id in ids if ids.count(trigger_id) > 1})
+        if duplicates:
+            raise ValueError(f"workflow trigger ids must be unique: {duplicates}")
+        return self
+
+
+def get_automation_config() -> AutomationConfig:
+    """Load workflow automation from the instance configuration."""
+    raw = api_config.get_config().get("automation", {})
+    if not isinstance(raw, dict):
+        raise ValueError("automation in CLIMATE_SERVICE_CONFIG must be a mapping")
+    return AutomationConfig.model_validate(raw)

--- a/open_climate_service/automation/service.py
+++ b/open_climate_service/automation/service.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from open_climate_service import config as api_config
-from open_climate_service.automation.config import AutomationConfig, get_automation_config
+from open_climate_service.automation.config import AutomationConfig, WorkflowTrigger, get_automation_config
 from open_climate_service.jobs import store as job_store
-from open_climate_service.jobs.models import JobEvent
+from open_climate_service.jobs.models import DATASET_UPDATED_EVENT_TYPE, JobEvent
 from open_climate_service.openeo import workflows
 from open_climate_service.openeo.jobs import OpenEOJobService, get_openeo_job_service
 from open_climate_service.openeo.schemas import OpenEOJobCreate
+from open_climate_service.shared.time import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +41,94 @@ def _resolve_event_values(value: Any, event: JobEvent) -> Any:
     return value
 
 
+def _activation_path() -> Path:
+    """Return the file recording each trigger's activation boundary."""
+    data_dir = api_config.get_data_dir()
+    if data_dir is not None:
+        base = data_dir
+    else:
+        xdg_data = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+        base = xdg_data / "climate-service"
+    return base / "automation" / "activation.json"
+
+
+def _load_activations() -> dict[str, str]:
+    """Return persisted trigger activation times, tolerating a missing or corrupt file."""
+    path = _activation_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save_activations(activations: dict[str, str]) -> None:
+    """Persist trigger activation times."""
+    path = _activation_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(activations, indent=2) + "\n", encoding="utf-8")
+
+
+def _is_before_activation(event: JobEvent, activation_iso: str | None) -> bool:
+    """True when an event predates a trigger's activation boundary (backfill)."""
+    if activation_iso is None:
+        return False
+    try:
+        activation = datetime.fromisoformat(activation_iso)
+    except ValueError:
+        return False
+    event_time = event.time
+    if event_time.tzinfo is None:
+        event_time = event_time.replace(tzinfo=timezone.utc)
+    if activation.tzinfo is None:
+        activation = activation.replace(tzinfo=timezone.utc)
+    return event_time < activation
+
+
+_MANAGED_OUTPUT_PARAMETER = "output_dataset_id"
+
+
+def _resolved_output_dataset(trigger: WorkflowTrigger, workflow: Any) -> str | None:
+    """Return a trigger's statically resolvable managed output, or None.
+
+    Only workflows that declare an ``output_dataset_id`` parameter produce a
+    managed dataset. File-producing workflows and ``$event`` references cannot
+    be resolved statically and are left to the per-store lock at run time.
+    """
+    parameters = getattr(workflow, "parameters", None)
+    if not isinstance(parameters, list):
+        return None
+    names = {param.get("name") for param in parameters if isinstance(param, dict)}
+    if _MANAGED_OUTPUT_PARAMETER not in names:
+        return None
+    value = trigger.arguments.get(_MANAGED_OUTPUT_PARAMETER)
+    if isinstance(value, str) and value and not value.startswith("$event"):
+        return value
+    return None
+
+
+def _validate_output_ownership(config: AutomationConfig) -> None:
+    """Refuse triggers on one source that would concurrently write one output."""
+    bindings: dict[tuple[str, str], list[str]] = {}
+    for trigger in config.workflow_triggers:
+        workflow = workflows.get_workflow(trigger.workflow_id)
+        output = _resolved_output_dataset(trigger, workflow) if workflow is not None else None
+        if output is None:
+            continue
+        bindings.setdefault((trigger.on_update_of, output), []).append(trigger.id)
+    duplicates = [(key, ids) for key, ids in bindings.items() if len(ids) > 1]
+    if duplicates:
+        details = "; ".join(
+            f"source {source!r}, output {output!r}: {', '.join(ids)}" for (source, output), ids in duplicates
+        )
+        raise ValueError(
+            f"workflow triggers would concurrently write the same managed output: {details}. "
+            "Give each trigger a distinct output_dataset_id."
+        )
+
+
 class WorkflowAutomationService:
     """Dispatch configured workflows once for each matching durable event."""
 
@@ -50,61 +143,86 @@ class WorkflowAutomationService:
         self._config: AutomationConfig | None = None
 
     def start(self) -> None:
-        """Load configuration and validate every workflow target."""
+        """Load configuration, validate workflow targets, and record activation boundaries."""
         self._config = self._config_loader()
         if not self._config.workflow_triggers or api_config.is_read_only():
             return
         for trigger in self._config.workflow_triggers:
             if workflows.get_workflow(trigger.workflow_id) is None:
                 raise ValueError(f"Workflow trigger {trigger.id!r} references unknown workflow {trigger.workflow_id!r}")
+        _validate_output_ownership(self._config)
+        activations = _load_activations()
+        now = utc_now().isoformat()
+        changed = False
+        for trigger in self._config.workflow_triggers:
+            if trigger.id not in activations:
+                activations[trigger.id] = now
+                changed = True
+        if changed:
+            _save_activations(activations)
 
     def replay(self) -> None:
-        """Consume every persisted event; deterministic jobs make replay idempotent."""
-        if api_config.is_read_only():
+        """Consume persisted events, honouring each trigger's activation boundary."""
+        config = self._config or self._config_loader()
+        if api_config.is_read_only() or not config.workflow_triggers:
             return
+        service = self._openeo_service or get_openeo_job_service()
+        activations = _load_activations()
         for record in job_store.list_job_records():
-            self.consume(record.events)
+            for event in record.events:
+                if event.type != DATASET_UPDATED_EVENT_TYPE:
+                    continue
+                for trigger in config.workflow_triggers:
+                    if trigger.on_update_of != event.data.get("dataset_id"):
+                        continue
+                    if not trigger.replay_existing and _is_before_activation(event, activations.get(trigger.id)):
+                        continue
+                    self._submit(trigger, event, service)
 
     def consume(self, events: list[JobEvent]) -> None:
-        """Submit workflows matching the supplied successful-job events."""
+        """Submit workflows for newly persisted successful-job events."""
         config = self._config or self._config_loader()
-        if api_config.is_read_only():
+        if api_config.is_read_only() or not config.workflow_triggers:
             return
         service = self._openeo_service or get_openeo_job_service()
         for event in events:
-            if event.type != "dataset.updated":
+            if event.type != DATASET_UPDATED_EVENT_TYPE:
                 continue
-            dataset_id = event.data.get("dataset_id")
             for trigger in config.workflow_triggers:
-                if trigger.on_update_of != dataset_id:
+                if trigger.on_update_of != event.data.get("dataset_id"):
                     continue
-                arguments = _resolve_event_values(trigger.arguments, event)
-                body = OpenEOJobCreate(
-                    title=f"{trigger.workflow_id} after {dataset_id} update",
-                    description=f"Triggered by {event.event_id} using automation rule {trigger.id}",
-                    process={
-                        "process_graph": {
-                            "workflow": {
-                                "process_id": trigger.workflow_id,
-                                "arguments": arguments,
-                                "result": True,
-                            }
-                        }
-                    },
-                )
-                job, created = service.create_triggered_job(
-                    body,
-                    source_event_id=event.event_id,
-                    trigger_id=trigger.id,
-                )
-                service.start_triggered_job(job.id)
-                if created:
-                    logger.info(
-                        "Submitted workflow %s as job %s for event %s",
-                        trigger.workflow_id,
-                        job.id,
-                        event.event_id,
-                    )
+                self._submit(trigger, event, service)
+
+    def _submit(self, trigger: WorkflowTrigger, event: JobEvent, service: OpenEOJobService) -> None:
+        """Create and start the deterministic job for one trigger/event pair."""
+        dataset_id = event.data.get("dataset_id")
+        arguments = _resolve_event_values(trigger.arguments, event)
+        body = OpenEOJobCreate(
+            title=f"{trigger.workflow_id} after {dataset_id} update",
+            description=f"Triggered by {event.event_id} using automation rule {trigger.id}",
+            process={
+                "process_graph": {
+                    "workflow": {
+                        "process_id": trigger.workflow_id,
+                        "arguments": arguments,
+                        "result": True,
+                    }
+                }
+            },
+        )
+        job, created = service.create_triggered_job(
+            body,
+            source_event_id=event.event_id,
+            trigger_id=trigger.id,
+        )
+        service.start_triggered_job(job.id)
+        if created:
+            logger.info(
+                "Submitted workflow %s as job %s for event %s",
+                trigger.workflow_id,
+                job.id,
+                event.event_id,
+            )
 
 
 _service: WorkflowAutomationService | None = None

--- a/open_climate_service/automation/service.py
+++ b/open_climate_service/automation/service.py
@@ -60,25 +60,37 @@ def _load_activations() -> dict[str, str]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        logger.warning("Could not read automation activation file %s; triggers will not replay history", path)
         return {}
-    return payload if isinstance(payload, dict) else {}
+    if not isinstance(payload, dict):
+        logger.warning("Automation activation file %s is not a mapping; triggers will not replay history", path)
+        return {}
+    return {key: value for key, value in payload.items() if isinstance(key, str) and isinstance(value, str)}
 
 
 def _save_activations(activations: dict[str, str]) -> None:
-    """Persist trigger activation times."""
+    """Persist trigger activation times atomically so a crash cannot leave a truncated file."""
     path = _activation_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(activations, indent=2) + "\n", encoding="utf-8")
+    temp = path.with_suffix(".tmp")
+    temp.write_text(json.dumps(activations, indent=2) + "\n", encoding="utf-8")
+    os.replace(temp, path)
 
 
 def _is_before_activation(event: JobEvent, activation_iso: str | None) -> bool:
-    """True when an event predates a trigger's activation boundary (backfill)."""
-    if activation_iso is None:
-        return False
+    """True when an event predates a trigger's activation boundary.
+
+    A missing or unreadable activation counts as *before* activation: ``start()`` always stamps
+    one, so its absence is an anomaly, and skipping is the safe reading of the
+    ``replay_existing: false`` guarantee — replaying all history is the failure mode this guard
+    exists to prevent.
+    """
+    if not isinstance(activation_iso, str) or not activation_iso:
+        return True
     try:
         activation = datetime.fromisoformat(activation_iso)
     except ValueError:
-        return False
+        return True
     event_time = event.time
     if event_time.tzinfo is None:
         event_time = event_time.replace(tzinfo=timezone.utc)
@@ -129,6 +141,33 @@ def _validate_output_ownership(config: AutomationConfig) -> None:
         )
 
 
+def _iter_strings(value: Any) -> Any:
+    """Yield every string in a nested mapping/list, for event-reference validation."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_strings(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_strings(item)
+
+
+def _validate_event_references(config: AutomationConfig) -> None:
+    """Refuse arguments that look like event references but are not the known tokens.
+
+    ``_resolve_event_values`` substitutes only exact whole-string matches, so a typo such as
+    ``$event.datasetid`` would otherwise be submitted as a literal and fail only at run time.
+    """
+    for trigger in config.workflow_triggers:
+        for value in _iter_strings(trigger.arguments):
+            if "$event" in value and value not in _EVENT_VALUES:
+                raise ValueError(
+                    f"Workflow trigger {trigger.id!r} argument {value!r} looks like an event reference "
+                    f"but is not one of {sorted(_EVENT_VALUES)}"
+                )
+
+
 class WorkflowAutomationService:
     """Dispatch configured workflows once for each matching durable event."""
 
@@ -143,14 +182,21 @@ class WorkflowAutomationService:
         self._config: AutomationConfig | None = None
 
     def start(self) -> None:
-        """Load configuration, validate workflow targets, and record activation boundaries."""
+        """Load configuration, validate triggers, and record activation boundaries.
+
+        Validation runs even on a read-only instance so a configuration error surfaces at startup
+        rather than only once the instance is made writable.
+        """
         self._config = self._config_loader()
-        if not self._config.workflow_triggers or api_config.is_read_only():
+        if not self._config.workflow_triggers:
             return
         for trigger in self._config.workflow_triggers:
             if workflows.get_workflow(trigger.workflow_id) is None:
                 raise ValueError(f"Workflow trigger {trigger.id!r} references unknown workflow {trigger.workflow_id!r}")
         _validate_output_ownership(self._config)
+        _validate_event_references(self._config)
+        if api_config.is_read_only():
+            return
         activations = _load_activations()
         now = utc_now().isoformat()
         changed = False
@@ -177,7 +223,7 @@ class WorkflowAutomationService:
                         continue
                     if not trigger.replay_existing and _is_before_activation(event, activations.get(trigger.id)):
                         continue
-                    self._submit(trigger, event, service)
+                    self._submit_safely(trigger, event, service)
 
     def consume(self, events: list[JobEvent]) -> None:
         """Submit workflows for newly persisted successful-job events."""
@@ -191,7 +237,19 @@ class WorkflowAutomationService:
             for trigger in config.workflow_triggers:
                 if trigger.on_update_of != event.data.get("dataset_id"):
                     continue
-                self._submit(trigger, event, service)
+                self._submit_safely(trigger, event, service)
+
+    def _submit_safely(self, trigger: WorkflowTrigger, event: JobEvent, service: OpenEOJobService) -> None:
+        """Submit one trigger/event pair without letting a failure skip its siblings."""
+        try:
+            self._submit(trigger, event, service)
+        except Exception:
+            logger.exception(
+                "Workflow trigger %s failed for event %s (dataset %s)",
+                trigger.id,
+                event.event_id,
+                event.data.get("dataset_id"),
+            )
 
     def _submit(self, trigger: WorkflowTrigger, event: JobEvent, service: OpenEOJobService) -> None:
         """Create and start the deterministic job for one trigger/event pair."""

--- a/open_climate_service/automation/service.py
+++ b/open_climate_service/automation/service.py
@@ -1,0 +1,118 @@
+"""Consume durable dataset updates and submit configured openEO workflows."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from open_climate_service import config as api_config
+from open_climate_service.automation.config import AutomationConfig, get_automation_config
+from open_climate_service.jobs import store as job_store
+from open_climate_service.jobs.models import JobEvent
+from open_climate_service.openeo import workflows
+from open_climate_service.openeo.jobs import OpenEOJobService, get_openeo_job_service
+from open_climate_service.openeo.schemas import OpenEOJobCreate
+
+logger = logging.getLogger(__name__)
+
+_EVENT_VALUES = {
+    "$event.dataset_id": "dataset_id",
+    "$event.artifact_id": "artifact_id",
+    "$event.action": "action",
+    "$event.previous_end": "previous_end",
+    "$event.current_end": "current_end",
+}
+
+
+def _resolve_event_values(value: Any, event: JobEvent) -> Any:
+    """Replace exact event references recursively while preserving literal values."""
+    if isinstance(value, str) and value in _EVENT_VALUES:
+        return event.data.get(_EVENT_VALUES[value])
+    if isinstance(value, list):
+        return [_resolve_event_values(item, event) for item in value]
+    if isinstance(value, dict):
+        return {key: _resolve_event_values(item, event) for key, item in value.items()}
+    return value
+
+
+class WorkflowAutomationService:
+    """Dispatch configured workflows once for each matching durable event."""
+
+    def __init__(
+        self,
+        *,
+        config_loader: Callable[[], AutomationConfig] = get_automation_config,
+        openeo_service: OpenEOJobService | None = None,
+    ) -> None:
+        self._config_loader = config_loader
+        self._openeo_service = openeo_service
+        self._config: AutomationConfig | None = None
+
+    def start(self) -> None:
+        """Load configuration and validate every workflow target."""
+        self._config = self._config_loader()
+        if not self._config.workflow_triggers or api_config.is_read_only():
+            return
+        for trigger in self._config.workflow_triggers:
+            if workflows.get_workflow(trigger.workflow_id) is None:
+                raise ValueError(f"Workflow trigger {trigger.id!r} references unknown workflow {trigger.workflow_id!r}")
+
+    def replay(self) -> None:
+        """Consume every persisted event; deterministic jobs make replay idempotent."""
+        if api_config.is_read_only():
+            return
+        for record in job_store.list_job_records():
+            self.consume(record.events)
+
+    def consume(self, events: list[JobEvent]) -> None:
+        """Submit workflows matching the supplied successful-job events."""
+        config = self._config or self._config_loader()
+        if api_config.is_read_only():
+            return
+        service = self._openeo_service or get_openeo_job_service()
+        for event in events:
+            if event.type != "dataset.updated":
+                continue
+            dataset_id = event.data.get("dataset_id")
+            for trigger in config.workflow_triggers:
+                if trigger.on_update_of != dataset_id:
+                    continue
+                arguments = _resolve_event_values(trigger.arguments, event)
+                body = OpenEOJobCreate(
+                    title=f"{trigger.workflow_id} after {dataset_id} update",
+                    description=f"Triggered by {event.event_id} using automation rule {trigger.id}",
+                    process={
+                        "process_graph": {
+                            "workflow": {
+                                "process_id": trigger.workflow_id,
+                                "arguments": arguments,
+                                "result": True,
+                            }
+                        }
+                    },
+                )
+                job, created = service.create_triggered_job(
+                    body,
+                    source_event_id=event.event_id,
+                    trigger_id=trigger.id,
+                )
+                service.start_triggered_job(job.id)
+                if created:
+                    logger.info(
+                        "Submitted workflow %s as job %s for event %s",
+                        trigger.workflow_id,
+                        job.id,
+                        event.event_id,
+                    )
+
+
+_service: WorkflowAutomationService | None = None
+
+
+def get_workflow_automation_service() -> WorkflowAutomationService:
+    """Return the process-local automation service singleton."""
+    global _service
+    if _service is None:
+        _service = WorkflowAutomationService()
+    return _service

--- a/open_climate_service/ingestions/processes.py
+++ b/open_climate_service/ingestions/processes.py
@@ -11,7 +11,7 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.extents.services import get_extent_or_404
 from open_climate_service.ingestions import services
 from open_climate_service.ingestions.schemas import IngestionResponse, SyncAction
-from open_climate_service.jobs.models import JobEventDraft, JobExecutionResult
+from open_climate_service.jobs.models import DATASET_UPDATED_EVENT_TYPE, JobEventDraft, JobExecutionResult
 
 
 def execute_ingestion(
@@ -71,7 +71,7 @@ def execute_sync(
     ):
         events.append(
             JobEventDraft(
-                type="dataset.updated",
+                type=DATASET_UPDATED_EVENT_TYPE,
                 source=f"/datasets/{dataset_id}",
                 data={
                     "dataset_id": dataset_id,

--- a/open_climate_service/jobs/models.py
+++ b/open_climate_service/jobs/models.py
@@ -8,6 +8,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+DATASET_UPDATED_EVENT_TYPE = "dataset.updated"
+"""Event type persisted when a sync actually appends or rematerializes a dataset."""
+
 
 class JobCancelledError(Exception):
     """Raised by a job implementation when cooperative cancellation is honored."""

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -121,6 +121,11 @@ class JobService:
         self._executor = executor or ThreadProcessExecutor(max_workers=max_workers)
         self._futures: dict[str, Future[None]] = {}
         self._lock = threading.Lock()
+        self._event_consumer: Callable[[list[JobEvent]], None] | None = None
+
+    def set_event_consumer(self, consumer: Callable[[list[JobEvent]], None] | None) -> None:
+        """Register the process-local consumer for newly persisted domain events."""
+        self._event_consumer = consumer
 
     def shutdown(self) -> None:
         """Stop the executor without waiting for outstanding work."""
@@ -360,7 +365,7 @@ class JobService:
                 else:
                     result = execution_result
                     events = []
-                store.mutate_job_record(
+                completed = store.mutate_job_record(
                     job_id,
                     lambda current: current.model_copy(
                         update={
@@ -377,6 +382,11 @@ class JobService:
                         }
                     ),
                 )
+                if completed.events and self._event_consumer is not None:
+                    try:
+                        self._event_consumer(completed.events)
+                    except Exception:
+                        logger.exception("Failed to consume events for completed job %s", job_id)
                 return
             except JobCancelledError:
                 store.mutate_job_record(

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -1,5 +1,6 @@
 """Open Climate Service -- Climate and earth observation data API for DHIS2."""
 
+import logging
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -21,6 +22,8 @@ from open_climate_service.scheduler import routes as scheduler_routes
 from open_climate_service.scheduler.service import get_scheduler_service
 from open_climate_service.stac import routes as stac_routes
 from open_climate_service.system import routes as system_routes
+
+logger = logging.getLogger(__name__)
 
 # Hosted browser tools that read a Zarr store directly over HTTP. They are the reason a local
 # instance needs any cross-origin story at all: each is a public page fetching a store that may
@@ -78,7 +81,12 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     automation_service = get_workflow_automation_service()
     automation_service.start()
     job_service.set_event_consumer(automation_service.consume)
-    automation_service.replay()
+    try:
+        automation_service.replay()
+    except Exception:
+        # Replay must not take down startup: a partial replay is idempotent and the consumer
+        # above still handles every newly persisted event.
+        logger.exception("Workflow automation replay failed; continuing startup")
     scheduler_service = get_scheduler_service()
     scheduler_service.start()
     try:

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 
 import open_climate_service.startup  # noqa: F401  # pyright: ignore[reportUnusedImport]
+from open_climate_service.automation.service import get_workflow_automation_service
 from open_climate_service.data_registry import routes as dataset_template_routes
 from open_climate_service.extents import routes as extent_routes
 from open_climate_service.ingestions import routes as ingestion_routes
@@ -74,11 +75,16 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     job_service.recover_pending_jobs()
     openeo_service = get_openeo_job_service()
     openeo_service.recover_pending_jobs()
+    automation_service = get_workflow_automation_service()
+    automation_service.start()
+    job_service.set_event_consumer(automation_service.consume)
+    automation_service.replay()
     scheduler_service = get_scheduler_service()
     scheduler_service.start()
     try:
         yield
     finally:
+        job_service.set_event_consumer(None)
         scheduler_service.shutdown()
         job_service.shutdown()
         openeo_service.shutdown()

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -12,7 +12,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, TypeVar
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import portalocker
 from fastapi import HTTPException
@@ -230,6 +230,69 @@ class OpenEOJobService:
             ],
         )
         return store_create_job(record)
+
+    def create_triggered_job(
+        self,
+        body: OpenEOJobCreate,
+        *,
+        source_event_id: str,
+        trigger_id: str,
+    ) -> tuple[OpenEOJobRecord, bool]:
+        """Create at most one job for a durable event and automation trigger."""
+        if not isinstance(body.process.get("process_graph"), dict):
+            raise ValueError("process.process_graph must be an object")
+        job_id = str(uuid5(NAMESPACE_URL, f"ocs:{source_event_id}:{trigger_id}"))
+        existing = store_get_job(job_id)
+        if existing is not None:
+            return existing, False
+        now = utc_now()
+        candidate = OpenEOJobRecord(
+            id=job_id,
+            title=body.title,
+            description=body.description,
+            process=body.process,
+            status=OpenEOJobStatus.CREATED,
+            created=now,
+            updated=now,
+            links=[
+                {"rel": "self", "href": f"/jobs/{job_id}", "type": "application/json"},
+                {"rel": "results", "href": f"/jobs/{job_id}/results", "type": "application/json"},
+            ],
+        )
+
+        def _create_once(records: list[dict[str, object]]) -> tuple[OpenEOJobRecord, bool]:
+            for raw in records:
+                if raw.get("id") == job_id:
+                    return OpenEOJobRecord.model_validate(raw), False
+            records.append(_serialize(candidate))
+            return candidate, True
+
+        return _mutate_store(_create_once)
+
+    def start_triggered_job(self, job_id: str) -> bool:
+        """Atomically claim and enqueue a created automation job.
+
+        The conditional transition prevents two OCS processes replaying the same
+        durable event from both executing its deterministic job.
+        """
+
+        def _claim(records: list[dict[str, object]]) -> bool:
+            for index, raw in enumerate(records):
+                if raw.get("id") != job_id:
+                    continue
+                current = OpenEOJobRecord.model_validate(raw)
+                if current.status != OpenEOJobStatus.CREATED:
+                    return False
+                records[index] = _serialize(
+                    current.model_copy(update={"status": OpenEOJobStatus.QUEUED, "updated": utc_now()})
+                )
+                return True
+            raise KeyError(job_id)
+
+        claimed = _mutate_store(_claim)
+        if claimed:
+            self._enqueue(job_id)
+        return claimed
 
     def get_job_or_404(self, job_id: str) -> OpenEOJobRecord:
         record = store_get_job(job_id)

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -50,18 +50,28 @@ def _resolve_openeo_jobs_dir() -> Path:
 
 
 _JOBS_DIR = _resolve_openeo_jobs_dir()
-_JOBS_INDEX = _JOBS_DIR / "jobs.json"
+
+
+def _jobs_index() -> Path:
+    """Return the openEO jobs index path, derived from ``_JOBS_DIR`` at call time.
+
+    Derived at call time rather than import time so a test that monkeypatches ``_JOBS_DIR``
+    isolates the whole store. The previous module-level constant froze ``jobs.json`` at import;
+    ``_ensure_store`` then mkdir'd the patched ``tmp_path`` while ``write_text`` still targeted
+    the real XDG path, whose parent does not exist on a fresh runner (CLIM-849 CI failure).
+    """
+    return _JOBS_DIR / "jobs.json"
 
 
 def _ensure_store() -> None:
     _JOBS_DIR.mkdir(parents=True, exist_ok=True)
-    if not _JOBS_INDEX.exists():
-        _JOBS_INDEX.write_text("[]\n", encoding="utf-8")
+    if not _jobs_index().exists():
+        _jobs_index().write_text("[]\n", encoding="utf-8")
 
 
 def _load_raw_records() -> list[dict[str, object]]:
     _ensure_store()
-    with open(_JOBS_INDEX, encoding="utf-8") as fh:
+    with open(_jobs_index(), encoding="utf-8") as fh:
         portalocker.lock(fh, portalocker.LOCK_SH)
         try:
             payload = json.load(fh)
@@ -74,7 +84,7 @@ def _load_raw_records() -> list[dict[str, object]]:
 
 def _mutate_store(mutation: Callable[[list[dict[str, object]]], _T]) -> _T:
     _ensure_store()
-    with open(_JOBS_INDEX, "r+", encoding="utf-8") as fh:
+    with open(_jobs_index(), "r+", encoding="utf-8") as fh:
         portalocker.lock(fh, portalocker.LOCK_EX)
         try:
             payload = json.load(fh)
@@ -244,18 +254,17 @@ class OpenEOJobService:
         if not isinstance(body.process.get("process_graph"), dict):
             raise ValueError("process.process_graph must be an object")
         job_id = str(uuid5(NAMESPACE_URL, f"ocs:{source_event_id}:{trigger_id}"))
-        existing = store_get_job(job_id)
-        if existing is not None:
-            return existing, False
         now = utc_now()
         candidate = OpenEOJobRecord(
             id=job_id,
-            title=body.title,
+            title=body.title if body.title is not None else _derive_job_title(body.process),
             description=body.description,
             process=body.process,
             status=OpenEOJobStatus.CREATED,
             created=now,
             updated=now,
+            plan=body.plan,
+            budget=body.budget,
             links=[
                 {"rel": "self", "href": f"/jobs/{job_id}", "type": "application/json"},
                 {"rel": "results", "href": f"/jobs/{job_id}/results", "type": "application/json"},

--- a/tests/test_ingestion_async.py
+++ b/tests/test_ingestion_async.py
@@ -311,6 +311,8 @@ def test_successful_job_persists_result_and_events_atomically(monkeypatch: pytes
 
     monkeypatch.setattr("open_climate_service.jobs.store.mutate_job_record", mutate)
     service = JobService()
+    consume = MagicMock()
+    service.set_event_consumer(consume)
     submitted = service.submit_callable_job(func=_fake_event_job_callable, label="sync", request={})
 
     service._execute_job(submitted.job_id)
@@ -322,6 +324,7 @@ def test_successful_job_persists_result_and_events_atomically(monkeypatch: pytes
     assert completed.events[0].event_id == f"{submitted.job_id}:0"
     assert completed.events[0].type == "dataset.updated"
     assert completed.events[0].time == completed.finished_at
+    consume.assert_called_once_with(completed.events)
 
 
 @pytest.mark.parametrize("action", [SyncAction.APPEND, SyncAction.REMATERIALIZE])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,26 @@ async def test_lifespan_recovers_jobs_and_shuts_down(monkeypatch: pytest.MonkeyP
         def shutdown(self) -> None:
             calls.append("shutdown")
 
+        def set_event_consumer(self, consumer: object | None) -> None:
+            calls.append("consumer-set" if consumer is not None else "consumer-unset")
+
+    class FakeOpenEOJobService:
+        def recover_pending_jobs(self) -> None:
+            calls.append("openeo-recover")
+
+        def shutdown(self) -> None:
+            calls.append("openeo-shutdown")
+
+    class FakeAutomationService:
+        def consume(self, events: object) -> None:
+            pass
+
+        def start(self) -> None:
+            calls.append("automation-start")
+
+        def replay(self) -> None:
+            calls.append("automation-replay")
+
     class FakeSchedulerService:
         def start(self) -> None:
             calls.append("scheduler-start")
@@ -25,9 +45,29 @@ async def test_lifespan_recovers_jobs_and_shuts_down(monkeypatch: pytest.MonkeyP
             calls.append("scheduler-shutdown")
 
     monkeypatch.setattr(main, "get_job_service", lambda: FakeJobService())
+    monkeypatch.setattr(main, "get_openeo_job_service", lambda: FakeOpenEOJobService())
+    monkeypatch.setattr(main, "get_workflow_automation_service", lambda: FakeAutomationService())
     monkeypatch.setattr(main, "get_scheduler_service", lambda: FakeSchedulerService())
 
     async with main._lifespan(FastAPI()):
-        assert calls == ["recover", "scheduler-start"]
+        assert calls == [
+            "recover",
+            "openeo-recover",
+            "automation-start",
+            "consumer-set",
+            "automation-replay",
+            "scheduler-start",
+        ]
 
-    assert calls == ["recover", "scheduler-start", "scheduler-shutdown", "shutdown"]
+    assert calls == [
+        "recover",
+        "openeo-recover",
+        "automation-start",
+        "consumer-set",
+        "automation-replay",
+        "scheduler-start",
+        "consumer-unset",
+        "scheduler-shutdown",
+        "shutdown",
+        "openeo-shutdown",
+    ]

--- a/tests/test_workflow_automation.py
+++ b/tests/test_workflow_automation.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 
 from open_climate_service.automation.config import AutomationConfig, WorkflowTrigger
 from open_climate_service.automation.service import WorkflowAutomationService, _resolve_event_values
-from open_climate_service.jobs.models import JobEvent
+from open_climate_service.jobs.models import DATASET_UPDATED_EVENT_TYPE, JobEvent
 from open_climate_service.openeo.jobs import OpenEOJobService
 from open_climate_service.openeo.schemas import OpenEOJobCreate, OpenEOJobRecord, OpenEOJobStatus
 
@@ -21,7 +21,7 @@ def _event(dataset_id: str = "chirps") -> JobEvent:
     return JobEvent(
         event_id="native-job:0",
         time=datetime(2026, 8, 19, tzinfo=UTC),
-        type="dataset.updated",
+        type=DATASET_UPDATED_EVENT_TYPE,
         source=f"/datasets/{dataset_id}",
         data={
             "dataset_id": dataset_id,
@@ -322,3 +322,63 @@ def test_unresolvable_output_reference_is_not_checked(monkeypatch: pytest.Monkey
     )
 
     service.start()  # must not raise; a runtime $event reference is left to the store lock
+
+
+def test_missing_activation_skips_replay_for_default_triggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing activation file must not turn into a full history replay."""
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(), True)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+    monkeypatch.setattr(
+        "open_climate_service.automation.service.job_store.list_job_records", lambda: [_record_with(_event())]
+    )
+    monkeypatch.setattr("open_climate_service.automation.service._load_activations", lambda: {})
+    monkeypatch.setattr("open_climate_service.automation.service._save_activations", lambda _: None)
+
+    service.replay()
+
+    openeo.create_triggered_job.assert_not_called()
+
+
+def test_one_failing_trigger_does_not_skip_siblings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure in one trigger's submission must not skip the remaining triggers."""
+    openeo = MagicMock()
+    openeo.create_triggered_job.side_effect = [RuntimeError("boom"), (_openeo_record(), True)]
+    triggers = [
+        WorkflowTrigger(id="a", on_update_of="chirps", workflow_id="wf", arguments={"x": 1}),
+        WorkflowTrigger(id="b", on_update_of="chirps", workflow_id="wf", arguments={"x": 1}),
+    ]
+    service = WorkflowAutomationService(
+        config_loader=lambda: AutomationConfig(workflow_triggers=triggers), openeo_service=openeo
+    )
+
+    service.consume([_event()])
+
+    assert openeo.create_triggered_job.call_count == 2
+    openeo.start_triggered_job.assert_called_once_with("triggered-job")
+
+
+def test_unknown_event_reference_is_rejected_at_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo like $event.datasetid must fail at startup, not submit as a literal."""
+    workflow = _workflow("dataset_id")
+    service = _service_for_output_check(
+        monkeypatch,
+        workflow,
+        WorkflowTrigger(id="t", on_update_of="chirps", workflow_id="wf", arguments={"dataset_id": "$event.datasetid"}),
+    )
+
+    with pytest.raises(ValueError, match="looks like an event reference"):
+        service.start()
+
+
+def test_start_validates_triggers_on_a_read_only_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read-only must skip running, not skip validating configuration."""
+    monkeypatch.setattr("open_climate_service.automation.service.api_config.is_read_only", lambda: True)
+    monkeypatch.setattr("open_climate_service.automation.service.workflows.get_workflow", lambda _: None)
+    trigger = WorkflowTrigger(id="t", on_update_of="chirps", workflow_id="missing", arguments={})
+    service = WorkflowAutomationService(
+        config_loader=lambda: AutomationConfig(workflow_triggers=[trigger]), openeo_service=MagicMock()
+    )
+
+    with pytest.raises(ValueError, match="references unknown workflow"):
+        service.start()

--- a/tests/test_workflow_automation.py
+++ b/tests/test_workflow_automation.py
@@ -1,0 +1,182 @@
+"""Tests for durable dataset-update workflow automation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from open_climate_service.automation.config import AutomationConfig, WorkflowTrigger
+from open_climate_service.automation.service import WorkflowAutomationService, _resolve_event_values
+from open_climate_service.jobs.models import JobEvent
+from open_climate_service.openeo.jobs import OpenEOJobService
+from open_climate_service.openeo.schemas import OpenEOJobCreate, OpenEOJobRecord, OpenEOJobStatus
+
+
+def _event(dataset_id: str = "chirps") -> JobEvent:
+    return JobEvent(
+        event_id="native-job:0",
+        time=datetime(2026, 8, 19, tzinfo=UTC),
+        type="dataset.updated",
+        source=f"/datasets/{dataset_id}",
+        data={
+            "dataset_id": dataset_id,
+            "artifact_id": "artifact-2",
+            "action": "append",
+            "previous_end": "2026-08-17",
+            "current_end": "2026-08-18",
+        },
+    )
+
+
+def _config() -> AutomationConfig:
+    return AutomationConfig(
+        workflow_triggers=[
+            WorkflowTrigger(
+                id="chap-after-chirps",
+                on_update_of="chirps",
+                workflow_id="aggregate_to_chap_csv",
+                arguments={
+                    "dataset_id": "$event.dataset_id",
+                    "temporal_extent": ["$event.previous_end", "$event.current_end"],
+                    "method": "mean",
+                },
+            )
+        ]
+    )
+
+
+def _openeo_record(status: OpenEOJobStatus = OpenEOJobStatus.CREATED) -> OpenEOJobRecord:
+    return OpenEOJobRecord(
+        id="triggered-job",
+        process={"process_graph": {}},
+        status=status,
+        created=datetime(2026, 8, 19, tzinfo=UTC),
+    )
+
+
+def test_trigger_ids_must_be_unique() -> None:
+    trigger = _config().workflow_triggers[0]
+    with pytest.raises(ValidationError, match="must be unique"):
+        AutomationConfig(workflow_triggers=[trigger, trigger])
+
+
+def test_event_references_are_resolved_recursively() -> None:
+    assert _resolve_event_values(
+        {"source": "$event.dataset_id", "range": ["$event.previous_end", "$event.current_end"]},
+        _event(),
+    ) == {"source": "chirps", "range": ["2026-08-17", "2026-08-18"]}
+
+
+def test_matching_update_submits_and_starts_workflow_once() -> None:
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(), True)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+
+    service.consume([_event()])
+
+    body = openeo.create_triggered_job.call_args.args[0]
+    node = body.process["process_graph"]["workflow"]
+    assert node == {
+        "process_id": "aggregate_to_chap_csv",
+        "arguments": {
+            "dataset_id": "chirps",
+            "temporal_extent": ["2026-08-17", "2026-08-18"],
+            "method": "mean",
+        },
+        "result": True,
+    }
+    assert openeo.create_triggered_job.call_args.kwargs == {
+        "source_event_id": "native-job:0",
+        "trigger_id": "chap-after-chirps",
+    }
+    openeo.start_triggered_job.assert_called_once_with("triggered-job")
+
+
+def test_nonmatching_and_non_update_events_are_ignored() -> None:
+    openeo = MagicMock()
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+    other = _event("era5")
+    unrelated = other.model_copy(update={"type": "dataset.created"})
+
+    service.consume([other, unrelated])
+
+    openeo.create_triggered_job.assert_not_called()
+
+
+def test_replay_starts_an_existing_created_job_after_interrupted_submission() -> None:
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(), False)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+
+    service.consume([_event()])
+
+    openeo.start_triggered_job.assert_called_once_with("triggered-job")
+
+
+def test_replay_delegates_atomic_claim_for_an_existing_queued_job() -> None:
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(OpenEOJobStatus.QUEUED), False)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+
+    service.consume([_event()])
+
+    openeo.start_triggered_job.assert_called_once_with("triggered-job")
+
+
+def test_triggered_job_creation_is_deterministic_and_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    records: list[dict[str, object]] = []
+
+    def mutate(mutation: Callable[[list[dict[str, object]]], Any]) -> Any:
+        return mutation(records)
+
+    monkeypatch.setattr("open_climate_service.openeo.jobs._mutate_store", mutate)
+    service = OpenEOJobService()
+    body = OpenEOJobCreate(process={"process_graph": {"result": {"process_id": "constant"}}})
+    try:
+        first, first_created = service.create_triggered_job(
+            body,
+            source_event_id="native-job:0",
+            trigger_id="chap-after-chirps",
+        )
+        second, second_created = service.create_triggered_job(
+            body,
+            source_event_id="native-job:0",
+            trigger_id="chap-after-chirps",
+        )
+    finally:
+        service.shutdown()
+
+    assert first.id == second.id
+    assert first_created is True
+    assert second_created is False
+    assert len(records) == 1
+
+
+def test_triggered_job_start_is_an_atomic_one_time_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    records: list[dict[str, object]] = []
+
+    def mutate(mutation: Callable[[list[dict[str, object]]], Any]) -> Any:
+        return mutation(records)
+
+    monkeypatch.setattr("open_climate_service.openeo.jobs._mutate_store", mutate)
+    service = OpenEOJobService()
+    enqueue = MagicMock()
+    monkeypatch.setattr(service, "_enqueue", enqueue)
+    body = OpenEOJobCreate(process={"process_graph": {"result": {"process_id": "constant"}}})
+    try:
+        job, _ = service.create_triggered_job(
+            body,
+            source_event_id="native-job:0",
+            trigger_id="chap-after-chirps",
+        )
+
+        assert service.start_triggered_job(job.id) is True
+        assert service.start_triggered_job(job.id) is False
+        enqueue.assert_called_once_with(job.id)
+    finally:
+        service.shutdown()

--- a/tests/test_workflow_automation.py
+++ b/tests/test_workflow_automation.py
@@ -180,3 +180,145 @@ def test_triggered_job_start_is_an_atomic_one_time_claim(monkeypatch: pytest.Mon
         enqueue.assert_called_once_with(job.id)
     finally:
         service.shutdown()
+
+
+def _record_with(event: JobEvent) -> MagicMock:
+    record = MagicMock()
+    record.events = [event]
+    return record
+
+
+def test_new_trigger_does_not_backfill_events_before_activation(monkeypatch: pytest.MonkeyPatch) -> None:
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(), True)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=openeo)
+
+    activation = datetime(2026, 8, 19, tzinfo=UTC)
+    old_event = _event().model_copy(update={"time": datetime(2026, 8, 18, tzinfo=UTC)})
+    monkeypatch.setattr(
+        "open_climate_service.automation.service.job_store.list_job_records", lambda: [_record_with(old_event)]
+    )
+    monkeypatch.setattr(
+        "open_climate_service.automation.service._load_activations",
+        lambda: {"chap-after-chirps": activation.isoformat()},
+    )
+    monkeypatch.setattr("open_climate_service.automation.service._save_activations", lambda _: None)
+
+    service.replay()
+
+    openeo.create_triggered_job.assert_not_called()
+
+
+def test_replay_existing_replays_events_before_activation(monkeypatch: pytest.MonkeyPatch) -> None:
+    openeo = MagicMock()
+    openeo.create_triggered_job.return_value = (_openeo_record(), True)
+    trigger = WorkflowTrigger(
+        id="chap-after-chirps",
+        on_update_of="chirps",
+        workflow_id="aggregate_to_chap_csv",
+        arguments={"dataset_id": "$event.dataset_id"},
+        replay_existing=True,
+    )
+    service = WorkflowAutomationService(
+        config_loader=lambda: AutomationConfig(workflow_triggers=[trigger]), openeo_service=openeo
+    )
+
+    activation = datetime(2026, 8, 19, tzinfo=UTC)
+    old_event = _event().model_copy(update={"time": datetime(2026, 8, 18, tzinfo=UTC)})
+    monkeypatch.setattr(
+        "open_climate_service.automation.service.job_store.list_job_records", lambda: [_record_with(old_event)]
+    )
+    monkeypatch.setattr(
+        "open_climate_service.automation.service._load_activations",
+        lambda: {"chap-after-chirps": activation.isoformat()},
+    )
+    monkeypatch.setattr("open_climate_service.automation.service._save_activations", lambda _: None)
+
+    service.replay()
+
+    openeo.create_triggered_job.assert_called_once()
+
+
+def test_start_records_activation_for_new_triggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved: dict[str, str] = {}
+    monkeypatch.setattr(
+        "open_climate_service.automation.service.workflows.get_workflow",
+        lambda _: {"id": "aggregate_to_chap_csv"},
+    )
+    monkeypatch.setattr("open_climate_service.automation.service._load_activations", lambda: {})
+    monkeypatch.setattr("open_climate_service.automation.service._save_activations", saved.update)
+    service = WorkflowAutomationService(config_loader=_config, openeo_service=MagicMock())
+
+    service.start()
+
+    assert "chap-after-chirps" in saved
+
+
+def _workflow(*parameter_names: str) -> MagicMock:
+    workflow = MagicMock()
+    workflow.parameters = [{"name": name} for name in parameter_names]
+    return workflow
+
+
+def _service_for_output_check(
+    monkeypatch: pytest.MonkeyPatch, workflow: MagicMock, *triggers: WorkflowTrigger
+) -> WorkflowAutomationService:
+    monkeypatch.setattr("open_climate_service.automation.service.workflows.get_workflow", lambda _: workflow)
+    monkeypatch.setattr("open_climate_service.automation.service._load_activations", lambda: {})
+    monkeypatch.setattr("open_climate_service.automation.service._save_activations", lambda _: None)
+    return WorkflowAutomationService(
+        config_loader=lambda: AutomationConfig(workflow_triggers=list(triggers)), openeo_service=MagicMock()
+    )
+
+
+def test_duplicate_managed_output_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = _workflow("dataset_id", "output_dataset_id")
+    service = _service_for_output_check(
+        monkeypatch,
+        workflow,
+        WorkflowTrigger(id="a", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "out"}),
+        WorkflowTrigger(id="b", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "out"}),
+    )
+
+    with pytest.raises(ValueError, match="same managed output"):
+        service.start()
+
+
+def test_distinct_managed_outputs_are_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = _workflow("dataset_id", "output_dataset_id")
+    service = _service_for_output_check(
+        monkeypatch,
+        workflow,
+        WorkflowTrigger(id="a", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "out-a"}),
+        WorkflowTrigger(id="b", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "out-b"}),
+    )
+
+    service.start()  # must not raise
+
+
+def test_file_producing_workflow_is_not_checked(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = _workflow("dataset_id")  # no output_dataset_id -> file-producing
+    service = _service_for_output_check(
+        monkeypatch,
+        workflow,
+        WorkflowTrigger(id="a", on_update_of="chirps", workflow_id="wf", arguments={"dataset_id": "$event.dataset_id"}),
+        WorkflowTrigger(id="b", on_update_of="chirps", workflow_id="wf", arguments={"dataset_id": "$event.dataset_id"}),
+    )
+
+    service.start()  # must not raise
+
+
+def test_unresolvable_output_reference_is_not_checked(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = _workflow("dataset_id", "output_dataset_id")
+    service = _service_for_output_check(
+        monkeypatch,
+        workflow,
+        WorkflowTrigger(
+            id="a", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "$event.dataset_id"}
+        ),
+        WorkflowTrigger(
+            id="b", on_update_of="chirps", workflow_id="wf", arguments={"output_dataset_id": "$event.dataset_id"}
+        ),
+    )
+
+    service.start()  # must not raise; a runtime $event reference is left to the store lock


### PR DESCRIPTION
**Implements Phase 3: event-driven openEO workflow trigger.** 

When a successful sync appends or rematerializes a dataset, OCS submits each matching
configured workflow as an independent openEO job.

## How it works

A native sync job persists a `dataset.updated` event (Phase 2). The automation
service consumes that event and, for each trigger whose `on_update_of` matches,
submits the bound workflow through the openEO job service:

```yaml
automation:
  workflow_triggers:
    - id: chirps-to-chap
      on_update_of: chirps3_precipitation_daily
      workflow_id: aggregate_to_chap_csv
      arguments:
        dataset_id: $event.dataset_id
        temporal_extent: [$event.previous_end, $event.current_end]
        method: mean
        period_type: day
```

## Behaviour

- **Fan-out** — each matching trigger creates one independent job; YAML order is
  not execution order; no workflow-to-workflow dependencies.
- **Idempotent replay** — deterministic `(event ID, trigger ID)` job IDs plus an
  atomic create/claim, so restart replay never duplicates a job.
- **No accidental backfill** — `replay_existing: false` by default with a
  persisted per-trigger activation time; opt in per trigger to replay history.
- **Output ownership** — startup refuses two triggers on one source that resolve
  to the same literal `output_dataset_id`; the per-store lock remains the final
  write-safety boundary.
- **Shared contract** — one `dataset.updated` event-type constant between emitter
  and consumer.

## Deliberately out of scope

- No concurrency setting: triggered jobs share the existing openEO pool;
  backpressure is deferred to CLIM-845.
- No workflow dependency graph, no automatic CLIM-840 export, no forecast
  refresh (Phase 4).