### PR TITLE
fix(ingestion): materialize contiguous temporal unions

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -228,7 +228,7 @@ async def periods(self, start: str, end: str) -> list[str]:
 
 Note `end` stays a plain `str`, so there is no missing-value case to handle.
 
-**Honour `end` when it is given.** If your plugin returns periods outside the requested scope, the ingestion is refused with `Materialized artifact coverage does not match the requested scope`. That guard is helpful — it catches a plugin that ignores the range rather than silently storing more than was asked for — but it means a lead-day plugin has to filter rather than ignore.
+**Honour `end` when it is given.** If your plugin returns periods outside the requested temporal union, ingestion is refused before mutation. That guard catches a plugin that ignores the range rather than silently storing more than was asked for, so a lead-day plugin has to filter rather than ignore.
 
 `temporal_direction` is separate from `sync.kind` on purpose: a forecast is still `temporal` for sync (re-run it and you get fresher data); what differs is which way its periods run. It cannot be combined with `sync.kind: static`, which has no upstream to look ahead into.
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -47,12 +47,33 @@ class ENACTSRainfallPlugin(BaseDatasetPlugin):
 strings) the source has available between `start` and `end`. The framework uses it to
 determine which periods are missing and need to be fetched.
 
+Ingestion requires a unique, ascending sequence with no missing calendar periods
+between the first and last period. Here `period_type: daily` means consecutive
+days, not just date-formatted acquisition identifiers. Sparse event or satellite
+acquisitions are not supported by this contract; they need an explicit sparse-period
+policy before they can use this ingestion path. `Cadence.IRREGULAR` describes
+variable-length calendar periods such as dekads, which still have a defined next
+period, and does not exempt a dataset from continuity checks. Explicit timestamp
+values in STAC describe stored coordinates; they do not change ingestion policy.
+
+For a contiguous existing store, a forward extension queries only the missing
+delta, beginning at the next period after committed coverage. The source need not
+retain older periods already stored by OCS. Requests wholly within committed
+coverage do not query the source. Extending backwards or repairing an existing gap
+requires the source to reproduce the complete union, including committed history.
+
 **`fetch_period`** — fetches exactly one period and returns it as an `xarray.Dataset`
 normalized to `(t, y, x)`. Write it as a regular (blocking) method and the framework runs
 it in a worker thread, so ordinary blocking I/O is fine; the framework appends the result
 directly to the Icechunk-backed Zarr store, so the function should not write to disk. For
 a natively-async source (e.g. lazy Zarr access), declare it `async def fetch_period(...)`
 instead — the orchestrator awaits it directly.
+
+**Event-loop lifetime** — planning may call `periods()` on a different event loop
+from asynchronous `fetch_period()` calls. Do not retain loop-bound resources such
+as async HTTP sessions, tasks, or locks from `periods()` for reuse during fetching.
+Create and close them within the call that uses them; ordinary configuration and
+in-memory metadata may be shared on the plugin instance.
 
 The framework **closes the dataset you return** after writing it (releasing the
 `open_rasterio` / `open_dataset` handles), so return a self-contained dataset — not a lazy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,4 +269,4 @@ Ingest and sync enumerate the complete source-valid union before writing. A forw
 
 ### The append execution mode avoids re-downloading history
 
-`append` downloads only the missing range and rebuilds the full zarr from all cached files. This means the local cache (NetCDF files in `data/downloads/`) is the source of truth for the full time series; the zarr is a derived view. If the cache is deleted, a rematerialize is required to recover.
+`append` writes only the source-available periods missing from the committed Icechunk store. The committed store is authoritative for existing history, while a temporary Icechunk branch preserves the pre-ingest snapshot until normalization and artifact registration succeed. Earlier requests, gaps, and release-style updates instead build a complete sibling replacement.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,13 +221,13 @@ Every zarr artifact must have GeoZarr root attributes for map rendering to work 
 
 ## Artifact deduplication and version history
 
-When a new ingestion request arrives, the framework checks whether an existing artifact already covers the requested scope:
+When a new ingestion request arrives, the framework plans against the periods already committed in the managed store:
 
 - same `dataset_id`
 - same bbox (from the configured extent)
-- overlapping time range
+- the contiguous union of committed and requested source-valid periods
 
-If a match exists and `overwrite=false`, the existing artifact is returned without re-downloading. If `overwrite=true`, the existing artifact is replaced.
+If the union extends forward, only missing periods are appended. A non-adjacent request also fetches the intervening source-valid periods. If the union starts before existing coverage, or the committed coordinate is gapped or out of order, the framework rematerializes the union in a sibling store and publishes it only after successful validation and normalization. `request_scope` records what the caller asked for; artifact `coverage` records the cumulative realized store.
 
 The artifact store keeps the full history of records for sync deduplication and provenance. Old artifacts are not deleted automatically. For long-running instances, `records.json` grows over time. The long-term direction is a proper transactional store, but for the current scale (tens of artifacts per instance) a JSON file is adequate.
 
