### PR TITLE
fix(era5): collapse the expver dimension on CDS downloads

### DIFF
--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -82,7 +82,7 @@ class ERA5LandCDSHourlyPlugin(BaseDatasetPlugin):
             monthly_ds = self._cached_ds
         assert monthly_ds is not None
         timestamp = np.datetime64(dt.replace(tzinfo=None), "h").astype("datetime64[ns]")
-        return monthly_ds.sel(t=timestamp)
+        return _drop_auxiliary_variables(monthly_ds.sel(t=timestamp), self.variable)
 
     def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
         xmin, ymin, xmax, ymax = bbox
@@ -106,7 +106,7 @@ class ERA5LandCDSHourlyPlugin(BaseDatasetPlugin):
             remote = _CdsClient().submit("reanalysis-era5-land", params)
             remote.download(str(target))
             ds = xr.open_dataset(target, engine="netcdf4").load()
-        ds = ds[[self.variable]]
+        ds = _collapse_expver(ds[[self.variable]])
         time_dim = "valid_time" if "valid_time" in ds.dims else "time"
         ds = ds.rename({"longitude": "x", "latitude": "y", time_dim: "t"})
         if self.variable == "t2m":
@@ -162,7 +162,7 @@ class ERA5LandDailyTemperaturePlugin(BaseDatasetPlugin):
 
         assert monthly_ds is not None
         timestamp = np.datetime64(period_id, "D").astype("datetime64[ns]")
-        return monthly_ds.sel(t=slice(timestamp, timestamp))
+        return _drop_auxiliary_variables(monthly_ds.sel(t=slice(timestamp, timestamp)), "t2m")
 
     def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
         xmin, ymin, xmax, ymax = bbox
@@ -188,7 +188,7 @@ class ERA5LandDailyTemperaturePlugin(BaseDatasetPlugin):
             remote.download(str(target))
             ds = xr.open_dataset(target, engine="netcdf4").load()
 
-        ds = ds[["t2m"]]
+        ds = _collapse_expver(ds[["t2m"]])
         time_dim = "valid_time" if "valid_time" in ds.dims else "time"
         ds = ds.rename({"longitude": "x", "latitude": "y", time_dim: "t"})
         return kelvin_to_celsius(ds, {"variable": "t2m"})
@@ -237,14 +237,14 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
             remote.download(str(target))
             ds = xr.open_dataset(target, engine="netcdf4").load()
 
-        ds = ds[[self.variable]]
+        ds = _collapse_expver(ds[[self.variable]])
         time_dim = "valid_time" if "valid_time" in ds.dims else "time"
         rename_map = {"longitude": "x", "latitude": "y", time_dim: "t"}
         ds = ds.rename({k: v for k, v in rename_map.items() if k in ds})
 
         if self.variable == "t2m":
             ds = kelvin_to_celsius(ds, {"variable": self.variable})
-        return ds
+        return _drop_auxiliary_variables(ds, self.variable)
 
 
 class ERA5LandMonthlyPrecipitationPlugin(ERA5LandMonthlyPlugin):
@@ -448,6 +448,38 @@ _GRID_MAPPING_NAMES = ("spatial_ref", "crs")
 """Scalar coordinates that carry the CRS rather than data, so they must survive the cleanup."""
 
 
