### PR TITLE
fix(ingestions): preserve existing store until overwrite succeeds

### DIFF
--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -346,6 +346,7 @@ def _create_streaming_artifact(
             status_code=409,
             detail=f"An ingest or sync is already running for dataset '{dataset['id']}'. Wait for it to finish.",
         )
+    replacement_path: Path | None = None
     try:
         # First thing under the lock, before anything looks at the store. A swap killed between
         # its two renames leaves the published path missing and the data at `.retired`; ingest
@@ -354,11 +355,14 @@ def _create_streaming_artifact(
         # `.retired`. Healing before any inspection makes the next sync an ordinary append.
         recover_interrupted_swap(store_path)
 
+        ingest_path = store_path
         if overwrite and store_path.exists():
-            if store_path.is_dir():
-                shutil.rmtree(store_path)
-            else:
-                store_path.unlink()
+            # Build overwrite data beside the published store. Fetching is the least reliable
+            # part of ingestion, so the current data must remain readable until the replacement
+            # has been fetched, validated, and normalized successfully.
+            replacement_path = store_path.with_name(f"{store_path.name}.replacement")
+            _remove_store_path(replacement_path)
+            ingest_path = replacement_path
 
         result = run_streaming_ingest_sync(
             plugin=plugin,
@@ -367,17 +371,17 @@ def _create_streaming_artifact(
             bbox=bbox,
             start=start,
             end=end,
-            store_path=store_path,
+            store_path=ingest_path,
             period_type=str(dataset["period_type"]),
             on_progress=on_progress,
             is_cancel_requested=is_cancel_requested,
             save_cursor=save_cursor,
             periods=periods,
         )
-        if result.periods_written == 0 and not store_path.exists():
+        if result.periods_written == 0 and not ingest_path.exists():
             raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
 
-        coverage_data = get_data_coverage_for_paths(dataset, icechunk_path=str(store_path.resolve()))
+        coverage_data = get_data_coverage_for_paths(dataset, icechunk_path=str(ingest_path.resolve()))
         if not coverage_data.get("has_data", True):
             raise HTTPException(
                 status_code=409,
@@ -406,7 +410,9 @@ def _create_streaming_artifact(
                 )
             request_scope = request_scope.model_copy(update={"end": coverage.temporal.end})
 
-        _maybe_build_pyramid(store_path, dataset)
+        _maybe_build_pyramid(ingest_path, dataset)
+        if replacement_path is not None:
+            _swap_store(replacement_path, store_path)
 
         record = ArtifactRecord(
             artifact_id=str(uuid4()),
@@ -432,11 +438,23 @@ def _create_streaming_artifact(
             return publish_artifact_record(stored_record.artifact_id)
         return stored_record
     finally:
+        if replacement_path is not None:
+            # Failed fetches and validations leave only a disposable partial replacement. A
+            # successful swap has already moved this path away, making cleanup a no-op.
+            _remove_store_path(replacement_path)
         lock.release()
 
 
 def _retired_path(target: Path) -> Path:
     return target.with_name(f"{target.name}.retired")
+
+
+def _remove_store_path(path: Path) -> None:
+    """Remove a disposable store path whether it is a directory, file, or symlink."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        shutil.rmtree(path)
 
 
 def recover_interrupted_swap(target: Path) -> bool:

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -438,11 +438,19 @@ def _create_streaming_artifact(
             return publish_artifact_record(stored_record.artifact_id)
         return stored_record
     finally:
-        if replacement_path is not None:
-            # Failed fetches and validations leave only a disposable partial replacement. A
-            # successful swap has already moved this path away, making cleanup a no-op.
-            _remove_store_path(replacement_path)
-        lock.release()
+        try:
+            if replacement_path is not None:
+                # Failed fetches and validations leave only a disposable partial replacement. A
+                # successful swap has already moved this path away, making cleanup a no-op.
+                try:
+                    _remove_store_path(replacement_path)
+                except Exception:
+                    # Cleanup is best-effort: the published store is still intact and the next
+                    # overwrite removes this path before reuse. Do not mask the ingest failure.
+                    logger.warning("Could not remove replacement store '%s'", replacement_path, exc_info=True)
+        finally:
+            # Releasing the in-process writer lock must not depend on filesystem cleanup.
+            lock.release()
 
 
 def _retired_path(target: Path) -> Path:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -930,6 +930,67 @@ def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(
     assert not store_path.with_name(f"{store_path.name}.retired").exists()
 
 
+def test_create_artifact_overwrite_releases_lock_when_replacement_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {
+            "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
+        },
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+
+    class TrackingLock:
+        released = False
+
+        def acquire(self, *, blocking: bool) -> bool:
+            assert blocking is False
+            return True
+
+        def release(self) -> None:
+            self.released = True
+
+    lock = TrackingLock()
+    cleanup_calls = 0
+
+    def fail_final_cleanup(path: Path) -> None:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if cleanup_calls == 2:
+            raise PermissionError(f"cannot remove {path}")
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
+    monkeypatch.setattr(services, "_acquire_store_lock", lambda _: lock)
+    monkeypatch.setattr(services, "_remove_store_path", fail_final_cleanup)
+    monkeypatch.setattr(
+        services,
+        "run_streaming_ingest_sync",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("upstream fetch failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream fetch failed"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-03",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=True,
+            publish=False,
+        )
+
+    assert cleanup_calls == 2
+    assert lock.released is True
+
+
 def test_create_artifact_overwrite_keeps_existing_store_when_replacement_is_invalid(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -814,7 +814,76 @@ def test_create_artifact_returns_409_when_streaming_plugin_has_no_periods(
         )
 
 
-def test_create_artifact_overwrite_resets_existing_icechunk_store(
+def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {
+            "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
+        },
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    replacement_path = store_path.with_name(f"{store_path.name}.replacement")
+    store_path.mkdir()
+    (store_path / "stale").write_text("old", encoding="utf-8")
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
+    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
+
+    def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
+        replacement = kwargs["store_path"]
+        assert isinstance(replacement, Path)
+        assert replacement == replacement_path
+        assert (store_path / "stale").read_text(encoding="utf-8") == "old"
+        replacement.mkdir()
+        (replacement / "fresh").write_text("new", encoding="utf-8")
+        return type("Result", (), {"periods_written": 1})()
+
+    def fake_coverage(*args: object, **kwargs: object) -> dict[str, object]:
+        assert kwargs["icechunk_path"] == str(replacement_path.resolve())
+        assert (store_path / "stale").read_text(encoding="utf-8") == "old"
+        return {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        }
+
+    def fake_build_pyramid(path: Path, dataset: dict[str, object]) -> None:
+        assert path == replacement_path
+        assert (store_path / "stale").read_text(encoding="utf-8") == "old"
+        (path / "normalized").write_text("complete", encoding="utf-8")
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
+    monkeypatch.setattr(services, "get_data_coverage_for_paths", fake_coverage)
+    monkeypatch.setattr(services, "_maybe_build_pyramid", fake_build_pyramid)
+
+    artifact = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-03",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=True,
+        publish=False,
+    )
+
+    assert artifact.path == str(store_path.resolve())
+    assert not (store_path / "stale").exists()
+    assert (store_path / "fresh").read_text(encoding="utf-8") == "new"
+    assert (store_path / "normalized").read_text(encoding="utf-8") == "complete"
+    assert not replacement_path.exists()
+    assert not store_path.with_name(f"{store_path.name}.retired").exists()
+
+
+def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -829,41 +898,87 @@ def test_create_artifact_overwrite_resets_existing_icechunk_store(
     }
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
-    (store_path / "stale").write_text("old", encoding="utf-8")
+    (store_path / "committed").write_text("old", encoding="utf-8")
 
     monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
-    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
-    def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
-        assert not store_path.exists()
-        store_path.mkdir()
+    def failing_ingest(**kwargs: object) -> object:
+        replacement = kwargs["store_path"]
+        assert isinstance(replacement, Path)
+        assert (store_path / "committed").read_text(encoding="utf-8") == "old"
+        replacement.mkdir()
+        (replacement / "partial").write_text("incomplete", encoding="utf-8")
+        raise RuntimeError("upstream fetch failed")
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", failing_ingest)
+
+    with pytest.raises(RuntimeError, match="upstream fetch failed"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-03",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=True,
+            publish=False,
+        )
+
+    assert (store_path / "committed").read_text(encoding="utf-8") == "old"
+    assert not store_path.with_name(f"{store_path.name}.replacement").exists()
+    assert not store_path.with_name(f"{store_path.name}.retired").exists()
+
+
+def test_create_artifact_overwrite_keeps_existing_store_when_replacement_is_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {
+            "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
+        },
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    replacement_path = store_path.with_name(f"{store_path.name}.replacement")
+    store_path.mkdir()
+    (store_path / "committed").write_text("old", encoding="utf-8")
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
+
+    def incomplete_ingest(**kwargs: object) -> object:
+        replacement = kwargs["store_path"]
+        assert replacement == replacement_path
+        replacement_path.mkdir()
         return type("Result", (), {"periods_written": 1})()
 
-    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", incomplete_ingest)
     monkeypatch.setattr(
         services,
         "get_data_coverage_for_paths",
-        lambda *args, **kwargs: {
-            "coverage": {
-                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
-                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
-            }
-        },
+        lambda *args, **kwargs: {"has_data": False},
     )
 
-    artifact = services.create_artifact(
-        dataset=dataset,
-        start="2026-01-01",
-        end="2026-01-03",
-        bbox=[1.0, 2.0, 3.0, 4.0],
-        country_code=None,
-        overwrite=True,
-        publish=False,
-    )
+    with pytest.raises(services.HTTPException, match="Materialized artifact contains no data"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-03",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=True,
+            publish=False,
+        )
 
-    assert artifact.path == str(store_path.resolve())
+    assert (store_path / "committed").read_text(encoding="utf-8") == "old"
+    assert not replacement_path.exists()
+    assert not store_path.with_name(f"{store_path.name}.retired").exists()
 
 
 def test_create_artifact_rejects_missing_plugin_definition() -> None:


### PR DESCRIPTION
## Problem

`overwrite=True` deleted the existing Icechunk store before fetching replacement data. An upstream fetch or validation failure could therefore destroy a valid published dataset.

## Fix

- Build overwrite data in a sibling `.replacement` store.
- Validate and normalize the replacement before publication.
- Swap it into the published path only after successful completion.
- Remove partial replacements on failure while preserving the existing store.
- Reuse the existing recoverable store-swap mechanism.