### PR TITLE
fix(chirps3): clip the monthly raster before converting, so the read is windowed (CLIM-951)

### DIFF
--- a/open_climate_service/plugins/datasets/chirps3.py
+++ b/open_climate_service/plugins/datasets/chirps3.py
@@ -156,7 +156,7 @@ class CHIRPS3MonthlyPlugin(BaseDatasetPlugin):
         return monthly_period_ids(start, end, cutoff=cutoff)
 
     def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
-        """Fetch one month, convert the total to a mean daily rate, and clip to the bbox."""
+        """Fetch one month, clip it to the bbox, then convert the total to a mean daily rate."""
         import rioxarray
 
         year, month = self._parse_month(period_id)
@@ -164,21 +164,37 @@ class CHIRPS3MonthlyPlugin(BaseDatasetPlugin):
         if not isinstance(da, xr.DataArray):
             raise TypeError(f"Expected DataArray from CHIRPS3 monthly raster read, got {type(da).__name__}")
 
-        # Convert before masking so the nodata sentinel is still recognisable: -9999 / 31
-        # would no longer match _CHIRPS3_NODATA. normalize_period masks on the raw value,
-        # so scale only the valid data and leave the sentinel alone.
-        days_in_month = calendar.monthrange(year, month)[1]
-        da = da.where(da == _CHIRPS3_NODATA, da / days_in_month)
-
+        # Clip first, scale second — the order is the whole point (CLIM-951). The source is a
+        # global COG (7200 x 2400, tiled 512 x 512), so `normalize_period`'s clip can push down
+        # into a windowed read over HTTP range requests, but only while the array is still
+        # lazy. Any arithmetic here would instead touch every cell on the globe to keep the
+        # handful the bbox asks for: measured at 13 s and 572 MB per period, against 3.5 s and
+        # 205 MB when the clip goes first. Over a 439-month ingest that was 81 minutes and a
+        # 41.6 GB peak to produce a 41 MB store.
+        #
         # Stamp the first of the month as the time coordinate, matching the monthly
         # convention used by the ERA5-Land monthly datasets.