@@ -265,7 +265,7 @@ Each instance is configured for one place. This keeps the data model simple (no 
 
 ### Temporal gaps are not allowed
 
-The sync engine validates that new data connects to the end of the existing artifact before appending. If a gap exists, the sync fails rather than silently producing a dataset with a hole. This is a deliberate constraint: downstream consumers (DHIS2, CHAP) depend on continuous time series and should not receive data with silent gaps.
+Ingest and sync enumerate the complete source-valid union before writing. A forward request fills any intervening periods, while an earlier or already-gapped shape is rematerialized in ascending order. This is a deliberate constraint: downstream consumers (DHIS2, CHAP) depend on continuous, monotonic time series and should not receive data with silent gaps.
 
 ### The append execution mode avoids re-downloading history
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -198,8 +198,8 @@ Implemented sync behavior:
 - plugin `periods()` clamps target end to actually available data before execution
 - append V1 downloads only the missing range, then rebuilds the canonical artifact from local cache
 - Zarr materialization clips cached upstream data to the requested artifact scope
-- artifact reuse ignores records whose stored coverage does not match the requested scope
-- newly materialized artifacts are rejected when realized temporal coverage does not match the requested scope
+- artifact records keep caller request scope as provenance and cumulative realized store coverage separately
+- existing stores are updated from a planned contiguous union; earlier or gapped ranges rematerialize in ascending order
 
 ## How The Current Flow Works
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -196,8 +196,8 @@ Implemented sync behavior:
 - release datasets rematerialize when a newer requested release exists
 - static datasets return `not_syncable`
 - plugin `periods()` clamps target end to actually available data before execution
-- append V1 downloads only the missing range, then rebuilds the canonical artifact from local cache
-- Zarr materialization clips cached upstream data to the requested artifact scope
+- append execution reuses the planned source delta and writes only missing periods to the committed Icechunk store
+- rematerialization builds and validates the complete contiguous union in a sibling store before publication
 - artifact records keep caller request scope as provenance and cumulative realized store coverage separately
 - existing stores are updated from a planned contiguous union; earlier or gapped ranges rematerialize in ascending order
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -379,8 +379,8 @@ Implemented behavior:
 - `static` datasets return `not_syncable`
 - preserve stable managed dataset identity
 - use template-level `sync_execution`
-- `append` execution downloads only the missing period range, then rebuilds the canonical artifact from the local cache
-- `rematerialize` execution downloads the full original request range through the requested end period
+- `append` execution reuses the sync planner's source-available delta and writes only periods missing from the committed store
+- `rematerialize` execution downloads the complete planned contiguous union into a sibling store and publishes it only after validation
 - return the updated dataset view plus structured `sync_detail`
 - validate realized temporal coverage against the planned contiguous artifact scope; retain the caller's request scope separately as provenance
 
@@ -466,8 +466,9 @@ Expected planning response:
 - `delta_start` is `2024-02-01`
 - `delta_end` is `2024-02-10`
 
-`append` here means Open Climate Service downloads only the missing period range and then
-rebuilds the canonical artifact from local cache. It is not in-place Zarr mutation.
+`append` here means Open Climate Service reuses the planner's source-available delta and
+writes only missing periods to the existing Icechunk store. A rollback snapshot protects
+the previously committed store until normalization and artifact registration succeed.
 
 Where these timestamps come from:
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -382,7 +382,7 @@ Implemented behavior:
 - `append` execution downloads only the missing period range, then rebuilds the canonical artifact from the local cache
 - `rematerialize` execution downloads the full original request range through the requested end period
 - return the updated dataset view plus structured `sync_detail`
-- reject a rebuilt artifact before storing or publishing it if realized temporal coverage does not match the requested scope
+- validate realized temporal coverage against the planned contiguous artifact scope; retain the caller's request scope separately as provenance
 
 Current sync constraints:
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -469,6 +469,18 @@ Expected planning response:
 `append` here means Open Climate Service reuses the planner's source-available delta and
 writes only missing periods to the existing Icechunk store. A rollback snapshot protects
 the previously committed store until normalization and artifact registration succeed.
+Progress counts the new periods in this append, excluding already committed history.
+
+If a complete store has lost its artifact record, repeating `/ingest` reconstructs the
+record from the store without querying or fetching historical source data. Recovery
+validates and normalizes the store and honors the request's publication setting.
+
+Interrupted directory rollback can leave a rejected replacement at `<store>.failed`.
+The next ingest restores a missing target from `<store>.retired` and removes the
+rejected copy once the target exists. If rollback itself fails, the job reports that
+failure and preserves the recovery branch and snapshot; inspect the reported store
+paths before retrying. Snapshot reset is skipped if the original repository could
+not be restored.
 
 Where these timestamps come from:
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -441,20 +441,45 @@ def _plan_streaming_materialization(
     current_end = max(committed, key=lambda value: _period_order_key(value, period_type))
     materialization_start = min((current_start, start), key=lambda value: _period_order_key(value, period_type))
     materialization_end = max((current_end, end), key=lambda value: _period_order_key(value, period_type))
+    committed_is_contiguous = _periods_are_contiguous(committed, period_type)
 
-    # The sync planner already queried the source for the forward delta. Reuse that
-    # exact result when the committed store is itself a safe contiguous prefix. This
-    # avoids a second network call and also supports rolling sources that no longer
-    # enumerate historical periods which are already committed locally.
-    if (
-        periods is not None
-        and materialization_start == current_start
-        and _periods_are_contiguous(committed, period_type)
-    ):
-        delta = _normalize_ordered_periods(periods, period_type=period_type, source="Ingestion plugin")
-        if not delta:
-            raise HTTPException(status_code=409, detail="Source has no new data for the requested temporal scope")
+    # A request wholly contained by an already contiguous store cannot add data.
+    # Reuse the current artifact without asking a rolling source to enumerate
+    # historical periods that it may no longer expose.
+    if materialization_start == current_start and materialization_end == current_end and committed_is_contiguous:
+        return _StreamingMaterializationPlan(
+            action=SyncAction.NO_OP,
+            start=current_start,
+            end=current_end,
+            periods=committed,
+            has_committed_periods=True,
+        )
+
+    # A contiguous store that only needs a forward extension requires the source
+    # to enumerate the missing delta, not reproduce committed history. Reuse a
+    # sync planner's prefetched delta when present; direct ingestion queries it here.
+    if materialization_start == current_start and committed_is_contiguous:
         expected_start = next_period_string(current_end, period_type)
+        source_periods = _normalize_ordered_periods(
+            periods if periods is not None else asyncio.run(plugin.periods(expected_start, materialization_end)),
+            period_type=period_type,
+            source="Ingestion plugin",
+        )
+        # Plugins should honor the requested bounds, but accepting an already
+        # committed leading prefix keeps broader source enumerators compatible.
+        delta = [
+            period
+            for period in source_periods
+            if _period_order_key(period, period_type) >= _period_order_key(expected_start, period_type)
+        ]
+        if not delta:
+            return _StreamingMaterializationPlan(
+                action=SyncAction.NO_OP,
+                start=current_start,
+                end=current_end,
+                periods=committed,
+                has_committed_periods=True,
+            )
         if delta[0] != expected_start or not _periods_are_contiguous(delta, period_type):
             raise HTTPException(
                 status_code=409,
@@ -579,6 +604,11 @@ def _create_streaming_artifact(
             overwrite=overwrite,
             periods=periods,
         )
+        if plan.action == SyncAction.NO_OP:
+            existing = get_latest_artifact_for_dataset_or_404(str(dataset["id"]))
+            if publish and existing.publication.status != PublicationStatus.PUBLISHED:
+                return publish_artifact_record(existing.artifact_id)
+            return existing
         materialization_scope = request_scope.model_copy(update={"start": plan.start, "end": plan.end})
 
         ingest_path = store_path

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Protocol, cast
@@ -45,6 +46,7 @@ from open_climate_service.ingestions.schemas import (
     IngestionListResponse,
     IngestionResponse,
     PublicationStatus,
+    SyncAction,
     SyncDetail,
     SyncResponse,
 )
@@ -59,6 +61,10 @@ from open_climate_service.shared.time import (
 )
 from open_climate_service.streaming.orchestrator import run_streaming_ingest_sync
 from open_climate_service.streaming.protocol import IngestionPlugin
+from open_climate_service.streaming.store import (
+    open_or_create_repo,
+    read_committed_period_ids_ordered,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +86,17 @@ _MAX_CONSOLIDATED_CACHE_ENTRIES = 512
 # Avoids reading and deserializing the full artifact index on every chunk request
 # from the /icechunk/ endpoint.  Invalidated when records.json changes on disk.
 _icechunk_artifact_cache: dict[str, tuple[float, "ArtifactRecord"]] = {}
+
+
+@dataclass(frozen=True)
+class _StreamingMaterializationPlan:
+    """Write shape selected before a streaming ingest mutates its store."""
+
+    action: SyncAction
+    start: str
+    end: str
+    periods: list[str] | None
+    has_committed_periods: bool
 
 
 def _acquire_store_lock(store_path: Path) -> threading.Lock:
@@ -287,6 +304,148 @@ def create_artifact(
     raise HTTPException(status_code=500, detail=f"Dataset '{dataset['id']}' does not define ingestion.plugin")
 
 
+def _period_order_key(period: str, period_type: str) -> str:
+    """Return a lexically sortable key for one normalized period id."""
+    normalized = normalize_period_string(period, period_type)
+    if period_type == "climatology":
+        try:
+            return f"{int(normalized):03d}"
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Source returned invalid climatology period '{period}'",
+            ) from exc
+    return normalized
+
+
+def _normalize_ordered_periods(
+    periods: list[str], *, period_type: str, source: str, require_ordered: bool = True
+) -> list[str]:
+    """Normalize periods and optionally require a unique, ascending sequence."""
+    try:
+        normalized = [normalize_period_string(period, period_type) for period in periods]
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=f"{source} returned an invalid period sequence: {exc}") from exc
+    keys = [_period_order_key(period, period_type) for period in normalized]
+    if require_ordered and (len(set(normalized)) != len(normalized) or keys != sorted(keys)):
+        raise HTTPException(
+            status_code=409,
+            detail=f"{source} periods must be unique and in ascending order; refusing to mutate the store",
+        )
+    return normalized
+
+
+def _plan_streaming_materialization(
+    *,
+    plugin: IngestionPlugin,
+    store_path: Path,
+    start: str,
+    end: str,
+    period_type: str,
+    overwrite: bool,
+    periods: list[str] | None,
+) -> _StreamingMaterializationPlan:
+    """Plan a contiguous union before allowing streaming ingest to write.
+
+    A forward request can append only when the committed coordinate is an exact
+    prefix of every source-valid period in the union. Earlier requests, gaps, or
+    non-monotonic committed coordinates require a sibling-store rematerialization.
+    """
+    committed = _normalize_ordered_periods(
+        read_committed_period_ids_ordered(store_path, period_type),
+        period_type=period_type,
+        source="Committed store",
+        require_ordered=False,
+    )
+    if overwrite:
+        return _StreamingMaterializationPlan(
+            action=SyncAction.REMATERIALIZE,
+            start=start,
+            end=end,
+            periods=periods,
+            has_committed_periods=bool(committed),
+        )
+
+    if not committed:
+        available = _normalize_ordered_periods(
+            periods if periods is not None else asyncio.run(plugin.periods(start, end)),
+            period_type=period_type,
+            source="Ingestion plugin",
+        )
+        if not available:
+            raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
+        if available[0] != start:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Source cannot materialize the requested scope from {start}; first available is {available[0]}",
+            )
+        if _period_order_key(available[-1], period_type) > _period_order_key(end, period_type):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Source returned period {available[-1]} beyond the requested scope ending {end}",
+            )
+        return _StreamingMaterializationPlan(
+            action=SyncAction.APPEND,
+            start=start,
+            end=available[-1],
+            periods=available,
+            has_committed_periods=False,
+        )
+
+    current_start = min(committed, key=lambda value: _period_order_key(value, period_type))
+    current_end = max(committed, key=lambda value: _period_order_key(value, period_type))
+    materialization_start = min((current_start, start), key=lambda value: _period_order_key(value, period_type))
+    materialization_end = max((current_end, end), key=lambda value: _period_order_key(value, period_type))
+
+    available = _normalize_ordered_periods(
+        asyncio.run(plugin.periods(materialization_start, materialization_end)),
+        period_type=period_type,
+        source="Ingestion plugin",
+    )
+    if not available:
+        raise HTTPException(status_code=409, detail="Source has no data for the requested temporal union")
+    if available[0] != materialization_start:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Source cannot materialize the requested temporal union from "
+                f"{materialization_start}; first available period is {available[0]}"
+            ),
+        )
+    if _period_order_key(available[-1], period_type) > _period_order_key(materialization_end, period_type):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Source returned period {available[-1]} beyond the requested temporal union ending "
+                f"{materialization_end}"
+            ),
+        )
+    available_set = set(available)
+    missing_committed = [period for period in committed if period not in available_set]
+    if missing_committed:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Source can no longer reproduce committed period(s) required for the temporal union: "
+                + ", ".join(missing_committed[:5])
+            ),
+        )
+
+    committed_is_prefix = available[: len(committed)] == committed
+    action = (
+        SyncAction.APPEND
+        if committed_is_prefix and materialization_start == current_start
+        else SyncAction.REMATERIALIZE
+    )
+    return _StreamingMaterializationPlan(
+        action=action,
+        start=materialization_start,
+        end=available[-1],
+        periods=available,
+        has_committed_periods=True,
+    )
+
+
 def _create_streaming_artifact(
     *,
     dataset: dict[str, object],
@@ -313,15 +472,6 @@ def _create_streaming_artifact(
     if bbox is None:
         raise HTTPException(status_code=400, detail="Streaming ingest requires a bounding box")
 
-    existing = _find_existing_artifact(
-        dataset_id=str(dataset["id"]),
-        request_scope=request_scope,
-    )
-    if existing is not None and not overwrite:
-        if publish and existing.publication.status != PublicationStatus.PUBLISHED:
-            return publish_artifact_record(existing.artifact_id)
-        return existing
-
     ingestion = dataset.get("ingestion")
     raw_params = ingestion.get("params") if isinstance(ingestion, dict) else None
     if raw_params is None:
@@ -343,6 +493,12 @@ def _create_streaming_artifact(
             detail=f"An ingest or sync is already running for dataset '{dataset['id']}'. Wait for it to finish.",
         )
     replacement_path: Path | None = None
+    rollback_repo: Any | None = None
+    rollback_branch: str | None = None
+    rollback_snapshot: str | None = None
+    published_swap_pending = False
+    store_committed = False
+    plugin_handed_to_orchestrator = False
     try:
         # First thing under the lock, before anything looks at the store. A swap killed between
         # its two renames leaves the published path missing and the data at `.retired`; ingest
@@ -351,28 +507,51 @@ def _create_streaming_artifact(
         # `.retired`. Healing before any inspection makes the next sync an ordinary append.
         recover_interrupted_swap(store_path)
 
+        plan = _plan_streaming_materialization(
+            plugin=plugin,
+            store_path=store_path,
+            start=start,
+            end=end,
+            period_type=str(dataset["period_type"]),
+            overwrite=overwrite,
+            periods=periods,
+        )
+        materialization_scope = request_scope.model_copy(update={"start": plan.start, "end": plan.end})
+
         ingest_path = store_path
-        if overwrite and store_path.exists():
-            # Build overwrite data beside the published store. Fetching is the least reliable
-            # part of ingestion, so the current data must remain readable until the replacement
-            # has been fetched, validated, and normalized successfully.
+        if plan.action == SyncAction.REMATERIALIZE and store_path.exists():
+            # Build a prepend/overwrite beside the published store. Fetching is the least
+            # reliable part of ingestion, so the current data remains readable until the
+            # contiguous replacement has been fetched, validated, and normalized.
             replacement_path = store_path.with_name(f"{store_path.name}.replacement")
             _remove_store_path(replacement_path)
             ingest_path = replacement_path
+        elif plan.has_committed_periods:
+            # Icechunk commits each fetched period independently. Keep the pre-ingest
+            # snapshot reachable so an exception after any commit can restore the public
+            # branch instead of leaving a partial append or a stale pyramid behind.
+            repo = open_or_create_repo(store_path)
+            snapshot = repo.lookup_branch("main")
+            branch = f"ocs-ingest-rollback-{uuid4().hex}"
+            repo.create_branch(branch, snapshot)
+            rollback_repo = repo
+            rollback_snapshot = snapshot
+            rollback_branch = branch
 
+        plugin_handed_to_orchestrator = True
         result = run_streaming_ingest_sync(
             plugin=plugin,
             params=params,
             dataset=dataset,
             bbox=bbox,
-            start=start,
-            end=end,
+            start=plan.start,
+            end=plan.end,
             store_path=ingest_path,
             period_type=str(dataset["period_type"]),
             on_progress=on_progress,
             is_cancel_requested=is_cancel_requested,
             save_cursor=save_cursor,
-            periods=periods,
+            periods=plan.periods,
         )
         if result.periods_written == 0 and not ingest_path.exists():
             raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
@@ -390,25 +569,45 @@ def _create_streaming_artifact(
             spatial=CoverageSpatial(**coverage_data["coverage"]["spatial"]),
             spatial_wgs84=CoverageSpatial(**_spatial_wgs84_data) if _spatial_wgs84_data else None,
         )
-        # Temporal datasets: verify the realized coverage matches the requested scope
-        # and clamp the request end to the realized (possibly source-limited) end. A
-        # non-temporal (ordinal) dataset — e.g. a day-of-year climatology — has no
-        # temporal coverage, so there is nothing to match or clamp.
+        # Temporal datasets validate against the cumulative materialization scope, not
+        # the raw user request. The latter remains on the record as operation provenance.
+        # A brand-new store may legitimately clamp its end to source availability; an
+        # update was already planned from the source's exact available period sequence.
         if coverage.temporal.start is not None:
-            if not _temporal_coverage_matches_streaming_request_scope(coverage.temporal, request_scope):
+            coverage_matches_plan = (
+                _temporal_coverage_matches_request_scope(coverage.temporal, materialization_scope)
+                if plan.has_committed_periods
+                else _temporal_coverage_matches_streaming_request_scope(coverage.temporal, materialization_scope)
+            )
+            if not coverage_matches_plan:
                 raise HTTPException(
                     status_code=409,
                     detail=(
-                        "Materialized artifact coverage does not match the requested scope: "
+                        "Materialized artifact coverage does not match the planned contiguous scope: "
                         f"coverage={coverage.temporal.start}..{coverage.temporal.end}, "
-                        f"request={request_scope.start}..{request_scope.end}"
+                        f"plan={materialization_scope.start}..{materialization_scope.end}"
                     ),
                 )
-            request_scope = request_scope.model_copy(update={"end": coverage.temporal.end})
 
-        _maybe_build_pyramid(ingest_path, dataset)
+        retired_store_existed = _retired_path(store_path).exists()
+        normalized = _maybe_build_pyramid(
+            ingest_path,
+            dataset,
+            retain_previous=plan.has_committed_periods and replacement_path is None,
+        )
+        if plan.has_committed_periods and not normalized:
+            raise RuntimeError(f"Could not normalize '{dataset['id']}'; the dataset update was rolled back")
+        if not retired_store_existed and _retired_path(store_path).exists():
+            # Pyramid normalization replaced the published repository but retained
+            # the previous one until its matching artifact record is durable. From
+            # here, rollback is a directory swap rather than an Icechunk branch reset.
+            published_swap_pending = True
+            rollback_repo = None
+            rollback_branch = None
+            rollback_snapshot = None
         if replacement_path is not None:
-            _swap_store(replacement_path, store_path)
+            _swap_store(replacement_path, store_path, retain_previous=True)
+            published_swap_pending = True
 
         record = ArtifactRecord(
             artifact_id=str(uuid4()),
@@ -430,11 +629,44 @@ def _create_streaming_artifact(
             publish=publish,
             overwrite=overwrite,
         )
+        store_committed = True
+        if published_swap_pending:
+            _finalize_store_swap(store_path)
+            published_swap_pending = False
         if publish and stored_record.publication.status != PublicationStatus.PUBLISHED:
             return publish_artifact_record(stored_record.artifact_id)
         return stored_record
     finally:
         try:
+            if published_swap_pending:
+                try:
+                    _rollback_store_swap(store_path)
+                    published_swap_pending = False
+                except Exception:
+                    logger.error(
+                        "Could not restore the previous store for '%s' after artifact registration failed",
+                        store_path,
+                        exc_info=True,
+                    )
+            if not plugin_handed_to_orchestrator:
+                close_plugin = getattr(plugin, "close", None)
+                if callable(close_plugin):
+                    try:
+                        close_plugin()
+                    except Exception:
+                        logger.warning("Could not close ingestion plugin after planning failure", exc_info=True)
+            if rollback_repo is not None and rollback_branch is not None and rollback_snapshot is not None:
+                try:
+                    if not store_committed:
+                        rollback_repo.reset_branch("main", rollback_snapshot)
+                    rollback_repo.delete_branch(rollback_branch)
+                except Exception:
+                    logger.error(
+                        "Could not %s append transaction for '%s'",
+                        "roll back" if not store_committed else "clean up",
+                        store_path,
+                        exc_info=True,
+                    )
             if replacement_path is not None:
                 # Failed fetches and validations leave only a disposable partial replacement. A
                 # successful swap has already moved this path away, making cleanup a no-op.
@@ -485,7 +717,7 @@ def recover_interrupted_swap(target: Path) -> bool:
     return True
 
 
-def _swap_store(staging: Path, target: Path) -> None:
+def _swap_store(staging: Path, target: Path, *, retain_previous: bool = False) -> None:
     """Move ``staging`` into ``target``'s place, keeping the original until the swap lands.
 
     Two directory renames on one filesystem rather than a copy, so the cost is metadata
@@ -509,10 +741,37 @@ def _swap_store(staging: Path, target: Path) -> None:
     except Exception:
         retired.rename(target)  # leave the store exactly as it was
         raise
-    shutil.rmtree(retired, ignore_errors=True)
+    if not retain_previous:
+        shutil.rmtree(retired, ignore_errors=True)
 
 
-def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
+def _finalize_store_swap(target: Path) -> None:
+    """Discard the previous store after its replacement record is durable."""
+    _remove_store_path(_retired_path(target))
+
+
+def _rollback_store_swap(target: Path) -> None:
+    """Restore the retained store when replacement metadata cannot be persisted."""
+    retired = _retired_path(target)
+    if not retired.exists():
+        return
+    failed = target.with_name(f"{target.name}.failed")
+    _remove_store_path(failed)
+    target.rename(failed)
+    try:
+        retired.rename(target)
+    except Exception:
+        failed.rename(target)
+        raise
+    _remove_store_path(failed)
+
+
+def _maybe_build_pyramid(
+    store_path: Path,
+    dataset: dict[str, object],
+    *,
+    retain_previous: bool = False,
+) -> bool:
     """Apply GeoZarr conventions and a multiscale pyramid to the committed Icechunk store.
 
     Streaming ingest writes a flat store with root GeoZarr attrs but no
@@ -530,8 +789,9 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
     attrs on every commit. We detect that case and skip the read-rewrite entirely, avoiding
     the write amplification of re-emitting the whole store on every sync.
 
-    Errors are logged and swallowed so that the plain flat artifact is still
-    registered.
+    Returns whether normalization completed. Errors remain logged and swallowed
+    so a brand-new plain flat artifact can still be registered; callers updating
+    an existing pyramid use the return value to roll back instead.
     """
     from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
 
@@ -544,7 +804,7 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
         ds = open_icechunk_dataset(store_path)
     except Exception:
         logger.warning("Could not open Icechunk store for GeoZarr write; skipping", exc_info=True)
-        return
+        return False
 
     try:
         already_normalized = "spatial_ref" in ds.coords or "spatial_ref" in ds.variables
@@ -564,7 +824,7 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
                 "Store '%s' is already GeoZarr-normalized and flat; skipping read-rewrite",
                 store_path.name,
             )
-            return
+            return True
         # `ds` reads lazily from `store_path`, and the rewrite overwrites that same store —
         # the aliasing is why this used to materialise everything first. Build into a sibling
         # store and swap it in, so the source stays readable while topozarr streams the
@@ -580,7 +840,7 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
                 commit_message="Applied GeoZarr conventions",
             )
             ds.close()  # drop the read session before the directory moves under it
-            _swap_store(staging, store_path)
+            _swap_store(staging, store_path, retain_previous=retain_previous)
         finally:
             # A failed build leaves a partial copy of the whole store behind. That matters most
             # when the failure *was* disk exhaustion: the flat-store fallback below would
@@ -593,8 +853,10 @@ def _maybe_build_pyramid(store_path: Path, dataset: dict[str, object]) -> None:
             store_path.name,
             exc_info=True,
         )
+        return False
     finally:
         ds.close()
+    return True
 
 
 def _load_streaming_plugin(plugin_path: str, *, params: dict[str, object]) -> IngestionPlugin:
@@ -1024,7 +1286,7 @@ def _store_artifact_record(
             dataset_id=record.dataset_id,
             request_scope=record.request_scope,
         )
-        if existing is not None:
+        if existing is not None and existing.coverage == record.coverage:
             if publish and existing.publication.status != PublicationStatus.PUBLISHED:
                 return existing
             return existing

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -1396,8 +1396,6 @@ def _store_artifact_record(
             request_scope=record.request_scope,
         )
         if existing is not None and existing.coverage == record.coverage:
-            if publish and existing.publication.status != PublicationStatus.PUBLISHED:
-                return existing
             return existing
 
         records.append(record)

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -55,6 +55,7 @@ from open_climate_service.publications.services import managed_dataset_id_for, p
 from open_climate_service.shared.time import (
     datetime_to_period_string,
     dekad_start,
+    next_period_string,
     normalize_period_string,
     utc_now,
     utc_today,
@@ -97,6 +98,14 @@ class _StreamingMaterializationPlan:
     end: str
     periods: list[str] | None
     has_committed_periods: bool
+
+
+@dataclass(frozen=True)
+class _StoreNormalizationResult:
+    """Outcome of normalizing a store, including whether its directory was swapped."""
+
+    completed: bool
+    swapped: bool = False
 
 
 def _acquire_store_lock(store_path: Path) -> threading.Lock:
@@ -335,6 +344,41 @@ def _normalize_ordered_periods(
     return normalized
 
 
+def _periods_are_contiguous(periods: list[str], period_type: str) -> bool:
+    """Return whether each period immediately follows the previous one."""
+    return all(next_period_string(previous, period_type) == current for previous, current in zip(periods, periods[1:]))
+
+
+def _validate_source_periods(
+    periods: list[str],
+    *,
+    start: str,
+    end: str,
+    period_type: str,
+    scope: str,
+) -> list[str]:
+    """Normalize and validate one source-provided materialization sequence."""
+    available = _normalize_ordered_periods(periods, period_type=period_type, source="Ingestion plugin")
+    if not available:
+        raise HTTPException(status_code=409, detail=f"Source has no data for the requested {scope}")
+    if available[0] != start:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Source cannot materialize the requested {scope} from {start}; first available is {available[0]}",
+        )
+    if _period_order_key(available[-1], period_type) > _period_order_key(end, period_type):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Source returned period {available[-1]} beyond the requested {scope} ending {end}",
+        )
+    if not _periods_are_contiguous(available, period_type):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Source returned a non-contiguous period sequence for the requested {scope}",
+        )
+    return available
+
+
 def _plan_streaming_materialization(
     *,
     plugin: IngestionPlugin,
@@ -352,38 +396,39 @@ def _plan_streaming_materialization(
     non-monotonic committed coordinates require a sibling-store rematerialization.
     """
     committed = _normalize_ordered_periods(
-        read_committed_period_ids_ordered(store_path, period_type),
+        read_committed_period_ids_ordered(
+            store_path,
+            period_type,
+            time_dim=str(getattr(plugin, "time_dim", "t")),
+        ),
         period_type=period_type,
         source="Committed store",
         require_ordered=False,
     )
     if overwrite:
+        available = _validate_source_periods(
+            periods if periods is not None else asyncio.run(plugin.periods(start, end)),
+            start=start,
+            end=end,
+            period_type=period_type,
+            scope="temporal scope",
+        )
         return _StreamingMaterializationPlan(
             action=SyncAction.REMATERIALIZE,
             start=start,
-            end=end,
-            periods=periods,
+            end=available[-1],
+            periods=available,
             has_committed_periods=bool(committed),
         )
 
     if not committed:
-        available = _normalize_ordered_periods(
+        available = _validate_source_periods(
             periods if periods is not None else asyncio.run(plugin.periods(start, end)),
+            start=start,
+            end=end,
             period_type=period_type,
-            source="Ingestion plugin",
+            scope="temporal scope",
         )
-        if not available:
-            raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
-        if available[0] != start:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Source cannot materialize the requested scope from {start}; first available is {available[0]}",
-            )
-        if _period_order_key(available[-1], period_type) > _period_order_key(end, period_type):
-            raise HTTPException(
-                status_code=409,
-                detail=f"Source returned period {available[-1]} beyond the requested scope ending {end}",
-            )
         return _StreamingMaterializationPlan(
             action=SyncAction.APPEND,
             start=start,
@@ -397,29 +442,47 @@ def _plan_streaming_materialization(
     materialization_start = min((current_start, start), key=lambda value: _period_order_key(value, period_type))
     materialization_end = max((current_end, end), key=lambda value: _period_order_key(value, period_type))
 
-    available = _normalize_ordered_periods(
+    # The sync planner already queried the source for the forward delta. Reuse that
+    # exact result when the committed store is itself a safe contiguous prefix. This
+    # avoids a second network call and also supports rolling sources that no longer
+    # enumerate historical periods which are already committed locally.
+    if (
+        periods is not None
+        and materialization_start == current_start
+        and _periods_are_contiguous(committed, period_type)
+    ):
+        delta = _normalize_ordered_periods(periods, period_type=period_type, source="Ingestion plugin")
+        if not delta:
+            raise HTTPException(status_code=409, detail="Source has no new data for the requested temporal scope")
+        expected_start = next_period_string(current_end, period_type)
+        if delta[0] != expected_start or not _periods_are_contiguous(delta, period_type):
+            raise HTTPException(
+                status_code=409,
+                detail=(f"Source append periods must form a contiguous sequence beginning at {expected_start}"),
+            )
+        if _period_order_key(delta[-1], period_type) > _period_order_key(materialization_end, period_type):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Source returned period {delta[-1]} beyond the requested temporal union ending "
+                    f"{materialization_end}"
+                ),
+            )
+        return _StreamingMaterializationPlan(
+            action=SyncAction.APPEND,
+            start=current_start,
+            end=delta[-1],
+            periods=[*committed, *delta],
+            has_committed_periods=True,
+        )
+
+    available = _validate_source_periods(
         asyncio.run(plugin.periods(materialization_start, materialization_end)),
+        start=materialization_start,
+        end=materialization_end,
         period_type=period_type,
-        source="Ingestion plugin",
+        scope="temporal union",
     )
-    if not available:
-        raise HTTPException(status_code=409, detail="Source has no data for the requested temporal union")
-    if available[0] != materialization_start:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "Source cannot materialize the requested temporal union from "
-                f"{materialization_start}; first available period is {available[0]}"
-            ),
-        )
-    if _period_order_key(available[-1], period_type) > _period_order_key(materialization_end, period_type):
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"Source returned period {available[-1]} beyond the requested temporal union ending "
-                f"{materialization_end}"
-            ),
-        )
     available_set = set(available)
     missing_committed = [period for period in committed if period not in available_set]
     if missing_committed:
@@ -589,22 +652,19 @@ def _create_streaming_artifact(
                     ),
                 )
 
-        retired_store_existed = _retired_path(store_path).exists()
-        normalized = _maybe_build_pyramid(
+        normalization = _maybe_build_pyramid(
             ingest_path,
             dataset,
             retain_previous=plan.has_committed_periods and replacement_path is None,
         )
-        if plan.has_committed_periods and not normalized:
+        if plan.has_committed_periods and not normalization.completed:
             raise RuntimeError(f"Could not normalize '{dataset['id']}'; the dataset update was rolled back")
-        if not retired_store_existed and _retired_path(store_path).exists():
+        if normalization.swapped and ingest_path == store_path:
             # Pyramid normalization replaced the published repository but retained
             # the previous one until its matching artifact record is durable. From
-            # here, rollback is a directory swap rather than an Icechunk branch reset.
+            # here, rollback first restores that repository and then resets its main
+            # branch to the pre-ingest snapshot retained above.
             published_swap_pending = True
-            rollback_repo = None
-            rollback_branch = None
-            rollback_snapshot = None
         if replacement_path is not None:
             _swap_store(replacement_path, store_path, retain_previous=True)
             published_swap_pending = True
@@ -631,14 +691,26 @@ def _create_streaming_artifact(
         )
         store_committed = True
         if published_swap_pending:
-            _finalize_store_swap(store_path)
-            published_swap_pending = False
+            try:
+                _finalize_store_swap(store_path)
+                published_swap_pending = False
+            except Exception:
+                # The record and replacement are already durable. Retaining the old
+                # directory is only a cleanup leak; restoring it would make the record
+                # point at stale data. A later run may retry the cleanup.
+                logger.warning("Could not remove retired store '%s' after commit", store_path, exc_info=True)
+            # A swapped-out repository either disappeared with successful cleanup or
+            # remains only as a retired fallback. Never try to operate on its temporary
+            # branch through the newly published repository path.
+            rollback_repo = None
+            rollback_branch = None
+            rollback_snapshot = None
         if publish and stored_record.publication.status != PublicationStatus.PUBLISHED:
             return publish_artifact_record(stored_record.artifact_id)
         return stored_record
     finally:
         try:
-            if published_swap_pending:
+            if published_swap_pending and not store_committed:
                 try:
                     _rollback_store_swap(store_path)
                     published_swap_pending = False
@@ -648,6 +720,12 @@ def _create_streaming_artifact(
                         store_path,
                         exc_info=True,
                     )
+            elif published_swap_pending:
+                try:
+                    _finalize_store_swap(store_path)
+                    published_swap_pending = False
+                except Exception:
+                    logger.warning("Could not clean up retired store '%s'", store_path, exc_info=True)
             if not plugin_handed_to_orchestrator:
                 close_plugin = getattr(plugin, "close", None)
                 if callable(close_plugin):
@@ -771,7 +849,7 @@ def _maybe_build_pyramid(
     dataset: dict[str, object],
     *,
     retain_previous: bool = False,
-) -> bool:
+) -> _StoreNormalizationResult:
     """Apply GeoZarr conventions and a multiscale pyramid to the committed Icechunk store.
 
     Streaming ingest writes a flat store with root GeoZarr attrs but no
@@ -789,9 +867,10 @@ def _maybe_build_pyramid(
     attrs on every commit. We detect that case and skip the read-rewrite entirely, avoiding
     the write amplification of re-emitting the whole store on every sync.
 
-    Returns whether normalization completed. Errors remain logged and swallowed
-    so a brand-new plain flat artifact can still be registered; callers updating
-    an existing pyramid use the return value to roll back instead.
+    Returns whether normalization completed and whether it swapped the store.
+    Errors remain logged and swallowed so a brand-new plain flat artifact can
+    still be registered; callers updating an existing store use the result to
+    roll back instead.
     """
     from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
 
