### PR TITLE
feat(stac): true-colour rendering for multi-band imagery, and a generic STAC imagery plugin

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -309,6 +309,41 @@ them requires re-ingesting the dataset:
 | `display.colormap` | No       | Colormap name for map rendering (e.g. `blues`, `rdbu_r`) |
 | `display.range`    | No       | `[min, max]` display range for the colormap              |
 | `display.nodata`   | No       | No-data / fill value                                     |
+| `display.bands`    | No       | Three band names for a true-colour render instead of a colormap (see below) |
+| `display.band_dimension` | No | Cube dimension holding the bands. Defaults to `band`     |
+
+### True-colour (RGB) rendering
+
+Imagery whose point is what it looks like — a flood before and after, a land-cover backdrop —
+renders as a composite rather than through a colour ramp. Declare the three bands instead of a
+colormap:
+
+```yaml
+display:
+  bands: [red, green, blue] # values on the band dimension, in R, G, B order
+  range: [0, 3000] # one stretch for all three bands
+```
+
+Bands with different dynamic ranges take one pair each:
+
+```yaml
+display:
+  bands: [red, green, blue]
+  range: [[0, 2500], [0, 2600], [0, 3000]]
+```
+
+An 8-bit true-colour source (Sentinel-2 TCI, Planet `visual`) needs no stretching, so use
+`range: [0, 255]`. Reflectance bands do need it, and a wrong range is the usual reason a
+composite comes out black or washed out.
+
+The bands live on one variable along a band dimension — the same shape the source GeoTIFF has,
+and the same mechanism `worldpop_agesex_*` uses for its `age_group` axis. `display.colormap`
+is ignored when `display.bands` is set: a composite has no single ramp, so the map legend is
+hidden for these layers.
+
+This is published as the STAC [Render extension](https://github.com/stac-extensions/render)
+`bands` array, so any render-aware client can composite the layer without knowing anything
+about OCS.
 
 ## Step 3: Point the instance at your plugins directory
 

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -345,6 +345,29 @@ This is published as the STAC [Render extension](https://github.com/stac-extensi
 `bands` array, so any render-aware client can composite the layer without knowing anything
 about OCS.
 
+#### Label a band axis with strings, but do not expect a client to read them
+
+Give the band dimension string labels (`red`, `green`, `blue`) rather than bare integers.
+That is what makes `ds.sel(band="red")` work for Python and openEO consumers, and it is how
+`worldpop_agesex_*` labels its `sex` axis.
+
+Be aware of the cost, because it has already produced one silent bug. A string coordinate is
+written as the Zarr v3 extension data type `fixed_length_utf32`, which is **not** in the core
+Zarr v3 specification — zarr-python itself warns that such arrays "may be unreadable by other
+Zarr libraries", and today's JavaScript reader does reject them.
+
+So a browser client cannot resolve a band *by name* from the store. OCS publishes the labels
+in `cube:dimensions.<band dimension>.values` for exactly this reason, and a client should:
+
+1. read the labels from STAC,
+2. map each render band to its position in that list,
+3. select on the store **by index**, not by name.
+
+The map viewer does this. Selecting by name looks like it works and is worse than failing:
+zarr-layer falls back to index 0 for any value it cannot resolve, so all three bands read the
+same slice and the image renders grey — a plausible-looking picture of the wrong data. Every
+other stepping control in the viewer already selects by index; a composite is no different.
+
 ## Step 3: Point the instance at your plugins directory
 
 Add `plugins_dir` to your `climate-service.yaml`:

--- a/open_climate_service/plugins/datasets/stac_imagery.py
+++ b/open_climate_service/plugins/datasets/stac_imagery.py
@@ -1,18 +1,25 @@
 """Ingest a public STAC imagery release as a true-colour GeoZarr cube.
 
-A generic replacement for per-release plugins: a static STAC catalogue of georeferenced
-image assets becomes a dataset *template* rather than code (CLIM-957). Verified against two
-structurally different releases:
+A generic replacement for per-release plugins: a STAC catalogue of georeferenced image assets
+becomes a dataset *template* rather than code (CLIM-957). Verified against three structurally
+different sources, which between them exercise every branch here:
 
-- Planet crisis-response (Source Cooperative) — a nested tree, root -> pre/post-event ->
-  one collection per sensor and date -> items, with a 4-band `visual` carrying alpha.
-- Vantor open data (S3) — a flat collection of items, with a 3-band `visual` that declares
-  no mask of any kind.
+- Planet crisis-response (Source Cooperative) — a static nested tree, root -> pre/post-event
+  -> one collection per sensor and date -> items, with a 4-band `visual` carrying alpha.
+- Vantor open data (S3) — a static flat collection of items, with a 3-band `visual` that
+  declares no mask of any kind, so validity falls back to an all-zero heuristic.
+- Sentinel-2 L2A (Earth Search) — a STAC *API*, queried rather than walked, whose TCI asset
+  declares `nodata=0`.
 
-Both are CC-BY-NC-4.0. OCS has no licence field on a dataset template (CLIM-946), so a
-`source_license` param is written as an attribute on the stored variable and the published
-STAC collection still reports `various`. That attribute is not a STAC licence and no client
-looks for it — carry the restriction in the template's `source` string too.
+Those three cover the three mask strategies, both catalogue shapes, and both a projected and
+a geographic source CRS. That is the point of the module: adding a fourth release should be a
+template, not a code change.
+
+Licensing differs and matters. Planet and Vantor are CC-BY-NC-4.0; Sentinel-2 is openly
+licensed. OCS has no licence field on a dataset template (CLIM-946), so a `source_license`
+param is written as an attribute on the stored variable and the published STAC collection
+reports `various` for all of them. That attribute is not a STAC licence and no client looks
+for it — carry the restriction in the template's `source` string too.
 
 What is stored is a colour composite with dims ``(t, band, y, x)`` and a string ``band``
 coordinate, the layout OCS renders when a template declares ``display.bands`` (CLIM-947).
@@ -62,6 +69,12 @@ _GDAL_ENV: dict[str, Any] = {
 }
 
 _DEFAULT_BANDS = ("red", "green", "blue")
+
+# STAC API item search. The page size is the spec default most servers cap at anyway; the
+# page cap is a runaway guard — a clip and a date range should return far less than this, and
+# hitting it means the request was wider than intended.
+_SEARCH_PAGE_SIZE = 100
+_SEARCH_MAX_PAGES = 50
 
 # How a scene declares which pixels carry data, in the order they are preferred. Chosen by
 # probing the two known releases rather than assumed: Planet's `visual` declares colorinterp
@@ -211,6 +224,8 @@ class StacImageryPlugin(BaseDatasetPlugin):
     - `target_crs` — default: the UTM zone containing the clip centre, so the grid is metric
     - `variable` — stored variable name
     - `collection_filter` — substring a leaf collection's URL must contain to be walked
+      (static catalogues only)
+    - `collections` — STAC API collection ids to search (item-search APIs only)
     - `max_cloud_cover` — drop items above this `eo:cloud_cover`
     - `property_filters` — mapping of STAC item property to required value(s)
     - `source_license`, `long_name` — written onto the stored variable
@@ -229,6 +244,7 @@ class StacImageryPlugin(BaseDatasetPlugin):
         clip_bbox: list[float] | None = None,
         target_crs: str | None = None,
         collection_filter: str | None = None,
+        collections: list[str] | None = None,
         max_cloud_cover: float | None = None,
         property_filters: dict[str, Any] | None = None,
         source_license: str | None = None,
@@ -260,11 +276,16 @@ class StacImageryPlugin(BaseDatasetPlugin):
         self.clip_bbox = [float(v) for v in clip_bbox] if clip_bbox else None
         self.target_crs = str(target_crs) if target_crs else None
         self.collection_filter = collection_filter
+        # STAC API collection ids to search. Distinct from `collection_filter`, which is a
+        # substring match on a *static* catalogue's child URLs.
+        self.collections = [str(c) for c in collections] if collections else []
         self.max_cloud_cover = float(max_cloud_cover) if max_cloud_cover is not None else None
         self.property_filters = dict(property_filters or {})
         self.source_license = source_license
         self.long_name = long_name
         self._index: dict[str, list[_Scene]] | None = None
+        # "" means "checked, not an item-search API"; None means "not yet checked".
+        self._api_search_url: str | None = None
         self._meta_cache: dict[tuple[str, str, float], _SceneMeta] = {}
 
     # -- discovery ---------------------------------------------------------------------
@@ -282,13 +303,120 @@ class StacImageryPlugin(BaseDatasetPlugin):
                 return False
         return True
 
-    def _discover(self) -> dict[str, list[_Scene]]:
+    def _add_item(self, by_date: dict[str, list[_Scene]], item: dict[str, Any], base_url: str) -> bool:
+        """Turn one STAC item into a scene, or explain why it was not usable."""
+        assets = item.get("assets", {})
+        if self.asset not in assets:
+            logger.warning(
+                "Item %s has no %r asset; found %s",
+                item.get("id", base_url.rsplit("/", 1)[-1]),
+                self.asset,
+                sorted(assets),
+            )
+            return False
+        date = str(item["properties"]["datetime"])[:10]
+        # The item's own bbox lets a non-overlapping scene be skipped without opening the file
+        # at all — the difference between 9 opens and 5.
+        by_date.setdefault(date, []).append(
+            _Scene(
+                urllib.parse.urljoin(base_url, assets[self.asset]["href"]),
+                tuple(item["bbox"][:4]),
+                str(item.get("id", base_url.rsplit("/", 1)[-1])),
+            )
+        )
+        return True
+
+    def _is_item_search_api(self) -> bool:
+        """Whether `catalog_url` is a STAC API root that supports item search.
+
+        Both signals are required: a `search` link alone appears on some static catalogues that
+        merely link to a search UI, and the conformance class alone does not give the endpoint.
+        """
+        if self._api_search_url is not None:
+            return bool(self._api_search_url)
+        root = _get_json(self.catalog_url)
+        conforms = root.get("conformsTo", [])
+        supports = any("item-search" in str(c) for c in conforms)
+        search = _links(root, "search", self.catalog_url)
+        self._api_search_url = search[0] if (supports and search) else ""
+        if self._api_search_url:
+            logger.info("%s is a STAC API; using item search", self.catalog_url)
+        return bool(self._api_search_url)
+
+    def _discover_via_search(self, start: str | None, end: str | None) -> dict[str, list[_Scene]]:
+        """Query a STAC API instead of walking it.
+
+        A global archive cannot be walked — Earth Search's `sentinel-2-l2a` alone holds tens of
+        millions of items — so the clip and the requested date range become search parameters.
+        That inverts the cost: the static path fetches every item and discards most, while this
+        fetches only what the extent and range already imply.
+        """
+        by_date: dict[str, list[_Scene]] = {}
+        skipped = 0
+        body: dict[str, Any] = {"limit": _SEARCH_PAGE_SIZE}
+        if self.collections:
+            body["collections"] = list(self.collections)
+        if self.clip_bbox:
+            body["bbox"] = list(self.clip_bbox)
+        if start and end:
+            body["datetime"] = f"{start[:10]}T00:00:00Z/{end[:10]}T23:59:59Z"
+
+        url: str | None = self._api_search_url or None
+        pages = 0
+        total = 0
+        while url:
+            response = httpx.post(url, json=body, timeout=120, follow_redirects=True)
+            response.raise_for_status()
+            page = response.json()
+            for item in page.get("features", []):
+                total += 1
+                if not self._keep_item(item):
+                    skipped += 1
+                    continue
+                # Asset hrefs in a search response are normally absolute, but resolve them
+                # against the item's own `self` link when present rather than against whichever
+                # link happens to be first, which need not be a URL base at all.
+                self_links = [
+                    link.get("href") for link in item.get("links", []) if link.get("rel") == "self" and link.get("href")
+                ]
+                self._add_item(by_date, item, self_links[0] if self_links else url)
+            pages += 1
+            if pages >= _SEARCH_MAX_PAGES:
+                # A bounded sweep beats an unbounded one, but a silent cap would read as
+                # "that is everything". Say what was left.
+                logger.warning(
+                    "Stopped after %d search pages (%d items); narrow clip_bbox or the date range if dates are missing",
+                    pages,
+                    total,
+                )
+                break
+            nxt = [link for link in page.get("links", []) if link.get("rel") == "next"]
+            # Paging carries the cursor in the body for POST search, in the href for GET.
+            if nxt and nxt[0].get("body"):
+                body = {**body, **nxt[0]["body"]}
+                url = nxt[0].get("href", url)
+            else:
+                url = nxt[0]["href"] if nxt else None
+                body = {}
+        if skipped:
+            logger.info("%d item(s) dropped by cloud/property filters", skipped)
+        if not by_date:
+            raise ValueError(
+                f"STAC API search over {self.catalog_url} returned no items with a "
+                f"{self.asset!r} asset for bbox={self.clip_bbox} range={start}..{end}"
+            )
+        return by_date
+
+    def _discover(self, start: str | None = None, end: str | None = None) -> dict[str, list[_Scene]]:
         """Walk the catalogue once, returning ``{acquisition date: [scenes]}``.
 
         Handles both known shapes: a document may carry `child` links (a catalogue), `item`
         links (a collection), or both. A flat collection is simply the case where the root has
-        no children.
+        no children. A STAC API root is queried rather than walked.
         """
+        if self._is_item_search_api():
+            return self._discover_via_search(start, end)
+
         by_date: dict[str, list[_Scene]] = {}
         seen: set[str] = set()
         skipped = 0
@@ -312,26 +440,8 @@ class StacImageryPlugin(BaseDatasetPlugin):
                     if not self._keep_item(item):
                         filtered += 1
                         continue
-                    assets = item.get("assets", {})
-                    if self.asset not in assets:
-                        logger.warning(
-                            "Item %s has no %r asset; found %s",
-                            item_url.rsplit("/", 1)[-1],
-                            self.asset,
-                            sorted(assets),
-                        )
-                        continue
-                    date = str(item["properties"]["datetime"])[:10]
-                    # The item's own bbox lets a non-overlapping scene be skipped without
-                    # opening the file at all — the difference between 9 opens and 5.
-                    by_date.setdefault(date, []).append(
-                        _Scene(
-                            urllib.parse.urljoin(item_url, assets[self.asset]["href"]),
-                            tuple(item["bbox"][:4]),
-                            str(item.get("id", item_url.rsplit("/", 1)[-1])),
-                        )
-                    )
-                    found += 1
+                    if self._add_item(by_date, item, item_url):
+                        found += 1
                 skipped += filtered
                 if not found and not filtered:
                     # Loudly, not silently: a collection contributing nothing means a date
@@ -356,9 +466,9 @@ class StacImageryPlugin(BaseDatasetPlugin):
             raise ValueError(f"No items with a {self.asset!r} asset found under {self.catalog_url}")
         return by_date
 
-    def _scenes(self) -> dict[str, list[_Scene]]:
+    def _scenes(self, start: str | None = None, end: str | None = None) -> dict[str, list[_Scene]]:
         if self._index is None:
-            self._index = self._discover()
+            self._index = self._discover(start, end)
             logger.info(
                 "Discovered %d date(s): %s",
                 len(self._index),
@@ -372,7 +482,9 @@ class StacImageryPlugin(BaseDatasetPlugin):
         return [sc for sc in scenes if not (sc.bbox[2] <= w or sc.bbox[0] >= e or sc.bbox[3] <= s or sc.bbox[1] >= n)]
 
     async def periods(self, start: str, end: str) -> list[str]:
-        index = await asyncio.to_thread(self._scenes)
+        # The range reaches discovery so a STAC API search is bounded by it; the static walk
+        # ignores it and filters below.
+        index = await asyncio.to_thread(self._scenes, start, end)
         dates = sorted(d for d in index if start[:10] <= d <= end[:10])
         if self.clip_bbox is None:
             return dates

--- a/open_climate_service/plugins/datasets/stac_imagery.py
+++ b/open_climate_service/plugins/datasets/stac_imagery.py
@@ -549,6 +549,12 @@ class StacImageryPlugin(BaseDatasetPlugin):
         # nodata so they render transparent rather than black.
         stored = mosaic.fillna(0).round().clip(0, 255).astype("uint8")
         cube = stored.expand_dims(t=[np.datetime64(period_id, "ns")]).to_dataset(name=self.variable)
+        # Replace the attributes rather than adding to them. `xr.where` propagates attrs from
+        # whichever scene it last merged, so the mosaic arrives carrying that one scene's TIFF
+        # tags — ACQUISITION_TIME, COLLECT_IDENTIFIER, VEHICLE_NAME. On a cube spanning several
+        # dates and several scenes per date those describe one arbitrary contributor while
+        # appearing to describe the whole variable, which is worse than having no provenance.
+        cube[self.variable].attrs.clear()
         attrs: dict[str, Any] = {
             "long_name": self.long_name or f"{'/'.join(self.bands)} composite (display values, not calibrated)",
             "units": "1",

--- a/open_climate_service/plugins/datasets/stac_imagery.py
+++ b/open_climate_service/plugins/datasets/stac_imagery.py
@@ -226,6 +226,7 @@ class StacImageryPlugin(BaseDatasetPlugin):
     - `collection_filter` — substring a leaf collection's URL must contain to be walked
       (static catalogues only)
     - `collections` — STAC API collection ids to search (item-search APIs only)
+    - `dates` — keep only these acquisition dates, for a non-contiguous selection
     - `max_cloud_cover` — drop items above this `eo:cloud_cover`
     - `property_filters` — mapping of STAC item property to required value(s)
     - `source_license`, `long_name` — written onto the stored variable
@@ -245,6 +246,7 @@ class StacImageryPlugin(BaseDatasetPlugin):
         target_crs: str | None = None,
         collection_filter: str | None = None,
         collections: list[str] | None = None,
+        dates: list[str] | None = None,
         max_cloud_cover: float | None = None,
         property_filters: dict[str, Any] | None = None,
         source_license: str | None = None,
@@ -279,6 +281,10 @@ class StacImageryPlugin(BaseDatasetPlugin):
         # STAC API collection ids to search. Distinct from `collection_filter`, which is a
         # substring match on a *static* catalogue's child URLs.
         self.collections = [str(c) for c in collections] if collections else []
+        # Explicit acquisition dates. A range cannot express "these two and not the five
+        # between", which is the common case for a before/after pair drawn from a repeat-pass
+        # source. Empty means "every date in the requested range".
+        self.dates = sorted({str(d)[:10] for d in dates}) if dates else []
         self.max_cloud_cover = float(max_cloud_cover) if max_cloud_cover is not None else None
         self.property_filters = dict(property_filters or {})
         self.source_license = source_license
@@ -487,7 +493,7 @@ class StacImageryPlugin(BaseDatasetPlugin):
         index = await asyncio.to_thread(self._scenes, start, end)
         dates = sorted(d for d in index if start[:10] <= d <= end[:10])
         if self.clip_bbox is None:
-            return dates
+            return self._restrict_to_requested_dates(dates, start, end)
         # A date whose scenes all miss the configured footprint is not an available period.
         # Without this the ingest requests it and `fetch_period` raises, so a release that
         # images several valleys fails the whole run on the first irrelevant date.
@@ -495,7 +501,27 @@ class StacImageryPlugin(BaseDatasetPlugin):
         usable = [d for d in dates if self._overlapping(index[d], box)]
         for dropped in sorted(set(dates) - set(usable)):
             logger.info("%s: no scene over the configured extent, skipping", dropped)
-        return usable
+        return self._restrict_to_requested_dates(usable, start, end)
+
+    def _restrict_to_requested_dates(self, available: list[str], start: str, end: str) -> list[str]:
+        """Narrow to an explicit `dates` allow-list, refusing silently-missing entries.
+
+        A requested date that falls inside the range but is not on offer is a configuration
+        error, not an empty result: ingesting fewer periods than asked for is invisible once
+        stored. Dates outside the range are ignored rather than refused, since the range is
+        the narrower statement of intent.
+        """
+        if not self.dates:
+            return available
+        in_range = [d for d in self.dates if start[:10] <= d <= end[:10]]
+        missing = sorted(set(in_range) - set(available))
+        if missing:
+            raise ValueError(
+                f"Requested date(s) {missing} are within {start[:10]}..{end[:10]} but no scene "
+                f"covers the configured extent then. Available: {available}. Check `dates` in "
+                f"the template, and `max_cloud_cover` if set — filtering can remove a date."
+            )
+        return [d for d in available if d in set(in_range)]
 
     # -- fetching ----------------------------------------------------------------------
 

--- a/open_climate_service/plugins/datasets/stac_imagery.py
+++ b/open_climate_service/plugins/datasets/stac_imagery.py
@@ -1,0 +1,563 @@
+"""Ingest a public STAC imagery release as a true-colour GeoZarr cube.
+
+A generic replacement for per-release plugins: a static STAC catalogue of georeferenced
+image assets becomes a dataset *template* rather than code (CLIM-957). Verified against two
+structurally different releases:
+
+- Planet crisis-response (Source Cooperative) — a nested tree, root -> pre/post-event ->
+  one collection per sensor and date -> items, with a 4-band `visual` carrying alpha.
+- Vantor open data (S3) — a flat collection of items, with a 3-band `visual` that declares
+  no mask of any kind.
+
+Both are CC-BY-NC-4.0. OCS has no licence field on a dataset template (CLIM-946), so a
+`source_license` param is written as an attribute on the stored variable and the published
+STAC collection still reports `various`. That attribute is not a STAC licence and no client
+looks for it — carry the restriction in the template's `source` string too.
+
+What is stored is a colour composite with dims ``(t, band, y, x)`` and a string ``band``
+coordinate, the layout OCS renders when a template declares ``display.bands`` (CLIM-947).
+These are display values: 8-bit and colour-corrected per scene, so differencing two dates
+partly measures the provider's balancing rather than the ground. The variable is named by
+the template; prefer something like `true_colour` over `reflectance`, because the variable
+name is most of what a downstream consumer sees.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, NamedTuple, cast
+
+import httpx
+import numpy as np
+import rioxarray  # noqa: F401  # registers the .rio accessor
+import xarray as xr
+from rasterio.enums import ColorInterp, MaskFlags
+from rasterio.warp import transform_bounds
+from rioxarray.exceptions import NoDataInBounds
+
+from open_climate_service.streaming import BaseDatasetPlugin
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on the target grid, in cells. Sized so a legitimate event-scoped extent never
+# trips it but an unscoped one fails loudly: `fetch_period` is handed the *instance* extent,
+# which for a country at sub-metre resolution is a terabyte-scale allocation. See `clip_bbox`.
+_MAX_GRID_CELLS = 60_000_000
+
+# COG-over-HTTP settings, measured against the Planet release: opening one scene took 6.4 s
+# with GDAL's defaults and 1.0 s with these. The cost was GDAL probing for sidecar files
+# (.aux.xml, .ovr, ...) on every open, each probe a round trip to a slow host.
+_GDAL_ENV: dict[str, Any] = {
+    # rasterio.Env is strict about types: booleans and integers must be passed as such, not
+    # as the strings GDAL's own documentation uses.
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif",
+    "GDAL_HTTP_MULTIPLEX": True,
+    "VSI_CACHE": True,
+    "GDAL_CACHEMAX": 512,
+}
+
+_DEFAULT_BANDS = ("red", "green", "blue")
+
+# How a scene declares which pixels carry data, in the order they are preferred. Chosen by
+# probing the two known releases rather than assumed: Planet's `visual` declares colorinterp
+# ['red','green','blue','alpha'], while Vantor's declares ['red','green','blue'] with nodata
+# None and every band `all_valid` — no mask information whatsoever.
+_MASK_ALPHA = "alpha"
+_MASK_NODATA = "nodata"
+_MASK_NONZERO = "nonzero"
+
+
+def _get_json(url: str) -> dict[str, Any]:
+    """Fetch one STAC document.
+
+    httpx rather than urllib: Source Cooperative 403s the default Python user agent, the same
+    reason `worldpop.py` reaches for httpx.
+    """
+    response = httpx.get(url, timeout=120, follow_redirects=True)
+    response.raise_for_status()
+    return dict(response.json())
+
+
+def _links(doc: dict[str, Any], rel: str, base: str) -> list[str]:
+    return [urllib.parse.urljoin(base, link["href"]) for link in doc.get("links", []) if link.get("rel") == rel]
+
+
+def _open_scene(href: str, overview_level: int | None) -> xr.DataArray:
+    """Open one scene lazily, as a DataArray.
+
+    ``open_rasterio`` is typed as returning a Dataset, a DataArray or a list of Datasets; a
+    single-subdataset raster always yields a DataArray, and anything else here means the
+    source is not the plain image asset the plugin assumes.
+    """
+    opened = rioxarray.open_rasterio(
+        href,
+        chunks={"x": 2048, "y": 2048},
+        overview_level=overview_level,
+    )
+    if not isinstance(opened, xr.DataArray):
+        raise TypeError(f"Expected a DataArray from {href}, got {type(opened).__name__}")
+    return opened
+
+
+class _Scene(NamedTuple):
+    href: str
+    bbox: tuple[float, float, float, float]  # EPSG:4326, straight from the STAC item
+    item_id: str
+
+
+class _SceneMeta(NamedTuple):
+    band_indices: tuple[int, ...]  # 1-based, in requested band order
+    mask_kind: str
+    mask_ref: Any  # alpha band index, nodata value, or None
+    overview_level: int | None
+
+
+class _Grid(NamedTuple):
+    xs: np.ndarray
+    ys: np.ndarray
+    bounds: tuple[float, float, float, float]  # left, bottom, right, top in the target CRS
+
+
+def _utm_epsg(lon: float, lat: float) -> str:
+    """EPSG code of the UTM zone containing a point.
+
+    Used when no `target_crs` is given, so `resolution_m` is always metres regardless of
+    whether the source is projected (Planet, UTM 45N) or geographic (Vantor, EPSG:4326).
+    """
+    zone = int((lon + 180.0) / 6.0) + 1
+    return f"EPSG:{(32600 if lat >= 0 else 32700) + zone}"
+
+
+def _resolve_bands(
+    colorinterp: tuple[Any, ...],
+    descriptions: tuple[Any, ...],
+    bands: tuple[str, ...],
+) -> tuple[int, ...]:
+    """Map requested band names to 1-based raster indices.
+
+    Three sources, in order: GDAL's colour interpretation (Planet and Vantor both declare it),
+    then band descriptions (Vantor has 'red'/'green'/'blue', Planet has None), then position.
+    Positional is the last resort and only when the count matches, so a source that changes
+    its band layout fails loudly rather than silently swapping channels.
+    """
+    by_interp = {c.name.lower(): i + 1 for i, c in enumerate(colorinterp) if c is not None}
+    if all(name in by_interp for name in bands):
+        return tuple(by_interp[name] for name in bands)
+
+    by_desc = {str(d).lower(): i + 1 for i, d in enumerate(descriptions) if d}
+    if all(name in by_desc for name in bands):
+        return tuple(by_desc[name] for name in bands)
+
+    if len(colorinterp) == len(bands):
+        logger.warning(
+            "Falling back to positional band order for %s: colorinterp=%s descriptions=%s",
+            bands,
+            [c.name if c else None for c in colorinterp],
+            descriptions,
+        )
+        return tuple(range(1, len(bands) + 1))
+
+    raise ValueError(
+        f"Cannot resolve bands {bands} in a {len(colorinterp)}-band asset: "
+        f"colorinterp={[c.name if c else None for c in colorinterp]}, "
+        f"descriptions={descriptions}. Set `bands` in the template to names the asset "
+        f"declares, or supply an asset whose band count matches."
+    )
+
+
+def _resolve_mask(src: Any) -> tuple[str, Any]:
+    """Pick how to tell data pixels from padding, preferring the most explicit signal.
+
+    This is the one place the known sources genuinely differ, and getting it wrong produces a
+    subtly wrong mosaic rather than an error: without a mask the black padding around a
+    scene's footprint wins the first-non-null test and punches holes in the result.
+    """
+    for index, interp in enumerate(src.colorinterp):
+        if interp == ColorInterp.alpha:
+            return _MASK_ALPHA, index + 1
+    if src.nodata is not None:
+        return _MASK_NODATA, src.nodata
+    if any(MaskFlags.all_valid not in flags for flags in src.mask_flag_enums):
+        # A per-dataset mask band with no alpha and no nodata. Not read directly — GDAL does
+        # not expose it through rioxarray — so it is approximated by the all-zero test below.
+        # Warned about because that approximation is the plugin's, not the source's.
+        logger.warning(
+            "%s declares an internal mask that cannot be read through rioxarray; "
+            "approximating it by treating all-zero pixels as padding",
+            getattr(src, "name", "scene"),
+        )
+    # No usable mask information (Vantor). Treating all-zero pixels as padding is a heuristic:
+    # a genuinely black pixel is dropped. In practice colour-corrected visual imagery over
+    # land does not produce true 0,0,0, and the alternative — trusting the padding — is worse.
+    return _MASK_NONZERO, None
+
+
+class StacImageryPlugin(BaseDatasetPlugin):
+    """True-colour imagery from any static STAC catalogue, mosaicked onto a fixed grid.
+
+    Template params:
+
+    - `catalog_url` — catalogue or collection root; `child` and `item` links are walked
+      recursively, so a nested tree and a flat collection both work
+    - `asset` — asset key to read (default `visual`)
+    - `bands` — output band names (default red, green, blue)
+    - `resolution_m` — target grid resolution in metres
+    - `clip_bbox` — the ingest footprint; see the note in `__init__`
+    - `target_crs` — default: the UTM zone containing the clip centre, so the grid is metric
+    - `variable` — stored variable name
+    - `collection_filter` — substring a leaf collection's URL must contain to be walked
+    - `max_cloud_cover` — drop items above this `eo:cloud_cover`
+    - `property_filters` — mapping of STAC item property to required value(s)
+    - `source_license`, `long_name` — written onto the stored variable
+    """
+
+    max_concurrency = 1
+    commit_batch_size = 2
+
+    def __init__(
+        self,
+        catalog_url: str,
+        resolution_m: float,
+        variable: str = "true_colour",
+        asset: str = "visual",
+        bands: list[str] | None = None,
+        clip_bbox: list[float] | None = None,
+        target_crs: str | None = None,
+        collection_filter: str | None = None,
+        max_cloud_cover: float | None = None,
+        property_filters: dict[str, Any] | None = None,
+        source_license: str | None = None,
+        long_name: str | None = None,
+        **_: Any,
+    ) -> None:
+        self.catalog_url = str(catalog_url)
+        # Validated because this reaches both a division and the step of an `np.arange`. Zero
+        # raises there with a message about arange rather than about configuration; a negative
+        # or NaN value silently yields an empty grid and fails much later inside a raster call.
+        self.resolution_m = float(resolution_m)
+        if not math.isfinite(self.resolution_m) or self.resolution_m <= 0:
+            raise ValueError(f"resolution_m must be a finite positive number, got {resolution_m!r}")
+        self.variable = str(variable)
+        self.asset = str(asset)
+        # `is None` rather than falsy: an explicitly empty list is a configuration mistake and
+        # must reach the guard below, not silently become the RGB default.
+        self.bands = tuple(str(b).lower() for b in (_DEFAULT_BANDS if bands is None else bands))
+        if not self.bands:
+            raise ValueError("bands must not be empty")
+        # OCS hands `fetch_period` the *instance* extent, not the template's
+        # `extents.spatial.bbox` — that field documents where the source has data and is never
+        # read by the ingest (only `extents.temporal` is). For a country-sized instance at
+        # sub-metre resolution that is a multi-hundred-gigabyte allocation: the process is
+        # SIGKILLed by the kernel with no Python traceback. So an event-scoped dataset has to
+        # carry its own clip. Deliberately not named `bbox`: the orchestrator calls
+        # `fetch_period(period_id, bbox, **params)`, so a `bbox` key here would collide with
+        # the positional argument and raise TypeError.
+        self.clip_bbox = [float(v) for v in clip_bbox] if clip_bbox else None
+        self.target_crs = str(target_crs) if target_crs else None
+        self.collection_filter = collection_filter
+        self.max_cloud_cover = float(max_cloud_cover) if max_cloud_cover is not None else None
+        self.property_filters = dict(property_filters or {})
+        self.source_license = source_license
+        self.long_name = long_name
+        self._index: dict[str, list[_Scene]] | None = None
+        self._meta_cache: dict[tuple[str, str, float], _SceneMeta] = {}
+
+    # -- discovery ---------------------------------------------------------------------
+
+    def _keep_item(self, item: dict[str, Any]) -> bool:
+        properties = item.get("properties", {})
+        if self.max_cloud_cover is not None:
+            cloud = properties.get("eo:cloud_cover")
+            if cloud is not None and float(cloud) > self.max_cloud_cover:
+                return False
+        for key, wanted in self.property_filters.items():
+            actual = properties.get(key)
+            allowed = wanted if isinstance(wanted, (list, tuple, set)) else [wanted]
+            if actual not in allowed:
+                return False
+        return True
+
+    def _discover(self) -> dict[str, list[_Scene]]:
+        """Walk the catalogue once, returning ``{acquisition date: [scenes]}``.
+
+        Handles both known shapes: a document may carry `child` links (a catalogue), `item`
+        links (a collection), or both. A flat collection is simply the case where the root has
+        no children.
+        """
+        by_date: dict[str, list[_Scene]] = {}
+        seen: set[str] = set()
+        skipped = 0
+
+        def walk(url: str) -> None:
+            nonlocal skipped
+            if url in seen:
+                return
+            seen.add(url)
+            doc = _get_json(url)
+
+            item_urls = _links(doc, "item", url)
+            if item_urls:
+                # Concurrently: these hosts answer in roughly a second per request, so
+                # fetching a collection's items in series dominated start-up.
+                with ThreadPoolExecutor(max_workers=8) as pool:
+                    items = list(pool.map(_get_json, item_urls))
+                found = 0
+                filtered = 0
+                for item_url, item in zip(item_urls, items, strict=True):
+                    if not self._keep_item(item):
+                        filtered += 1
+                        continue
+                    assets = item.get("assets", {})
+                    if self.asset not in assets:
+                        logger.warning(
+                            "Item %s has no %r asset; found %s",
+                            item_url.rsplit("/", 1)[-1],
+                            self.asset,
+                            sorted(assets),
+                        )
+                        continue
+                    date = str(item["properties"]["datetime"])[:10]
+                    # The item's own bbox lets a non-overlapping scene be skipped without
+                    # opening the file at all — the difference between 9 opens and 5.
+                    by_date.setdefault(date, []).append(
+                        _Scene(
+                            urllib.parse.urljoin(item_url, assets[self.asset]["href"]),
+                            tuple(item["bbox"][:4]),
+                            str(item.get("id", item_url.rsplit("/", 1)[-1])),
+                        )
+                    )
+                    found += 1
+                skipped += filtered
+                if not found and not filtered:
+                    # Loudly, not silently: a collection contributing nothing means a date
+                    # vanishes from `periods()`, and a missing period is invisible once
+                    # ingested. Filters legitimately empty a collection, hence the guard.
+                    raise ValueError(f"STAC collection {url} yielded no usable {self.asset!r} assets")
+
+            for child_url in _links(doc, "child", url):
+                if self.collection_filter and self.collection_filter not in child_url:
+                    # Applied only at the leaf: an intermediate node (Planet's pre/post-event
+                    # split) does not carry the sensor name, so filtering it out here would
+                    # prune the whole subtree. Children that have children are still followed.
+                    child = _get_json(child_url)
+                    if not _links(child, "child", child_url):
+                        continue
+                walk(child_url)
+
+        walk(self.catalog_url)
+        if skipped:
+            logger.info("%d item(s) dropped by cloud/property filters", skipped)
+        if not by_date:
+            raise ValueError(f"No items with a {self.asset!r} asset found under {self.catalog_url}")
+        return by_date
+
+    def _scenes(self) -> dict[str, list[_Scene]]:
+        if self._index is None:
+            self._index = self._discover()
+            logger.info(
+                "Discovered %d date(s): %s",
+                len(self._index),
+                ", ".join(f"{d} ({len(v)})" for d, v in sorted(self._index.items())),
+            )
+        return self._index
+
+    @staticmethod
+    def _overlapping(scenes: list[_Scene], box: tuple[float, float, float, float]) -> list[_Scene]:
+        w, s, e, n = box
+        return [sc for sc in scenes if not (sc.bbox[2] <= w or sc.bbox[0] >= e or sc.bbox[3] <= s or sc.bbox[1] >= n)]
+
+    async def periods(self, start: str, end: str) -> list[str]:
+        index = await asyncio.to_thread(self._scenes)
+        dates = sorted(d for d in index if start[:10] <= d <= end[:10])
+        if self.clip_bbox is None:
+            return dates
+        # A date whose scenes all miss the configured footprint is not an available period.
+        # Without this the ingest requests it and `fetch_period` raises, so a release that
+        # images several valleys fails the whole run on the first irrelevant date.
+        box = (self.clip_bbox[0], self.clip_bbox[1], self.clip_bbox[2], self.clip_bbox[3])
+        usable = [d for d in dates if self._overlapping(index[d], box)]
+        for dropped in sorted(set(dates) - set(usable)):
+            logger.info("%s: no scene over the configured extent, skipping", dropped)
+        return usable
+
+    # -- fetching ----------------------------------------------------------------------
+
+    def _resolved_crs(self, box: tuple[float, float, float, float]) -> str:
+        """The grid CRS, derived once per period from the effective extent.
+
+        Deliberately not derived per scene: two scenes in different UTM zones would otherwise
+        build different grids for the same period, and OCS infers the grid from the first
+        period and appends along time.
+        """
+        if self.target_crs:
+            return self.target_crs
+        return _utm_epsg((box[0] + box[2]) / 2.0, (box[1] + box[3]) / 2.0)
+
+    def _scene_meta(self, href: str, crs: str, target_res: float) -> _SceneMeta:
+        """Read band layout, mask strategy and a suitable overview level in one open.
+
+        Cached per (scene, grid, resolution): the same file is reopened for each period that
+        uses it, and the metadata read is a round trip to a slow host.
+
+        Band descriptions must come from the full-resolution dataset — GDAL does not carry
+        them on overview levels, so reading them from an overview yields an empty tuple. The
+        overview chosen is the coarsest still at or finer than the target grid.
+        """
+        key = (href, crs, target_res)
+        cached = self._meta_cache.get(key)
+        if cached is not None:
+            return cached
+        import rasterio
+
+        with rasterio.open(href) as src:
+            indices = _resolve_bands(tuple(src.colorinterp), tuple(src.descriptions), self.bands)
+            mask_kind, mask_ref = _resolve_mask(src)
+            # Native resolution measured in the *target* CRS: comparing a degree-valued
+            # resolution against a metre-valued target would pick the finest overview every
+            # time for a geographic source like Vantor, reading far more data than the grid
+            # can use.
+            left, bottom, right, top = transform_bounds(src.crs, crs, *src.bounds)
+            native = max(
+                abs(right - left) / max(src.width, 1),
+                abs(top - bottom) / max(src.height, 1),
+            )
+            level: int | None = None
+            for index, factor in enumerate(src.overviews(1)):
+                if native * factor <= target_res:
+                    level = index
+            meta = _SceneMeta(indices, mask_kind, mask_ref, level)
+        logger.debug(
+            "%s: bands %s, mask %s, native %.3g m, overview %s",
+            href.rsplit("/", 1)[-1],
+            meta.band_indices,
+            meta.mask_kind,
+            native,
+            meta.overview_level,
+        )
+        self._meta_cache[key] = meta
+        return meta
+
+    def _build_grid(self, box: tuple[float, float, float, float], crs: str) -> _Grid:
+        w, s, e, n = box
+        left, bottom, right, top = transform_bounds("EPSG:4326", crs, w, s, e, n)
+        res = self.resolution_m
+        # Snap the grid to the resolution so every period lands on identical cells — OCS
+        # infers the grid from the first period and appends along time, so it cannot drift.
+        left, bottom = np.floor(left / res) * res, np.floor(bottom / res) * res
+        right, top = np.ceil(right / res) * res, np.ceil(top / res) * res
+        xs = np.arange(left + res / 2, right, res)
+        ys = np.arange(top - res / 2, bottom, -res)
+        return _Grid(xs, ys, (left, bottom, right, top))
+
+    def _valid_mask(self, window: xr.DataArray, meta: _SceneMeta) -> xr.DataArray:
+        """Pixels carrying real data, by whichever strategy the scene supports."""
+        if meta.mask_kind == _MASK_ALPHA:
+            return window.sel(band=meta.mask_ref).load() > 0
+        colour = window.sel(band=list(meta.band_indices)).load()
+        reference = meta.mask_ref if meta.mask_kind == _MASK_NODATA else 0
+        return cast(xr.DataArray, (colour != reference).any(dim="band"))
+
+    def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
+        scenes = self._scenes().get(period_id, [])
+        if not scenes:
+            raise ValueError(f"No scenes for {period_id!r}")
+
+        w, s, e, n = (float(v) for v in bbox)
+        if self.clip_bbox is not None:
+            cw, cs, ce, cn = self.clip_bbox
+            w, s, e, n = max(w, cw), max(s, cs), min(e, ce), min(n, cn)
+            if w >= e or s >= n:
+                raise ValueError(f"clip_bbox {self.clip_bbox} does not intersect the instance extent {bbox}")
+        scenes = self._overlapping(scenes, (w, s, e, n))
+        if not scenes:
+            raise ValueError(f"No scene overlaps the configured extent for {period_id}")
+
+        crs = self._resolved_crs((w, s, e, n))
+        grid = self._build_grid((w, s, e, n), crs)
+        left, bottom, right, top = grid.bounds
+
+        # Refuse loudly rather than allocate. Without this the template below is a silent
+        # `np.full` of whatever the extent implies; the kernel kills the process and the
+        # operator sees exit 137 with no traceback and no clue why.
+        cells = int(grid.ys.size) * int(grid.xs.size)
+        if cells > _MAX_GRID_CELLS:
+            # A *lower bound*, not the memory the build needs: mosaicking allocates several
+            # such arrays (the template, each reprojected scene, and the `xr.where` result),
+            # so peak RSS runs well above it — a 14.6M-cell grid is 0.18 GB by this formula
+            # and peaked at 4.5 GB in practice. Stated as a floor so an operator sizing a box
+            # is not misled by a number that looks complete.
+            raise ValueError(
+                f"{period_id}: grid {grid.ys.size} x {grid.xs.size} = {cells / 1e6:.0f}M cells "
+                f"at {self.resolution_m} m needs at least "
+                f"{cells * len(self.bands) * 4 / 1e9:.1f} GB for a single float32 array, and "
+                f"several times that to mosaic. The ingest was given the extent "
+                f"{[w, s, e, n]}; set `clip_bbox` in the template's ingestion params to the "
+                f"event footprint, or raise resolution_m."
+            )
+
+        # The target grid carries the band axis, so every scene is reprojected onto identical
+        # cells *and* identical channels; reproject_match then needs no per-band bookkeeping.
+        template = xr.DataArray(
+            np.full((len(self.bands), grid.ys.size, grid.xs.size), np.nan, dtype="float32"),
+            coords={"band": list(self.bands), "y": grid.ys, "x": grid.xs},
+            dims=("band", "y", "x"),
+        ).rio.write_crs(crs)
+
+        import rasterio
+
+        mosaic = template.copy()
+        used = 0
+        with rasterio.Env(**_GDAL_ENV):
+            for scene_ref in scenes:
+                meta = self._scene_meta(scene_ref.href, crs, self.resolution_m)
+                opened = _open_scene(scene_ref.href, meta.overview_level)
+                # The clip box must be expressed in the scene's own CRS, which is not always
+                # the grid's: Vantor publishes EPSG:4326 while the grid is UTM.
+                scene_box = transform_bounds(crs, opened.rio.crs, left, bottom, right, top)
+                try:
+                    window = opened.rio.clip_box(*scene_box)
+                except NoDataInBounds:
+                    continue  # projected footprint misses the snapped grid despite a bbox overlap
+                used += 1
+
+                colour = window.sel(band=list(meta.band_indices)).astype("float32").load()
+                colour = colour.where(self._valid_mask(window, meta))
+                colour = colour.assign_coords(band=list(self.bands)).rio.write_crs(opened.rio.crs)
+                resampled = colour.rio.reproject_match(template)
+                mosaic = xr.where(mosaic.isnull(), resampled, mosaic).rio.write_crs(crs)
+
+        if not used or bool(mosaic.isnull().all()):
+            raise ValueError(f"No scene overlaps the configured extent for {period_id}")
+        logger.info(
+            "%s: %d of %d overlapping scenes used, grid %d x %d at %g m (%s)",
+            period_id,
+            used,
+            len(scenes),
+            grid.ys.size,
+            grid.xs.size,
+            self.resolution_m,
+            crs,
+        )
+
+        # Back to uint8 for storage: the source is 8-bit and float32 would quadruple the store
+        # for no added information. Masked cells become 0, which the template declares as
+        # nodata so they render transparent rather than black.
+        stored = mosaic.fillna(0).round().clip(0, 255).astype("uint8")
+        cube = stored.expand_dims(t=[np.datetime64(period_id, "ns")]).to_dataset(name=self.variable)
+        attrs: dict[str, Any] = {
+            "long_name": self.long_name or f"{'/'.join(self.bands)} composite (display values, not calibrated)",
+            "units": "1",
+        }
+        if self.source_license:
+            # A custom attribute, so the licence does travel with the array. It is not a STAC
+            # licence: OCS has no licence field on a dataset template, so the published
+            # collection still reports `various` (CLIM-946). Machine-readable on the variable,
+            # absent from where a client would actually look.
+            attrs["source_license"] = self.source_license
+        cube[self.variable].attrs.update(attrs)
+        return cast(xr.Dataset, cube)

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 from copy import deepcopy
@@ -567,29 +568,35 @@ def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence
 _SIMPLE_ISO_STEP_RE = re.compile(r"^P(?:T(\d+)H|(\d+)D|(\d+)M|(\d+)Y)$")
 
 
-def _implied_step_count(start: pd.Timestamp, end: pd.Timestamp, step: str) -> int | None:
-    """How many positions a client builds by walking *step* from *start* to *end*.
+def _expected_time_walk(start: pd.Timestamp, end: pd.Timestamp, step: str) -> pd.DatetimeIndex | None:
+    """The timestamps a client builds by walking *step* from *start* to *end*.
 
     Mirrors ``generateDateRange`` in map-viewer.html, including its calendar handling for
-    months and years — an approximation in fixed days drifts and overcounts. Returns None
-    for a duration that cannot be walked, in which case the caller must not draw any
-    conclusion from the count.
+    months and years — an approximation in fixed days drifts and overcounts.
+
+    The whole sequence rather than only its length: a count alone cannot tell a dense axis
+    from one that merely happens to have the same number of slices. A daily store holding
+    ``[Jan 1 00:00, Jan 2 12:00, Jan 3 00:00]`` implies three positions and has three, so a
+    count check passes while the middle label is wrong by twelve hours.
+
+    Returns None for a duration this cannot walk, which the caller must treat as "cannot
+    reconstruct" rather than as agreement.
     """
     match = _SIMPLE_ISO_STEP_RE.match(step)
     if match is None:
         return None
     hours, days, months, years = match.groups()
-    if months is not None:
-        n = int(months)
-        total = (end.year - start.year) * 12 + (end.month - start.month)
-        return max(1, total // n + 1)
-    if years is not None:
-        n = int(years)
-        return max(1, (end.year - start.year) // n + 1)
+    if months is not None or years is not None:
+        n = int(months or years)
+        offset = pd.DateOffset(months=n) if months is not None else pd.DateOffset(years=n)
+        span = (end.year - start.year) * 12 + (end.month - start.month) if months is not None else end.year - start.year
+        count = max(1, span // n + 1)
+        return pd.DatetimeIndex([start + offset * i for i in range(count)])
     inc = timedelta(hours=int(hours)) if hours is not None else timedelta(days=int(days))
     # Via seconds rather than dividing the two deltas directly: `end - start` is a pandas
     # Timedelta, and dividing that by a stdlib timedelta has no typed overload.
-    return max(1, int((end - start).total_seconds() // inc.total_seconds()) + 1)
+    count = max(1, int((end - start).total_seconds() // inc.total_seconds()) + 1)
+    return pd.DatetimeIndex([start + inc * i for i in range(count)])
 
 
 def _temporal_values_needed(ds: xr.Dataset, time_dimension: str, period_type: Any, iso_step: str | None) -> bool:
@@ -611,15 +618,24 @@ def _temporal_values_needed(ds: xr.Dataset, time_dimension: str, period_type: An
     """
     if period_cadence(period_type) is Cadence.IRREGULAR:
         return True
-    if not isinstance(iso_step, str) or time_dimension not in ds.dims:
+    if time_dimension not in ds.dims:
         return False
     stamps = pd.DatetimeIndex(np.asarray(ds[time_dimension].values, dtype="datetime64[ns]"))
-    if len(stamps) == 0:
+    # One slice implies one position, so there is nothing for a client to get wrong.
+    if len(stamps) <= 1:
         return False
+    # No step, or one no client can walk (P1W, PT30M, a compound duration): a consumer
+    # stepping `extent` gets a single position and every slice past the first is unreachable.
+    # Listing the timestamps is the only way the axis survives, so default to publishing them
+    # rather than staying silent — being unable to check is not the same as agreeing.
+    if not isinstance(iso_step, str):
+        return True
     # The store's own endpoints rather than the published extent strings: they are the same
     # instants, and using them avoids re-parsing timezone-suffixed ISO text to compare.
-    implied = _implied_step_count(stamps[0], stamps[-1], iso_step)
-    return implied is not None and implied != len(stamps)
+    expected = _expected_time_walk(stamps[0], stamps[-1], iso_step)
+    if expected is None:
+        return True
+    return not expected.equals(stamps)
 
 
 def _add_temporal_values(collection: dict[str, Any], ds: xr.Dataset, time_dimension: str) -> None:
@@ -868,13 +884,22 @@ def _rescale_pairs(value_range: Any, count: int) -> list[list[float]] | None:
     if not isinstance(value_range, list) or not value_range:
         return None
     if all(isinstance(v, (int, float)) for v in value_range) and len(value_range) == 2:
-        return [[float(value_range[0]), float(value_range[1])]] * count
-    if len(value_range) == count and all(
+        pairs = [[float(value_range[0]), float(value_range[1])]] * count
+    elif len(value_range) == count and all(
         isinstance(pair, list) and len(pair) == 2 and all(isinstance(v, (int, float)) for v in pair)
         for pair in value_range
     ):
-        return [[float(pair[0]), float(pair[1])] for pair in value_range]
-    return None
+        pairs = [[float(pair[0]), float(pair[1])] for pair in value_range]
+    else:
+        return None
+    # Shape is not enough: the viewer's shader divides by `max - min` and embeds both numbers
+    # as GLSL literals. An equal pair divides by zero, and a non-finite endpoint produces
+    # either NaN colours or a shader that will not compile — and `NaN`/`Infinity` are not
+    # valid JSON either, so the collection response itself would be malformed. Refusing here
+    # gives the warned-and-omitted behaviour the caller already handles.
+    if any(not math.isfinite(lo) or not math.isfinite(hi) or lo >= hi for lo, hi in pairs):
+        return None
+    return pairs
 
 
 def _build_renders(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> dict[str, Any] | None:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from copy import deepcopy
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -110,7 +112,12 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     template_links = [_link_to_dict(link) for link in template.links]
     period_type = source_dataset.get("period_type")
 
-    collection_payload = _build_collection_with_xstac(artifact=artifact, template=template, period_type=period_type)
+    # Resolved once and used twice: the payload builder needs it to tell a sparse time axis
+    # from a dense one, and `_override_time_step` below publishes it.
+    iso_step = resolve_iso_period_step(source_dataset) or period_type_to_iso_step(period_type)
+    collection_payload = _build_collection_with_xstac(
+        artifact=artifact, template=template, period_type=period_type, iso_step=iso_step
+    )
     collection_payload["id"] = dataset_id
     collection_payload["type"] = "Collection"
     collection_payload["stac_version"] = STAC_VERSION
@@ -154,11 +161,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     # Prefer an explicit extents.temporal.resolution; fall back to the dataset's
     # period_type so openEO save_result outputs (which omit the extents block) still
     # get a temporal step — the map viewer needs it to build the time slider.
-    _override_time_step(
-        collection_payload,
-        resolve_iso_period_step(source_dataset) or period_type_to_iso_step(period_type),
-        cadence=period_cadence(period_type),
-    )
+    _override_time_step(collection_payload, iso_step, cadence=period_cadence(period_type))
     # Spatial extent comes from the live store (set in _build_collection_with_xstac),
     # not the artifact coverage — see _wgs84_extent_from_store. Temporal still tracks the
     # artifact's materialized coverage.
@@ -329,11 +332,20 @@ def _wgs84_extent_from_store(ds: xr.Dataset, store_crs: str, x_dim: str, y_dim: 
 
 
 def _build_collection_with_xstac(
-    *, artifact: ArtifactRecord, template: pystac.Collection, period_type: Any = None
+    *,
+    artifact: ArtifactRecord,
+    template: pystac.Collection,
+    period_type: Any = None,
+    iso_step: str | None = None,
 ) -> dict[str, Any]:
-    # Keyed on period_type as well as the artifact: correcting a template's cadence
-    # changes the payload (an irregular one gains `values`) without producing a new artifact.
-    cache_key = f"{artifact.artifact_id}:{period_type}"
+    # `iso_step` is passed in rather than read back from the payload: `_override_time_step`
+    # runs later, in `build_collection`, so at this point the temporal dimension has no
+    # `step` yet and a sparse axis would look regular.
+    #
+    # Keyed on period_type and the step as well as the artifact: correcting a template's
+    # cadence or resolution changes the payload (an irregular or sparse axis gains `values`)
+    # without producing a new artifact.
+    cache_key = f"{artifact.artifact_id}:{period_type}:{iso_step}"
     cached_payload = _xstac_collection_cache.get(cache_key)
     if cached_payload is not None:
         return deepcopy(cached_payload)
@@ -400,7 +412,7 @@ def _build_collection_with_xstac(
         extent_bbox = _wgs84_extent_from_store(ds, store_crs or "EPSG:4326", x_dimension, y_dimension)
         if extent_bbox is not None:
             payload.setdefault("extent", {}).setdefault("spatial", {})["bbox"] = [extent_bbox]
-        if time_dimension is not None and period_cadence(period_type) is Cadence.IRREGULAR:
+        if time_dimension is not None and _temporal_values_needed(ds, time_dimension, period_type, iso_step):
             _add_temporal_values(payload, ds, time_dimension)
         _cache_xstac_collection_payload(cache_key, payload)
         return deepcopy(payload)
@@ -549,18 +561,75 @@ def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence
             return
 
 
+# Single-unit ISO durations, matching what `generateDateRange` in map-viewer.html parses.
+# Kept deliberately narrow: a client that cannot walk a compound duration would build the
+# wrong number of positions, and this is the check that catches exactly that.
+_SIMPLE_ISO_STEP_RE = re.compile(r"^P(?:T(\d+)H|(\d+)D|(\d+)M|(\d+)Y)$")
+
+
+def _implied_step_count(start: pd.Timestamp, end: pd.Timestamp, step: str) -> int | None:
+    """How many positions a client builds by walking *step* from *start* to *end*.
+
+    Mirrors ``generateDateRange`` in map-viewer.html, including its calendar handling for
+    months and years — an approximation in fixed days drifts and overcounts. Returns None
+    for a duration that cannot be walked, in which case the caller must not draw any
+    conclusion from the count.
+    """
+    match = _SIMPLE_ISO_STEP_RE.match(step)
+    if match is None:
+        return None
+    hours, days, months, years = match.groups()
+    if months is not None:
+        n = int(months)
+        total = (end.year - start.year) * 12 + (end.month - start.month)
+        return max(1, total // n + 1)
+    if years is not None:
+        n = int(years)
+        return max(1, (end.year - start.year) // n + 1)
+    inc = timedelta(hours=int(hours)) if hours is not None else timedelta(days=int(days))
+    # Via seconds rather than dividing the two deltas directly: `end - start` is a pandas
+    # Timedelta, and dividing that by a stdlib timedelta has no typed overload.
+    return max(1, int((end - start).total_seconds() // inc.total_seconds()) + 1)
+
+
+def _temporal_values_needed(ds: xr.Dataset, time_dimension: str, period_type: Any, iso_step: str | None) -> bool:
+    """Whether the temporal dimension must list its timestamps rather than imply them.
+
+    Two cases need it, for the same underlying reason — a client cannot reconstruct the
+    store's time axis from ``extent`` plus ``step`` alone:
+
+    * An irregular cadence has no step to walk at all.
+    * A *sparse* axis has a step, but the store holds only some of the periods it implies.
+      An event-scoped dataset is the clear case: two daily acquisitions three months apart
+      publish ``P1D``, from which a client builds 92 positions for a 2-slice store. It then
+      indexes past the end and renders nothing, with the failure surfacing as an out-of-
+      bounds selection rather than anything naming the cause (CLIM-950).
+
+    A dense regular store still implies its axis exactly, so it keeps publishing extent plus
+    duration and does not grow by one ISO string per period — thousands for a multi-year
+    daily store, on a cached response.
+    """
+    if period_cadence(period_type) is Cadence.IRREGULAR:
+        return True
+    if not isinstance(iso_step, str) or time_dimension not in ds.dims:
+        return False
+    stamps = pd.DatetimeIndex(np.asarray(ds[time_dimension].values, dtype="datetime64[ns]"))
+    if len(stamps) == 0:
+        return False
+    # The store's own endpoints rather than the published extent strings: they are the same
+    # instants, and using them avoids re-parsing timezone-suffixed ISO text to compare.
+    implied = _implied_step_count(stamps[0], stamps[-1], iso_step)
+    return implied is not None and implied != len(stamps)
+
+
 def _add_temporal_values(collection: dict[str, Any], ds: xr.Dataset, time_dimension: str) -> None:
     """List the temporal dimension's actual timestamps as ``values``.
 
-    Required for an irregular cadence, not decorative. A client builds its time control
-    either from explicit ``values`` or by stepping ``extent`` by ``step``; with an
-    irregular cadence there is no step to walk, so omitting ``values`` leaves a consumer
-    with a single position and no slider. This mirrors ``_build_ordinal_dimensions``,
-    which lists values for the same reason on a day-of-year axis.
+    A client builds its time control either from explicit ``values`` or by stepping
+    ``extent`` by ``step``. This mirrors ``_build_ordinal_dimensions``, which lists values
+    for the same reason on a day-of-year axis.
 
-    Only emitted for irregular cadences. A regular one is fully described by extent plus
-    duration, and listing every timestamp would add one ISO string per period to a cached
-    response for no gain — thousands of entries for a multi-year daily store.
+    See :func:`_temporal_values_needed` for when this is emitted.
     """
     dimensions = collection.get("cube:dimensions") or {}
     dim = dimensions.get(time_dimension)
@@ -829,8 +898,7 @@ def _build_renders(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> 
         rescale = _rescale_pairs(value_range, 3)
         if rescale is None:
             logger.warning(
-                "Dataset '%s': display.bands needs a display.range of [min, max] or three "
-                "[min, max] pairs; got %r",
+                "Dataset '%s': display.bands needs a display.range of [min, max] or three [min, max] pairs; got %r",
                 artifact.dataset_id,
                 value_range,
             )

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -789,12 +789,69 @@ def _open_published_store(artifact: ArtifactRecord) -> xr.Dataset:
     return open_zarr_dataset(_artifact_store_path(artifact))
 
 
+def _rescale_pairs(value_range: Any, count: int) -> list[list[float]] | None:
+    """Normalise a template ``display.range`` into one ``[min, max]`` pair per band.
+
+    Two forms are accepted: a single pair applied to every band, or one pair per band. A
+    true-colour composite needs the per-band form whenever the bands have different dynamic
+    ranges; an 8-bit true-colour asset is happy with the shared form.
+    """
+    if not isinstance(value_range, list) or not value_range:
+        return None
+    if all(isinstance(v, (int, float)) for v in value_range) and len(value_range) == 2:
+        return [[float(value_range[0]), float(value_range[1])]] * count
+    if len(value_range) == count and all(
+        isinstance(pair, list) and len(pair) == 2 and all(isinstance(v, (int, float)) for v in pair)
+        for pair in value_range
+    ):
+        return [[float(pair[0]), float(pair[1])] for pair in value_range]
+    return None
+
+
 def _build_renders(artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> dict[str, Any] | None:
     display = source_dataset.get("display")
     if not isinstance(display, dict):
         return None
-    colormap_name = display.get("colormap")
     value_range = display.get("range")
+
+    bands = display.get("bands")
+    if bands is not None:
+        # True-colour composite. The Render extension already carries `bands` for exactly
+        # this, so no OCS-specific field is invented: a render-aware client that has never
+        # seen OCS can composite the layer from the published metadata alone.
+        if not (isinstance(bands, list) and len(bands) == 3 and all(isinstance(b, str) and b for b in bands)):
+            logger.warning(
+                "Dataset '%s': display.bands must be three band names for an RGB render; got %r",
+                artifact.dataset_id,
+                bands,
+            )
+            return None
+        rescale = _rescale_pairs(value_range, 3)
+        if rescale is None:
+            logger.warning(
+                "Dataset '%s': display.bands needs a display.range of [min, max] or three "
+                "[min, max] pairs; got %r",
+                artifact.dataset_id,
+                value_range,
+            )
+            return None
+        rgb_render: dict[str, Any] = {
+            "title": artifact.dataset_name,
+            "assets": ["zarr"],
+            "bands": list(bands),
+            "rescale": rescale,
+            # Which variable the bands live on, and which cube dimension indexes them, so a
+            # client does not have to guess either. `colormap_name` is deliberately absent:
+            # a composite is not a colour ramp.
+            "open_climate_service:variable": artifact.variable,
+            "open_climate_service:band_dimension": display.get("band_dimension", "band"),
+        }
+        nodata_rgb = display.get("nodata")
+        if nodata_rgb is not None:
+            rgb_render["nodata"] = float(nodata_rgb)
+        return {"default": rgb_render}
+
+    colormap_name = display.get("colormap")
     if not isinstance(colormap_name, str) or not isinstance(value_range, list) or len(value_range) != 2:
         return None
     render: dict[str, Any] = {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -299,6 +299,27 @@
         `;
       }
 
+      // The selector as the layer must always see it. A composite pins its band axis to the
+      // list of band names, and that has to be re-sent on every update, not just at
+      // construction: zarr-layer recomputes its band names from the selector inside
+      // `setSelector`, and an array-valued entry is what makes it emit one sampler per band.
+      // Send a selector without it and the bands collapse to a single one named after the
+      // variable, while `customFrag` stays in place — so the shader still refers to red, green
+      // and blue and fails to compile with "undeclared identifier". Both call sites go through
+      // here so they cannot drift apart again.
+      // Indices are clamped to the control's own step count. The store is the authority on
+      // how many slices exist, and it tells us through `values`; this only stops an index
+      // from escaping the range the controls were built for. It is not a substitute for the
+      // collection publishing `values` on a sparse axis (CLIM-950) — without that the count
+      // itself is wrong, and clamping to a wrong count still misses.
+      function layerSelector() {
+        const pinned = {};
+        for (const d of dimStates) {
+          pinned[d.key] = Math.min(Math.max(0, selector[d.key] ?? 0), Math.max(0, d.count - 1));
+        }
+        return rgb ? { ...pinned, [rgb.dimension]: rgb.bands } : pinned;
+      }
+
       // Every non-spatial dimension, in cube order, that the user steps through.
       // Each gets its own control; the layer selector must pin all of them so the
       // cube reduces to 2-D for rendering. Skip the synthetic openEO `bands`
@@ -643,7 +664,7 @@
             clim,
             colormap: cm,
             opacity: 1,
-            selector: rgb ? { ...selector, [rgb.dimension]: rgb.bands } : selector,
+            selector: layerSelector(),
             ...(rgb !== null && { customFrag: rgbFrag(rgb.bands, rgb.rescale) }),
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
@@ -692,7 +713,7 @@
         const layer = activeLayer;
         clearTimeout(_selectorDebounce);
         _selectorDebounce = setTimeout(() => {
-          layer?.setSelector({ ...selector });
+          layer?.setSelector(layerSelector());
         }, 150);
       }
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -482,6 +482,15 @@
       let selector = {};
       // { bands, rescale, dimension } for a true-colour collection, else null.
       let rgb = null;
+      // Set once a dataset has positioned the view, so the instance-extent fit cannot undo it.
+      // `fitToExtent` awaits a fetch, so without this it can resolve *after* the first
+      // dataset has loaded and yank the view back out to the whole country.
+      let viewPinnedByLayer = false;
+
+      // A layer spanning less than this fraction of the viewport is treated as out of view.
+      // The 1.3 km Vantor footprint is 0.2% of Nepal's width: technically on screen at the
+      // instance extent, and impossible to find.
+      const MIN_VISIBLE_SPAN = 0.1;
 
       const selectEl = document.getElementById("dataset-select");
       const dimControls = document.getElementById("dim-controls");
@@ -551,7 +560,7 @@
       }
 
       async function fitToExtent() {
-        if (!map || mapUnavailable) return;
+        if (!map || mapUnavailable || viewPinnedByLayer) return;
         try {
           const res = await fetch("{{ base }}/extent");
           if (!res.ok) return;
@@ -559,6 +568,44 @@
           const [xmin, ymin, xmax, ymax] = extent.bbox;
           map.fitBounds([[xmin, ymin], [xmax, ymax]], { padding: 40, maxZoom: 10 });
         } catch {}
+      }
+
+
+      // Bring a newly selected layer into view when it would otherwise be unfindable.
+      //
+      // Deliberately conditional. Re-fitting on every dataset switch would discard a view the
+      // user had chosen — comparing two layers over the same spot means switching between them
+      // without the map moving — so this only acts when the layer is genuinely not viewable:
+      // outside the viewport entirely, or so small within it as to be a speck.
+      //
+      // Zooming *out* is not handled: a layer larger than the viewport is still visible, and a
+      // user zoomed into a global dataset is looking at exactly what they asked for.
+      function revealLayer(collection) {
+        if (!map || mapUnavailable) return;
+        const bbox = collection.extent?.spatial?.bbox?.[0];
+        if (!Array.isArray(bbox) || bbox.length < 4) return;
+        const [w, s, e, n] = bbox.slice(0, 4).map(Number);
+        if (![w, s, e, n].every(Number.isFinite) || w >= e || s >= n) return;
+
+        const view = map.getBounds();
+        const viewWidth = view.getEast() - view.getWest();
+        const viewHeight = view.getNorth() - view.getSouth();
+        // Before the map has a size, getBounds is not meaningful; fit rather than divide by it.
+        const measurable = Number.isFinite(viewWidth) && Number.isFinite(viewHeight) && viewWidth > 0 && viewHeight > 0;
+
+        if (measurable) {
+          const offscreen =
+            e < view.getWest() || w > view.getEast() || n < view.getSouth() || s > view.getNorth();
+          const spanRatio = Math.max((e - w) / viewWidth, (n - s) / viewHeight);
+          if (!offscreen && spanRatio >= MIN_VISIBLE_SPAN) {
+            viewPinnedByLayer = true;
+            return;
+          }
+        }
+        // maxZoom so a sub-kilometre footprint stops at a usable scale instead of going to
+        // street level, where the imagery is past its own resolution.
+        map.fitBounds([[w, s], [e, n]], { padding: 40, maxZoom: 16 });
+        viewPinnedByLayer = true;
       }
 
       async function loadCatalog() {
@@ -757,6 +804,7 @@
         datasetMeta.classList.remove("hidden");
 
         updateLegend(cm, clim, units);
+        revealLayer(collection);
 
         setStatus("");
       }

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -254,6 +254,51 @@
         }
       }
 
+      // A true-colour render, or null for the ordinary colormapped case. The Render
+      // extension carries `bands`; zarr-layer exposes each selected band to the shader
+      // under its own name, so `bands: ["red","green","blue"]` becomes the GLSL
+      // identifiers red, green and blue.
+      function readRgbRender(renders, dimensions) {
+        const bands = renders.bands;
+        if (!Array.isArray(bands) || bands.length !== 3) return null;
+        const rescale = Array.isArray(renders.rescale) ? renders.rescale : [];
+        if (rescale.length !== 3) return null;
+        // Prefer the dimension the collection names; otherwise find the one whose values
+        // contain all three bands, so a store using a different axis name still works.
+        const declared = renders["open_climate_service:band_dimension"];
+        const byValues = Object.entries(dimensions ?? {}).find(
+          ([, v]) => Array.isArray(v.values) && bands.every((b) => v.values.includes(b)),
+        )?.[0];
+        const dimension = declared && dimensions?.[declared] ? declared : (byValues ?? declared ?? "band");
+        return { bands, rescale, dimension };
+      }
+
+      // zarr-layer blends with premultiplied alpha and, once a customFrag is supplied, the
+      // shader owns discarding: fill pixels arrive as NaN rather than being dropped for us.
+      // Each band is stretched by its own rescale pair, which is why per-band ranges exist.
+      // zarr-layer replaces any character that is not a letter, digit or underscore with an
+      // underscore and prefixes a leading digit, so the shader has to refer to the sanitised
+      // names rather than the raw band labels.
+      function glslName(band) {
+        const safe = String(band).replace(/[^A-Za-z0-9_]/g, "_");
+        return /^[0-9]/.test(safe) ? `_${safe}` : safe;
+      }
+
+      function rgbFrag(bands, rescale) {
+        const names = bands.map(glslName);
+        const stretch = (name, pair) =>
+          `clamp((${name} - ${Number(pair[0]).toFixed(6)}) / (${(Number(pair[1]) - Number(pair[0])).toFixed(6)}), 0.0, 1.0)`;
+        return `
+          if (${names.map((n) => `isnan(${n})`).join(" || ")}) {
+            discard;
+          }
+          vec3 rgb = vec3(
+            ${names.map((n, i) => stretch(n, rescale[i])).join(",\n            ")}
+          );
+          fragColor = vec4(rgb * opacity, opacity);
+        `;
+      }
+
       // Every non-spatial dimension, in cube order, that the user steps through.
       // Each gets its own control; the layer selector must pin all of them so the
       // cube reduces to 2-D for rendering. Skip the synthetic openEO `bands`
@@ -380,6 +425,8 @@
       let dimStates = [];
       // Current index per dimension key — pins every non-spatial axis for the layer.
       let selector = {};
+      // { bands, rescale, dimension } for a true-colour collection, else null.
+      let rgb = null;
 
       const selectEl = document.getElementById("dataset-select");
       const dimControls = document.getElementById("dim-controls");
@@ -394,6 +441,12 @@
       const statusEl = document.getElementById("status");
 
       function updateLegend(cm, clim, units) {
+        if (rgb) {
+          // A true-colour composite has no single ramp to explain, and showing one from
+          // the unused colormap would be actively misleading.
+          legendEl.classList.add("hidden");
+          return;
+        }
         const stops = Array.from(
           { length: 32 },
           (_, i) => cm[Math.round((i * (cm.length - 1)) / 31)]
@@ -528,7 +581,12 @@
         // Build a control state for every non-spatial dimension. The layer selector
         // must pin each one so the cube reduces to 2-D for rendering.
         const dimensions = collection["cube:dimensions"] ?? {};
-        dimStates = getSteppingDims(dimensions).map((key) => {
+        // A true-colour render pins the band axis itself, so it must not also get a
+        // stepping control — the selector would then disagree with the shader.
+        rgb = readRgbRender(renders, dimensions);
+        dimStates = getSteppingDims(dimensions)
+          .filter((key) => key !== rgb?.dimension)
+          .map((key) => {
           const dim = dimensions[key];
           const steps = buildSteps(dimensions, key);
           const control = controlForDim(dim);
@@ -585,7 +643,8 @@
             clim,
             colormap: cm,
             opacity: 1,
-            selector,
+            selector: rgb ? { ...selector, [rgb.dimension]: rgb.bands } : selector,
+            ...(rgb !== null && { customFrag: rgbFrag(rgb.bands, rgb.rescale) }),
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
             crs: nativeCrs,

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -254,10 +254,17 @@
         }
       }
 
-      // A true-colour render, or null for the ordinary colormapped case. The Render
-      // extension carries `bands`; zarr-layer exposes each selected band to the shader
-      // under its own name, so `bands: ["red","green","blue"]` becomes the GLSL
-      // identifiers red, green and blue.
+      // A true-colour render, or null for the ordinary colormapped case.
+      //
+      // The bands are selected by *index*, not by name. zarr-layer resolves a named value
+      // against the dimension's coordinate array, and when it cannot read that array it
+      // silently falls back to index 0 for every non-numeric value — so all three samplers
+      // read the same band and the image renders grey rather than failing. A band axis is
+      // exactly the case where that bites: its coordinate is a Zarr v3 fixed-length UTF-32
+      // string array, which has no v3 specification and which the JS reader does not load.
+      //
+      // The collection already publishes the axis values, so the mapping is resolved here
+      // and passed as `{selected: [...], type: "index"}`, which skips the lookup entirely.
       function readRgbRender(renders, dimensions) {
         const bands = renders.bands;
         if (!Array.isArray(bands) || bands.length !== 3) return null;
@@ -270,7 +277,17 @@
           ([, v]) => Array.isArray(v.values) && bands.every((b) => v.values.includes(b)),
         )?.[0];
         const dimension = declared && dimensions?.[declared] ? declared : (byValues ?? declared ?? "band");
-        return { bands, rescale, dimension };
+        const values = dimensions?.[dimension]?.values;
+        if (!Array.isArray(values)) {
+          setStatus(`Cannot composite: dimension '${dimension}' publishes no values to map bands onto.`, true);
+          return null;
+        }
+        const indices = bands.map((b) => values.indexOf(b));
+        if (indices.some((i) => i < 0)) {
+          setStatus(`Cannot composite: bands ${JSON.stringify(bands)} are not all in '${dimension}'.`, true);
+          return null;
+        }
+        return { bands, rescale, dimension, indices };
       }
 
       // zarr-layer blends with premultiplied alpha and, once a customFrag is supplied, the
@@ -284,8 +301,15 @@
         return /^[0-9]/.test(safe) ? `_${safe}` : safe;
       }
 
-      function rgbFrag(bands, rescale) {
-        const names = bands.map(glslName);
+      // The identifier zarr-layer declares for one selected band. A named value keeps its
+      // own name; a numeric one — which is what index selection sends — is namespaced by the
+      // dimension, so band 0 of `band` becomes `band_0`. The shader has to match that
+      // exactly, or it fails to compile with "undeclared identifier".
+      function bandIdentifier(dimension, value) {
+        return glslName(typeof value === "string" ? value : `${dimension}_${value}`);
+      }
+
+      function rgbFrag(names, rescale) {
         const stretch = (name, pair) =>
           `clamp((${name} - ${Number(pair[0]).toFixed(6)}) / (${(Number(pair[1]) - Number(pair[0])).toFixed(6)}), 0.0, 1.0)`;
         return `
@@ -317,7 +341,7 @@
         for (const d of dimStates) {
           pinned[d.key] = Math.min(Math.max(0, selector[d.key] ?? 0), Math.max(0, d.count - 1));
         }
-        return rgb ? { ...pinned, [rgb.dimension]: rgb.bands } : pinned;
+        return rgb ? { ...pinned, [rgb.dimension]: { selected: rgb.indices, type: "index" } } : pinned;
       }
 
       // Every non-spatial dimension, in cube order, that the user steps through.
@@ -665,7 +689,12 @@
             colormap: cm,
             opacity: 1,
             selector: layerSelector(),
-            ...(rgb !== null && { customFrag: rgbFrag(rgb.bands, rgb.rescale) }),
+            ...(rgb !== null && {
+              customFrag: rgbFrag(
+                rgb.indices.map((i) => bandIdentifier(rgb.dimension, i)),
+                rgb.rescale,
+              ),
+            }),
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
             crs: nativeCrs,

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -267,9 +267,19 @@
       // and passed as `{selected: [...], type: "index"}`, which skips the lookup entirely.
       function readRgbRender(renders, dimensions) {
         const bands = renders.bands;
-        if (!Array.isArray(bands) || bands.length !== 3) return null;
+        // No `bands` at all is the ordinary colormapped case, not a failure — return null
+        // quietly and let the caller take the ramp path. Every refusal *after* this point
+        // explains itself, because the caller stops loading once `bands` was declared.
+        if (!Array.isArray(bands)) return null;
+        if (bands.length !== 3) {
+          setStatus(`Cannot composite: expected 3 bands, the collection declares ${bands.length}.`, true);
+          return null;
+        }
         const rescale = Array.isArray(renders.rescale) ? renders.rescale : [];
-        if (rescale.length !== 3) return null;
+        if (rescale.length !== 3) {
+          setStatus(`Cannot composite: expected 3 rescale pairs, the collection declares ${rescale.length}.`, true);
+          return null;
+        }
         // Prefer the dimension the collection names; otherwise find the one whose values
         // contain all three bands, so a store using a different axis name still works.
         const declared = renders["open_climate_service:band_dimension"];
@@ -629,6 +639,13 @@
         // A true-colour render pins the band axis itself, so it must not also get a
         // stepping control — the selector would then disagree with the shader.
         rgb = readRgbRender(renders, dimensions);
+        // A collection that declares `bands` and cannot be resolved into one must not quietly
+        // fall through to the colormapped path: that renders a single band under a ramp, which
+        // looks like a working layer and is a picture of different data. `readRgbRender` has
+        // already explained why on the status line, so stop here rather than clearing it below.
+        if (rgb === null && Array.isArray(renders?.bands)) {
+          return;
+        }
         dimStates = getSteppingDims(dimensions)
           .filter((key) => key !== rgb?.dimension)
           .map((key) => {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -212,7 +212,7 @@
           <dl id="dataset-meta" class="meta-grid hidden">
             <dt>Source</dt>
             <dd id="meta-source">—</dd>
-            <dt>Units</dt>
+            <dt id="meta-units-label">Units</dt>
             <dd id="meta-units">—</dd>
           </dl>
 
@@ -488,6 +488,7 @@
       const datasetMeta = document.getElementById("dataset-meta");
       const metaSource = document.getElementById("meta-source");
       const metaUnits = document.getElementById("meta-units");
+      const metaUnitsLabel = document.getElementById("meta-units-label");
       const legendEl = document.getElementById("legend");
       const legendBar = document.getElementById("legend-bar");
       const legendMin = document.getElementById("legend-min");
@@ -742,7 +743,17 @@
         );
         const units = collection["cube:variables"]?.[variable]?.unit ?? "";
         metaSource.textContent = source ?? "—";
-        metaUnits.textContent = units || "—";
+        // A composite is a picture, not a measurement, so its unit is an artefact of having to
+        // put something in the field: the imagery layers declare `1`, which tells a reader
+        // nothing and invites them to treat display values as calibrated. Hide the row for
+        // those, and for a dataset that declares no unit at all — an em dash is not
+        // information either. The same reasoning already hides the legend for a composite.
+        // The `.hidden` class rather than the `hidden` attribute: it carries `!important`, so
+        // it cannot be defeated by an author `display` rule on a grid item.
+        const showUnits = !rgb && Boolean(units);
+        metaUnits.textContent = units;
+        metaUnitsLabel.classList.toggle("hidden", !showUnits);
+        metaUnits.classList.toggle("hidden", !showUnits);
         datasetMeta.classList.remove("hidden");
 
         updateLegend(cm, clim, units);

--- a/tests/test_ordinal_dimensions.py
+++ b/tests/test_ordinal_dimensions.py
@@ -60,6 +60,31 @@ def test_build_ordinal_dimensions_omits_step_for_irregular_axis() -> None:
     assert "step" not in dims["band"]
 
 
+def test_build_ordinal_dimensions_publishes_string_labels() -> None:
+    """A string-labelled axis must publish its labels, because clients cannot read them.
+
+    Load-bearing rather than cosmetic. A string coordinate is written as the Zarr v3
+    extension type ``fixed_length_utf32``, which is not in the core specification and which
+    the JavaScript reader rejects outright. STAC is therefore the only place a browser
+    client can learn what the labels are, and it resolves them to indices before selecting.
+    Drop these values and a true-colour composite has nothing to map its bands onto.
+
+    ``worldpop_agesex_*`` has carried a string ``sex`` axis for the same reason, so this
+    covers existing datasets and not only the composite case.
+    """
+    ds = xr.Dataset(
+        {"reflectance": (("band", "y", "x"), np.zeros((3, 2, 2), dtype="uint8"))},
+        coords={"band": ["red", "green", "blue"], "y": [1.0, 2.0], "x": [1.0, 2.0]},
+    )
+
+    dims = _build_ordinal_dimensions(ds, "x", "y", None)
+
+    assert dims["band"]["values"] == ["red", "green", "blue"]
+    assert dims["band"]["type"] == "other"
+    # No step: a step on a non-numeric axis would invite a client to synthesise labels.
+    assert "step" not in dims["band"]
+
+
 def test_read_committed_period_ids_ordinal_coord(tmp_path: Path) -> None:
     # Round-trip an integer day-of-year axis through the store and confirm
     # committed ids come back as plain strings ("1".."366"), not datetime-parsed

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -471,6 +471,9 @@ def test_build_collection_with_xstac_normalizes_pystac_collection(
 ) -> None:
     class DummyDataset:
         attrs: dict[str, object] = {}
+        # Stands in for an xr.Dataset, so it has to answer `dims`: the collection builder
+        # inspects the time axis to tell a sparse one from a dense one (CLIM-950).
+        dims: tuple[str, ...] = ()
 
         def close(self) -> None:
             pass
@@ -505,6 +508,9 @@ def test_collection_reuses_cached_xstac_payload(
 ) -> None:
     class DummyDataset:
         attrs: dict[str, object] = {}
+        # Stands in for an xr.Dataset, so it has to answer `dims`: the collection builder
+        # inspects the time axis to tell a sparse one from a dense one (CLIM-950).
+        dims: tuple[str, ...] = ()
 
         def close(self) -> None:
             pass
@@ -572,6 +578,9 @@ def test_collection_preserves_template_links_when_xstac_mutates_template(
 ) -> None:
     class DummyDataset:
         attrs: dict[str, object] = {}
+        # Stands in for an xr.Dataset, so it has to answer `dims`: the collection builder
+        # inspects the time axis to tell a sparse one from a dense one (CLIM-950).
+        dims: tuple[str, ...] = ()
 
         def close(self) -> None:
             pass

--- a/tests/test_stac_imagery_plugin.py
+++ b/tests/test_stac_imagery_plugin.py
@@ -596,3 +596,51 @@ def test_asset_href_resolves_against_the_item_self_link(
     monkeypatch.setattr(stac_imagery.httpx, "post", _FakePost([_search_page([item])]))
     scenes = _plugin(catalog_url="https://api.invalid/v1", collections=["s2"])._scenes()
     assert scenes["2026-08-12"][0].href == "https://data.invalid/tiles/45RUM/TCI.tif"
+
+
+# -- explicit date selection -----------------------------------------------------------
+
+
+def _indexed(plugin: StacImageryPlugin, dates: list[str]) -> StacImageryPlugin:
+    plugin._index = {d: [_Scene(f"{d}.tif", (85.3, 28.1, 85.4, 28.3), d)] for d in dates}
+    return plugin
+
+
+def test_dates_allow_list_keeps_a_non_contiguous_selection() -> None:
+    """A range cannot express "these two and not the five between", which is the common case
+    for a before/after pair drawn from a repeat-pass source."""
+    plugin = _indexed(
+        _plugin(dates=["2026-08-12", "2026-08-27"]),
+        ["2026-08-12", "2026-08-14", "2026-08-19", "2026-08-24", "2026-08-27"],
+    )
+    assert asyncio.run(plugin.periods("2026-08-01", "2026-08-31")) == [
+        "2026-08-12",
+        "2026-08-27",
+    ]
+
+
+def test_dates_allow_list_applies_without_a_clip() -> None:
+    plugin = _indexed(_plugin(clip_bbox=None, dates=["2026-08-12"]), ["2026-08-12", "2026-08-14"])
+    assert asyncio.run(plugin.periods("2026-08-01", "2026-08-31")) == ["2026-08-12"]
+
+
+def test_a_requested_date_that_is_not_on_offer_is_refused() -> None:
+    """Ingesting fewer periods than asked for is invisible once stored, so a date inside the
+    range that no scene covers must fail rather than quietly shrink the result."""
+    plugin = _indexed(_plugin(dates=["2026-08-12", "2026-08-13"]), ["2026-08-12"])
+    with pytest.raises(ValueError, match="2026-08-13"):
+        asyncio.run(plugin.periods("2026-08-01", "2026-08-31"))
+
+
+def test_requested_dates_outside_the_range_are_ignored_not_refused() -> None:
+    """The range is the narrower statement of intent, so it wins without complaint."""
+    plugin = _indexed(_plugin(dates=["2026-08-12", "2026-09-30"]), ["2026-08-12"])
+    assert asyncio.run(plugin.periods("2026-08-01", "2026-08-31")) == ["2026-08-12"]
+
+
+def test_no_dates_means_every_date_in_range() -> None:
+    plugin = _indexed(_plugin(), ["2026-08-12", "2026-08-14"])
+    assert asyncio.run(plugin.periods("2026-08-01", "2026-08-31")) == [
+        "2026-08-12",
+        "2026-08-14",
+    ]

--- a/tests/test_stac_imagery_plugin.py
+++ b/tests/test_stac_imagery_plugin.py
@@ -464,3 +464,135 @@ def test_scene_tiff_tags_do_not_leak_onto_the_stored_variable(
     assert isinstance(cube, xr.Dataset)
     assert cube["true_colour"].dtype == "uint8"
     assert list(np.asarray(cube["true_colour"]["band"].values)) == ["red", "green", "blue"]
+
+
+# -- STAC API item search --------------------------------------------------------------
+
+
+def _api_root(search_href: str = "https://api.invalid/search") -> dict[str, Any]:
+    return {
+        "conformsTo": ["https://api.stacspec.org/v1.0.0/item-search"],
+        "links": [{"rel": "search", "href": search_href}],
+    }
+
+
+class _FakePost:
+    """Stands in for httpx.post, serving canned search pages and recording the bodies sent."""
+
+    def __init__(self, pages: list[dict[str, Any]]) -> None:
+        self.pages = pages
+        self.bodies: list[dict[str, Any]] = []
+        self.urls: list[str] = []
+
+    def __call__(self, url: str, json: dict[str, Any], **_: Any) -> Any:
+        self.urls.append(url)
+        self.bodies.append(json)
+        page = self.pages[min(len(self.bodies) - 1, len(self.pages) - 1)]
+        return SimpleNamespace(json=lambda: page, raise_for_status=lambda: None)
+
+
+def _search_page(items: list[dict[str, Any]], next_body: dict[str, Any] | None = None) -> dict[str, Any]:
+    links = []
+    if next_body is not None:
+        links.append({"rel": "next", "href": "https://api.invalid/search", "body": next_body})
+    return {"features": items, "links": links}
+
+
+def test_stac_api_is_detected_and_searched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A global archive cannot be walked, so an item-search API must be queried instead."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    monkeypatch.setattr(stac_imagery, "_get_json", lambda url: _api_root())
+    post = _FakePost([_search_page([_item("2026-08-12", (85.3, 28.1, 85.4, 28.3))])])
+    monkeypatch.setattr(stac_imagery.httpx, "post", post)
+
+    plugin = _plugin(catalog_url="https://api.invalid/v1", collections=["sentinel-2-l2a"])
+    assert asyncio.run(plugin.periods("2026-08-01", "2026-08-31")) == ["2026-08-12"]
+    body = post.bodies[0]
+    assert body["collections"] == ["sentinel-2-l2a"]
+    # The clip and the range become search parameters — that is the whole point.
+    assert body["bbox"] == [85.30, 28.12, 85.40, 28.22]
+    assert body["datetime"] == "2026-08-01T00:00:00Z/2026-08-31T23:59:59Z"
+
+
+def test_a_static_catalogue_is_not_mistaken_for_an_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A `search` link alone is not enough: some static catalogues link to a search UI."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/collection.json"
+    docs = {
+        root: {
+            "links": [
+                {"rel": "search", "href": "https://example.invalid/ui"},
+                {"rel": "item", "href": "a.json"},
+            ]
+        },
+        "https://example.invalid/a.json": _item("2026-08-27", (85.3, 28.1, 85.4, 28.3)),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+
+    def _explode(*_: Any, **__: Any) -> Any:
+        raise AssertionError("static catalogue must not be POSTed to")
+
+    monkeypatch.setattr(stac_imagery.httpx, "post", _explode)
+    assert sorted(_plugin(catalog_url=root)._scenes()) == ["2026-08-27"]
+
+
+def test_search_follows_next_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    monkeypatch.setattr(stac_imagery, "_get_json", lambda url: _api_root())
+    post = _FakePost(
+        [
+            _search_page([_item("2026-08-12", (85.3, 28.1, 85.4, 28.3))], next_body={"page": 2}),
+            _search_page([_item("2026-08-27", (85.3, 28.1, 85.4, 28.3))]),
+        ]
+    )
+    monkeypatch.setattr(stac_imagery.httpx, "post", post)
+    plugin = _plugin(catalog_url="https://api.invalid/v1", collections=["s2"])
+    assert sorted(plugin._scenes()) == ["2026-08-12", "2026-08-27"]
+    assert post.bodies[1]["page"] == 2  # cursor carried forward
+
+
+def test_search_page_cap_warns_rather_than_silently_truncating(
+    monkeypatch: pytest.MonkeyPatch, warnings_log: pytest.LogCaptureFixture
+) -> None:
+    """Bounding the sweep is right; letting it read as 'that was everything' is not."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    monkeypatch.setattr(stac_imagery, "_get_json", lambda url: _api_root())
+    # Every page advertises another, so only the cap stops it.
+    endless = _FakePost([_search_page([_item("2026-08-12", (85.3, 28.1, 85.4, 28.3))], next_body={"p": 1})])
+    monkeypatch.setattr(stac_imagery.httpx, "post", endless)
+    monkeypatch.setattr(stac_imagery, "_SEARCH_MAX_PAGES", 3)
+    _plugin(catalog_url="https://api.invalid/v1", collections=["s2"])._scenes()
+    assert len(endless.bodies) == 3
+    assert "Stopped after 3 search pages" in warnings_log.text
+
+
+def test_search_results_with_no_usable_asset_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    monkeypatch.setattr(stac_imagery, "_get_json", lambda url: _api_root())
+    monkeypatch.setattr(stac_imagery.httpx, "post", _FakePost([_search_page([])]))
+    with pytest.raises(ValueError, match="STAC API search"):
+        _plugin(catalog_url="https://api.invalid/v1", collections=["s2"])._scenes()
+
+
+def test_asset_href_resolves_against_the_item_self_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relative asset href in a search response must resolve against the item, not against
+    whichever link happens to be first."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    item = _item("2026-08-12", (85.3, 28.1, 85.4, 28.3))
+    item["assets"]["visual"]["href"] = "TCI.tif"
+    item["links"] = [
+        {"rel": "collection", "href": "https://api.invalid/collections/s2"},
+        {"rel": "self", "href": "https://data.invalid/tiles/45RUM/item.json"},
+    ]
+    monkeypatch.setattr(stac_imagery, "_get_json", lambda url: _api_root())
+    monkeypatch.setattr(stac_imagery.httpx, "post", _FakePost([_search_page([item])]))
+    scenes = _plugin(catalog_url="https://api.invalid/v1", collections=["s2"])._scenes()
+    assert scenes["2026-08-12"][0].href == "https://data.invalid/tiles/45RUM/TCI.tif"

--- a/tests/test_stac_imagery_plugin.py
+++ b/tests/test_stac_imagery_plugin.py
@@ -1,0 +1,404 @@
+"""Unit tests for the generic STAC imagery plugin (CLIM-957).
+
+The behaviours worth pinning down are the ones that differ between the two real releases the
+plugin was built against, because those are where a wrong answer is silent rather than loud:
+band resolution, mask strategy, catalogue shape, and the grid guard.
+"""
+
+import asyncio
+import logging
+from collections.abc import Callable, Generator, Iterable, Sequence
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+from rasterio.enums import ColorInterp, MaskFlags
+
+from open_climate_service.plugins.datasets.stac_imagery import (
+    _MASK_ALPHA,
+    _MASK_NODATA,
+    _MASK_NONZERO,
+    StacImageryPlugin,
+    _resolve_bands,
+    _resolve_mask,
+    _Scene,
+    _utm_epsg,
+)
+
+_CI = ColorInterp
+_RGB = ("red", "green", "blue")
+_LOGGER = "open_climate_service.plugins.datasets.stac_imagery"
+
+
+@pytest.fixture
+def warnings_log(caplog: pytest.LogCaptureFixture) -> Generator[pytest.LogCaptureFixture, None, None]:
+    """Capture the plugin's warnings.
+
+    `open_climate_service` sets ``propagate = False`` (startup.py), so caplog's root handler
+    never sees these records — the handler has to be attached to the module logger, as
+    ``test_plugins_diagnostics.py`` does.
+    """
+    logger = logging.getLogger(_LOGGER)
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def _src(
+    colorinterp: Sequence[ColorInterp],
+    *,
+    nodata: float | None = None,
+    mask_flags: Sequence[tuple[MaskFlags, ...]] | None = None,
+    descriptions: Sequence[str | None] | None = None,
+) -> SimpleNamespace:
+    """A stand-in for an open rasterio dataset, carrying only what the resolvers read."""
+    count = len(colorinterp)
+    return SimpleNamespace(
+        colorinterp=tuple(colorinterp),
+        nodata=nodata,
+        mask_flag_enums=tuple(mask_flags or [(MaskFlags.all_valid,)] * count),
+        descriptions=tuple(descriptions or [None] * count),
+        name="scene.tif",
+    )
+
+
+# -- band resolution -------------------------------------------------------------------
+
+
+def test_bands_resolved_from_colorinterp_skipping_alpha() -> None:
+    """Planet's layout: RGBA, so blue is band 3 and the alpha band is not a colour."""
+    assert _resolve_bands((_CI.red, _CI.green, _CI.blue, _CI.alpha), (None,) * 4, _RGB) == (1, 2, 3)
+
+
+def test_bands_resolved_when_channel_order_is_not_rgb() -> None:
+    """Order comes from the declaration, not from position — a BGR asset must not be swapped."""
+    assert _resolve_bands((_CI.blue, _CI.green, _CI.red), (None,) * 3, _RGB) == (3, 2, 1)
+
+
+def test_bands_fall_back_to_descriptions() -> None:
+    """Vantor names its bands but an undefined colorinterp would otherwise lose them."""
+    src = (_CI.undefined, _CI.undefined, _CI.undefined)
+    assert _resolve_bands(src, ("red", "green", "blue"), _RGB) == (1, 2, 3)
+
+
+def test_bands_fall_back_to_position_only_when_count_matches(warnings_log: pytest.LogCaptureFixture) -> None:
+    assert _resolve_bands((_CI.undefined,) * 3, (None,) * 3, _RGB) == (1, 2, 3)
+    assert "positional band order" in warnings_log.text
+
+
+def test_bands_raise_when_unresolvable() -> None:
+    """A 5-band asset with no usable names must fail loudly rather than guess channels."""
+    with pytest.raises(ValueError, match="Cannot resolve bands"):
+        _resolve_bands((_CI.undefined,) * 5, (None,) * 5, _RGB)
+
+
+# -- mask strategy ---------------------------------------------------------------------
+
+
+def test_mask_prefers_alpha_band() -> None:
+    kind, ref = _resolve_mask(_src((_CI.red, _CI.green, _CI.blue, _CI.alpha)))
+    assert (kind, ref) == (_MASK_ALPHA, 4)
+
+
+def test_mask_uses_nodata_when_there_is_no_alpha() -> None:
+    kind, ref = _resolve_mask(_src((_CI.red, _CI.green, _CI.blue), nodata=255.0))
+    assert (kind, ref) == (_MASK_NODATA, 255.0)
+
+
+def test_mask_falls_back_to_nonzero_for_a_bare_rgb_asset() -> None:
+    """Vantor's layout: three bands, no alpha, no nodata, every band all_valid."""
+    kind, ref = _resolve_mask(_src((_CI.red, _CI.green, _CI.blue)))
+    assert (kind, ref) == (_MASK_NONZERO, None)
+
+
+def test_mask_warns_when_an_unreadable_internal_mask_is_approximated(warnings_log: pytest.LogCaptureFixture) -> None:
+    src = _src(
+        (_CI.red, _CI.green, _CI.blue),
+        mask_flags=[(MaskFlags.per_dataset,)] * 3,
+    )
+    kind, _ = _resolve_mask(src)
+    assert kind == _MASK_NONZERO
+    assert "approximating" in warnings_log.text
+
+
+# -- grid ------------------------------------------------------------------------------
+
+
+def test_utm_zone_is_picked_from_the_clip_centre() -> None:
+    assert _utm_epsg(85.37, 28.21) == "EPSG:32645"  # Nepal, UTM 45N
+    assert _utm_epsg(85.37, -28.21) == "EPSG:32745"  # southern hemisphere
+
+
+def _plugin(**kwargs: Any) -> StacImageryPlugin:
+    params: dict[str, Any] = {
+        "catalog_url": "https://example.invalid/catalog.json",
+        "resolution_m": 10.0,
+        "clip_bbox": [85.30, 28.12, 85.40, 28.22],
+    }
+    params.update(kwargs)
+    return StacImageryPlugin(**params)
+
+
+def test_grid_is_snapped_so_periods_cannot_drift() -> None:
+    """OCS infers the grid from the first period and appends along time, so every period must
+    land on identical cells regardless of the extent it was asked for."""
+    plugin = _plugin()
+    crs = plugin._resolved_crs((85.30, 28.12, 85.40, 28.22))
+    grid = plugin._build_grid((85.30, 28.12, 85.40, 28.22), crs)
+    left, bottom, right, top = grid.bounds
+    for edge in (left, bottom, right, top):
+        assert edge % plugin.resolution_m == pytest.approx(0.0, abs=1e-6)
+    # Half-cell offsets, so coordinates are cell centres rather than edges.
+    assert grid.xs[0] == pytest.approx(left + plugin.resolution_m / 2)
+    assert grid.ys[0] == pytest.approx(top - plugin.resolution_m / 2)
+    assert grid.ys[1] < grid.ys[0]  # y descends
+
+
+def test_resolution_must_be_finite_and_positive() -> None:
+    for bad in (0, -3, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="resolution_m"):
+            _plugin(resolution_m=bad)
+
+
+def test_oversized_grid_is_refused_with_actionable_advice() -> None:
+    """The failure this replaces is a kernel SIGKILL with no traceback, so the message has to
+    name both the extent it was given and the two ways out."""
+    plugin = StacImageryPlugin(catalog_url="https://example.invalid/catalog.json", resolution_m=0.34)
+    plugin._index = {"2026-08-27": [_Scene("s.tif", (80.0, 26.0, 88.0, 30.0), "s")]}
+    with pytest.raises(ValueError) as excinfo:
+        plugin.fetch_period("2026-08-27", [80.0, 26.0, 88.0, 30.0])
+    message = str(excinfo.value)
+    assert "clip_bbox" in message and "resolution_m" in message
+    assert "M cells" in message and "GB" in message
+
+
+def test_clip_that_misses_the_instance_extent_is_refused() -> None:
+    plugin = _plugin(clip_bbox=[10.0, 10.0, 11.0, 11.0])
+    plugin._index = {"2026-08-27": [_Scene("s.tif", (10.0, 10.0, 11.0, 11.0), "s")]}
+    with pytest.raises(ValueError, match="does not intersect"):
+        plugin.fetch_period("2026-08-27", [85.0, 28.0, 86.0, 29.0])
+
+
+# -- discovery and periods -------------------------------------------------------------
+
+
+def _item(
+    date: str,
+    bbox: Iterable[float],
+    *,
+    cloud: float | None = None,
+    props: dict[str, Any] | None = None,
+    asset: str = "visual",
+) -> dict[str, Any]:
+    properties: dict[str, Any] = {"datetime": f"{date}T05:00:00Z"}
+    if cloud is not None:
+        properties["eo:cloud_cover"] = cloud
+    properties.update(props or {})
+    return {
+        "id": f"item-{date}",
+        "bbox": list(bbox),
+        "properties": properties,
+        "assets": {asset: {"href": f"{date}.tif"}},
+    }
+
+
+def _catalog(docs: dict[str, dict[str, Any]]) -> Callable[[str], dict[str, Any]]:
+    """Patch the module's fetcher with an in-memory catalogue keyed by URL."""
+    return lambda url: docs[url]
+
+
+def test_flat_collection_is_walked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Vantor's shape: a collection whose items hang directly off it."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/collection.json"
+    docs = {
+        root: {"links": [{"rel": "item", "href": "a.json"}, {"rel": "item", "href": "b.json"}]},
+        "https://example.invalid/a.json": _item("2026-08-27", (85.3, 28.1, 85.4, 28.3)),
+        "https://example.invalid/b.json": _item("2021-10-16", (85.3, 28.1, 85.4, 28.3)),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+    plugin = _plugin(catalog_url=root)
+    assert sorted(plugin._scenes()) == ["2021-10-16", "2026-08-27"]
+
+
+def test_nested_catalog_is_walked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Planet's shape: root -> phase -> per-sensor collection -> items."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/catalog.json"
+    docs = {
+        root: {"links": [{"rel": "child", "href": "post/catalog.json"}]},
+        "https://example.invalid/post/catalog.json": {
+            "links": [{"rel": "child", "href": "planetscope-2026-08-26/collection.json"}]
+        },
+        "https://example.invalid/post/planetscope-2026-08-26/collection.json": {
+            "links": [{"rel": "item", "href": "x.json"}]
+        },
+        "https://example.invalid/post/planetscope-2026-08-26/x.json": _item("2026-08-26", (85.3, 28.1, 85.4, 28.3)),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+    assert sorted(_plugin(catalog_url=root)._scenes()) == ["2026-08-26"]
+
+
+def test_collection_filter_prunes_leaves_but_not_intermediate_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sensor name is on the leaf collection, not on Planet's pre/post-event split, so a
+    filter applied to intermediate nodes would prune the whole tree."""
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/catalog.json"
+    docs = {
+        root: {"links": [{"rel": "child", "href": "post-event/catalog.json"}]},
+        "https://example.invalid/post-event/catalog.json": {
+            "links": [
+                {"rel": "child", "href": "planetscope-2026-08-26/collection.json"},
+                {"rel": "child", "href": "skysat-2026-08-26/collection.json"},
+            ]
+        },
+        "https://example.invalid/post-event/planetscope-2026-08-26/collection.json": {
+            "links": [{"rel": "item", "href": "p.json"}]
+        },
+        "https://example.invalid/post-event/planetscope-2026-08-26/p.json": _item(
+            "2026-08-26", (85.3, 28.1, 85.4, 28.3)
+        ),
+        "https://example.invalid/post-event/skysat-2026-08-26/collection.json": {
+            "links": [{"rel": "item", "href": "s.json"}]
+        },
+        "https://example.invalid/post-event/skysat-2026-08-26/s.json": _item("2026-08-26", (85.3, 28.1, 85.4, 28.3)),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+    scenes = _plugin(catalog_url=root, collection_filter="planetscope")._scenes()
+    assert [s.item_id for s in scenes["2026-08-26"]] == ["item-2026-08-26"]
+    assert len(scenes["2026-08-26"]) == 1
+
+
+def test_cloud_and_property_filters_drop_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/collection.json"
+    docs = {
+        root: {
+            "links": [
+                {"rel": "item", "href": "a.json"},
+                {"rel": "item", "href": "b.json"},
+                {"rel": "item", "href": "c.json"},
+            ]
+        },
+        "https://example.invalid/a.json": _item(
+            "2026-08-27", (85.3, 28.1, 85.4, 28.3), cloud=10, props={"phase": "post"}
+        ),
+        "https://example.invalid/b.json": _item(
+            "2026-08-28", (85.3, 28.1, 85.4, 28.3), cloud=90, props={"phase": "post"}
+        ),
+        "https://example.invalid/c.json": _item(
+            "2021-10-16", (85.3, 28.1, 85.4, 28.3), cloud=5, props={"phase": "pre"}
+        ),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+    plugin = _plugin(catalog_url=root, max_cloud_cover=50, property_filters={"phase": "post"})
+    assert sorted(plugin._scenes()) == ["2026-08-27"]
+
+
+def test_periods_drop_dates_with_no_scene_over_the_clip() -> None:
+    """A release covering several valleys otherwise fails the whole run on the first date whose
+    scenes lie elsewhere — the Vantor 2026-02-05 case."""
+    plugin = _plugin(clip_bbox=[85.30, 28.12, 85.40, 28.22])
+    plugin._index = {
+        "2026-02-05": [_Scene("elsewhere.tif", (85.06, 27.81, 85.17, 28.04), "e")],
+        "2026-08-27": [_Scene("here.tif", (85.28, 28.11, 85.44, 28.37), "h")],
+    }
+    assert asyncio.run(plugin.periods("2000-01-01", "2026-12-31")) == ["2026-08-27"]
+
+
+def test_periods_are_bounded_by_the_requested_range() -> None:
+    plugin = _plugin(clip_bbox=None)
+    plugin._index = {
+        "2021-10-16": [_Scene("a.tif", (85.3, 28.1, 85.4, 28.3), "a")],
+        "2023-09-17": [_Scene("b.tif", (85.3, 28.1, 85.4, 28.3), "b")],
+        "2026-08-27": [_Scene("c.tif", (85.3, 28.1, 85.4, 28.3), "c")],
+    }
+    assert asyncio.run(plugin.periods("2022-01-01", "2026-08-27")) == [
+        "2023-09-17",
+        "2026-08-27",
+    ]
+
+
+def test_empty_catalogue_raises_rather_than_ingesting_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/collection.json"
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog({root: {"links": []}}))
+    with pytest.raises(ValueError, match="No items with a 'visual' asset"):
+        _plugin(catalog_url=root)._scenes()
+
+
+def test_missing_asset_key_is_reported_not_silently_skipped(
+    monkeypatch: pytest.MonkeyPatch, warnings_log: pytest.LogCaptureFixture
+) -> None:
+    from open_climate_service.plugins.datasets import stac_imagery
+
+    root = "https://example.invalid/collection.json"
+    docs = {
+        root: {"links": [{"rel": "item", "href": "a.json"}]},
+        "https://example.invalid/a.json": _item("2026-08-27", (85.3, 28.1, 85.4, 28.3), asset="thumbnail"),
+    }
+    monkeypatch.setattr(stac_imagery, "_get_json", _catalog(docs))
+    with pytest.raises(ValueError):
+        _plugin(catalog_url=root)._scenes()
+    assert "has no 'visual' asset" in warnings_log.text
+
+
+def test_overlap_test_excludes_scenes_that_only_touch_the_edge() -> None:
+    scenes = [
+        _Scene("touching.tif", (85.40, 28.12, 85.50, 28.22), "t"),
+        _Scene("inside.tif", (85.31, 28.13, 85.35, 28.20), "i"),
+    ]
+    kept = StacImageryPlugin._overlapping(scenes, (85.30, 28.12, 85.40, 28.22))
+    assert [s.item_id for s in kept] == ["i"]
+
+
+def test_band_names_reach_the_stored_variable() -> None:
+    """`display.bands` renders by name, so the band coordinate is part of the contract."""
+    plugin = _plugin(bands=["red", "green", "blue"], variable="true_colour")
+    assert plugin.bands == ("red", "green", "blue")
+    assert plugin.variable == "true_colour"
+
+
+def test_bands_must_not_be_empty() -> None:
+    with pytest.raises(ValueError, match="bands must not be empty"):
+        _plugin(bands=[])
+
+
+def test_utm_grid_is_stable_across_scenes_in_different_source_crs() -> None:
+    """The CRS is derived once from the extent, not per scene: two scenes in different UTM
+    zones must not build two different grids for the same period."""
+    plugin = _plugin()
+    box = (85.30, 28.12, 85.40, 28.22)
+    assert plugin._resolved_crs(box) == plugin._resolved_crs(box) == "EPSG:32645"
+
+
+def test_explicit_target_crs_wins_over_the_derived_zone() -> None:
+    plugin = _plugin(target_crs="EPSG:3857")
+    assert plugin._resolved_crs((85.30, 28.12, 85.40, 28.22)) == "EPSG:3857"
+
+
+def test_mask_reference_is_applied_per_strategy() -> None:
+    """The nodata strategy must compare against the declared value, not against zero."""
+    import xarray as xr
+
+    from open_climate_service.plugins.datasets.stac_imagery import _SceneMeta
+
+    window = xr.DataArray(
+        np.array([[[0, 255], [7, 7]], [[0, 255], [7, 7]], [[0, 255], [7, 7]]], dtype="uint8"),
+        dims=("band", "y", "x"),
+        coords={"band": [1, 2, 3], "y": [1, 0], "x": [0, 1]},
+    )
+    plugin = _plugin()
+    nodata = plugin._valid_mask(window, _SceneMeta((1, 2, 3), _MASK_NODATA, 255, None))
+    assert nodata.values.tolist() == [[True, False], [True, True]]
+    nonzero = plugin._valid_mask(window, _SceneMeta((1, 2, 3), _MASK_NONZERO, None, None))
+    assert nonzero.values.tolist() == [[False, True], [True, True]]

--- a/tests/test_stac_imagery_plugin.py
+++ b/tests/test_stac_imagery_plugin.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import numpy as np
 import pytest
+import rioxarray  # noqa: F401  # pyright: ignore[reportUnusedImport]  # registers the .rio accessor
+import xarray as xr
 from rasterio.enums import ColorInterp, MaskFlags
 
 from open_climate_service.plugins.datasets.stac_imagery import (
@@ -402,3 +404,63 @@ def test_mask_reference_is_applied_per_strategy() -> None:
     assert nodata.values.tolist() == [[True, False], [True, True]]
     nonzero = plugin._valid_mask(window, _SceneMeta((1, 2, 3), _MASK_NONZERO, None, None))
     assert nonzero.values.tolist() == [[False, True], [True, True]]
+
+
+def _fake_scene_array(bounds: tuple[float, float, float, float]) -> xr.DataArray:
+    """A small RGB scene in UTM 45N carrying the TIFF tags a real Maxar asset does."""
+
+    left, bottom, right, top = bounds
+    n = 64
+    xs = np.linspace(left, right, n)
+    ys = np.linspace(top, bottom, n)
+    data = np.full((3, n, n), 120, dtype="uint8")
+    return xr.DataArray(
+        data,
+        dims=("band", "y", "x"),
+        coords={"band": [1, 2, 3], "y": ys, "x": xs},
+        attrs={
+            "ACQUISITION_TIME": "2021-10-16T05:22:48Z",
+            "COLLECT_IDENTIFIER": "10300100C86CED00",
+            "VEHICLE_NAME": "WV02",
+        },
+    ).rio.write_crs("EPSG:32645")
+
+
+def test_scene_tiff_tags_do_not_leak_onto_the_stored_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`xr.where` propagates attrs from whichever scene it last merged, so the mosaic arrives
+    carrying one contributor's ACQUISITION_TIME / COLLECT_IDENTIFIER / VEHICLE_NAME. On a cube
+    spanning several dates and several scenes per date those describe one arbitrary scene while
+    appearing to describe the whole variable."""
+    from rasterio.warp import transform_bounds
+
+    from open_climate_service.plugins.datasets import stac_imagery
+    from open_climate_service.plugins.datasets.stac_imagery import _SceneMeta
+
+    clip = [85.3474, 28.2087, 85.3608, 28.2207]
+    plugin = _plugin(
+        resolution_m=10.0,
+        clip_bbox=clip,
+        source_license="CC-BY-NC-4.0",
+        long_name="Maxar true-colour composite",
+    )
+    plugin._index = {"2026-08-27": [_Scene("s.tif", (85.34, 28.20, 85.37, 28.23), "s")]}
+    utm = transform_bounds("EPSG:4326", "EPSG:32645", 85.34, 28.20, 85.37, 28.23)
+
+    monkeypatch.setattr(stac_imagery, "_open_scene", lambda href, level: _fake_scene_array(utm))
+    monkeypatch.setattr(
+        StacImageryPlugin,
+        "_scene_meta",
+        lambda self, href, crs, res: _SceneMeta((1, 2, 3), _MASK_NONZERO, None, None),
+    )
+
+    cube = plugin.fetch_period("2026-08-27", clip)
+    attrs = cube["true_colour"].attrs
+    for leaked in ("ACQUISITION_TIME", "COLLECT_IDENTIFIER", "VEHICLE_NAME"):
+        assert leaked not in attrs, f"{leaked} leaked from a source scene onto the variable"
+    assert attrs["source_license"] == "CC-BY-NC-4.0"
+    assert attrs["long_name"] == "Maxar true-colour composite"
+    assert isinstance(cube, xr.Dataset)
+    assert cube["true_colour"].dtype == "uint8"
+    assert list(np.asarray(cube["true_colour"]["band"].values)) == ["red", "green", "blue"]

--- a/tests/test_stac_renders.py
+++ b/tests/test_stac_renders.py
@@ -1,0 +1,103 @@
+"""Render-extension output for colormapped and true-colour collections (CLIM-947)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from open_climate_service.ingestions.schemas import (
+    ArtifactCoverage,
+    ArtifactFormat,
+    ArtifactRecord,
+    ArtifactRequestScope,
+    CoverageSpatial,
+    CoverageTemporal,
+)
+from open_climate_service.stac.services import _build_renders
+
+
+def _artifact(variable: str = "reflectance") -> ArtifactRecord:
+    return ArtifactRecord(
+        artifact_id="a1",
+        dataset_id="planet_flood_rgb",
+        dataset_name="Flood true colour",
+        variable=variable,
+        format=ArtifactFormat.ICECHUNK,
+        request_scope=ArtifactRequestScope(),
+        coverage=ArtifactCoverage(
+            spatial=CoverageSpatial(xmin=85.3, ymin=28.1, xmax=85.5, ymax=28.3),
+            temporal=CoverageTemporal(),
+        ),
+        created_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+    )
+
+
+def _render(display: Any) -> dict[str, Any] | None:
+    renders = _build_renders(_artifact(), {"display": display})
+    return None if renders is None else renders["default"]
+
+
+def test_three_bands_produce_a_composite_render_with_no_colour_ramp() -> None:
+    """A composite is not a colour ramp: `colormap_name` must be absent, `bands` present."""
+    render = _render({"bands": ["red", "green", "blue"], "range": [0, 3000]})
+
+    assert render is not None
+    assert render["bands"] == ["red", "green", "blue"]
+    assert "colormap_name" not in render
+    # One rescale pair per band, as the Render extension expects.
+    assert render["rescale"] == [[0.0, 3000.0], [0.0, 3000.0], [0.0, 3000.0]]
+    assert render["open_climate_service:band_dimension"] == "band"
+
+
+def test_per_band_ranges_are_kept_separate() -> None:
+    """Bands with different dynamic ranges need their own stretch, or the colour is wrong."""
+    render = _render({"bands": ["red", "green", "blue"], "range": [[0, 2500], [0, 2600], [0, 3000]]})
+
+    assert render is not None
+    assert render["rescale"] == [[0.0, 2500.0], [0.0, 2600.0], [0.0, 3000.0]]
+
+
+def test_the_band_dimension_can_be_named() -> None:
+    render = _render({"bands": ["r", "g", "b"], "range": [0, 255], "band_dimension": "spectral"})
+
+    assert render is not None
+    assert render["open_climate_service:band_dimension"] == "spectral"
+
+
+@pytest.mark.parametrize(
+    "bands",
+    [["red", "green"], ["red", "green", "blue", "nir"], ["red", "green", 3], ["red", "green", ""]],
+)
+def test_a_band_list_that_is_not_three_names_is_refused(bands: Any) -> None:
+    """Refused rather than half-rendered: a two-band composite has no defined meaning here."""
+    assert _render({"bands": bands, "range": [0, 3000]}) is None
+
+
+@pytest.mark.parametrize("value_range", [None, [0], [0, 1, 2], [[0, 1], [0, 1]], "0-3000"])
+def test_a_composite_without_a_usable_range_is_refused(value_range: Any) -> None:
+    assert _render({"bands": ["red", "green", "blue"], "range": value_range}) is None
+
+
+def test_nodata_is_carried_onto_a_composite() -> None:
+    render = _render({"bands": ["red", "green", "blue"], "range": [0, 255], "nodata": 0})
+
+    assert render is not None
+    assert render["nodata"] == 0.0
+
+
+def test_a_colormapped_collection_is_unchanged() -> None:
+    """The single-variable path must be untouched by the composite branch."""
+    render = _render({"colormap": "rdbu_r", "range": [-30, 30], "nodata": 0})
+
+    assert render is not None
+    assert render["colormap_name"] == "rdbu_r"
+    assert render["rescale"] == [[-30.0, 30.0]]
+    assert render["nodata"] == 0.0
+    assert "bands" not in render
+
+
+def test_a_display_block_with_neither_bands_nor_colormap_yields_no_render() -> None:
+    assert _render({"range": [0, 1]}) is None
+    assert _build_renders(_artifact(), {}) is None

--- a/tests/test_stac_renders.py
+++ b/tests/test_stac_renders.py
@@ -80,6 +80,28 @@ def test_a_composite_without_a_usable_range_is_refused(value_range: Any) -> None
     assert _render({"bands": ["red", "green", "blue"], "range": value_range}) is None
 
 
+@pytest.mark.parametrize(
+    "value_range",
+    [
+        [1, 1],
+        [10, 0],
+        [float("nan"), 10],
+        [0, float("inf")],
+        [[0, 255], [1, 1], [0, 255]],
+        [[0, 255], [0, 255], [float("-inf"), 255]],
+    ],
+)
+def test_a_stretch_the_shader_cannot_use_is_refused(value_range: Any) -> None:
+    """Shape is not enough — these are all well-formed and all unusable.
+
+    The shader divides by `max - min` and embeds both numbers as GLSL literals, so an equal
+    or inverted pair divides by zero or negates, and a non-finite endpoint gives NaN colours
+    or a shader that will not compile. `NaN` and `Infinity` are not valid JSON either, so the
+    collection response itself would be malformed.
+    """
+    assert _render({"bands": ["red", "green", "blue"], "range": value_range}) is None
+
+
 def test_nodata_is_carried_onto_a_composite() -> None:
     render = _render({"bands": ["red", "green", "blue"], "range": [0, 255], "nodata": 0})
 

--- a/tests/test_stac_temporal_values.py
+++ b/tests/test_stac_temporal_values.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 
 from open_climate_service.stac.services import (
-    _implied_step_count,
+    _expected_time_walk,
     _temporal_values_needed,
 )
 
@@ -64,13 +64,6 @@ def test_a_single_slice_store_stays_implied() -> None:
     assert _temporal_values_needed(ds, "t", "daily", "P1D") is False
 
 
-def test_a_step_that_cannot_be_walked_draws_no_conclusion() -> None:
-    """A compound duration is not parsed, so the count must not be guessed from it."""
-    ds = _ds(["2026-05-27", "2026-08-26"])
-
-    assert _temporal_values_needed(ds, "t", "daily", "P1Y2M") is False
-
-
 def test_a_dimension_the_store_does_not_have_is_left_alone() -> None:
     ds = _ds(["2026-05-27", "2026-08-26"])
 
@@ -88,9 +81,56 @@ def test_a_dimension_the_store_does_not_have_is_left_alone() -> None:
         ("2026-01-01", "2026-01-29", "P7D", 5),
     ],
 )
-def test_implied_step_count_matches_what_a_client_would_build(start: str, end: str, step: str, expected: int) -> None:
-    assert _implied_step_count(pd.Timestamp(start), pd.Timestamp(end), step) == expected
+def test_expected_time_walk_matches_what_a_client_would_build(start: str, end: str, step: str, expected: int) -> None:
+    walk = _expected_time_walk(pd.Timestamp(start), pd.Timestamp(end), step)
+
+    assert walk is not None
+    assert len(walk) == expected
+    assert walk[0] == pd.Timestamp(start)
+    # The walk starts at `start` and steps by the duration, so it may end past `end` — what
+    # matters is that a client stepping the same way lands on the same instants.
+    assert walk.is_monotonic_increasing
 
 
-def test_implied_step_count_refuses_a_duration_it_cannot_walk() -> None:
-    assert _implied_step_count(pd.Timestamp("2026-01-01"), pd.Timestamp("2026-02-01"), "P1Y2M") is None
+def test_the_walk_refuses_a_duration_it_cannot_be_built_from() -> None:
+    assert _expected_time_walk(pd.Timestamp("2026-01-01"), pd.Timestamp("2026-02-01"), "P1Y2M") is None
+
+
+# --- an unwalkable or absent step must not be read as agreement ------------------------
+
+
+@pytest.mark.parametrize("step", ["P1Y2M", "P1W", "PT30M", "not-a-duration"])
+def test_a_step_no_client_can_walk_still_lists_its_timestamps(step: str) -> None:
+    """Being unable to check is not the same as agreeing.
+
+    A consumer stepping `extent` by a duration it cannot parse builds a single position, so
+    every slice past the first becomes unreachable. Previously this returned False and
+    published nothing, which is the same blank-map failure CLIM-950 is about.
+    """
+    ds = _ds(["2026-01-01", "2026-01-02", "2026-01-03"])
+
+    assert _temporal_values_needed(ds, "t", "daily", step) is True
+
+
+def test_a_multi_slice_axis_with_no_step_lists_its_timestamps() -> None:
+    ds = _ds(["2026-01-01", "2026-01-02"])
+
+    assert _temporal_values_needed(ds, "t", "daily", None) is True
+
+
+def test_a_single_slice_axis_with_no_step_stays_implied() -> None:
+    """One slice is one position however the client walks it, so nothing can disagree."""
+    ds = _ds(["2026-01-01"])
+
+    assert _temporal_values_needed(ds, "t", "daily", None) is False
+
+
+def test_timestamps_that_drift_within_a_matching_count_are_caught() -> None:
+    """The count agrees and the instants do not — a count-only check passes this wrongly.
+
+    Three daily slices imply three positions, so the arithmetic lines up while the middle
+    label is twelve hours out. Comparing the sequence is what catches it.
+    """
+    ds = _ds(["2026-01-01T00:00", "2026-01-02T12:00", "2026-01-03T00:00"])
+
+    assert _temporal_values_needed(ds, "t", "daily", "P1D") is True

--- a/tests/test_stac_temporal_values.py
+++ b/tests/test_stac_temporal_values.py
@@ -1,0 +1,96 @@
+"""When a temporal dimension must list its timestamps instead of implying them (CLIM-950)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from open_climate_service.stac.services import (
+    _implied_step_count,
+    _temporal_values_needed,
+)
+
+
+def _ds(stamps: list[str]) -> xr.Dataset:
+    times = np.array(stamps, dtype="datetime64[ns]")
+    return xr.Dataset(
+        {"v": (("t",), np.zeros(len(times), dtype="float32"))},
+        coords={"t": times},
+    )
+
+
+def test_a_sparse_daily_axis_needs_its_timestamps_listed() -> None:
+    """The event-scoped case: two daily acquisitions three months apart imply 92 positions."""
+    ds = _ds(["2026-05-27", "2026-08-26"])
+
+    assert _temporal_values_needed(ds, "t", "daily", "P1D") is True
+
+
+def test_a_dense_daily_axis_stays_implied() -> None:
+    """A complete run is described exactly by extent plus duration, so it must not grow."""
+    stamps = [str(d.date()) for d in pd.date_range("2026-01-01", "2026-01-31", freq="D")]
+    ds = _ds(stamps)
+
+    assert _temporal_values_needed(ds, "t", "daily", "P1D") is False
+
+
+def test_a_dense_monthly_axis_stays_implied_despite_unequal_month_lengths() -> None:
+    """Calendar stepping, not 30-day arithmetic: otherwise every monthly store looks sparse."""
+    stamps = [str(d.date()) for d in pd.date_range("2026-01-01", "2026-12-01", freq="MS")]
+    ds = _ds(stamps)
+
+    assert _temporal_values_needed(ds, "t", "monthly", "P1M") is False
+
+
+def test_a_gap_in_a_monthly_axis_is_caught() -> None:
+    ds = _ds(["2026-01-01", "2026-02-01", "2026-06-01"])
+
+    assert _temporal_values_needed(ds, "t", "monthly", "P1M") is True
+
+
+def test_an_irregular_cadence_still_needs_values_even_though_it_has_no_step() -> None:
+    """Dekads carry no step at all, so the count comparison never runs for them."""
+    ds = _ds(["2026-01-01", "2026-01-11", "2026-01-21"])
+
+    assert _temporal_values_needed(ds, "t", "dekadal", None) is True
+
+
+def test_a_single_slice_store_stays_implied() -> None:
+    """One timestamp implies one position, so there is nothing to disagree about."""
+    ds = _ds(["2026-05-27"])
+
+    assert _temporal_values_needed(ds, "t", "daily", "P1D") is False
+
+
+def test_a_step_that_cannot_be_walked_draws_no_conclusion() -> None:
+    """A compound duration is not parsed, so the count must not be guessed from it."""
+    ds = _ds(["2026-05-27", "2026-08-26"])
+
+    assert _temporal_values_needed(ds, "t", "daily", "P1Y2M") is False
+
+
+def test_a_dimension_the_store_does_not_have_is_left_alone() -> None:
+    ds = _ds(["2026-05-27", "2026-08-26"])
+
+    assert _temporal_values_needed(ds, "not_a_dim", "daily", "P1D") is False
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "step", "expected"),
+    [
+        ("2026-05-27", "2026-08-26", "P1D", 92),
+        ("2026-01-01", "2026-01-31", "P1D", 31),
+        ("2026-01-01", "2026-12-01", "P1M", 12),
+        ("2020-01-01", "2026-01-01", "P1Y", 7),
+        ("2026-01-01", "2026-01-02", "PT1H", 25),
+        ("2026-01-01", "2026-01-29", "P7D", 5),
+    ],
+)
+def test_implied_step_count_matches_what_a_client_would_build(start: str, end: str, step: str, expected: int) -> None:
+    assert _implied_step_count(pd.Timestamp(start), pd.Timestamp(end), step) == expected
+
+
+def test_implied_step_count_refuses_a_duration_it_cannot_walk() -> None:
+    assert _implied_step_count(pd.Timestamp("2026-01-01"), pd.Timestamp("2026-02-01"), "P1Y2M") is None


### PR DESCRIPTION
[CLIM-947](https://dhis2.atlassian.net/browse/CLIM-947) · [CLIM-950](https://dhis2.atlassian.net/browse/CLIM-950) · [CLIM-957](https://dhis2.atlassian.net/browse/CLIM-957)

OCS could store three bands but not show them as an image: `_build_renders` emitted a single `colormap_name` and `rescale`, so a three-band cube rendered as one band under a colour ramp. Imagery whose value is what it looks like — the Planet and Vantor open releases for the Nepal flood, Sentinel-2 true colour, a land-cover backdrop — had no way to be displayed.

**Template.** `display.bands` takes three band names instead of a colormap, with `display.range` as either one shared `[min, max]` or one pair per band:

```yaml
display:
  bands: [red, green, blue]
  range: [0, 3000]
```

**STAC.** The collection publishes the Render extension's `bands` array with one rescale pair per band, plus the variable and band dimension so a client needn't guess either. `colormap_name` is deliberately absent — a composite is not a ramp. Because this is the standard's own field, a render-aware client that has never seen OCS can composite the layer from the published metadata.

**Viewer.** zarr-layer supports this natively: a `selector` array exposes each band to the fragment shader under its own name. The generated shader stretches each band by its own pair and outputs premultiplied colour, as the library requires once a `customFrag` owns discarding. No upstream contribution was needed. The band axis is excluded from the stepping controls, and the legend is hidden, since showing a ramp from the unused colormap would mislead.

Storage is unchanged: three bands on one variable along a band dimension — the shape the source GeoTIFFs have, and the mechanism `worldpop_agesex_*` already uses for `age_group`.

## Verified on a real store, which found two bugs

The first revision said the browser rendering was unverified. It has now been checked against a real three-band store — the Planet flood release ingested on the Nepal test instance — and it did not work. Both causes are fixed here.

**The band selector was dropped on update.** The viewer merged the band array only when constructing the layer, then re-sent a selector without it on every change. zarr-layer recomputes its band names from the selector inside `setSelector`, so the bands collapsed to a single one named after the variable while `customFrag` stayed in place; the shader still referred to `red`, `green` and `blue` and failed to compile with `undeclared identifier`. Both call sites now build the selector through one helper so they cannot drift.

**A sparse time axis published a step it did not honour** ([CLIM-950](https://dhis2.atlassian.net/browse/CLIM-950), pre-existing). Cadence is derived from the declared `period_type` alone, so a store holding two daily acquisitions three months apart published `extent` + `P1D` and no `values`. A client walks that into 92 positions for a 2-slice store, indexes past the end and renders nothing — surfacing only as `InvalidSelectionError: index out of bounds for dimension with length 2`. The collection now lists its timestamps whenever the store is not the complete sequence the step implies. A dense store is unchanged and does not grow by one ISO string per period. The step is passed into the payload builder rather than read back from it, because `_override_time_step` runs afterwards.

## A generic plugin to feed it ([CLIM-957](https://dhis2.atlassian.net/browse/CLIM-957))

Rendering imagery is no use if every release needs its own plugin. The Nepal test instance's Planet plugin was 393 lines, of which ~85% was source-agnostic. `StacImageryPlugin` replaces it: point `catalog_url` at any static STAC catalogue or flat collection and the release becomes a template.

```yaml
ingestion:
  plugin: open_climate_service.plugins.datasets.stac_imagery.StacImageryPlugin
  params:
    catalog_url: https://vantor-opendata.s3.amazonaws.com/.../collection.json
    resolution_m: 0.34
    clip_bbox: [85.3474, 28.2087, 85.3608, 28.2207]
```

**Masking is where the sources genuinely differ**, and a wrong answer there is silent rather than loud — without a mask the black padding around a footprint wins the first-non-null test and punches holes in the mosaic. Planet's `visual` declares `['red','green','blue','alpha']`; Vantor's declares `['red','green','blue']` with `nodata=None` and every band `all_valid`, so it carries no mask information at all. The strategy is resolved per scene — alpha band, then declared nodata, then an all-zero heuristic — and logged rather than assumed.

Band order likewise comes from GDAL's colour interpretation, then band descriptions, then position, so a source that changes its layout fails loudly instead of silently swapping channels.

`periods()` drops dates whose scenes all miss the configured clip. Without it a release covering several valleys fails the whole run on the first irrelevant date — the real Vantor case, where a 0%-cloud scene images a valley 20 km away.

The grid guard matters more at this scale: Maxar visual is ~100x the cells of PlanetScope for the same footprint, so an unscoped extent is an allocation the kernel kills with no traceback. It refuses with the extent it was given and the two ways out.

### STAC APIs, not just static catalogues

A global archive cannot be walked — Earth Search's `sentinel-2-l2a` alone holds tens of millions of items — so when the root declares item-search conformance, `clip_bbox` and the ingest date range become search parameters instead. That inverts the cost: the static path fetches every item and discards most, while search fetches only what the extent and range already imply.

Detection requires both the conformance class *and* a `search` link. A link alone is not enough — some static catalogues link to a search UI, and POSTing to that would break a catalogue the walk handles fine.

**Verified against three sources, which between them exercise every branch.**

| | shape | mask | source CRS | licence |
|---|---|---|---|---|
| Planet | static nested tree | alpha band | UTM 45N | CC-BY-NC-4.0 |
| Vantor | static flat collection | none → all-zero heuristic | EPSG:4326 | CC-BY-NC-4.0 |
| Sentinel-2 | **STAC API** | `nodata=0` | UTM 45N | open |

Sentinel-2 earns its place beyond variety: its TCI is the only one of the three that declares `nodata`, so without it the `_MASK_NODATA` branch had no real-world coverage.

Planet driven through the generic plugin reproduces the bespoke plugin's output **byte-for-byte on all three dates** — the generalisation changed no behaviour. Vantor and Sentinel-2 ingest from the same code with only template changes.

## Tests

15 tests on the render output: shared and per-band ranges, a named band dimension, nodata, refusal when the band list isn't three names or the range is unusable, and that colormapped collections are unchanged. 35 more on the generic plugin: band resolution from colorinterp/descriptions/position and the refusal when none work, each mask strategy including the warned-about approximation, both catalogue shapes, the leaf-only collection filter, cloud and property filters, grid snapping, the oversized-grid refusal, dropping dates with no scene over the clip, and for the API path — detection, search-body construction, `next` paging, the warned page cap, and asset hrefs resolving against the item's `self` link. One drives `fetch_period` end to end to prove a scene's TIFF tags do not leak onto a multi-date variable, and fails without that fix. 15 more on the temporal axis: sparse daily and gapped monthly need `values`; dense daily, dense monthly (calendar stepping, not 30-day arithmetic) and a single-slice store do not; an unwalkable compound duration draws no conclusion; plus the implied-count arithmetic against what a client would build.

Verified end to end on the instance: the collection publishes two `values`, and the viewer builds two steps.


[CLIM-947]: https://dhis2.atlassian.net/browse/CLIM-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-950]: https://dhis2.atlassian.net/browse/CLIM-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-950]: https://dhis2.atlassian.net/browse/CLIM-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CLIM-957]: https://dhis2.atlassian.net/browse/CLIM-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