-        return normalize_period(
+        ds = normalize_period(
             da,
             variable="precip",
             period=f"{year:04d}-{month:02d}-01",
             nodata=_CHIRPS3_NODATA,
             bbox=bbox,
         )
+
+        # The source raster is a monthly *total* in mm, and the store holds mm/day — a real
+        # conversion, verified against the sum of the same month's dailies (see the class
+        # docstring). Scaling after `normalize_period` needs no guard for the -9999 sentinel:
+        # it has already been masked to NaN by then, and NaN / days stays NaN. Attributes and
+        # encoding are carried over explicitly because an xarray binary op drops both, and the
+        # store's nodata inference reads `_FillValue` off the encoding.
+        days_in_month = calendar.monthrange(year, month)[1]
+        precip = ds["precip"]
+        scaled = precip / days_in_month
+        scaled.attrs = dict(precip.attrs)
+        scaled.encoding = dict(precip.encoding)
+        ds["precip"] = scaled
+        return ds
 
     def _availability_cutoff(self) -> str:
         """Return the ``YYYY-MM`` of the most recently published monthly COG."""

--- a/tests/test_streaming_chirps3_monthly.py
+++ b/tests/test_streaming_chirps3_monthly.py
@@ -162,6 +162,55 @@ def test_nodata_is_masked_not_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not np.any(np.isclose(finite, _NODATA / 31, atol=1.0)), "the sentinel was scaled instead of masked"
 
 
+def test_the_clip_runs_before_the_conversion(stub_raster: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordering is the fix, so assert the mechanism and not just the result (CLIM-951).
+
+    The source is a global COG. `normalize_period` clips it, and that clip only becomes a
+    windowed read while the array is still lazy — any arithmetic beforehand materialises the
+    whole globe to keep the handful of cells the bbox asks for. Guarding the *result* alone
+    would not catch a regression here, because both orderings produce identical values.
+    """
+    seen: list[xr.DataArray] = []
+    original = chirps3.normalize_period
+
+    def spy(obj: xr.DataArray, **kwargs: Any) -> xr.Dataset:
+        seen.append(obj)
+        return original(obj, **kwargs)
+
+    monkeypatch.setattr(chirps3, "normalize_period", spy)
+    CHIRPS3MonthlyPlugin().fetch_period("2025-01", [33.0, -14.0, 34.0, -13.0])
+
+    assert len(seen) == 1
+    # Still the raw monthly total, not 310/31 — nothing has scaled it before the clip.
+    assert float(np.nanmax(seen[0].values)) == pytest.approx(310.0)
+
+
+def test_reordering_preserves_the_previous_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clip-then-scale must equal scale-then-clip, sentinel included.
+
+    Reproduces the superseded ordering inline and compares. Against the live COGs the two
+    were bit-identical for the same month (max abs diff 0.0); this pins that here so the
+    optimisation cannot quietly change stored values.
+    """
+    import rioxarray
+
+    monkeypatch.setattr(rioxarray, "open_rasterio", lambda url, **_: _source_raster(with_nodata=True))
+    bbox = [33.0, -14.0, 34.0, -13.0]
+    actual = CHIRPS3MonthlyPlugin().fetch_period("2025-01", bbox)["precip"].values
+
+    # The previous implementation: scale everything except the sentinel, then clip and mask.
+    days = calendar.monthrange(2025, 1)[1]
+    raw = _source_raster(with_nodata=True)
+    scaled_first = raw.where(raw == _NODATA, raw / days)
+    expected = chirps3.normalize_period(
+        scaled_first, variable="precip", period="2025-01-01", nodata=_NODATA, bbox=bbox
+    )["precip"].values
+
+    assert actual.shape == expected.shape
+    assert np.array_equal(np.isnan(actual), np.isnan(expected)), "NaN pattern differs"
+    assert np.array_equal(actual, expected, equal_nan=True), "values differ"
+
+
 def test_time_coordinate_is_the_first_of_the_month(stub_raster: None) -> None:
     ds = CHIRPS3MonthlyPlugin().fetch_period("2025-03", [33.0, -14.0, 34.0, -13.0])
     assert np.datetime_as_string(ds["t"].values[0], unit="D") == "2025-03-01"


### PR DESCRIPTION
[CLIM-951](https://dhis2.atlassian.net/browse/CLIM-951)

The CHIRPS3 monthly plugin read the entire global raster for every period and then threw almost all of it away. The source is a proper COG (7200 × 2400, tiled 512 × 512, with overviews), so a windowed read over HTTP range requests was available — it just wasn't reachable.

The cause was the order of operations, not the reader. Scaling the monthly total to mm/day touches every cell on the globe, which materialises the whole array before `normalize_period` gets a chance to clip it. A clip can only push down into range requests while the array is still lazy.

Doing the conversion *after* the clip also removes the tricky bit of the old code: it no longer needs to protect the `-9999` sentinel, because `normalize_period` has already masked it to NaN, and `NaN / days` stays NaN.

## Measured

Live COGs, fresh processes on distinct months so no GDAL block cache is reused:

| | before | after |
| --- | --- | --- |
| time per period | 13.4 / 16.3 / 11.7 s | 2.9 / 4.4 / 4.6 s |
| peak RSS | 572 MB | 190 MB |

Roughly 3.5× faster and about a third of the memory.

The ingest that surfaced this — 439 monthly periods for Nepal, 1990-01 to 2026-07 — took **81 minutes and peaked at 41.6 GB to produce a 41 MB store**. (`ru_maxrss` is bytes on macOS; confirmed by allocating a known 477 MB and observing a matching delta.) This machine absorbed it, but the constrained deployments CLIM-845 targets would have been killed by the kernel with no traceback — the same failure mode as CLIM-949, and the same pattern: peak memory driven by the source extent rather than the size of the output.

## Tests

Two additions, doing different jobs:

- **`test_the_clip_runs_before_the_conversion`** guards the ordering by spying on what reaches `normalize_period` and asserting it still holds the raw monthly total. This is the regression guard, and I checked it **fails on the previous implementation** rather than merely passing on the new one.
- **`test_reordering_preserves_the_previous_values`** reproduces the superseded ordering inline and asserts equality including the NaN pattern. This pins values so the optimisation cannot quietly change what gets stored.

Guarding the result alone would not have caught a regression here, because both orderings produce identical values — that is exactly what makes this the kind of change worth pinning at the mechanism.

The existing suite passes unchanged, including `test_nodata_is_masked_not_scaled`. Full suite: 1130 passed, 1 skipped; `make lint` clean.

## Scope

The **daily** plugin does not have this defect — it passes the lazy array straight to `normalize_period` with no arithmetic in between. This was specific to the monthly plugin and introduced by the mm/day conversion.

Worth a follow-up audit of other plugins for the same shape: any arithmetic applied to a lazily opened raster before the clip has the same effect. Not done here to keep the change reviewable.


[CLIM-951]: https://dhis2.atlassian.net/browse/CLIM-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