@@ -804,7 +883,7 @@ def _maybe_build_pyramid(
         ds = open_icechunk_dataset(store_path)
     except Exception:
         logger.warning("Could not open Icechunk store for GeoZarr write; skipping", exc_info=True)
-        return False
+        return _StoreNormalizationResult(completed=False)
 
     try:
         already_normalized = "spatial_ref" in ds.coords or "spatial_ref" in ds.variables
@@ -824,7 +903,7 @@ def _maybe_build_pyramid(
                 "Store '%s' is already GeoZarr-normalized and flat; skipping read-rewrite",
                 store_path.name,
             )
-            return True
+            return _StoreNormalizationResult(completed=True)
         # `ds` reads lazily from `store_path`, and the rewrite overwrites that same store —
         # the aliasing is why this used to materialise everything first. Build into a sibling
         # store and swap it in, so the source stays readable while topozarr streams the
@@ -853,10 +932,10 @@ def _maybe_build_pyramid(
             store_path.name,
             exc_info=True,
         )
-        return False
+        return _StoreNormalizationResult(completed=False)
     finally:
         ds.close()
-    return True
+    return _StoreNormalizationResult(completed=True, swapped=True)
 
 
 def _load_streaming_plugin(plugin_path: str, *, params: dict[str, object]) -> IngestionPlugin:
@@ -1281,7 +1360,7 @@ def _store_artifact_record(
     """Persist a newly created artifact record while avoiding lost updates."""
 
     def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
-        existing = _find_existing_artifact_in_records(
+        existing = _find_artifact_by_request_scope(
             records=records,
             dataset_id=record.dataset_id,
             request_scope=record.request_scope,
@@ -1308,7 +1387,7 @@ def _upsert_artifact_record(
         return _store_artifact_record(record, publish=publish)
 
     def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
-        existing = _find_existing_artifact_in_records(
+        existing = _find_artifact_by_request_scope(
             records=records,
             dataset_id=record.dataset_id,
             request_scope=record.request_scope,
@@ -1521,6 +1600,26 @@ def _find_existing_artifact_in_records(
             )
             continue
         return record
+    return None
+
+
+def _find_artifact_by_request_scope(
+    *,
+    records: list[ArtifactRecord],
+    dataset_id: str,
+    request_scope: ArtifactRequestScope,
+) -> ArtifactRecord | None:
+    """Return the latest materialized record for the same operation request.
+
+    Unlike the API reuse lookup above, persistence must allow cumulative coverage
+    to extend beyond a finite incremental request. The caller compares coverage
+    when deduplicating and replaces the record explicitly for overwrite semantics.
+    """
+    for record in reversed(records):
+        if record.dataset_id != dataset_id or record.request_scope != request_scope:
+            continue
+        if _artifact_storage_exists(record):
+            return record
     return None
 
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -91,7 +91,7 @@ _icechunk_artifact_cache: dict[str, tuple[float, "ArtifactRecord"]] = {}
 
 @dataclass(frozen=True)
 class _StreamingMaterializationPlan:
-    """Write shape selected before a streaming ingest mutates its store."""
+    """Cumulative bounds and periods to fetch, selected before store mutation."""
 
     action: SyncAction
     start: str
@@ -315,16 +315,15 @@ def create_artifact(
 
 def _period_order_key(period: str, period_type: str) -> str:
     """Return a lexically sortable key for one normalized period id."""
-    normalized = normalize_period_string(period, period_type)
     if period_type == "climatology":
         try:
-            return f"{int(normalized):03d}"
+            return f"{int(period):03d}"
         except ValueError as exc:
             raise HTTPException(
                 status_code=409,
-                detail=f"Source returned invalid climatology period '{period}'",
+                detail=f"Invalid climatology period '{period}'",
             ) from exc
-    return normalized
+    return period
 
 
 def _normalize_ordered_periods(
@@ -335,12 +334,13 @@ def _normalize_ordered_periods(
         normalized = [normalize_period_string(period, period_type) for period in periods]
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=409, detail=f"{source} returned an invalid period sequence: {exc}") from exc
-    keys = [_period_order_key(period, period_type) for period in normalized]
-    if require_ordered and (len(set(normalized)) != len(normalized) or keys != sorted(keys)):
-        raise HTTPException(
-            status_code=409,
-            detail=f"{source} periods must be unique and in ascending order; refusing to mutate the store",
-        )
+    if require_ordered:
+        keys = [_period_order_key(period, period_type) for period in normalized]
+        if len(set(normalized)) != len(normalized) or keys != sorted(keys):
+            raise HTTPException(
+                status_code=409,
+                detail=f"{source} periods must be unique and in ascending order; refusing to mutate the store",
+            )
     return normalized
 
 
@@ -498,7 +498,7 @@ def _plan_streaming_materialization(
             action=SyncAction.APPEND,
             start=current_start,
             end=delta[-1],
-            periods=[*committed, *delta],
+            periods=delta,
             has_committed_periods=True,
         )
 
@@ -608,10 +608,18 @@ def _create_streaming_artifact(
             periods=periods,
         )
         if plan.action == SyncAction.NO_OP:
-            existing = get_latest_artifact_for_dataset_or_404(str(dataset["id"]))
-            if publish and existing.publication.status != PublicationStatus.PUBLISHED:
-                return publish_artifact_record(existing.artifact_id)
-            return existing
+            try:
+                existing = get_latest_artifact_for_dataset_or_404(str(dataset["id"]))
+            except HTTPException as exc:
+                if exc.status_code != 404:
+                    raise
+                # Committed data may outlive its registration after a crash or
+                # loss of the index. Validate and register it without refetching.
+                logger.warning("Re-registering committed store '%s' without an artifact record", store_path)
+            else:
+                if publish and existing.publication.status != PublicationStatus.PUBLISHED:
+                    return publish_artifact_record(existing.artifact_id)
+                return existing
         materialization_scope = request_scope.model_copy(update={"start": plan.start, "end": plan.end})
 
         ingest_path = store_path
@@ -634,23 +642,24 @@ def _create_streaming_artifact(
             rollback_snapshot = snapshot
             rollback_branch = branch
 
-        plugin_handed_to_orchestrator = True
-        result = run_streaming_ingest_sync(
-            plugin=plugin,
-            params=params,
-            dataset=dataset,
-            bbox=bbox,
-            start=plan.start,
-            end=plan.end,
-            store_path=ingest_path,
-            period_type=str(dataset["period_type"]),
-            on_progress=on_progress,
-            is_cancel_requested=is_cancel_requested,
-            save_cursor=save_cursor,
-            periods=plan.periods,
-        )
-        if result.periods_written == 0 and not ingest_path.exists():
-            raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
+        if plan.action != SyncAction.NO_OP:
+            plugin_handed_to_orchestrator = True
+            result = run_streaming_ingest_sync(
+                plugin=plugin,
+                params=params,
+                dataset=dataset,
+                bbox=bbox,
+                start=plan.start,
+                end=plan.end,
+                store_path=ingest_path,
+                period_type=str(dataset["period_type"]),
+                on_progress=on_progress,
+                is_cancel_requested=is_cancel_requested,
+                save_cursor=save_cursor,
+                periods=plan.periods,
+            )
+            if result.periods_written == 0 and not ingest_path.exists():
+                raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
 
         coverage_data = get_data_coverage_for_paths(dataset, icechunk_path=str(ingest_path.resolve()))
         if not coverage_data.get("has_data", True):
@@ -719,7 +728,6 @@ def _create_streaming_artifact(
         )
         stored_record = _upsert_artifact_record(
             record,
-            publish=publish,
             overwrite=overwrite,
         )
         store_committed = True
@@ -743,11 +751,13 @@ def _create_streaming_artifact(
         return stored_record
     finally:
         try:
+            rollback_error: Exception | None = None
             if published_swap_pending and not store_committed:
                 try:
                     _rollback_store_swap(store_path)
                     published_swap_pending = False
-                except Exception:
+                except Exception as exc:
+                    rollback_error = exc
                     logger.error(
                         "Could not restore the previous store for '%s' after artifact registration failed",
                         store_path,
@@ -766,12 +776,19 @@ def _create_streaming_artifact(
                         close_plugin()
                     except Exception:
                         logger.warning("Could not close ingestion plugin after planning failure", exc_info=True)
-            if rollback_repo is not None and rollback_branch is not None and rollback_snapshot is not None:
+            if (
+                rollback_error is None
+                and rollback_repo is not None
+                and rollback_branch is not None
+                and rollback_snapshot is not None
+            ):
                 try:
                     if not store_committed:
                         rollback_repo.reset_branch("main", rollback_snapshot)
                     rollback_repo.delete_branch(rollback_branch)
-                except Exception:
+                except Exception as exc:
+                    if not store_committed:
+                        rollback_error = exc
                     logger.error(
                         "Could not %s append transaction for '%s'",
                         "roll back" if not store_committed else "clean up",
@@ -787,6 +804,12 @@ def _create_streaming_artifact(
                     # Cleanup is best-effort: the published store is still intact and the next
                     # overwrite removes this path before reuse. Do not mask the ingest failure.
                     logger.warning("Could not remove replacement store '%s'", replacement_path, exc_info=True)
+            if rollback_error is not None:
+                raise RuntimeError(
+                    f"Ingestion failed and rollback could not complete for '{store_path}'. "
+                    f"Retained recovery data and branch '{rollback_branch}' at snapshot '{rollback_snapshot}'; "
+                    "inspect the store and its .retired/.failed paths before retrying."
+                ) from rollback_error
         finally:
             # Releasing the in-process writer lock must not depend on filesystem cleanup.
             lock.release()
@@ -813,19 +836,26 @@ def recover_interrupted_swap(target: Path) -> bool:
     reader looks for. Called before the store is opened, so the next sync heals it rather
     than reporting an unreadable dataset.
 
+    An interrupted rollback also leaves its rejected replacement at ``.failed``.
+    Remove that copy only after the original store has been restored.
+
     Returns True when a recovery was performed.
     """
     retired = _retired_path(target)
-    if target.exists() or not retired.is_dir():
-        return False
-    retired.rename(target)
-    logger.warning(
-        "Recovered '%s' from '%s': a previous store swap was interrupted between its two "
-        "renames, leaving the published path missing.",
-        target.name,
-        retired.name,
-    )
-    return True
+    failed = target.with_name(f"{target.name}.failed")
+    recovered = False
+    if not target.exists() and retired.is_dir():
+        retired.rename(target)
+        recovered = True
+        logger.warning("Recovered '%s' from '%s' after an interrupted swap", target.name, retired.name)
+    # A rollback interrupted before or after restoring the retired store leaves
+    # its rejected replacement here. Delete it only once a usable target exists.
+    if target.exists() and failed.exists():
+        _remove_store_path(failed)
+        recovered = True
+    if not target.exists() and failed.exists():
+        raise RuntimeError(f"Cannot recover '{target}': only the rejected .failed store remains")
+    return recovered
 
 
 def _swap_store(staging: Path, target: Path, *, retain_previous: bool = False) -> None:
@@ -865,7 +895,7 @@ def _rollback_store_swap(target: Path) -> None:
     """Restore the retained store when replacement metadata cannot be persisted."""
     retired = _retired_path(target)
     if not retired.exists():
-        return
+        raise FileNotFoundError(f"Cannot roll back '{target}': retained store '{retired}' is missing")
     failed = target.with_name(f"{target.name}.failed")
     _remove_store_path(failed)
     target.rename(failed)
@@ -1002,7 +1032,7 @@ def register_artifact_record(record: ArtifactRecord, *, publish: bool) -> Artifa
     record's metadata — name, coverage, paths — rather than silently keeping the
     stale record, while preserving its artifact id and publication state.
     """
-    stored = _upsert_artifact_record(record, publish=publish, overwrite=True)
+    stored = _upsert_artifact_record(record, overwrite=True)
     if publish and stored.publication.status != PublicationStatus.PUBLISHED:
         return publish_artifact_record(stored.artifact_id)
     return stored
@@ -1385,11 +1415,7 @@ def _save_records(records: list[ArtifactRecord]) -> None:
     ARTIFACTS_INDEX_PATH.write_text(_encode_records(records), encoding="utf-8")
 
 
-def _store_artifact_record(
-    record: ArtifactRecord,
-    *,
-    publish: bool,
-) -> ArtifactRecord:
+def _store_artifact_record(record: ArtifactRecord) -> ArtifactRecord:
     """Persist a newly created artifact record while avoiding lost updates."""
 
     def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
@@ -1410,12 +1436,11 @@ def _store_artifact_record(
 def _upsert_artifact_record(
     record: ArtifactRecord,
     *,
-    publish: bool,
     overwrite: bool,
 ) -> ArtifactRecord:
     """Persist a new or replacement artifact record for the same logical request scope."""
     if not overwrite:
-        return _store_artifact_record(record, publish=publish)
+        return _store_artifact_record(record)
 
     def mutate(records: list[ArtifactRecord]) -> ArtifactRecord:
         existing = _find_artifact_by_request_scope(
@@ -1459,19 +1484,6 @@ def _mutate_records(mutation: Callable[[list[ArtifactRecord]], ArtifactRecord]) 
         os.fsync(handle.fileno())
         portalocker.unlock(handle)
         return result
-
-
-def _find_existing_artifact(
-    *,
-    dataset_id: str,
-    request_scope: ArtifactRequestScope,
-) -> ArtifactRecord | None:
-    """Return an existing artifact for an identical logical request when possible."""
-    return _find_existing_artifact_in_records(
-        records=_load_records(),
-        dataset_id=dataset_id,
-        request_scope=request_scope,
-    )
 
 
 def _normalize_request_period(value: str, *, period_type: str, field_name: str) -> str:
@@ -1602,38 +1614,6 @@ def _validate_download_scope(
         raise HTTPException(status_code=400, detail="download_end must be less than or equal to end")
 
 
-def _find_existing_artifact_in_records(
-    *,
-    records: list[ArtifactRecord],
-    dataset_id: str,
-    request_scope: ArtifactRequestScope,
-) -> ArtifactRecord | None:
-    """Return an existing artifact for an identical logical request from a provided record set."""
-    for record in reversed(records):
-        if not _artifact_storage_exists(record):
-            logger.warning(
-                "Ignoring stale artifact '%s' because backing storage is missing",
-                record.artifact_id,
-            )
-            continue
-        if record.dataset_id != dataset_id:
-            continue
-        if record.request_scope != request_scope:
-            continue
-        if not _artifact_coverage_matches_request_scope(record):
-            logger.warning(
-                "Ignoring existing artifact '%s' because coverage %s..%s does not match request scope %s..%s",
-                record.artifact_id,
-                record.coverage.temporal.start,
-                record.coverage.temporal.end,
-                record.request_scope.start,
-                record.request_scope.end,
-            )
-            continue
-        return record
-    return None
-
-
 def _find_artifact_by_request_scope(
     *,
     records: list[ArtifactRecord],
@@ -1642,9 +1622,9 @@ def _find_artifact_by_request_scope(
 ) -> ArtifactRecord | None:
     """Return the latest materialized record for the same operation request.
 
-    Unlike the API reuse lookup above, persistence must allow cumulative coverage
-    to extend beyond a finite incremental request. The caller compares coverage
-    when deduplicating and replaces the record explicitly for overwrite semantics.
+    Persistence allows cumulative coverage to extend beyond a finite incremental
+    request. The caller compares coverage when deduplicating and replaces the record
+    explicitly for overwrite semantics.
     """
     for record in reversed(records):
         if record.dataset_id != dataset_id or record.request_scope != request_scope:
@@ -1652,11 +1632,6 @@ def _find_artifact_by_request_scope(
         if _artifact_storage_exists(record):
             return record
     return None
-
-
-def _artifact_coverage_matches_request_scope(record: ArtifactRecord) -> bool:
-    """Return whether an existing artifact is safe to reuse for its request scope."""
-    return _temporal_coverage_matches_request_scope(record.coverage.temporal, record.request_scope)
 
 
 def _materialized_records(records: list[ArtifactRecord]) -> list[ArtifactRecord]:

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -441,7 +441,10 @@ def _plan_streaming_materialization(
             committed_periods=committed,
         )
 
-    if period_type == "climatology" and (not start.isdigit() or not end.isdigit()):
+    climatology_has_reference_bounds = period_type == "climatology" and not (
+        start.isdigit() and end.isdigit() and 1 <= int(start) <= 366 and 1 <= int(end) <= 366
+    )
+    if climatology_has_reference_bounds:
         # Date-shaped bounds describe the reference interval. Ask the source for
         # the ordinal materialization scope so a partial store cannot define its
         # own target and incorrectly appear complete.
@@ -644,9 +647,10 @@ def _create_streaming_artifact(
             _remove_store_path(replacement_path)
             ingest_path = replacement_path
         elif plan.action != SyncAction.NO_OP and plan.has_committed_periods:
-            # Icechunk commits each fetched period independently. Keep the pre-ingest
-            # snapshot reachable so an exception after any commit can restore the public
-            # branch instead of leaving a partial append or a stale pyramid behind.
+            # Icechunk commits each fetched period independently. Keep a pre-ingest
+            # snapshot for failures after ingest completes (for example normalization
+            # or record persistence). Mid-ingest failures retain their committed prefix
+            # so a retry can resume instead of downloading successful periods again.
             repo = open_or_create_repo(store_path)
             snapshot = repo.lookup_branch("main")
             branch = f"ocs-ingest-rollback-{uuid4().hex}"

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -61,7 +61,7 @@ from open_climate_service.shared.time import (
     utc_today,
 )
 from open_climate_service.streaming.orchestrator import run_streaming_ingest_sync
-from open_climate_service.streaming.protocol import IngestionPlugin
+from open_climate_service.streaming.protocol import IngestionPlugin, close_ingestion_plugin
 from open_climate_service.streaming.store import (
     open_or_create_repo,
     read_committed_period_ids_ordered,
@@ -385,6 +385,18 @@ def _validate_source_periods(
     return available
 
 
+def _no_op_streaming_plan(committed: list[str], current_start: str, current_end: str) -> _StreamingMaterializationPlan:
+    """Build the common plan for reusing an already complete store."""
+    return _StreamingMaterializationPlan(
+        action=SyncAction.NO_OP,
+        start=current_start,
+        end=current_end,
+        periods=committed,
+        has_committed_periods=True,
+        committed_periods=committed,
+    )
+
+
 def _plan_streaming_materialization(
     *,
     plugin: IngestionPlugin,
@@ -412,7 +424,7 @@ def _plan_streaming_materialization(
         source="Committed store",
         require_ordered=False,
     )
-    if overwrite:
+    if overwrite or not committed:
         available = _validate_source_periods(
             periods if periods is not None else asyncio.run(plugin.periods(start, end)),
             start=start,
@@ -421,7 +433,7 @@ def _plan_streaming_materialization(
             scope="temporal scope",
         )
         return _StreamingMaterializationPlan(
-            action=SyncAction.REMATERIALIZE,
+            action=SyncAction.REMATERIALIZE if overwrite else SyncAction.APPEND,
             start=available[0] if period_type == "climatology" else start,
             end=available[-1],
             periods=available,
@@ -429,7 +441,10 @@ def _plan_streaming_materialization(
             committed_periods=committed,
         )
 
-    if not committed:
+    if period_type == "climatology" and (not start.isdigit() or not end.isdigit()):
+        # Date-shaped bounds describe the reference interval. Ask the source for
+        # the ordinal materialization scope so a partial store cannot define its
+        # own target and incorrectly appear complete.
         available = _validate_source_periods(
             periods if periods is not None else asyncio.run(plugin.periods(start, end)),
             start=start,
@@ -437,21 +452,8 @@ def _plan_streaming_materialization(
             period_type=period_type,
             scope="temporal scope",
         )
-        return _StreamingMaterializationPlan(
-            action=SyncAction.APPEND,
-            start=available[0] if period_type == "climatology" else start,
-            end=available[-1],
-            periods=available,
-            has_committed_periods=False,
-            committed_periods=committed,
-        )
-
-    if period_type == "climatology" and (not start.isdigit() or not end.isdigit()):
-        # Date-shaped request bounds describe the reference interval, while the
-        # committed store is indexed by ordinal day. A complete climatology is
-        # immutable under this ingestion policy.
-        start = min(committed, key=lambda value: _period_order_key(value, period_type))
-        end = max(committed, key=lambda value: _period_order_key(value, period_type))
+        start, end = available[0], available[-1]
+        periods = available
 
     current_start = min(committed, key=lambda value: _period_order_key(value, period_type))
     current_end = max(committed, key=lambda value: _period_order_key(value, period_type))
@@ -463,14 +465,7 @@ def _plan_streaming_materialization(
     # Reuse the current artifact without asking a rolling source to enumerate
     # historical periods that it may no longer expose.
     if materialization_start == current_start and materialization_end == current_end and committed_is_contiguous:
-        return _StreamingMaterializationPlan(
-            action=SyncAction.NO_OP,
-            start=current_start,
-            end=current_end,
-            periods=committed,
-            has_committed_periods=True,
-            committed_periods=committed,
-        )
+        return _no_op_streaming_plan(committed, current_start, current_end)
 
     # A contiguous store that only needs a forward extension requires the source
     # to enumerate the missing delta, not reproduce committed history. Reuse a
@@ -490,14 +485,7 @@ def _plan_streaming_materialization(
             if _period_order_key(period, period_type) >= _period_order_key(expected_start, period_type)
         ]
         if not delta:
-            return _StreamingMaterializationPlan(
-                action=SyncAction.NO_OP,
-                start=current_start,
-                end=current_end,
-                periods=committed,
-                has_committed_periods=True,
-                committed_periods=committed,
-            )
+            return _no_op_streaming_plan(committed, current_start, current_end)
         if delta[0] != expected_start or not _periods_are_contiguous(delta, period_type):
             raise HTTPException(
                 status_code=409,
@@ -632,7 +620,10 @@ def _create_streaming_artifact(
                 logger.warning("Re-registering committed store '%s' without an artifact record", store_path)
             else:
                 temporal = existing.coverage.temporal
-                if temporal.start == plan.start and temporal.end == plan.end:
+                coverage_is_current = str(dataset["period_type"]) == "climatology" or (
+                    temporal.start == plan.start and temporal.end == plan.end
+                )
+                if coverage_is_current:
                     if publish and existing.publication.status != PublicationStatus.PUBLISHED:
                         return publish_artifact_record(existing.artifact_id)
                     return existing
@@ -679,7 +670,7 @@ def _create_streaming_artifact(
                 is_cancel_requested=is_cancel_requested,
                 save_cursor=save_cursor,
                 periods=plan.periods,
-                committed_periods=plan.committed_periods,
+                committed_periods=plan.committed_periods if ingest_path == store_path else [],
             )
             ingest_completed = True
             if result.periods_written == 0 and not ingest_path.exists():
@@ -786,12 +777,10 @@ def _create_streaming_artifact(
                 except Exception:
                     logger.warning("Could not clean up retired store '%s'", store_path, exc_info=True)
             if not plugin_handed_to_orchestrator:
-                close_plugin = getattr(plugin, "close", None)
-                if callable(close_plugin):
-                    try:
-                        close_plugin()
-                    except Exception:
-                        logger.warning("Could not close ingestion plugin after planning failure", exc_info=True)
+                try:
+                    close_ingestion_plugin(plugin)
+                except Exception:
+                    logger.warning("Could not close ingestion plugin after planning failure", exc_info=True)
             if (
                 rollback_error is None
                 and rollback_repo is not None
@@ -801,7 +790,14 @@ def _create_streaming_artifact(
                 try:
                     if not store_committed and ingest_completed:
                         rollback_repo.reset_branch("main", rollback_snapshot)
-                    rollback_repo.delete_branch(rollback_branch)
+                    try:
+                        rollback_repo.delete_branch(rollback_branch)
+                    except Exception as exc:
+                        # Recovery may already have removed the temporary ref. The
+                        # snapshot reset above is the operation that restores data;
+                        # an absent cleanup ref must not mask the original failure.
+                        if "ref not found" not in str(exc).lower():
+                            raise
                 except Exception as exc:
                     if not store_committed:
                         rollback_error = exc
@@ -965,11 +961,6 @@ def _maybe_build_pyramid(
     roll back instead.
     """
     from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
-
-    # Belt and braces: `_create_streaming_artifact` already heals this under the lock before
-    # ingest, which is the call that matters. Kept because this function is also entered
-    # directly, and because it is idempotent — a present target makes it a no-op.
-    recover_interrupted_swap(store_path)
 
     try:
         ds = open_icechunk_dataset(store_path)

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Protocol, cast
@@ -98,6 +98,7 @@ class _StreamingMaterializationPlan:
     end: str
     periods: list[str] | None
     has_committed_periods: bool
+    committed_periods: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -361,12 +362,17 @@ def _validate_source_periods(
     available = _normalize_ordered_periods(periods, period_type=period_type, source="Ingestion plugin")
     if not available:
         raise HTTPException(status_code=409, detail=f"Source has no data for the requested {scope}")
-    if available[0] != start:
+    # Climatology plugins enumerate ordinal day-of-year values while the API and
+    # management UI use date-shaped dataset bounds. Those bounds describe the
+    # reference climate interval, not the ordinal materialization axis.
+    if period_type != "climatology" and available[0] != start:
         raise HTTPException(
             status_code=409,
             detail=f"Source cannot materialize the requested {scope} from {start}; first available is {available[0]}",
         )
-    if _period_order_key(available[-1], period_type) > _period_order_key(end, period_type):
+    if period_type != "climatology" and _period_order_key(available[-1], period_type) > _period_order_key(
+        end, period_type
+    ):
         raise HTTPException(
             status_code=409,
             detail=f"Source returned period {available[-1]} beyond the requested {scope} ending {end}",
@@ -416,10 +422,11 @@ def _plan_streaming_materialization(
         )
         return _StreamingMaterializationPlan(
             action=SyncAction.REMATERIALIZE,
-            start=start,
+            start=available[0] if period_type == "climatology" else start,
             end=available[-1],
             periods=available,
             has_committed_periods=bool(committed),
+            committed_periods=committed,
         )
 
     if not committed:
@@ -432,11 +439,19 @@ def _plan_streaming_materialization(
         )
         return _StreamingMaterializationPlan(
             action=SyncAction.APPEND,
-            start=start,
+            start=available[0] if period_type == "climatology" else start,
             end=available[-1],
             periods=available,
             has_committed_periods=False,
+            committed_periods=committed,
         )
+
+    if period_type == "climatology" and (not start.isdigit() or not end.isdigit()):
+        # Date-shaped request bounds describe the reference interval, while the
+        # committed store is indexed by ordinal day. A complete climatology is
+        # immutable under this ingestion policy.
+        start = min(committed, key=lambda value: _period_order_key(value, period_type))
+        end = max(committed, key=lambda value: _period_order_key(value, period_type))
 
     current_start = min(committed, key=lambda value: _period_order_key(value, period_type))
     current_end = max(committed, key=lambda value: _period_order_key(value, period_type))
@@ -454,6 +469,7 @@ def _plan_streaming_materialization(
             end=current_end,
             periods=committed,
             has_committed_periods=True,
+            committed_periods=committed,
         )
 
     # A contiguous store that only needs a forward extension requires the source
@@ -480,6 +496,7 @@ def _plan_streaming_materialization(
                 end=current_end,
                 periods=committed,
                 has_committed_periods=True,
+                committed_periods=committed,
             )
         if delta[0] != expected_start or not _periods_are_contiguous(delta, period_type):
             raise HTTPException(
@@ -500,6 +517,7 @@ def _plan_streaming_materialization(
             end=delta[-1],
             periods=delta,
             has_committed_periods=True,
+            committed_periods=committed,
         )
 
     available = _validate_source_periods(
@@ -522,18 +540,13 @@ def _plan_streaming_materialization(
             ),
         )
 
-    committed_is_prefix = available[: len(committed)] == committed
-    action = (
-        SyncAction.APPEND
-        if committed_is_prefix and materialization_start == current_start
-        else SyncAction.REMATERIALIZE
-    )
     return _StreamingMaterializationPlan(
-        action=action,
+        action=SyncAction.REMATERIALIZE,
         start=materialization_start,
         end=available[-1],
         periods=available,
         has_committed_periods=True,
+        committed_periods=committed,
     )
 
 
@@ -590,6 +603,7 @@ def _create_streaming_artifact(
     published_swap_pending = False
     store_committed = False
     plugin_handed_to_orchestrator = False
+    ingest_completed = False
     try:
         # First thing under the lock, before anything looks at the store. A swap killed between
         # its two renames leaves the published path missing and the data at `.retired`; ingest
@@ -617,9 +631,17 @@ def _create_streaming_artifact(
                 # loss of the index. Validate and register it without refetching.
                 logger.warning("Re-registering committed store '%s' without an artifact record", store_path)
             else:
-                if publish and existing.publication.status != PublicationStatus.PUBLISHED:
-                    return publish_artifact_record(existing.artifact_id)
-                return existing
+                temporal = existing.coverage.temporal
+                if temporal.start == plan.start and temporal.end == plan.end:
+                    if publish and existing.publication.status != PublicationStatus.PUBLISHED:
+                        return publish_artifact_record(existing.artifact_id)
+                    return existing
+                logger.warning(
+                    "Re-registering committed store '%s' because artifact coverage %s..%s is stale",
+                    store_path,
+                    temporal.start,
+                    temporal.end,
+                )
         materialization_scope = request_scope.model_copy(update={"start": plan.start, "end": plan.end})
 
         ingest_path = store_path
@@ -630,7 +652,7 @@ def _create_streaming_artifact(
             replacement_path = store_path.with_name(f"{store_path.name}.replacement")
             _remove_store_path(replacement_path)
             ingest_path = replacement_path
-        elif plan.has_committed_periods:
+        elif plan.action != SyncAction.NO_OP and plan.has_committed_periods:
             # Icechunk commits each fetched period independently. Keep the pre-ingest
             # snapshot reachable so an exception after any commit can restore the public
             # branch instead of leaving a partial append or a stale pyramid behind.
@@ -657,7 +679,9 @@ def _create_streaming_artifact(
                 is_cancel_requested=is_cancel_requested,
                 save_cursor=save_cursor,
                 periods=plan.periods,
+                committed_periods=plan.committed_periods,
             )
+            ingest_completed = True
             if result.periods_written == 0 and not ingest_path.exists():
                 raise HTTPException(status_code=409, detail="Source has no data for the requested temporal scope")
 
@@ -701,7 +725,7 @@ def _create_streaming_artifact(
         )
         if plan.has_committed_periods and not normalization.completed:
             raise RuntimeError(f"Could not normalize '{dataset['id']}'; the dataset update was rolled back")
-        if normalization.swapped and ingest_path == store_path:
+        if normalization.swapped and ingest_path == store_path and plan.has_committed_periods:
             # Pyramid normalization replaced the published repository but retained
             # the previous one until its matching artifact record is durable. From
             # here, rollback first restores that repository and then resets its main
@@ -732,14 +756,6 @@ def _create_streaming_artifact(
         )
         store_committed = True
         if published_swap_pending:
-            try:
-                _finalize_store_swap(store_path)
-                published_swap_pending = False
-            except Exception:
-                # The record and replacement are already durable. Retaining the old
-                # directory is only a cleanup leak; restoring it would make the record
-                # point at stale data. A later run may retry the cleanup.
-                logger.warning("Could not remove retired store '%s' after commit", store_path, exc_info=True)
             # A swapped-out repository either disappeared with successful cleanup or
             # remains only as a retired fallback. Never try to operate on its temporary
             # branch through the newly published repository path.
@@ -783,7 +799,7 @@ def _create_streaming_artifact(
                 and rollback_snapshot is not None
             ):
                 try:
-                    if not store_committed:
+                    if not store_committed and ingest_completed:
                         rollback_repo.reset_branch("main", rollback_snapshot)
                     rollback_repo.delete_branch(rollback_branch)
                 except Exception as exc:
@@ -855,6 +871,19 @@ def recover_interrupted_swap(target: Path) -> bool:
         recovered = True
     if not target.exists() and failed.exists():
         raise RuntimeError(f"Cannot recover '{target}': only the rejected .failed store remains")
+    if target.exists() and (target / "repo").exists():
+        try:
+            repo = open_or_create_repo(target)
+            stale_branches = [branch for branch in repo.list_branches() if branch.startswith("ocs-ingest-rollback-")]
+            for branch in stale_branches:
+                repo.delete_branch(branch)
+            if stale_branches:
+                recovered = True
+                logger.warning("Removed %d stale ingest rollback branch(es) from '%s'", len(stale_branches), target)
+        except Exception:
+            # Swap recovery must remain usable for older or partially damaged
+            # repositories whose branch metadata cannot be inspected.
+            logger.warning("Could not clean stale ingest rollback branches from '%s'", target, exc_info=True)
     return recovered
 
 

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -391,9 +391,10 @@ def _plan_streaming_materialization(
 ) -> _StreamingMaterializationPlan:
     """Plan a contiguous union before allowing streaming ingest to write.
 
-    A forward request can append only when the committed coordinate is an exact
-    prefix of every source-valid period in the union. Earlier requests, gaps, or
-    non-monotonic committed coordinates require a sibling-store rematerialization.
+    A forward request extends a contiguous committed prefix by enumerating only
+    the missing delta; the source need not reproduce committed history. Earlier
+    requests, gaps, or non-monotonic committed coordinates require a sibling-store
+    rematerialization and a source that can reproduce the complete union.
     """
     committed = _normalize_ordered_periods(
         read_committed_period_ids_ordered(
@@ -511,11 +512,13 @@ def _plan_streaming_materialization(
     available_set = set(available)
     missing_committed = [period for period in committed if period not in available_set]
     if missing_committed:
+        missing_summary = ", ".join(missing_committed[:5])
+        if len(missing_committed) > 5:
+            missing_summary += f" and {len(missing_committed) - 5} more"
         raise HTTPException(
             status_code=409,
             detail=(
-                "Source can no longer reproduce committed period(s) required for the temporal union: "
-                + ", ".join(missing_committed[:5])
+                "Source can no longer reproduce committed period(s) required for the temporal union: " + missing_summary
             ),
         )
 
@@ -552,10 +555,10 @@ def _create_streaming_artifact(
 ) -> ArtifactRecord:
     """Create or update one plugin-backed Icechunk artifact.
 
-    The same helper is used for both initial ingest and store-based sync. The
-    streaming orchestrator enumerates the plugin's periods for the full requested
-    range, then appends only periods that are not already committed in the target
-    Icechunk-backed store.
+    The same helper is used for both initial ingest and store-based sync. Planning
+    enumerates the missing delta for a forward append, or the complete scope for
+    a new store or rematerialization. The orchestrator receives the planned periods
+    and fetches only those not already committed in its target Icechunk store.
     """
     if bbox is None:
         raise HTTPException(status_code=400, detail="Streaming ingest requires a bounding box")

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -719,7 +719,7 @@ def _create_streaming_artifact(
             dataset,
             retain_previous=plan.has_committed_periods and replacement_path is None,
         )
-        if plan.has_committed_periods and not normalization.completed:
+        if plan.action != SyncAction.NO_OP and plan.has_committed_periods and not normalization.completed:
             raise RuntimeError(f"Could not normalize '{dataset['id']}'; the dataset update was rolled back")
         if normalization.swapped and ingest_path == store_path and plan.has_committed_periods:
             # Pyramid normalization replaced the published repository but retained

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -71,7 +71,10 @@ def plan_sync(
     if not isinstance(sync_kind_value, str) or not sync_kind_value:
         raise ValueError("source_dataset must define sync.kind for sync planning")
     sync_kind = SyncKind(sync_kind_value)
-    current_start = latest_artifact.request_scope.start
+    # Request scope is operation provenance and may describe only the latest
+    # incremental ingest. Sync planning must use the cumulative realized store
+    # coverage as its artifact scope.
+    current_start = latest_artifact.coverage.temporal.start
 
     if sync_kind == SyncKind.STATIC:
         # Static datasets are never synced. Report NOT_SYNCABLE directly, reading the

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -31,10 +30,9 @@ from open_climate_service.ingestions.schemas import (
 from open_climate_service.publications.services import managed_dataset_id_for
 from open_climate_service.shared.time import (
     datetime_to_period_string,
-    dekad_bounds,
     dekad_start,
+    next_period_string,
     normalize_period_string,
-    parse_hourly_period_string,
     parse_period_string_to_datetime,
     utc_now,
     utc_today,
@@ -302,7 +300,7 @@ def run_sync(
         download_end=sync_detail.delta_end if download_start is not None else None,
         bbox=list(latest_artifact.request_scope.bbox) if latest_artifact.request_scope.bbox is not None else None,
         country_code=country_code,
-        overwrite=False,
+        overwrite=sync_detail.action == SyncAction.REMATERIALIZE,
         publish=publish,
         on_progress=on_progress,
         periods=sync_detail.periods,
@@ -378,30 +376,10 @@ def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
     This helper is part of sync planning because temporal datasets need to know
     whether another period could exist beyond the current materialized coverage.
     """
-    if period_type == "hourly":
-        timestamp = parse_hourly_period_string(latest_period_end)
-        return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
-    if period_type == "daily":
-        current = date.fromisoformat(latest_period_end)
-        return (current + timedelta(days=1)).isoformat()
-    if period_type == "dekadal":
-        # Step by the covered dekad's own length rather than a fixed 10 days, since the
-        # third dekad of a month runs 8-11 days.
-        _, dekad_end = dekad_bounds(latest_period_end)
-        return (dekad_end + timedelta(days=1)).isoformat()
-    if period_type == "weekly":
-        current = parse_period_string_to_datetime(latest_period_end).date()
-        next_week = datetime.combine(current + timedelta(days=7), time(0))
-        return datetime_to_period_string(next_week, period_type)
-    if period_type == "monthly":
-        current = date.fromisoformat(f"{latest_period_end}-01")
-        month = current.month + 1
-        year = current.year + (1 if month == 13 else 0)
-        month = 1 if month == 13 else month
-        return f"{year:04d}-{month:02d}"
-    if period_type == "yearly":
-        return str(int(latest_period_end) + 1)
-    raise ValueError(f"Unsupported period_type '{period_type}' for sync")
+    try:
+        return next_period_string(latest_period_end, period_type)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported period_type '{period_type}' for sync") from exc
 
 
 def _default_target_end(*, period_type: str) -> str:

--- a/open_climate_service/ingestions/sync_engine.py
+++ b/open_climate_service/ingestions/sync_engine.py
@@ -102,7 +102,7 @@ def plan_sync(
         target_end = _default_target_end(period_type=period_type)
 
     if sync_kind == SyncKind.TEMPORAL:
-        next_period_start = _next_period_start(current_end, period_type=period_type)
+        next_period_start = next_period_string(current_end, period_type)
         if next_period_start > target_end:
             return SyncDetail(
                 source_dataset_id=latest_artifact.dataset_id,
@@ -368,18 +368,6 @@ def _query_available_periods(
     params: dict[str, Any] = source_dataset.get("ingestion", {}).get("params") or {}
     plugin = instantiate_plugin(plugin_path, params)
     return asyncio.run(plugin.periods(start, target_end))
-
-
-def _next_period_start(latest_period_end: str, *, period_type: str) -> str:
-    """Return the next dataset-native period after a covered temporal end value.
-
-    This helper is part of sync planning because temporal datasets need to know
-    whether another period could exist beyond the current materialized coverage.
-    """
-    try:
-        return next_period_string(latest_period_end, period_type)
-    except ValueError as exc:
-        raise ValueError(f"Unsupported period_type '{period_type}' for sync") from exc
 
 
 def _default_target_end(*, period_type: str) -> str:

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -3,7 +3,7 @@
 import calendar
 import logging
 import re
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from enum import StrEnum
 from typing import Any, cast
 
@@ -324,6 +324,31 @@ def dekad_period_ids(start: str | date, end: str | date, *, cutoff: str | date |
         _, dekad_end = dekad_bounds(current)
         current = dekad_end + timedelta(days=1)
     return out
+
+
+def next_period_string(period: str, period_type: str) -> str:
+    """Return the dataset-native period immediately following ``period``."""
+    if period_type == "hourly":
+        timestamp = parse_hourly_period_string(period)
+        return datetime_to_period_string(timestamp + timedelta(hours=1), period_type)
+    if period_type == "daily":
+        return (date.fromisoformat(period) + timedelta(days=1)).isoformat()
+    if period_type == "dekadal":
+        _, end = dekad_bounds(period)
+        return (end + timedelta(days=1)).isoformat()
+    if period_type == "weekly":
+        current = parse_period_string_to_datetime(period).date()
+        return datetime_to_period_string(datetime.combine(current + timedelta(days=7), time(0)), period_type)
+    if period_type == "monthly":
+        current = date.fromisoformat(f"{period}-01")
+        year = current.year + (1 if current.month == 12 else 0)
+        month = 1 if current.month == 12 else current.month + 1
+        return f"{year:04d}-{month:02d}"
+    if period_type == "yearly":
+        return str(int(period) + 1)
+    if period_type == "climatology":
+        return str(int(period) + 1)
+    raise ValueError(f"Unsupported period_type '{period_type}'")
 
 
 def parse_hourly_period_string(value: str) -> datetime:

--- a/open_climate_service/shared/time.py
+++ b/open_climate_service/shared/time.py
@@ -38,7 +38,7 @@ _NON_TEMPORAL_PERIOD_TYPES = frozenset({"climatology"})
 # Period types a dataset template may declare. Deliberately *not* derived from
 # _PERIOD_TYPE_ISO_STEP: that map exists to give STAC a step for whatever is already in a
 # store, and includes "quarterly", which none of datetime_to_period_string,
-# normalize_period_string, numpy_datetime_to_period_string, _next_period_start or
+# normalize_period_string, numpy_datetime_to_period_string, next_period_string or
 # _default_target_end implement. Deriving the two from one set would advertise quarterly as
 # registerable and then fail at ingest, so they are kept apart.
 SUPPORTED_PERIOD_TYPES = (

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -31,7 +31,7 @@ from open_climate_service.shared.raster_contract import (
     prepare_for_publication,
     spatial_coords_match,
 )
-from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin
+from open_climate_service.streaming.protocol import GridSpec, IngestionPlugin, close_ingestion_plugin
 from open_climate_service.streaming.store import (
     committed_data_group,
     is_store_empty,
@@ -179,9 +179,7 @@ async def run_streaming_ingest(
 
     all_periods = periods if periods is not None else await plugin.periods(start, end)
     if not all_periods:
-        close_plugin = getattr(plugin, "close", None)
-        if callable(close_plugin):
-            close_plugin()
+        close_ingestion_plugin(plugin)
         return StreamingIngestResult(store_path=store_path, period_type=period_type, periods_written=0)
 
     committed = (
@@ -191,9 +189,7 @@ async def run_streaming_ingest(
     )
     pending = [period for period in all_periods if period not in committed]
     if not pending:
-        close_plugin = getattr(plugin, "close", None)
-        if callable(close_plugin):
-            close_plugin()
+        close_ingestion_plugin(plugin)
         return StreamingIngestResult(store_path=store_path, period_type=period_type, periods_written=0)
 
     if on_progress:
@@ -204,9 +200,7 @@ async def run_streaming_ingest(
     elif is_store_empty(store_path):
         is_first_write = True
     else:
-        close_plugin = getattr(plugin, "close", None)
-        if callable(close_plugin):
-            close_plugin()
+        close_ingestion_plugin(plugin)
         raise RuntimeError(
             f"Existing store at {store_path} holds data whose committed periods could not be read, so it is "
             "neither safe to append to nor safe to overwrite. Inspect the store, or remove it to re-ingest "
@@ -340,9 +334,7 @@ async def run_streaming_ingest(
             task.cancel()
         if tasks_to_cancel:
             await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
-        close_plugin = getattr(plugin, "close", None)
-        if callable(close_plugin):
-            close_plugin()
+        close_ingestion_plugin(plugin)
 
     # Prune intermediate ingest snapshots: each period commit created one snapshot;
     # only the final HEAD state needs to be retained.  expire_snapshots marks older

--- a/open_climate_service/streaming/orchestrator.py
+++ b/open_climate_service/streaming/orchestrator.py
@@ -154,6 +154,7 @@ async def run_streaming_ingest(
     is_cancel_requested: Callable[[], bool] | None = None,
     save_cursor: Callable[[dict[str, Any]], None] | None = None,
     periods: list[str] | None = None,
+    committed_periods: list[str] | None = None,
 ) -> StreamingIngestResult:
     """Stream one dataset into a flat Zarr v3 store one period at a time.
 
@@ -178,11 +179,21 @@ async def run_streaming_ingest(
 
     all_periods = periods if periods is not None else await plugin.periods(start, end)
     if not all_periods:
+        close_plugin = getattr(plugin, "close", None)
+        if callable(close_plugin):
+            close_plugin()
         return StreamingIngestResult(store_path=store_path, period_type=period_type, periods_written=0)
 
-    committed = read_committed_period_ids(store_path, period_type, time_dim=time_dim)
+    committed = (
+        set(committed_periods)
+        if committed_periods is not None
+        else read_committed_period_ids(store_path, period_type, time_dim=time_dim)
+    )
     pending = [period for period in all_periods if period not in committed]
     if not pending:
+        close_plugin = getattr(plugin, "close", None)
+        if callable(close_plugin):
+            close_plugin()
         return StreamingIngestResult(store_path=store_path, period_type=period_type, periods_written=0)
 
     if on_progress:
@@ -193,6 +204,9 @@ async def run_streaming_ingest(
     elif is_store_empty(store_path):
         is_first_write = True
     else:
+        close_plugin = getattr(plugin, "close", None)
+        if callable(close_plugin):
+            close_plugin()
         raise RuntimeError(
             f"Existing store at {store_path} holds data whose committed periods could not be read, so it is "
             "neither safe to append to nor safe to overwrite. Inspect the store, or remove it to re-ingest "
@@ -361,6 +375,7 @@ def run_streaming_ingest_sync(
     is_cancel_requested: Callable[[], bool] | None = None,
     save_cursor: Callable[[dict[str, Any]], None] | None = None,
     periods: list[str] | None = None,
+    committed_periods: list[str] | None = None,
 ) -> StreamingIngestResult:
     """Synchronous wrapper for threaded job execution.
 
@@ -389,5 +404,6 @@ def run_streaming_ingest_sync(
             is_cancel_requested=is_cancel_requested,
             save_cursor=save_cursor,
             periods=periods,
+            committed_periods=committed_periods,
         )
     )

--- a/open_climate_service/streaming/protocol.py
+++ b/open_climate_service/streaming/protocol.py
@@ -121,3 +121,10 @@ class IngestionPlugin(Protocol):
         natively-async sources; the orchestrator awaits or threads it accordingly.
         """
         ...
+
+
+def close_ingestion_plugin(plugin: IngestionPlugin) -> None:
+    """Close an ingestion plugin when it exposes an optional close hook."""
+    close = getattr(plugin, "close", None)
+    if callable(close):
+        close()

--- a/open_climate_service/streaming/protocol.py
+++ b/open_climate_service/streaming/protocol.py
@@ -99,6 +99,9 @@ class IngestionPlugin(Protocol):
       `t` / `x` / `y`), and `crs` (the CRS fallback for grid inference, default 4326)
 
     The store grid is inferred from the first fetched period.
+    Planning may run `periods(...)` on a different event loop from asynchronous
+    `fetch_period(...)` calls. Do not share loop-bound resources between them;
+    create and close those resources within the call that uses them.
     `ingestion.params` are forwarded to `fetch_period(...)` as `**params` for
     sources that prefer per-call configuration rather than constructor state.
 

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -80,19 +80,23 @@ def _open_committed(store_path: Path) -> Any:
     return xr.open_zarr(store) if group is None else xr.open_zarr(store, group=group)
 
 
-def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: str = "t") -> set[str]:
-    """Return period ids already committed in the store, or an empty set.
+def read_committed_period_ids_ordered(store_path: Path, period_type: str, *, time_dim: str = "t") -> list[str]:
+    """Return committed period ids in their stored coordinate order.
 
     Resume correctness is store-first: if the repository already contains a
     committed time step, the orchestrator treats that as authoritative even when
     a persisted cursor is stale or missing.
+
+    Order matters to ingestion planning: a set can identify already-written
+    periods, but cannot distinguish a safe forward append from a store whose time
+    axis contains a gap or runs backwards.
     """
     import pandas as pd
 
     from open_climate_service.shared.time import datetime_to_period_string
 
     if not store_path.exists():
-        return set()
+        return []
 
     try:
         # Level 0 rather than the root: the root time coordinate of a pyramided store is
@@ -101,7 +105,7 @@ def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: s
         ds = _open_committed(store_path)
         try:
             if time_dim not in ds.coords:
-                return set()
+                return []
             coord = ds[time_dim]
             if coord.dtype.kind != "M":
                 # Non-datetime (ordinal) step dimension — e.g. an integer
@@ -110,17 +114,22 @@ def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: s
                 # as datetimes would mangle every value and leave ``committed``
                 # empty, causing duplicate appends on resume.
                 if coord.dtype.kind in "iu":
-                    return {str(int(item)) for item in coord.values}
-                return {str(item.item()) for item in coord.values}
-            return {
+                    return [str(int(item)) for item in coord.values]
+                return [str(item.item()) for item in coord.values]
+            return [
                 datetime_to_period_string(pd.Timestamp(item.item()).to_pydatetime(), period_type)
                 for item in coord.values
-            }
+            ]
         finally:
             ds.close()
     except Exception:
         logger.debug("Could not read committed periods from %s", store_path, exc_info=True)
-        return set()
+        return []
+
+
+def read_committed_period_ids(store_path: Path, period_type: str, *, time_dim: str = "t") -> set[str]:
+    """Return period ids already committed in the store, or an empty set."""
+    return set(read_committed_period_ids_ordered(store_path, period_type, time_dim=time_dim))
 
 
 def is_store_empty(store_path: Path) -> bool:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -22,6 +22,39 @@ from open_climate_service.plugins.datasets.chirps3 import CHIRPS3DailyPlugin
 from open_climate_service.publications.services import managed_dataset_id_for
 
 
+class _PeriodsPlugin:
+    def __init__(self, periods: list[str]) -> None:
+        self.available_periods = periods
+        self.calls: list[tuple[str, str]] = []
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        self.calls.append((start, end))
+        return list(self.available_periods)
+
+    def fetch_period(self, period_id: str, bbox: list[float], **params: object) -> xr.Dataset:
+        raise AssertionError("planner tests must not fetch data")
+
+
+class _TransactionRepo:
+    def __init__(self) -> None:
+        self.created: list[tuple[str, str]] = []
+        self.reset: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
+
+    def lookup_branch(self, branch: str) -> str:
+        assert branch == "main"
+        return "before-ingest"
+
+    def create_branch(self, branch: str, snapshot: str) -> None:
+        self.created.append((branch, snapshot))
+
+    def reset_branch(self, branch: str, snapshot: str) -> None:
+        self.reset.append((branch, snapshot))
+
+    def delete_branch(self, branch: str) -> None:
+        self.deleted.append(branch)
+
+
 @pytest.fixture(autouse=True)
 def materialized_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(services, "_artifact_storage_exists", lambda _: True)
@@ -285,6 +318,25 @@ def test_mutate_records_persists_mutation(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert [record.artifact_id for record in records] == ["mutated"]
 
 
+def test_store_artifact_records_new_coverage_for_repeated_open_ended_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "artifacts"
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", artifacts_dir)
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", artifacts_dir / "records.json")
+    first = _artifact(artifact_id="first", end="2026-01-31")
+    first.request_scope.end = None
+    updated = _artifact(artifact_id="updated", end="2026-02-28")
+    updated.request_scope.end = None
+    services._save_records([first])
+
+    stored = services._store_artifact_record(updated, publish=False)
+
+    assert stored.artifact_id == "updated"
+    assert [record.artifact_id for record in services._load_records()] == ["first", "updated"]
+
+
 def test_find_existing_artifact_ignores_record_with_overwide_coverage() -> None:
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
@@ -410,6 +462,84 @@ def test_temporal_coverage_matches_streaming_request_scope_requires_exact_start(
     )
 
 
+def test_plan_streaming_materialization_fills_non_adjacent_periods(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02", "2026-01-03"])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *_args, **_kwargs: ["2026-01-01"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-03",
+        end="2026-01-03",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.APPEND
+    assert (plan.start, plan.end) == ("2026-01-01", "2026-01-03")
+    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert plugin.calls == [("2026-01-01", "2026-01-03")]
+
+
+def test_plan_streaming_materialization_rematerializes_a_preceding_range(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02", "2026-01-03"])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *_args, **_kwargs: ["2026-01-03"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-01",
+        end="2026-01-01",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.REMATERIALIZE
+    assert (plan.start, plan.end) == ("2026-01-01", "2026-01-03")
+    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
+def test_plan_streaming_materialization_rematerializes_a_gapped_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02", "2026-01-03"])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *_args, **_kwargs: ["2026-01-01", "2026-01-03"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-03",
+        end="2026-01-03",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.REMATERIALIZE
+    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
 def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -427,7 +557,7 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
 
-    plugin = object()
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02", "2026-01-03"])
     captured: dict[str, object] = {}
 
     def fake_load_streaming_plugin(plugin_path: str, *, params: dict[str, object]) -> object:
@@ -494,7 +624,7 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
         "on_progress": None,
         "is_cancel_requested": None,
         "save_cursor": None,
-        "periods": None,
+        "periods": ["2026-01-01", "2026-01-02", "2026-01-03"],
     }
     assert artifact.format == ArtifactFormat.ICECHUNK
     assert artifact.path == str(store_path.resolve())
@@ -518,7 +648,7 @@ def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
 
-    plugin = object()
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-02-01", "2026-02-10"])
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
@@ -568,6 +698,139 @@ def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
     assert artifact.coverage.temporal.end == "2026-02-10"
 
 
+def test_create_artifact_appends_a_contiguous_union_and_preserves_request_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02", "2026-01-03"])
+    transaction_repo = _TransactionRepo()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *_args, **_kwargs: ["2026-01-01"],
+    )
+    monkeypatch.setattr(services, "open_or_create_repo", lambda _: transaction_repo)
+    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
+
+    def fake_ingest(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return type("Result", (), {"periods_written": 2})()
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_ingest)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+
+    artifact = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-03",
+        end="2026-01-03",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+
+    assert captured["start"] == "2026-01-01"
+    assert captured["end"] == "2026-01-03"
+    assert captured["periods"] == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert captured["store_path"] == store_path
+    assert artifact.coverage.temporal == CoverageTemporal(start="2026-01-01", end="2026-01-03")
+    assert artifact.request_scope.start == "2026-01-03"
+    assert artifact.request_scope.end == "2026-01-03"
+    assert transaction_repo.reset == []
+    assert transaction_repo.deleted == [transaction_repo.created[0][0]]
+
+
+def test_create_artifact_rolls_back_append_when_pyramid_rebuild_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    transaction_repo = _TransactionRepo()
+    stored_records: list[ArtifactRecord] = []
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(
+        services,
+        "_plan_streaming_materialization",
+        lambda **_: services._StreamingMaterializationPlan(
+            action=services.SyncAction.APPEND,
+            start="2026-01-01",
+            end="2026-01-02",
+            periods=["2026-01-01", "2026-01-02"],
+            has_committed_periods=True,
+        ),
+    )
+    monkeypatch.setattr(services, "open_or_create_repo", lambda _: transaction_repo)
+    monkeypatch.setattr(
+        services,
+        "run_streaming_ingest_sync",
+        lambda **_: type("Result", (), {"periods_written": 1})(),
+    )
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-02"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        services,
+        "_upsert_artifact_record",
+        lambda record, **_: stored_records.append(record) or record,
+    )
+
+    with pytest.raises(RuntimeError, match="dataset update was rolled back"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-02",
+            end="2026-01-02",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    assert transaction_repo.reset == [("main", "before-ingest")]
+    assert transaction_repo.deleted == [transaction_repo.created[0][0]]
+    assert stored_records == []
+
+
 def test_create_artifact_forwards_country_code_to_streaming_plugin(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -582,7 +845,7 @@ def test_create_artifact_forwards_country_code_to_streaming_plugin(
             "params": {"version": "global2"},
         },
     }
-    plugin = object()
+    plugin = _PeriodsPlugin(["2020", "2021", "2022"])
     store_path = tmp_path / "worldpop_population_yearly.icechunk"
     captured: dict[str, object] = {}
 
@@ -684,7 +947,11 @@ def test_create_artifact_allows_streaming_coverage_clamped_to_source_availabilit
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-31"]),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
         services,
@@ -727,7 +994,8 @@ def test_create_artifact_allows_streaming_coverage_clamped_to_source_availabilit
     assert artifact.coverage.temporal.start == "2026-01-01"
     assert artifact.coverage.temporal.end == "2026-01-31"
     assert artifact.request_scope.start == "2026-01-01"
-    assert artifact.request_scope.end == "2026-01-31"
+    # Request scope is provenance; realized, source-clamped coverage is recorded separately.
+    assert artifact.request_scope.end == "2026-02-03"
 
 
 def test_create_artifact_rejects_streaming_coverage_with_late_start(
@@ -746,7 +1014,11 @@ def test_create_artifact_rejects_streaming_coverage_with_late_start(
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-31"]),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
         services,
@@ -766,7 +1038,7 @@ def test_create_artifact_rejects_streaming_coverage_with_late_start(
         },
     )
 
-    with pytest.raises(services.HTTPException, match="coverage does not match the requested scope"):
+    with pytest.raises(services.HTTPException, match="coverage does not match the planned contiguous scope"):
         services.create_artifact(
             dataset=dataset,
             start="2026-01-01",
@@ -793,7 +1065,7 @@ def test_create_artifact_returns_409_when_streaming_plugin_has_no_periods(
     }
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: _PeriodsPlugin([]))
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
         services,
@@ -856,10 +1128,11 @@ def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
             }
         }
 
-    def fake_build_pyramid(path: Path, dataset: dict[str, object]) -> None:
+    def fake_build_pyramid(path: Path, dataset: dict[str, object], **kwargs: object) -> bool:
         assert path == replacement_path
         assert (store_path / "stale").read_text(encoding="utf-8") == "old"
         (path / "normalized").write_text("complete", encoding="utf-8")
+        return True
 
     monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
     monkeypatch.setattr(services, "get_data_coverage_for_paths", fake_coverage)
@@ -881,6 +1154,71 @@ def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
     assert (store_path / "normalized").read_text(encoding="utf-8") == "complete"
     assert not replacement_path.exists()
     assert not store_path.with_name(f"{store_path.name}.retired").exists()
+
+
+def test_create_artifact_overwrite_restores_store_when_record_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {
+            "plugin": "open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin",
+        },
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    replacement_path = store_path.with_name(f"{store_path.name}.replacement")
+    store_path.mkdir()
+    (store_path / "committed").write_text("old", encoding="utf-8")
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+
+    def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
+        replacement = kwargs["store_path"]
+        assert replacement == replacement_path
+        assert isinstance(replacement, Path)
+        replacement.mkdir()
+        (replacement / "fresh").write_text("new", encoding="utf-8")
+        return type("Result", (), {"periods_written": 1})()
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: True)
+
+    def fail_record_write(*args: object, **kwargs: object) -> object:
+        raise OSError("artifact index unavailable")
+
+    monkeypatch.setattr(services, "_upsert_artifact_record", fail_record_write)
+
+    with pytest.raises(OSError, match="artifact index unavailable"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-03",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=True,
+            publish=False,
+        )
+
+    assert (store_path / "committed").read_text(encoding="utf-8") == "old"
+    assert not (store_path / "fresh").exists()
+    assert not replacement_path.exists()
+    assert not store_path.with_name(f"{store_path.name}.retired").exists()
+    assert not store_path.with_name(f"{store_path.name}.failed").exists()
 
 
 def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -20,9 +20,12 @@ from open_climate_service.ingestions.schemas import (
 )
 from open_climate_service.plugins.datasets.chirps3 import CHIRPS3DailyPlugin
 from open_climate_service.publications.services import managed_dataset_id_for
+from open_climate_service.shared.time import daily_period_ids
 
 
 class _PeriodsPlugin:
+    time_dim = "t"
+
     def __init__(self, periods: list[str]) -> None:
         self.available_periods = periods
         self.calls: list[tuple[str, str]] = []
@@ -337,6 +340,28 @@ def test_store_artifact_records_new_coverage_for_repeated_open_ended_request(
     assert [record.artifact_id for record in services._load_records()] == ["first", "updated"]
 
 
+def test_store_artifact_deduplicates_repeated_incremental_request_with_cumulative_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "artifacts"
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", artifacts_dir)
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", artifacts_dir / "records.json")
+    existing = _artifact(artifact_id="existing", end="2026-01-03")
+    existing.request_scope = ArtifactRequestScope(
+        start="2026-01-03",
+        end="2026-01-03",
+        bbox=(1.0, 2.0, 3.0, 4.0),
+    )
+    repeated = existing.model_copy(update={"artifact_id": "repeated"}, deep=True)
+    services._save_records([existing])
+
+    stored = services._store_artifact_record(repeated, publish=False)
+
+    assert stored.artifact_id == "existing"
+    assert [record.artifact_id for record in services._load_records()] == ["existing"]
+
+
 def test_find_existing_artifact_ignores_record_with_overwide_coverage() -> None:
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
@@ -540,6 +565,106 @@ def test_plan_streaming_materialization_rematerializes_a_gapped_store(
     assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
 
 
+def test_plan_streaming_materialization_uses_plugin_time_dimension(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["1", "2"])
+    plugin.time_dim = "dayofyear"
+    captured: dict[str, object] = {}
+
+    def fake_committed(path: Path, period_type: str, *, time_dim: str) -> list[str]:
+        captured.update(path=path, period_type=period_type, time_dim=time_dim)
+        return ["1"]
+
+    monkeypatch.setattr(services, "read_committed_period_ids_ordered", fake_committed)
+    store_path = tmp_path / "normal.icechunk"
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=store_path,
+        start="1",
+        end="2",
+        period_type="climatology",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert captured == {"path": store_path, "period_type": "climatology", "time_dim": "dayofyear"}
+    assert plan.action == services.SyncAction.APPEND
+
+
+def test_plan_streaming_materialization_rejects_source_gap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-03"])
+    monkeypatch.setattr(services, "read_committed_period_ids_ordered", lambda *args, **kwargs: [])
+
+    with pytest.raises(services.HTTPException, match="non-contiguous period sequence"):
+        services._plan_streaming_materialization(
+            plugin=plugin,
+            store_path=tmp_path / "dataset.icechunk",
+            start="2026-01-01",
+            end="2026-01-03",
+            period_type="daily",
+            overwrite=False,
+            periods=None,
+        )
+
+
+def test_plan_streaming_materialization_clamps_overwrite_to_source_availability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02"])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-01",
+        end="2026-01-03",
+        period_type="daily",
+        overwrite=True,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.REMATERIALIZE
+    assert plan.end == "2026-01-02"
+    assert plan.periods == ["2026-01-01", "2026-01-02"]
+
+
+def test_plan_streaming_materialization_reuses_prefetched_append_delta(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin([])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-01",
+        end="2026-01-03",
+        period_type="daily",
+        overwrite=False,
+        periods=["2026-01-02", "2026-01-03"],
+    )
+
+    assert plugin.calls == []
+    assert plan.action == services.SyncAction.APPEND
+    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
 def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -648,7 +773,7 @@ def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
     store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
     store_path.mkdir()
 
-    plugin = _PeriodsPlugin(["2026-01-01", "2026-02-01", "2026-02-10"])
+    plugin = _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-02-10"))
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
@@ -723,7 +848,11 @@ def test_create_artifact_appends_a_contiguous_union_and_preserves_request_proven
         lambda *_args, **_kwargs: ["2026-01-01"],
     )
     monkeypatch.setattr(services, "open_or_create_repo", lambda _: transaction_repo)
-    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        services,
+        "_maybe_build_pyramid",
+        lambda *_args, **_kwargs: services._StoreNormalizationResult(completed=True),
+    )
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     def fake_ingest(**kwargs: object) -> object:
@@ -779,7 +908,11 @@ def test_create_artifact_rolls_back_append_when_pyramid_rebuild_fails(
     transaction_repo = _TransactionRepo()
     stored_records: list[ArtifactRecord] = []
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
         services,
@@ -808,7 +941,11 @@ def test_create_artifact_rolls_back_append_when_pyramid_rebuild_fails(
             }
         },
     )
-    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        services,
+        "_maybe_build_pyramid",
+        lambda *_args, **_kwargs: services._StoreNormalizationResult(completed=False),
+    )
     monkeypatch.setattr(
         services,
         "_upsert_artifact_record",
@@ -950,7 +1087,7 @@ def test_create_artifact_allows_streaming_coverage_clamped_to_source_availabilit
     monkeypatch.setattr(
         services,
         "_load_streaming_plugin",
-        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-31"]),
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-31")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
@@ -1017,7 +1154,7 @@ def test_create_artifact_rejects_streaming_coverage_with_late_start(
     monkeypatch.setattr(
         services,
         "_load_streaming_plugin",
-        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-31"]),
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-31")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(
@@ -1104,7 +1241,11 @@ def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
     store_path.mkdir()
     (store_path / "stale").write_text("old", encoding="utf-8")
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
@@ -1128,11 +1269,13 @@ def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
             }
         }
 
-    def fake_build_pyramid(path: Path, dataset: dict[str, object], **kwargs: object) -> bool:
+    def fake_build_pyramid(
+        path: Path, dataset: dict[str, object], **kwargs: object
+    ) -> services._StoreNormalizationResult:
         assert path == replacement_path
         assert (store_path / "stale").read_text(encoding="utf-8") == "old"
         (path / "normalized").write_text("complete", encoding="utf-8")
-        return True
+        return services._StoreNormalizationResult(completed=True)
 
     monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_run_streaming_ingest_sync)
     monkeypatch.setattr(services, "get_data_coverage_for_paths", fake_coverage)
@@ -1174,7 +1317,11 @@ def test_create_artifact_overwrite_restores_store_when_record_write_fails(
     store_path.mkdir()
     (store_path / "committed").write_text("old", encoding="utf-8")
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
 
     def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
@@ -1196,7 +1343,11 @@ def test_create_artifact_overwrite_restores_store_when_record_write_fails(
             }
         },
     )
-    monkeypatch.setattr(services, "_maybe_build_pyramid", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        services,
+        "_maybe_build_pyramid",
+        lambda *_args, **_kwargs: services._StoreNormalizationResult(completed=True),
+    )
 
     def fail_record_write(*args: object, **kwargs: object) -> object:
         raise OSError("artifact index unavailable")
@@ -1221,6 +1372,151 @@ def test_create_artifact_overwrite_restores_store_when_record_write_fails(
     assert not store_path.with_name(f"{store_path.name}.failed").exists()
 
 
+def test_create_artifact_restores_pre_ingest_snapshot_when_pyramid_record_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    (store_path / "state").write_text("pre-ingest", encoding="utf-8")
+
+    class RestoringRepo(_TransactionRepo):
+        def reset_branch(self, branch: str, snapshot: str) -> None:
+            super().reset_branch(branch, snapshot)
+            (store_path / "state").write_text("pre-ingest", encoding="utf-8")
+
+    transaction_repo = RestoringRepo()
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-02"]),
+    )
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01"],
+    )
+    monkeypatch.setattr(services, "open_or_create_repo", lambda _: transaction_repo)
+
+    def fake_ingest(**kwargs: object) -> object:
+        (store_path / "state").write_text("post-append", encoding="utf-8")
+        return type("Result", (), {"periods_written": 1})()
+
+    def fake_normalize(path: Path, *args: object, **kwargs: object) -> services._StoreNormalizationResult:
+        staging = path.with_name(f"{path.name}.rebuild")
+        staging.mkdir()
+        (staging / "state").write_text("normalized-append", encoding="utf-8")
+        services._swap_store(staging, path, retain_previous=True)
+        return services._StoreNormalizationResult(completed=True, swapped=True)
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_ingest)
+    monkeypatch.setattr(services, "_maybe_build_pyramid", fake_normalize)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-02"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        services,
+        "_upsert_artifact_record",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("artifact index unavailable")),
+    )
+
+    with pytest.raises(OSError, match="artifact index unavailable"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-02",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    assert (store_path / "state").read_text(encoding="utf-8") == "pre-ingest"
+    assert transaction_repo.reset == [("main", "before-ingest")]
+    assert not store_path.with_name(f"{store_path.name}.retired").exists()
+
+
+def test_create_artifact_does_not_restore_old_store_when_post_commit_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    replacement_path = store_path.with_name(f"{store_path.name}.replacement")
+    store_path.mkdir()
+    (store_path / "state").write_text("old", encoding="utf-8")
+
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01", "2026-01-02"]),
+    )
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+
+    def fake_ingest(**kwargs: object) -> object:
+        replacement_path.mkdir()
+        (replacement_path / "state").write_text("new", encoding="utf-8")
+        return type("Result", (), {"periods_written": 2})()
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_ingest)
+    monkeypatch.setattr(
+        services,
+        "_maybe_build_pyramid",
+        lambda *args, **kwargs: services._StoreNormalizationResult(completed=True),
+    )
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-02"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **kwargs: record)
+    monkeypatch.setattr(
+        services,
+        "_finalize_store_swap",
+        lambda path: (_ for _ in ()).throw(PermissionError("cleanup denied")),
+    )
+
+    artifact = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-02",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=True,
+        publish=False,
+    )
+
+    assert artifact.coverage.temporal.end == "2026-01-02"
+    assert (store_path / "state").read_text(encoding="utf-8") == "new"
+    assert (store_path.with_name(f"{store_path.name}.retired") / "state").read_text(encoding="utf-8") == "old"
+
+
 def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1238,7 +1534,11 @@ def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(
     store_path.mkdir()
     (store_path / "committed").write_text("old", encoding="utf-8")
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
@@ -1303,7 +1603,11 @@ def test_create_artifact_overwrite_releases_lock_when_replacement_cleanup_fails(
         if cleanup_calls == 2:
             raise PermissionError(f"cannot remove {path}")
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_acquire_store_lock", lambda _: lock)
@@ -1347,7 +1651,11 @@ def test_create_artifact_overwrite_keeps_existing_store_when_replacement_is_inva
     store_path.mkdir()
     (store_path / "committed").write_text("old", encoding="utf-8")
 
-    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        services,
+        "_load_streaming_plugin",
+        lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
+    )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -511,7 +511,7 @@ def test_plan_streaming_materialization_fills_non_adjacent_periods(
     assert plan.action == services.SyncAction.APPEND
     assert (plan.start, plan.end) == ("2026-01-01", "2026-01-03")
     assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
-    assert plugin.calls == [("2026-01-01", "2026-01-03")]
+    assert plugin.calls == [("2026-01-02", "2026-01-03")]
 
 
 def test_plan_streaming_materialization_rematerializes_a_preceding_range(
@@ -663,6 +663,128 @@ def test_plan_streaming_materialization_reuses_prefetched_append_delta(
     assert plugin.calls == []
     assert plan.action == services.SyncAction.APPEND
     assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
+def test_plan_streaming_materialization_reuses_contained_coverage_without_querying_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin([])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01", "2026-01-02", "2026-01-03"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-02",
+        end="2026-01-03",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plugin.calls == []
+    assert plan.action == services.SyncAction.NO_OP
+    assert (plan.start, plan.end) == ("2026-01-01", "2026-01-03")
+
+
+def test_plan_streaming_materialization_queries_only_forward_delta(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin(["2026-01-03", "2026-01-04"])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01", "2026-01-02"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-01",
+        end="2026-01-04",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plugin.calls == [("2026-01-03", "2026-01-04")]
+    assert plan.action == services.SyncAction.APPEND
+    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+
+
+def test_plan_streaming_materialization_treats_empty_forward_delta_as_no_op(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _PeriodsPlugin([])
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01", "2026-01-02"],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "dataset.icechunk",
+        start="2026-01-01",
+        end="2026-01-04",
+        period_type="daily",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plugin.calls == [("2026-01-03", "2026-01-04")]
+    assert plan.action == services.SyncAction.NO_OP
+    assert (plan.start, plan.end) == ("2026-01-01", "2026-01-02")
+
+
+def test_create_artifact_reuses_existing_artifact_for_no_op_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    plugin = _PeriodsPlugin([])
+    existing = _artifact(artifact_id="existing", end="2026-01-03")
+
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01", "2026-01-02", "2026-01-03"],
+    )
+    monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: existing)
+    monkeypatch.setattr(
+        services,
+        "run_streaming_ingest_sync",
+        lambda **kwargs: pytest.fail("a no-op request must not run ingestion"),
+    )
+
+    result = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-02",
+        end="2026-01-03",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+
+    assert result is existing
+    assert plugin.calls == []
 
 
 def test_create_artifact_uses_streaming_plugin_for_direct_ingest(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -334,7 +334,7 @@ def test_store_artifact_records_new_coverage_for_repeated_open_ended_request(
     updated.request_scope.end = None
     services._save_records([first])
 
-    stored = services._store_artifact_record(updated, publish=False)
+    stored = services._store_artifact_record(updated)
 
     assert stored.artifact_id == "updated"
     assert [record.artifact_id for record in services._load_records()] == ["first", "updated"]
@@ -356,58 +356,13 @@ def test_store_artifact_deduplicates_repeated_incremental_request_with_cumulativ
     repeated = existing.model_copy(update={"artifact_id": "repeated"}, deep=True)
     services._save_records([existing])
 
-    stored = services._store_artifact_record(repeated, publish=False)
+    stored = services._store_artifact_record(repeated)
 
     assert stored.artifact_id == "existing"
     assert [record.artifact_id for record in services._load_records()] == ["existing"]
 
 
-def test_find_existing_artifact_ignores_record_with_overwide_coverage() -> None:
-    request_scope = ArtifactRequestScope(
-        start="2026-01-01",
-        end="2026-02-10",
-        bbox=(1.0, 2.0, 3.0, 4.0),
-    )
-    stale_artifact = _artifact(artifact_id="stale", end="2026-02-29")
-    stale_artifact.request_scope = request_scope
-    valid_artifact = _artifact(artifact_id="valid", end="2026-02-10")
-    valid_artifact.request_scope = request_scope
-
-    result = services._find_existing_artifact_in_records(
-        records=[stale_artifact, valid_artifact],
-        dataset_id="chirps3_precipitation_daily",
-        request_scope=request_scope,
-    )
-
-    assert result == valid_artifact
-
-
-def test_find_existing_artifact_does_not_reuse_clamped_icechunk_artifact_for_later_requested_end() -> None:
-    request_scope = ArtifactRequestScope(
-        start="2026-01-01",
-        end="2026-02-10",
-        bbox=(1.0, 2.0, 3.0, 4.0),
-    )
-    clamped = _artifact(artifact_id="icechunk", end="2026-01-31")
-    clamped.format = ArtifactFormat.ICECHUNK
-    clamped.path = "/tmp/chirps3_precipitation_daily.icechunk"
-    clamped.asset_paths = [clamped.path]
-    clamped.request_scope = ArtifactRequestScope(
-        start="2026-01-01",
-        end="2026-01-31",
-        bbox=(1.0, 2.0, 3.0, 4.0),
-    )
-
-    result = services._find_existing_artifact_in_records(
-        records=[clamped],
-        dataset_id="chirps3_precipitation_daily",
-        request_scope=request_scope,
-    )
-
-    assert result is None
-
-
-def test_find_existing_artifact_ignores_stale_record(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_artifact_by_request_scope_ignores_stale_record(monkeypatch: pytest.MonkeyPatch) -> None:
     request_scope = ArtifactRequestScope(
         start="2026-01-01",
         end="2026-02-10",
@@ -421,7 +376,7 @@ def test_find_existing_artifact_ignores_stale_record(monkeypatch: pytest.MonkeyP
         lambda record: record.artifact_id != "stale",
     )
 
-    result = services._find_existing_artifact_in_records(
+    result = services._find_artifact_by_request_scope(
         records=[stale_artifact, valid_artifact],
         dataset_id="chirps3_precipitation_daily",
         request_scope=request_scope,
@@ -510,7 +465,7 @@ def test_plan_streaming_materialization_fills_non_adjacent_periods(
 
     assert plan.action == services.SyncAction.APPEND
     assert (plan.start, plan.end) == ("2026-01-01", "2026-01-03")
-    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert plan.periods == ["2026-01-02", "2026-01-03"]
     assert plugin.calls == [("2026-01-02", "2026-01-03")]
 
 
@@ -693,7 +648,7 @@ def test_plan_streaming_materialization_reuses_prefetched_append_delta(
 
     assert plugin.calls == []
     assert plan.action == services.SyncAction.APPEND
-    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert plan.periods == ["2026-01-02", "2026-01-03"]
 
 
 def test_plan_streaming_materialization_reuses_contained_coverage_without_querying_source(
@@ -745,7 +700,7 @@ def test_plan_streaming_materialization_queries_only_forward_delta(
 
     assert plugin.calls == [("2026-01-03", "2026-01-04")]
     assert plan.action == services.SyncAction.APPEND
-    assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+    assert plan.periods == ["2026-01-03", "2026-01-04"]
 
 
 def test_plan_streaming_materialization_treats_empty_forward_delta_as_no_op(
@@ -871,7 +826,6 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
         }
 
     monkeypatch.setattr(services, "get_data_coverage_for_paths", fake_get_data_coverage_for_paths)
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     artifact = services.create_artifact(
@@ -947,7 +901,6 @@ def test_create_artifact_uses_streaming_plugin_for_store_based_sync(
             }
         },
     )
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     artifact = services.create_artifact(
@@ -1036,7 +989,7 @@ def test_create_artifact_appends_a_contiguous_union_and_preserves_request_proven
 
     assert captured["start"] == "2026-01-01"
     assert captured["end"] == "2026-01-03"
-    assert captured["periods"] == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert captured["periods"] == ["2026-01-02", "2026-01-03"]
     assert captured["store_path"] == store_path
     assert artifact.coverage.temporal == CoverageTemporal(start="2026-01-01", end="2026-01-03")
     assert artifact.request_scope.start == "2026-01-03"
@@ -1161,7 +1114,6 @@ def test_create_artifact_forwards_country_code_to_streaming_plugin(
             }
         },
     )
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     services.create_artifact(
@@ -1248,7 +1200,6 @@ def test_create_artifact_allows_streaming_coverage_clamped_to_source_availabilit
         "run_streaming_ingest_sync",
         lambda **kwargs: type("Result", (), {"periods_written": 1})(),
     )
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     def fake_get_data_coverage_for_paths(
@@ -1315,7 +1266,6 @@ def test_create_artifact_rejects_streaming_coverage_with_late_start(
         "run_streaming_ingest_sync",
         lambda **kwargs: type("Result", (), {"periods_written": 1})(),
     )
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
     monkeypatch.setattr(
         services,
@@ -1362,7 +1312,6 @@ def test_create_artifact_returns_409_when_streaming_plugin_has_no_periods(
         "run_streaming_ingest_sync",
         lambda **kwargs: type("Result", (), {"periods_written": 0})(),
     )
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     with pytest.raises(services.HTTPException, match="Source has no data for the requested temporal scope"):
         services.create_artifact(
@@ -1400,7 +1349,6 @@ def test_create_artifact_overwrite_replaces_existing_icechunk_store_on_success(
         lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **_: record)
 
     def fake_run_streaming_ingest_sync(**kwargs: object) -> object:
@@ -1525,9 +1473,11 @@ def test_create_artifact_overwrite_restores_store_when_record_write_fails(
     assert not store_path.with_name(f"{store_path.name}.failed").exists()
 
 
+@pytest.mark.parametrize("rollback_failure", ["none", "swap", "snapshot"])
 def test_create_artifact_restores_pre_ingest_snapshot_when_pyramid_record_write_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    rollback_failure: str,
 ) -> None:
     dataset: dict[str, object] = {
         "id": "chirps3_precipitation_daily",
@@ -1542,6 +1492,8 @@ def test_create_artifact_restores_pre_ingest_snapshot_when_pyramid_record_write_
 
     class RestoringRepo(_TransactionRepo):
         def reset_branch(self, branch: str, snapshot: str) -> None:
+            if rollback_failure == "snapshot":
+                raise OSError("snapshot reset failed")
             super().reset_branch(branch, snapshot)
             (store_path / "state").write_text("pre-ingest", encoding="utf-8")
 
@@ -1588,7 +1540,15 @@ def test_create_artifact_restores_pre_ingest_snapshot_when_pyramid_record_write_
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("artifact index unavailable")),
     )
 
-    with pytest.raises(OSError, match="artifact index unavailable"):
+    if rollback_failure == "swap":
+
+        def fail_rollback(path: Path) -> None:
+            raise OSError("store restore failed")
+
+        monkeypatch.setattr(services, "_rollback_store_swap", fail_rollback)
+    error = OSError if rollback_failure == "none" else RuntimeError
+    message = "artifact index unavailable" if rollback_failure == "none" else "rollback could not complete"
+    with pytest.raises(error, match=message) as raised:
         services.create_artifact(
             dataset=dataset,
             start="2026-01-01",
@@ -1599,9 +1559,19 @@ def test_create_artifact_restores_pre_ingest_snapshot_when_pyramid_record_write_
             publish=False,
         )
 
-    assert (store_path / "state").read_text(encoding="utf-8") == "pre-ingest"
-    assert transaction_repo.reset == [("main", "before-ingest")]
-    assert not store_path.with_name(f"{store_path.name}.retired").exists()
+    lock = services._acquire_store_lock(store_path)
+    assert lock.acquire(blocking=False)
+    lock.release()
+    if rollback_failure != "none":
+        assert isinstance(raised.value.__cause__, OSError)
+        assert transaction_repo.reset == []
+        assert transaction_repo.deleted == []
+        state = "normalized-append" if rollback_failure == "swap" else "post-append"
+        assert (store_path / "state").read_text(encoding="utf-8") == state
+    else:
+        assert (store_path / "state").read_text(encoding="utf-8") == "pre-ingest"
+        assert transaction_repo.reset == [("main", "before-ingest")]
+        assert not store_path.with_name(f"{store_path.name}.retired").exists()
 
 
 def test_create_artifact_does_not_restore_old_store_when_post_commit_cleanup_fails(
@@ -1693,7 +1663,6 @@ def test_create_artifact_overwrite_keeps_existing_store_when_fetch_fails(
         lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     def failing_ingest(**kwargs: object) -> object:
         replacement = kwargs["store_path"]
@@ -1762,7 +1731,6 @@ def test_create_artifact_overwrite_releases_lock_when_replacement_cleanup_fails(
         lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
     monkeypatch.setattr(services, "_acquire_store_lock", lambda _: lock)
     monkeypatch.setattr(services, "_remove_store_path", fail_final_cleanup)
     monkeypatch.setattr(
@@ -1810,7 +1778,6 @@ def test_create_artifact_overwrite_keeps_existing_store_when_replacement_is_inva
         lambda *args, **kwargs: _PeriodsPlugin(daily_period_ids("2026-01-01", "2026-01-03")),
     )
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
-    monkeypatch.setattr(services, "_find_existing_artifact", lambda **_: None)
 
     def incomplete_ingest(**kwargs: object) -> object:
         replacement = kwargs["store_path"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -600,6 +600,33 @@ def test_plan_streaming_materialization_accepts_date_bounds_for_climatology(
     assert plan.periods == [str(day) for day in range(1, 367)]
 
 
+def test_plan_streaming_materialization_completes_partial_climatology_for_date_bounds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    available = [str(day) for day in range(1, 367)]
+    plugin = _PeriodsPlugin(available)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: [str(day) for day in range(1, 201)],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "normal.icechunk",
+        start="1991-01-01",
+        end="2020-12-31",
+        period_type="climatology",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.APPEND
+    assert (plan.start, plan.end) == ("1", "366")
+    assert plan.periods == [str(day) for day in range(201, 367)]
+    assert plugin.calls == [("1991-01-01", "2020-12-31")]
+
+
 def test_plan_streaming_materialization_rejects_source_gap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -580,6 +580,26 @@ def test_plan_streaming_materialization_uses_plugin_time_dimension(
     assert plan.action == services.SyncAction.APPEND
 
 
+def test_plan_streaming_materialization_accepts_date_bounds_for_climatology(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plugin = _PeriodsPlugin([str(day) for day in range(1, 367)])
+    monkeypatch.setattr(services, "read_committed_period_ids_ordered", lambda *args, **kwargs: [])
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "normal.icechunk",
+        start="1991-01-01",
+        end="2020-12-31",
+        period_type="climatology",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert (plan.start, plan.end) == ("1", "366")
+    assert plan.periods == [str(day) for day in range(1, 367)]
+
+
 def test_plan_streaming_materialization_rejects_source_gap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -773,6 +793,57 @@ def test_create_artifact_reuses_existing_artifact_for_no_op_request(
     assert plugin.calls == []
 
 
+def test_create_artifact_refreshes_stale_record_for_no_op_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    stale = _artifact(artifact_id="stale", end="2026-01-02")
+    stored: list[ArtifactRecord] = []
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: _PeriodsPlugin([]))
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: ["2026-01-01", "2026-01-02", "2026-01-03"],
+    )
+    monkeypatch.setattr(services, "get_latest_artifact_for_dataset_or_404", lambda _: stale)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        services, "_maybe_build_pyramid", lambda *args, **kwargs: services._StoreNormalizationResult(completed=True)
+    )
+    monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **kwargs: stored.append(record) or record)
+
+    result = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-02",
+        end="2026-01-03",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+
+    assert result.coverage.temporal.end == "2026-01-03"
+    assert stored == [result]
+
+
 def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -857,6 +928,7 @@ def test_create_artifact_uses_streaming_plugin_for_direct_ingest(
         "is_cancel_requested": None,
         "save_cursor": None,
         "periods": ["2026-01-01", "2026-01-02", "2026-01-03"],
+        "committed_periods": [],
     }
     assert artifact.format == ArtifactFormat.ICECHUNK
     assert artifact.path == str(store_path.resolve())
@@ -1072,6 +1144,44 @@ def test_create_artifact_rolls_back_append_when_pyramid_rebuild_fails(
     assert transaction_repo.reset == [("main", "before-ingest")]
     assert transaction_repo.deleted == [transaction_repo.created[0][0]]
     assert stored_records == []
+
+
+def test_create_artifact_preserves_partial_append_when_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    store_path.mkdir()
+    transaction_repo = _TransactionRepo()
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: _PeriodsPlugin(["2026-01-02"]))
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(services, "read_committed_period_ids_ordered", lambda *args, **kwargs: ["2026-01-01"])
+    monkeypatch.setattr(services, "open_or_create_repo", lambda _: transaction_repo)
+    monkeypatch.setattr(
+        services,
+        "run_streaming_ingest_sync",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("transient fetch failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="transient fetch failure"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-02",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    assert transaction_repo.reset == []
+    assert transaction_repo.deleted == [transaction_repo.created[0][0]]
 
 
 def test_create_artifact_forwards_country_code_to_streaming_plugin(
@@ -1471,6 +1581,58 @@ def test_create_artifact_overwrite_restores_store_when_record_write_fails(
     assert not replacement_path.exists()
     assert not store_path.with_name(f"{store_path.name}.retired").exists()
     assert not store_path.with_name(f"{store_path.name}.failed").exists()
+
+
+def test_first_ingest_record_failure_is_not_masked_by_impossible_swap_rollback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dataset: dict[str, object] = {
+        "id": "chirps3_precipitation_daily",
+        "name": "Total precipitation (CHIRPS3)",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.Plugin"},
+    }
+    store_path = tmp_path / "chirps3_precipitation_daily.icechunk"
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: _PeriodsPlugin(["2026-01-01"]))
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+
+    def fake_ingest(**kwargs: object) -> object:
+        store_path.mkdir()
+        return type("Result", (), {"periods_written": 1})()
+
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", fake_ingest)
+    monkeypatch.setattr(
+        services,
+        "get_data_coverage_for_paths",
+        lambda *args, **kwargs: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-01"},
+                "spatial": {"xmin": 1.0, "ymin": 2.0, "xmax": 3.0, "ymax": 4.0},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        services,
+        "_maybe_build_pyramid",
+        lambda *args, **kwargs: services._StoreNormalizationResult(completed=True, swapped=True),
+    )
+    monkeypatch.setattr(
+        services,
+        "_upsert_artifact_record",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("artifact index unavailable")),
+    )
+
+    with pytest.raises(OSError, match="artifact index unavailable"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-01",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
 
 
 @pytest.mark.parametrize("rollback_failure", ["none", "swap", "snapshot"])

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -847,7 +847,7 @@ def test_create_artifact_reuses_existing_artifact_for_no_op_request(
     assert plugin.calls == []
 
 
-def test_create_artifact_refreshes_stale_record_for_no_op_store(
+def test_create_artifact_refreshes_stale_record_when_no_op_normalization_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     dataset: dict[str, object] = {
@@ -880,7 +880,7 @@ def test_create_artifact_refreshes_stale_record_for_no_op_store(
         },
     )
     monkeypatch.setattr(
-        services, "_maybe_build_pyramid", lambda *args, **kwargs: services._StoreNormalizationResult(completed=True)
+        services, "_maybe_build_pyramid", lambda *args, **kwargs: services._StoreNormalizationResult(completed=False)
     )
     monkeypatch.setattr(services, "_upsert_artifact_record", lambda record, **kwargs: stored.append(record) or record)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -565,6 +565,37 @@ def test_plan_streaming_materialization_rematerializes_a_gapped_store(
     assert plan.periods == ["2026-01-01", "2026-01-02", "2026-01-03"]
 
 
+@pytest.mark.parametrize("missing_count", [1, 5, 7])
+def test_plan_streaming_materialization_reports_missing_history(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    missing_count: int,
+) -> None:
+    committed = daily_period_ids("2026-01-02", f"2026-01-{missing_count + 2:02d}")
+    missing = committed[1:]
+    plugin = _PeriodsPlugin(["2026-01-01", "2026-01-02"])
+    monkeypatch.setattr(services, "read_committed_period_ids_ordered", lambda *args, **kwargs: committed)
+
+    with pytest.raises(services.HTTPException) as exc_info:
+        services._plan_streaming_materialization(
+            plugin=plugin,
+            store_path=tmp_path / "dataset.icechunk",
+            start="2026-01-01",
+            end="2026-01-01",
+            period_type="daily",
+            overwrite=False,
+            periods=None,
+        )
+
+    assert exc_info.value.status_code == 409
+    expected = ", ".join(missing[:5])
+    if missing_count > 5:
+        expected += f" and {missing_count - 5} more"
+    assert exc_info.value.detail == (
+        "Source can no longer reproduce committed period(s) required for the temporal union: " + expected
+    )
+
+
 def test_plan_streaming_materialization_uses_plugin_time_dimension(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -627,6 +627,33 @@ def test_plan_streaming_materialization_completes_partial_climatology_for_date_b
     assert plugin.calls == [("1991-01-01", "2020-12-31")]
 
 
+def test_plan_streaming_materialization_completes_partial_climatology_for_year_bounds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    available = [str(day) for day in range(1, 367)]
+    plugin = _PeriodsPlugin(available)
+    monkeypatch.setattr(
+        services,
+        "read_committed_period_ids_ordered",
+        lambda *args, **kwargs: [str(day) for day in range(1, 201)],
+    )
+
+    plan = services._plan_streaming_materialization(
+        plugin=plugin,
+        store_path=tmp_path / "normal.icechunk",
+        start="1991",
+        end="2020",
+        period_type="climatology",
+        overwrite=False,
+        periods=None,
+    )
+
+    assert plan.action == services.SyncAction.APPEND
+    assert (plan.start, plan.end) == ("1", "366")
+    assert plan.periods == [str(day) for day in range(201, 367)]
+    assert plugin.calls == [("1991", "2020")]
+
+
 def test_plan_streaming_materialization_rejects_source_gap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -296,6 +296,33 @@ def test_plan_sync_for_plugin_backed_icechunk_uses_committed_store_state(
     assert result.current_end == "2026-01-31"
 
 
+def test_plan_sync_uses_cumulative_coverage_start_not_latest_request_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        managed_dataset_id="chirps3_precipitation_daily_sle",
+        end="2026-01-03",
+    )
+    latest.request_scope.start = "2026-01-03"
+    latest.coverage.temporal.start = "2026-01-01"
+    monkeypatch.setattr(sync_engine, "_query_available_periods", lambda *args, **kwargs: ["2026-01-04"])
+
+    result = sync_engine.plan_sync(
+        source_dataset={
+            "id": "chirps3_precipitation_daily",
+            "period_type": "daily",
+            "sync": {"kind": "temporal", "execution": "append"},
+            "ingestion": {"plugin": "example.Plugin"},
+        },
+        latest_artifact=latest,
+        requested_end="2026-01-04",
+    )
+
+    assert result.action == SyncAction.APPEND
+    assert result.current_start == "2026-01-01"
+
+
 def test_plan_sync_marks_static_non_temporal_dataset_not_syncable() -> None:
     # A static, non-temporal dataset (e.g. a day-of-year climatology) has no temporal
     # end. Planning must return NOT_SYNCABLE, not raise/400 by trying to compute one.
@@ -1348,6 +1375,11 @@ def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
 
     seen: dict[str, object] = {}
 
+    class FakePlugin:
+        async def periods(self, start: str, end: str) -> list[str]:
+            assert (start, end) == ("2026-01-01", "2026-01-03")
+            return ["2026-01-01", "2026-01-02", "2026-01-03"]
+
     def fake_ingest(**kwargs: object) -> object:
         store_path = kwargs["store_path"]
         assert isinstance(store_path, Path)
@@ -1364,7 +1396,7 @@ def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
 
     monkeypatch.setattr(downloader, "get_icechunk_path", lambda _dataset: target)
     monkeypatch.setattr(ingestion_services, "run_streaming_ingest_sync", fake_ingest)
-    monkeypatch.setattr(ingestion_services, "_load_streaming_plugin", lambda *a, **k: object())
+    monkeypatch.setattr(ingestion_services, "_load_streaming_plugin", lambda *a, **k: FakePlugin())
     monkeypatch.setattr(ingestion_services, "_maybe_build_pyramid", lambda *a, **k: None)
     monkeypatch.setattr(
         ingestion_services,

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1093,6 +1093,50 @@ def test_run_sync_raises_clear_error_when_append_invariants_are_missing(monkeypa
         )
 
 
+def test_run_sync_preserves_rematerialize_action_as_overwrite(monkeypatch: pytest.MonkeyPatch) -> None:
+    latest = _artifact(
+        artifact_id="a1",
+        source_dataset_id="worldpop_population_yearly",
+        managed_dataset_id="worldpop_population_yearly_sle",
+        end="2024",
+    )
+    plan = SyncDetail(
+        source_dataset_id="worldpop_population_yearly",
+        sync_kind=SyncKind.RELEASE,
+        action=SyncAction.REMATERIALIZE,
+        reason="new_release_available",
+        message="new release",
+        current_start="2020",
+        current_end="2024",
+        target_end="2025",
+        target_end_source="request",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(sync_engine, "plan_sync", lambda **kwargs: plan)
+
+    def fake_create_artifact(**kwargs: object) -> ArtifactRecord:
+        captured.update(kwargs)
+        return _artifact(
+            artifact_id="a2",
+            source_dataset_id="worldpop_population_yearly",
+            managed_dataset_id="worldpop_population_yearly_sle",
+            end="2025",
+        )
+
+    sync_engine.run_sync(
+        latest_artifact=latest,
+        source_dataset={"id": "worldpop_population_yearly", "period_type": "yearly", "sync": {"kind": "release"}},
+        requested_end="2025",
+        country_code="SLE",
+        publish=False,
+        create_artifact_fn=fake_create_artifact,
+        get_dataset_fn=lambda dataset_id: _dataset_detail(dataset_id),
+    )
+
+    assert captured["overwrite"] is True
+    assert captured["periods"] is None
+
+
 def test_sync_dataset_forwards_country_code_from_extent(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset_id = "worldpop_population_yearly_sle"
     latest = _artifact(
@@ -1170,7 +1214,7 @@ def test_maybe_build_pyramid_calls_write_to_icechunk_store(tmp_path: Path, monke
 
     monkeypatch.setattr(downloader, "write_to_icechunk_store", fake_write)
 
-    _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "precip"})
+    result = _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "precip"})
 
     assert len(written) == 1
     # The rewrite cannot target the store it is reading from, so it goes to a sibling and is
@@ -1179,6 +1223,8 @@ def test_maybe_build_pyramid_calls_write_to_icechunk_store(tmp_path: Path, monke
     assert icechunk_path.is_dir()
     assert not written[0][1].exists()
     assert not icechunk_path.with_name(f"{icechunk_path.name}.retired").exists()
+    assert result.completed is True
+    assert result.swapped is True
 
 
 def test_maybe_build_pyramid_skips_rewrite_for_normalized_flat_store(
@@ -1213,9 +1259,11 @@ def test_maybe_build_pyramid_skips_rewrite_for_normalized_flat_store(
     written: list[tuple] = []
     monkeypatch.setattr(downloader, "write_to_icechunk_store", lambda *a, **kw: written.append(a))
 
-    _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "precip"})
+    result = _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "precip"})
 
     assert written == []  # already GeoZarr-normalized and flat → no rewrite
+    assert result.completed is True
+    assert result.swapped is False
 
 
 def test_maybe_build_pyramid_falls_back_on_build_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1239,7 +1287,10 @@ def test_maybe_build_pyramid_falls_back_on_build_error(tmp_path: Path, monkeypat
     monkeypatch.setattr(downloader, "write_to_icechunk_store", fake_write_fail)
 
     # Must not raise — errors are swallowed so the flat artifact is still registered.
-    _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "v"})
+    result = _maybe_build_pyramid(icechunk_path, {"id": "ds1", "variable": "v"})
+
+    assert result.completed is False
+    assert result.swapped is False
 
 
 def test_plan_sync_append_for_icechunk_artifact(
@@ -1397,7 +1448,11 @@ def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
     monkeypatch.setattr(downloader, "get_icechunk_path", lambda _dataset: target)
     monkeypatch.setattr(ingestion_services, "run_streaming_ingest_sync", fake_ingest)
     monkeypatch.setattr(ingestion_services, "_load_streaming_plugin", lambda *a, **k: FakePlugin())
-    monkeypatch.setattr(ingestion_services, "_maybe_build_pyramid", lambda *a, **k: None)
+    monkeypatch.setattr(
+        ingestion_services,
+        "_maybe_build_pyramid",
+        lambda *a, **k: ingestion_services._StoreNormalizationResult(completed=True),
+    )
     monkeypatch.setattr(
         ingestion_services,
         "get_data_coverage_for_paths",

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -21,6 +21,7 @@ from open_climate_service.ingestions.schemas import (
     SyncKind,
     SyncResponse,
 )
+from open_climate_service.shared.time import next_period_string
 
 
 def _artifact(
@@ -818,7 +819,7 @@ def test_default_target_end_rejects_unsupported_period_type() -> None:
 
 
 def test_next_period_start_preserves_hourly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-04-21T13", period_type="hourly")
+    result = next_period_string("2026-04-21T13", "hourly")
 
     assert result == "2026-04-21T14"
 
@@ -832,13 +833,13 @@ def test_default_weekly_target_end_uses_iso_week_format(monkeypatch: pytest.Monk
 
 
 def test_next_period_start_preserves_weekly_period_format() -> None:
-    result = sync_engine._next_period_start("2026-W17", period_type="weekly")
+    result = next_period_string("2026-W17", "weekly")
 
     assert result == "2026-W18"
 
 
 def test_next_period_start_rolls_weekly_period_across_iso_year_boundary() -> None:
-    result = sync_engine._next_period_start("2020-W53", period_type="weekly")
+    result = next_period_string("2020-W53", "weekly")
 
     assert result == "2021-W01"
 
@@ -1394,6 +1395,20 @@ def test_recover_interrupted_swap_is_a_no_op_for_a_brand_new_dataset(tmp_path: P
     from open_climate_service.ingestions.services import recover_interrupted_swap
 
     assert recover_interrupted_swap(tmp_path / "never-existed.icechunk") is False
+
+
+def test_recover_interrupted_swap_removes_stale_ingest_rollback_branches(tmp_path: Path) -> None:
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+    from open_climate_service.streaming.store import open_or_create_repo
+
+    target = tmp_path / "ds.icechunk"
+    repo = open_or_create_repo(target)
+    snapshot = repo.lookup_branch("main")
+    repo.create_branch("ocs-ingest-rollback-first", snapshot)
+    repo.create_branch("ocs-ingest-rollback-second", snapshot)
+
+    assert recover_interrupted_swap(target) is True
+    assert repo.list_branches() == {"main"}
 
 
 def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(

--- a/tests/test_datasets_sync.py
+++ b/tests/test_datasets_sync.py
@@ -1492,3 +1492,67 @@ def test_an_interrupted_swap_is_healed_before_ingest_reads_the_store(
     # And the delta landed on top of the history rather than replacing it.
     assert (target / "history").read_text(encoding="utf-8") == "2026-01-01,2026-01-02,2026-01-03"
     assert not retired.exists()
+
+
+@pytest.mark.parametrize("restored", [False, True])
+def test_recover_interrupted_rollback_removes_rejected_store(tmp_path: Path, restored: bool) -> None:
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    target = tmp_path / "ds.icechunk"
+    retired = tmp_path / "ds.icechunk.retired"
+    failed = tmp_path / "ds.icechunk.failed"
+    original = target if restored else retired
+    original.mkdir()
+    (original / "data").write_text("original", encoding="utf-8")
+    failed.mkdir()
+    (failed / "data").write_text("rejected", encoding="utf-8")
+
+    assert recover_interrupted_swap(target) is True
+    assert (target / "data").read_text(encoding="utf-8") == "original"
+    assert not retired.exists()
+    assert not failed.exists()
+    assert recover_interrupted_swap(target) is False
+
+
+def test_interrupted_rollback_preserves_copies_if_restore_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    target = tmp_path / "ds.icechunk"
+    retired = tmp_path / "ds.icechunk.retired"
+    failed = tmp_path / "ds.icechunk.failed"
+    retired.mkdir()
+    failed.mkdir()
+
+    def fail_rename(self: Path, destination: Path) -> Path:
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(Path, "rename", fail_rename)
+    with pytest.raises(OSError, match="rename failed"):
+        recover_interrupted_swap(target)
+    assert retired.exists()
+    assert failed.exists()
+    assert not target.exists()
+
+
+def test_rollback_refuses_to_claim_success_without_retained_store(tmp_path: Path) -> None:
+    from open_climate_service.ingestions.services import _rollback_store_swap
+
+    target = tmp_path / "ds.icechunk"
+    target.mkdir()
+    with pytest.raises(FileNotFoundError, match="retained store .* is missing"):
+        _rollback_store_swap(target)
+    assert target.exists()
+
+
+def test_recovery_does_not_publish_a_rejected_store_without_original(tmp_path: Path) -> None:
+    from open_climate_service.ingestions.services import recover_interrupted_swap
+
+    target = tmp_path / "ds.icechunk"
+    failed = tmp_path / "ds.icechunk.failed"
+    failed.mkdir()
+    with pytest.raises(RuntimeError, match="only the rejected .failed store remains"):
+        recover_interrupted_swap(target)
+    assert failed.exists()
+    assert not target.exists()

--- a/tests/test_dekadal_periods.py
+++ b/tests/test_dekadal_periods.py
@@ -183,25 +183,25 @@ def test_dekad_bounds_tile_the_month_without_gap_or_overlap() -> None:
 
 def test_next_period_start_steps_by_the_covered_dekads_own_length() -> None:
     """A fixed +10 days would land mid-month for every 11-day and 8-day third dekad."""
-    from open_climate_service.ingestions.sync_engine import _next_period_start
+    from open_climate_service.shared.time import next_period_string
 
-    assert _next_period_start("2026-01-01", period_type="dekadal") == "2026-01-11"
-    assert _next_period_start("2026-01-11", period_type="dekadal") == "2026-01-21"
+    assert next_period_string("2026-01-01", "dekadal") == "2026-01-11"
+    assert next_period_string("2026-01-11", "dekadal") == "2026-01-21"
     # 11-day third dekad: 21 Jan + 11 = 1 Feb, not 31 Jan.
-    assert _next_period_start("2026-01-21", period_type="dekadal") == "2026-02-01"
+    assert next_period_string("2026-01-21", "dekadal") == "2026-02-01"
     # 8-day third dekad in a common February.
-    assert _next_period_start("2026-02-21", period_type="dekadal") == "2026-03-01"
+    assert next_period_string("2026-02-21", "dekadal") == "2026-03-01"
     # 9-day third dekad in a leap February.
-    assert _next_period_start("2024-02-21", period_type="dekadal") == "2024-03-01"
+    assert next_period_string("2024-02-21", "dekadal") == "2024-03-01"
 
 
 def test_next_period_start_never_repeats_or_skips_a_dekad_across_a_year() -> None:
-    from open_climate_service.ingestions.sync_engine import _next_period_start
+    from open_climate_service.shared.time import next_period_string
 
     expected = dekad_period_ids("2026-01-01", "2026-12-31")
     walked = [expected[0]]
     while len(walked) < len(expected):
-        walked.append(_next_period_start(walked[-1], period_type="dekadal"))
+        walked.append(next_period_string(walked[-1], "dekadal"))
     assert walked == expected
 
 

--- a/tests/test_ingestion_rolling_source.py
+++ b/tests/test_ingestion_rolling_source.py
@@ -1,5 +1,6 @@
 """Rolling source ingestion preserves committed history without refetching it."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -33,10 +34,8 @@ class _RollingPlugin(BaseDatasetPlugin):
         return normalize_period(data, variable="precip", period=period_id)
 
 
-@pytest.mark.parametrize("request_start", ["2026-01-01", "2026-01-04"])
-def test_forward_ingestion_preserves_retired_source_history(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request_start: str
-) -> None:
+@pytest.fixture
+def rolling_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[_RollingPlugin, dict[str, object], Path]:
     plugin = _RollingPlugin()
     dataset: dict[str, object] = {
         "id": "rolling_precip",
@@ -50,6 +49,15 @@ def test_forward_ingestion_preserves_retired_source_history(
     monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
     monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
     monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    return plugin, dataset, store_path
+
+
+@pytest.mark.parametrize("request_start", ["2026-01-01", "2026-01-04"])
+def test_forward_ingestion_preserves_retired_source_history(
+    rolling_store: tuple[_RollingPlugin, dict[str, object], Path], request_start: str
+) -> None:
+    plugin, dataset, store_path = rolling_store
 
     def ingest(start: str, end: str) -> services.ArtifactRecord:
         return services.create_artifact(
@@ -88,3 +96,89 @@ def test_forward_ingestion_preserves_retired_source_history(
     assert repo.lookup_branch("main") == snapshot
     assert services._load_records()[-1].artifact_id == artifact.artifact_id
     assert len(plugin.fetched) == 4
+
+
+@pytest.mark.parametrize("publish", [False, True])
+def test_complete_store_without_record_is_registered_without_source_access(
+    rolling_store: tuple[_RollingPlugin, dict[str, object], Path],
+    monkeypatch: pytest.MonkeyPatch,
+    publish: bool,
+) -> None:
+    plugin, dataset, store_path = rolling_store
+    services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-02",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+    services.ARTIFACTS_INDEX_PATH.unlink()
+    plugin.available = []
+    plugin.queries.clear()
+    plugin.fetched.clear()
+    published: list[str] = []
+
+    def publish_record(artifact_id: str) -> services.ArtifactRecord:
+        published.append(artifact_id)
+        return services._load_records()[-1]
+
+    def unexpected_ingest(**kwargs: object) -> None:
+        raise AssertionError("Complete stores must not run the fetch orchestrator")
+
+    monkeypatch.setattr(services, "publish_artifact_record", publish_record)
+    monkeypatch.setattr(services, "run_streaming_ingest_sync", unexpected_ingest)
+    record = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-02",
+        end="2026-01-02",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=publish,
+    )
+    assert record.coverage.temporal == CoverageTemporal(start="2026-01-01", end="2026-01-02")
+    assert record.request_scope.start == "2026-01-02"
+    assert services._load_records()[-1].artifact_id == record.artifact_id
+    assert plugin.queries == []
+    assert plugin.fetched == []
+    assert published == ([record.artifact_id] if publish else [])
+    with open_icechunk_dataset(store_path) as stored:
+        assert stored["precip"][:, 0, 0].values.tolist() == [1.0, 2.0]
+
+
+def test_forward_append_progress_counts_only_new_periods(
+    rolling_store: tuple[_RollingPlugin, dict[str, object], Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, dataset, _ = rolling_store
+    progress: list[tuple[int | None, int | None]] = []
+
+    def report(done: int | None, total: int | None, message: str | None) -> None:
+        progress.append((done, total))
+
+    def ingest(end: str, on_progress: Callable[[int | None, int | None, str | None], None] | None = None) -> None:
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end=end,
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+            on_progress=on_progress,
+        )
+
+    ingest("2026-01-02")
+    plugin.available = ["2026-01-03"]
+    original_fetch = plugin.fetch_period
+    at_fetch: list[tuple[int | None, int | None]] = []
+
+    def fetch(period_id: str, bbox: list[float], **params: object) -> xr.Dataset:
+        at_fetch.append(progress[-1])
+        return original_fetch(period_id, bbox, **params)
+
+    monkeypatch.setattr(plugin, "fetch_period", fetch)
+    ingest("2026-01-03", report)
+    assert at_fetch == [(0, 1)]
+    assert progress[-1] == (1, 1)

--- a/tests/test_ingestion_rolling_source.py
+++ b/tests/test_ingestion_rolling_source.py
@@ -182,3 +182,72 @@ def test_forward_append_progress_counts_only_new_periods(
     ingest("2026-01-03", report)
     assert at_fetch == [(0, 1)]
     assert progress[-1] == (1, 1)
+
+
+def test_overwrite_rematerializes_existing_store(
+    rolling_store: tuple[_RollingPlugin, dict[str, object], Path],
+) -> None:
+    plugin, dataset, store_path = rolling_store
+    services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-02",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+    plugin.available.append("2026-01-03")
+    plugin.fetched.clear()
+
+    artifact = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-03",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=True,
+        publish=False,
+    )
+
+    assert plugin.fetched == plugin.available
+    assert artifact.coverage.temporal == CoverageTemporal(start="2026-01-01", end="2026-01-03")
+    with open_icechunk_dataset(store_path) as stored:
+        assert stored["precip"][:, 0, 0].values.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_append_record_failure_restores_existing_store(
+    rolling_store: tuple[_RollingPlugin, dict[str, object], Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, dataset, store_path = rolling_store
+    initial = services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-02",
+        bbox=[1.0, 2.0, 3.0, 4.0],
+        country_code=None,
+        overwrite=False,
+        publish=False,
+    )
+    plugin.available.append("2026-01-03")
+
+    def fail_record(*args: object, **kwargs: object) -> None:
+        raise OSError("record write failed")
+
+    monkeypatch.setattr(services, "_upsert_artifact_record", fail_record)
+    with pytest.raises(OSError, match="record write failed"):
+        services.create_artifact(
+            dataset=dataset,
+            start="2026-01-01",
+            end="2026-01-03",
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    assert services._load_records()[-1].artifact_id == initial.artifact_id
+    repo = services.open_or_create_repo(store_path)
+    assert not [branch for branch in repo.list_branches() if branch.startswith("ocs-ingest-rollback-")]
+    with open_icechunk_dataset(store_path) as stored:
+        assert stored["precip"][:, 0, 0].values.tolist() == [1.0, 2.0]

--- a/tests/test_ingestion_rolling_source.py
+++ b/tests/test_ingestion_rolling_source.py
@@ -1,0 +1,90 @@
+"""Rolling source ingestion preserves committed history without refetching it."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
+from open_climate_service.ingestions import services
+from open_climate_service.ingestions.schemas import CoverageTemporal
+from open_climate_service.streaming import BaseDatasetPlugin, normalize_period
+
+
+class _RollingPlugin(BaseDatasetPlugin):
+    def __init__(self) -> None:
+        self.available = ["2026-01-01", "2026-01-02"]
+        self.queries: list[tuple[str, str]] = []
+        self.fetched: list[str] = []
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        self.queries.append((start, end))
+        return [period for period in self.available if start <= period <= end]
+
+    def fetch_period(self, period_id: str, bbox: list[float], **params: object) -> xr.Dataset:
+        assert period_id in self.available, "Retired source periods must not be fetched"
+        self.fetched.append(period_id)
+        data = xr.DataArray(
+            np.full((2, 2), int(period_id[-2:]), dtype="float32"),
+            dims=("y", "x"),
+            coords={"y": [3.5, 2.5], "x": [1.5, 2.5]},
+        )
+        return normalize_period(data, variable="precip", period=period_id)
+
+
+@pytest.mark.parametrize("request_start", ["2026-01-01", "2026-01-04"])
+def test_forward_ingestion_preserves_retired_source_history(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request_start: str
+) -> None:
+    plugin = _RollingPlugin()
+    dataset: dict[str, object] = {
+        "id": "rolling_precip",
+        "name": "Rolling precipitation",
+        "variable": "precip",
+        "period_type": "daily",
+        "ingestion": {"plugin": "example.RollingPlugin"},
+    }
+    store_path = tmp_path / "rolling.icechunk"
+    monkeypatch.setattr(services, "_load_streaming_plugin", lambda *args, **kwargs: plugin)
+    monkeypatch.setattr(services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(services, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(services, "ARTIFACTS_INDEX_PATH", tmp_path / "artifacts" / "records.json")
+
+    def ingest(start: str, end: str) -> services.ArtifactRecord:
+        return services.create_artifact(
+            dataset=dataset,
+            start=start,
+            end=end,
+            bbox=[1.0, 2.0, 3.0, 4.0],
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    ingest("2026-01-01", "2026-01-02")
+    plugin.available = ["2026-01-03", "2026-01-04"]
+    artifact = ingest(request_start, "2026-01-04")
+
+    assert plugin.queries == [("2026-01-01", "2026-01-02"), ("2026-01-03", "2026-01-04")]
+    assert plugin.fetched == ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+    assert artifact.coverage.temporal == CoverageTemporal(start="2026-01-01", end="2026-01-04")
+    assert artifact.request_scope.start == request_start
+    assert services._load_records()[-1].coverage == artifact.coverage
+    with open_icechunk_dataset(store_path) as stored:
+        assert stored["precip"][:, 0, 0].values.tolist() == [1.0, 2.0, 3.0, 4.0]
+
+    # A gap in the missing delta must still fail before any data is written.
+    repo = services.open_or_create_repo(store_path)
+    snapshot = repo.lookup_branch("main")
+    plugin.available = ["2026-01-06"]
+    with pytest.raises(services.HTTPException, match="contiguous sequence beginning at 2026-01-05"):
+        ingest("2026-01-06", "2026-01-06")
+
+    # Extending backwards requires history that this rolling source has retired.
+    plugin.available = ["2026-01-03", "2026-01-04"]
+    with pytest.raises(services.HTTPException, match="Source cannot materialize"):
+        ingest("2025-12-31", "2026-01-04")
+    assert repo.lookup_branch("main") == snapshot
+    assert services._load_records()[-1].artifact_id == artifact.artifact_id
+    assert len(plugin.fetched) == 4

--- a/tests/test_streaming_pyramided_store.py
+++ b/tests/test_streaming_pyramided_store.py
@@ -120,6 +120,32 @@ def test_committed_periods_come_from_level_zero(tmp_path: Path) -> None:
     }
 
 
+def test_resetting_a_failed_append_restores_every_pyramid_level(tmp_path: Path) -> None:
+    """The CLIM-899 rollback snapshot restores level 0, root, and overviews together."""
+    store_path, repo = _pyramided_store(tmp_path)
+    before = repo.lookup_branch("main")
+    repo.create_branch("rollback-test", before)
+
+    session = repo.writable_session("main")
+    _period(3).to_zarr(session.store, group=committed_data_group(store_path), append_dim="t", zarr_format=3)
+    session.commit("partial append")
+    assert len(read_committed_period_ids(store_path, "daily")) == 3
+
+    repo.reset_branch("main", before)
+    repo.delete_branch("rollback-test")
+
+    store = repo.readonly_session("main").store
+    root = zarr.open_group(store, mode="r")
+    counts = {"root": root["t"].shape[0]}
+    for group in root.group_keys():
+        level = xr.open_zarr(store, group=group)
+        try:
+            counts[group] = level.sizes["t"]
+        finally:
+            level.close()
+    assert set(counts.values()) == {2}
+
+
 def test_spatial_guard_is_active_on_a_pyramided_store(tmp_path: Path) -> None:
     """Reading the root returned None here, silently disabling the mirrored-raster check."""
     store_path, _ = _pyramided_store(tmp_path)


### PR DESCRIPTION
Fixes CLIM-899 by making committed dataset coverage a contiguous union of existing and requested periods while keeping `request_scope` as operation provenance.

- Plan the complete materialization scope before modifying the store; use cumulative coverage when planning scheduled synchronization.
- Extend a contiguous committed store by querying only the missing forward delta. Already committed history need not remain available upstream; contained requests skip source enumeration.
- Rematerialize earlier or gapped coverage through a sibling store, requiring the source to reproduce the complete union.
- Roll back partial appends, pyramid failures, and artifact-record persistence failures, keeping pyramid levels aligned with the committed dataset.
- Report `and N more` when unavailable committed periods exceed the five entries shown in an error.
- Document that planning and asynchronous fetching may run on separate event loops, so plugins must not share loop-bound resources between those calls.

The contiguity guarantee remains based on calendar periods. Sparse event acquisitions need an explicit policy before using this ingestion path; variable-length dekads still have consecutive periods, and STAC timestamp values do not change ingestion policy.

Validation: 122 tests passed across dataset ingestion, synchronization, streaming orchestration, pyramid rollback, and the new real-store rolling-source regressions. Those regressions confirm that retired history is preserved without refetching, missing new periods are rejected, and failed backward extensions leave the committed store and artifact record unchanged. Ruff lint and formatting, mypy, Pyright, `mkdocs build --strict`, and `git diff --check` passed.