+_EXPVER_DIM = "expver"
+
+
+def _collapse_expver(ds: xr.Dataset) -> xr.Dataset:
+    """Merge ERA5's ``expver`` dimension into one series, preferring final over preliminary.
+
+    A CDS request spanning the boundary between final ERA5 (``expver=1``) and preliminary
+    ERA5T (``expver=5``) returns both along an ``expver`` dimension, each slice NaN wherever
+    the other supplies data. Left in place it doubles the array along a dimension the rest of
+    OCS does not model: aggregation then failed with ``boolean index did not match indexed
+    array`` on a mask half the size of the data (CLIM-923).
+
+    ``_drop_auxiliary_variables`` does not remove it — that keeps every dimension by design and
+    only strips scalar coordinates that became phantom variables. Both guards are needed.
+
+    Collapsed at the download boundary rather than on the way out, because a reduction applied
+    first corrupts the result: ``sum("t")`` over the all-NaN slice yields 0.0 rather than
+    propagating the gap.
+
+    Ascending ``expver`` order gives final data precedence without hard-coding 5 as the
+    preliminary value.
+    """
+    if _EXPVER_DIM not in ds.dims:
+        # Also covers the scalar case, where it is a coordinate rather than a dimension.
+        return ds.drop_vars(_EXPVER_DIM, errors="ignore")
+    versions = sorted(ds[_EXPVER_DIM].values.tolist())
+    merged = ds.sel({_EXPVER_DIM: versions[0]}, drop=True)
+    for version in versions[1:]:
+        merged = merged.combine_first(ds.sel({_EXPVER_DIM: version}, drop=True))
+    return merged.astype({name: ds[name].dtype for name in ds.data_vars})
+
+
 def _drop_auxiliary_variables(ds: xr.Dataset, variable: str) -> xr.Dataset:
     """Keep ``variable``, the dimension coordinates and the CRS, dropping everything else.
 
@@ -630,8 +662,10 @@ class ERA5LandPrecipDailyPlugin(ERA5LandEDHPrecipitationDailyPlugin):
     def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
         edh_latest = self._latest_available()
         if period_id <= edh_latest[:10]:
-            return self._fetch_daily_sync(period_id, bbox)
-        return self._fetch_cds_daily_sync(period_id, bbox)
+            # Delegate rather than repeat the parent's cleaning, so a future override of this
+            # method cannot silently shed it the way this one did (CLIM-923).
+            return super().fetch_period(period_id, bbox)
+        return _drop_auxiliary_variables(self._fetch_cds_daily_sync(period_id, bbox), self.variable)
 
     def _fetch_cds_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
         from open_climate_service import config as api_config
@@ -699,8 +733,10 @@ class ERA5LandTempDailyFromHourlyPlugin(_ERA5LandEDHBase):
     def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
         edh_latest = self._latest_available()
         if period_id <= edh_latest[:10]:
-            return self._fetch_daily_sync(period_id, bbox)
-        return self._fetch_cds_daily_sync(period_id, bbox)
+            cube = self._fetch_daily_sync(period_id, bbox)
+        else:
+            cube = self._fetch_cds_daily_sync(period_id, bbox)
+        return _drop_auxiliary_variables(cube, self.variable)
 
     def _fetch_daily_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
         from open_climate_service import config as api_config
@@ -833,7 +869,8 @@ class ERA5LandNormalsPlugin(BaseDatasetPlugin):
 
     def _fetch_sync(self, period_id: str, bbox: list[float]) -> xr.Dataset:
         clim = self._ensure_climatology(bbox)
-        return clim.sel({_NORMALS_DAYOFYEAR_DIM: [int(period_id)]})
+        selected = clim.sel({_NORMALS_DAYOFYEAR_DIM: [int(period_id)]})
+        return _drop_auxiliary_variables(selected, self.variable)
 
     def _ensure_climatology(self, bbox: list[float]) -> xr.Dataset:
         with self._lock:

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -82,7 +82,7 @@ class ERA5LandCDSHourlyPlugin(BaseDatasetPlugin):
             monthly_ds = self._cached_ds
         assert monthly_ds is not None
         timestamp = np.datetime64(dt.replace(tzinfo=None), "h").astype("datetime64[ns]")
-        return _drop_auxiliary_variables(monthly_ds.sel(t=timestamp), self.variable)
+        return monthly_ds.sel(t=timestamp)
 
     def _fetch_month(self, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
         xmin, ymin, xmax, ymax = bbox
@@ -111,7 +111,9 @@ class ERA5LandCDSHourlyPlugin(BaseDatasetPlugin):
         ds = ds.rename({"longitude": "x", "latitude": "y", time_dim: "t"})
         if self.variable == "t2m":
             ds = kelvin_to_celsius(ds, {"variable": self.variable})
-        return ds
+        # Cleaned on the cached monthly cube, while `t` is still a dimension. Doing it after
+        # `fetch_period`'s scalar `sel(t=...)` would take the demoted `t` coordinate with it.
+        return _drop_auxiliary_variables(ds, self.variable)
 
 
 class ERA5LandPrecipitationPlugin(ERA5LandCDSHourlyPlugin):

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -528,3 +528,33 @@ def test_precip_daily_edh_branch_delegates_so_the_parent_cleaning_applies(
 
     assert "number" not in ds.variables
     assert list(ds.data_vars) == ["tp"]
+
+
+def test_hourly_fetch_keeps_its_time_coordinate_after_cleaning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hourly plugin selects a scalar timestamp, which demotes `t` to a coordinate.
+
+    Cleaning after that selection would drop `t` along with the auxiliary coordinates, since
+    it is no longer a dimension — losing the period's own timestamp. The cleaning therefore
+    runs on the cached monthly cube instead.
+    """
+    plugin = ERA5LandCDSHourlyPlugin(variable="t2m")
+
+    def fake_fetch_month(self: object, year: int, month: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        from open_climate_service.plugins.datasets.era5_land import _drop_auxiliary_variables
+
+        ds = xr.Dataset(
+            {"t2m": (("t", "y", "x"), np.array([[[20.0]]], dtype=np.float32))},
+            coords={
+                "t": np.array(["2026-01-01T00"], dtype="datetime64[h]").astype("datetime64[ns]"),
+                "y": [9.0],
+                "x": [30.0],
+                "number": 0,
+            },
+        )
+        return _drop_auxiliary_variables(ds, "t2m")
+
+    monkeypatch.setattr(ERA5LandCDSHourlyPlugin, "_fetch_month", fake_fetch_month)
+    ds = plugin.fetch_period("2026-01-01T00", [-1.0, 8.0, 31.0, 10.0])
+
+    assert "t" in ds.coords
+    assert "number" not in ds.variables

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -12,7 +12,9 @@ from open_climate_service.plugins.datasets.era5_land import (
     ERA5LandEDHDailyPlugin,
     ERA5LandMonthlyPlugin,
     ERA5LandMonthlyPrecipitationPlugin,
+    ERA5LandPrecipDailyPlugin,
     ERA5LandPrecipitationPlugin,
+    _collapse_expver,
     _daily_availability_cutoff,
     _edh_open_zarr,
     _era5land_monthly_product_type,
@@ -417,3 +419,112 @@ def test_auxiliary_cleanup_honours_a_declared_grid_mapping() -> None:
     out = _drop_auxiliary_variables(ds, "t2m")
 
     assert "my_crs" in out.variables
+
+
+def _expver_nc(variable: str) -> xr.Dataset:
+    """A CDS download straddling the ERA5/ERA5T boundary.
+
+    Each ``expver`` slice is NaN where the other supplies data, which is how CDS returns a
+    request spanning the boundary: 1 is final, 5 is preliminary ERA5T.
+    """
+    final = np.array([[[1.0]], [[np.nan]]], dtype=np.float32)
+    preliminary = np.array([[[np.nan]], [[5.0]]], dtype=np.float32)
+    return xr.Dataset(
+        {variable: (("valid_time", "expver", "latitude", "longitude"), np.stack([final, preliminary], axis=1))},
+        coords={
+            "valid_time": np.array(["2026-05-01", "2026-06-01"], dtype="datetime64[ns]"),
+            "expver": [1, 5],
+            "latitude": [9.0],
+            "longitude": [30.0],
+        },
+    )
+
+
+def test_collapse_expver_prefers_final_and_fills_from_preliminary() -> None:
+    """Final ERA5 wins where it has data; ERA5T fills the recent months it does not cover."""
+    collapsed = _collapse_expver(_expver_nc("t2m"))
+
+    assert "expver" not in collapsed.dims
+    assert "expver" not in collapsed.coords
+    np.testing.assert_allclose(collapsed["t2m"].values.ravel(), [1.0, 5.0])
+    assert collapsed["t2m"].dtype == np.float32
+
+
+def test_collapse_expver_passes_through_a_cube_without_expver() -> None:
+    plain = _expver_nc("t2m").sel(expver=1, drop=True)
+
+    assert _collapse_expver(plain).identical(plain)
+
+
+def test_collapse_expver_drops_a_scalar_expver_coordinate() -> None:
+    """A single-version download carries expver as a coordinate, not a dimension."""
+    scalar = _expver_nc("t2m").sel(expver=5)
+    assert "expver" in scalar.coords
+
+    assert "expver" not in _collapse_expver(scalar).coords
+
+
+def test_monthly_fetch_collapses_expver_so_the_cube_stays_three_dimensional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A synced month straddling the ERA5T boundary must not double the array (CLIM-923).
+
+    Left in place, the extra dimension reached the store and broke aggregation with a mask
+    half the size of the data. ``_drop_auxiliary_variables`` does not catch it: that keeps
+    every dimension by design.
+    """
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    raw_ds = _expver_nc("t2m")
+    raw_ds["t2m"] = raw_ds["t2m"] + 273.15  # kelvin, as CDS delivers it
+
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", lambda: MagicMock())
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", lambda *a, **k: raw_ds)
+    ds = plugin.fetch_period("2026-06", [-1.0, 8.0, 31.0, 10.0])
+
+    assert set(ds.dims) == {"t", "y", "x"}
+    assert list(ds.data_vars) == ["t2m"]
+    np.testing.assert_allclose(ds["t2m"].values.ravel(), [1.0, 5.0], atol=1e-3)
+
+
+def test_monthly_fetch_drops_auxiliary_coordinates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``number`` is a scalar ensemble coordinate that otherwise persists as a phantom band."""
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+    raw_ds = xr.Dataset(
+        {"t2m": (("valid_time", "latitude", "longitude"), np.array([[[300.0]]], dtype=np.float32))},
+        coords={
+            "valid_time": np.array(["2026-06-01"], dtype="datetime64[ns]"),
+            "latitude": [9.0],
+            "longitude": [30.0],
+            "number": 0,
+        },
+    )
+
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", lambda: MagicMock())
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", lambda *a, **k: raw_ds)
+    ds = plugin.fetch_period("2026-06", [-1.0, 8.0, 31.0, 10.0])
+
+    assert "number" not in ds.coords
+    assert "number" not in ds.variables
+
+
+def test_precip_daily_edh_branch_delegates_so_the_parent_cleaning_applies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The override used to skip its parent's cleaning entirely (CLIM-923)."""
+    plugin = ERA5LandPrecipDailyPlugin()
+    dirty = xr.Dataset(
+        {"tp": (("t", "y", "x"), np.array([[[2.0]]], dtype=np.float32))},
+        coords={
+            "t": np.array(["2026-06-01"], dtype="datetime64[ns]"),
+            "y": [9.0],
+            "x": [30.0],
+            "number": 0,
+        },
+    )
+
+    monkeypatch.setattr(type(plugin), "_latest_available", lambda self: "2026-12-31")
+    monkeypatch.setattr(type(plugin), "_fetch_daily_sync", lambda self, period_id, bbox: dirty)
+    ds = plugin.fetch_period("2026-06-01", [-1.0, 8.0, 31.0, 10.0])
+
+    assert "number" not in ds.variables
+    assert list(ds.data_vars) == ["tp"]


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/CLIM-923

Reported from the South Sudan setup: after syncing monthly ERA5-Land to add new months, `aggregate_to_dhis2_json` failed with `boolean index did not match indexed array along axis 0; size of axis is 12728 but size of corresponding boolean axis is 6364`. 12728 is exactly 2 × 6364, the org-unit mask size — an extra dimension of length 2 on the variable.

**Cause.** A CDS request spanning the ERA5/ERA5T boundary returns final (`expver=1`) and preliminary (`expver=5`) data along an `expver` dimension, each slice NaN where the other supplies values. Syncing reaches exactly that window, so the dimension landed in the store.

`_drop_auxiliary_variables` does not catch this — it keeps every dimension by design and only strips scalar coordinates that became phantom variables. So the two guards are complementary, and this needed a new one.

**Change.** `_collapse_expver` merges the versions in ascending order, so final data takes precedence and ERA5T fills only what final does not cover, without hard-coding 5. Applied at the three CDS download boundaries rather than on the way out, because a reduction applied first corrupts the result: `sum("t")` over the all-NaN slice yields 0.0 instead of propagating the gap.

Also applies the existing aux-coord guard on the fetch paths that lacked it, and makes `ERA5LandPrecipDailyPlugin` delegate to `super().fetch_period` so an override cannot shed the parent's cleaning again — the defect @abyot spotted on #305.

**Tests.** Final-over-preliminary merge with dtype preserved, untouched passthrough, scalar-coord drop, and two plugin-boundary regressions (the monthly cube stays `(t, y, x)`; the precip-daily EDH branch inherits the parent's cleaning).

**Out of scope.** Stores already carrying the dimension need re-ingesting — the fix is forward-only. `aggregate_spatial` deliberately still flattens extra dimensions, since `worldpop_agesex_*` carries `age_group` legitimately; guarding the DHIS2 export against an ambiguous cube belongs with CLIM-840. The preliminary-data half — ERA5T months being committed as final and never refreshed — is CLIM-931.