### PR TITLE
fix(era5-land): move to the Zarr v3 EDH stores and refuse anything older (CLIM-955)

### DIFF
--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -13,6 +13,7 @@ import tempfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from threading import Lock
+from time import monotonic
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
@@ -369,10 +370,17 @@ _EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v
 _EDH_API_KEY_ENV = "EDH_API_KEY"
 
 
-# Only *confirmed* formats are cached. `lru_cache` would also memoise a None, so a single
-# transient timeout or 401 would disable the diagnostic for that store until the process
-# restarts — in a long-running worker that is indistinguishable from the store being fine.
+# A confirmed format never changes for a given URL, so it is cached for the process.
 _edh_zarr_format_cache: dict[str, int] = {}
+# An *unknown* result is cached only briefly, which is a deliberate middle course between two
+# bad extremes. Memoising it permanently (as `lru_cache` would) lets one transient timeout
+# disable the diagnostic for the process — indistinguishable from the store being healthy.
+# Not caching it at all is worse: `_latest_available` reopens the store for every period, so a
+# store that fsspec can read while these separate requests time out costs up to 30 s *per
+# period*, making an optional diagnostic the bottleneck during exactly the transient failure
+# it exists to tolerate. A short TTL bounds the cost and still self-heals.
+_EDH_UNKNOWN_FORMAT_TTL_SECONDS = 300.0
+_edh_zarr_format_unknown_until: dict[str, float] = {}
 # One warning per store per process. `_latest_available` reopens the store for every period,
 # so without this a multi-year ingest emits the same line thousands of times and buries it.
 _edh_superseded_warned: set[str] = set()
@@ -410,6 +418,8 @@ def _edh_zarr_format(url: str) -> int | None:
     cached = _edh_zarr_format_cache.get(url)
     if cached is not None:
         return cached
+    if monotonic() < _edh_zarr_format_unknown_until.get(url, 0.0):
+        return None  # probed recently and could not tell; do not re-probe per period
     headers = _edh_auth_header(url)
     for probe in ("zarr.json", ".zmetadata"):
         try:
@@ -423,7 +433,9 @@ def _edh_zarr_format(url: str) -> int | None:
             continue
         if zarr_format is not None:
             _edh_zarr_format_cache[url] = zarr_format
+            _edh_zarr_format_unknown_until.pop(url, None)
             return zarr_format
+    _edh_zarr_format_unknown_until[url] = monotonic() + _EDH_UNKNOWN_FORMAT_TTL_SECONDS
     return None
 
 
@@ -447,7 +459,13 @@ def _warn_if_superseded(url: str, ds: xr.Dataset) -> None:
     latest = ""
     time_dim = next((name for name in ("valid_time", "time") if name in ds.coords), None)
     if time_dim and ds.sizes.get(time_dim):
-        latest = f"; its latest timestamp is {str(ds[time_dim].isel({time_dim: -1}).values)[:16]}"
+        try:
+            # A lazy remote read: the coordinate chunk still has to be fetched and decoded, and
+            # that can fail on its own. The timestamp only sharpens the message, so losing it
+            # must not turn a store that opened successfully into a failed ingest.
+            latest = f"; its latest timestamp is {str(ds[time_dim].isel({time_dim: -1}).values)[:16]}"
+        except Exception:  # noqa: BLE001 — enrichment is optional, the warning is not
+            logger.debug("Could not read the latest timestamp of %s for the warning", url, exc_info=True)
     logger.warning(
         "Earth Data Hub store %s is Zarr v%d, not v3. EDH applies updates only to its Zarr v3 "
         "stores, so this one no longer advances%s. See CLIM-955.",

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -502,7 +502,11 @@ def _edh_auth_header(url: str) -> dict[str, str]:
     if not credentials:
         return {}
     login, _, password = credentials
-    return _basic_auth(login, password or "")
+    # `or "edh"`: the netrc entry EDH documents carries only a password, and Python then
+    # reports an empty login — which would build `:key` here while the EDH_API_KEY path builds
+    # `edh:key`. EDH happens to accept both today, so this is not a live failure, but two auth
+    # paths disagreeing means one of them works only by the service's tolerance.
+    return _basic_auth(login or "edh", password or "")
 
 
 def _basic_auth(login: str, password: str) -> dict[str, str]:

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -359,12 +359,12 @@ def _deaccumulate_tp(tp: xr.DataArray, time_dim: str = "valid_time") -> xr.DataA
 # Earth Data Hub (EDH) plugins — lazy Zarr access, no per-period downloads
 # ---------------------------------------------------------------------------
 
-# Hourly ERA5-Land: Zarr v2, and **no longer updated** — see the version warning below and
-# CLIM-955. EDH has migrated its ERA5 datasets to Zarr v3 and applies future updates only to
-# the v3 stores. Measured 2026-08-29: this store ends 2026-05-31 while the v3 daily store
-# below reaches 2026-07-31. Repointing needs the v3 URL, which is not discoverable from the
-# API (no catalogue endpoint) and must come from EDH rather than a guess.
-_EDH_HOURLY_URL = "https://api.earthdatahub.destine.eu/era5/reanalysis-era5-land-no-antartica-v0.zarr"
+# Hourly ERA5-Land: Zarr v3. The superseded v2 store (`reanalysis-era5-land-no-antartica-v0`)
+# stopped advancing at 2026-05-31 while this one tracks the daily store — EDH applies updates
+# only to its v3 stores (CLIM-955). Verified identical in every respect that matters to the
+# plugins below: 0-360 longitude, the same latitude range, a `valid_time` axis and the same 50
+# variables including t2m and tp.
+_EDH_HOURLY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-v0.zarr"
 # Daily ERA5-Land: new DestinE API, Zarr v3, requires an additional subscription
 _EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v1.zarr"
 _EDH_API_KEY_ENV = "EDH_API_KEY"
@@ -422,18 +422,21 @@ def _warn_if_superseded(url: str, ds: xr.Dataset) -> None:
     )
 
 
-def _edh_open_zarr(url: str, *, consolidated: bool | None = None) -> xr.Dataset:
+def _edh_open_zarr(url: str) -> xr.Dataset:
     """Open an Earth Data Hub Zarr store.
 
     Injects the ``EDH_API_KEY`` environment variable as HTTP Basic Auth
     (username ``edh``, password = key).  Falls back to netrc when the
     variable is not set.
 
-    Pass ``consolidated=True`` for Zarr v2 stores (the hourly ERA5-Land store).
+    Every store OCS pins is Zarr v3, which carries its metadata inline — so there is no
+    consolidated-metadata switch to set. `_warn_if_superseded` is the guard that this stays
+    true: EDH keeps superseded v2 stores readable, and they fail by going quiet, not by
+    erroring (CLIM-955).
     """
     opened = xr.open_zarr(
         _edh_authenticated_url(url),
-        consolidated=consolidated,
+        consolidated=None,
         storage_options={"client_kwargs": {"trust_env": True}},
     )
     _warn_if_superseded(url, opened)
@@ -475,7 +478,6 @@ class _ERA5LandEDHBase(BaseDatasetPlugin):
     """Shared cache and region logic for EDH Zarr plugins."""
 
     _edh_url: str  # set by subclass
-    _edh_consolidated: bool | None = None  # True for Zarr v2 stores
     _edh_lon_360: bool = False  # True when longitude is stored 0–360
 
     def __init__(self, variable: str) -> None:
@@ -495,7 +497,7 @@ class _ERA5LandEDHBase(BaseDatasetPlugin):
                 return self._cached_region
             self._close_cached_locked()
             xmin, ymin, xmax, ymax = bbox_tuple
-            ds = _edh_open_zarr(self._edh_url, consolidated=self._edh_consolidated)
+            ds = _edh_open_zarr(self._edh_url)
             # Extend bbox by half a grid step (0.05°) to avoid floating-point
             # boundary exclusion (e.g. 360 - 10.1 = 349.8999... misses the 349.9
             # grid point). CDS API is inclusive of boundary points; this aligns
@@ -532,7 +534,7 @@ class _ERA5LandEDHBase(BaseDatasetPlugin):
 
     def _latest_available(self) -> str:
         """Return the latest available timestamp from the EDH Zarr store."""
-        ds = _edh_open_zarr(self._edh_url, consolidated=self._edh_consolidated)
+        ds = _edh_open_zarr(self._edh_url)
         try:
             return str(np.datetime64(ds.valid_time.isel(valid_time=-1).values, "h"))
         finally:
@@ -675,7 +677,6 @@ class ERA5LandEDHPrecipitationDailyPlugin(_ERA5LandEDHBase):
     """
 
     _edh_url = _EDH_HOURLY_URL
-    _edh_consolidated = True
     _edh_lon_360 = True
     max_concurrency = 4
     commit_batch_size = 30
@@ -805,7 +806,6 @@ class ERA5LandTempDailyFromHourlyPlugin(_ERA5LandEDHBase):
     """
 
     _edh_url = _EDH_HOURLY_URL
-    _edh_consolidated = True
     _edh_lon_360 = True
     max_concurrency = 4
     commit_batch_size = 30

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from threading import Lock
 from time import monotonic
 from typing import Any, cast
+from urllib.error import HTTPError
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
@@ -359,125 +360,95 @@ def _deaccumulate_tp(tp: xr.DataArray, time_dim: str = "valid_time") -> xr.DataA
 # Earth Data Hub (EDH) plugins — lazy Zarr access, no per-period downloads
 # ---------------------------------------------------------------------------
 
-# Hourly ERA5-Land: Zarr v3. The superseded v2 store (`reanalysis-era5-land-no-antartica-v0`)
-# stopped advancing at 2026-05-31 while this one tracks the daily store — EDH applies updates
-# only to its v3 stores (CLIM-955). Verified identical in every respect that matters to the
-# plugins below: 0-360 longitude, the same latitude range, a `valid_time` axis and the same 50
-# variables including t2m and tp.
+# Hourly ERA5-Land, Zarr v3. The store this replaced stopped advancing at 2026-05-31 while the
+# daily store kept moving, because EDH applies updates only to its v3 stores (CLIM-955).
+# Verified identical in every respect that matters to the plugins below: 0-360 longitude, the
+# same latitude range, a `valid_time` axis and the same 50 variables including t2m and tp.
 _EDH_HOURLY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-v0.zarr"
 # Daily ERA5-Land: new DestinE API, Zarr v3, requires an additional subscription
 _EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v1.zarr"
 _EDH_API_KEY_ENV = "EDH_API_KEY"
 
 
-# A confirmed format never changes for a given URL, so it is cached for the process.
-_edh_zarr_format_cache: dict[str, int] = {}
-# An *unknown* result is cached only briefly, which is a deliberate middle course between two
-# bad extremes. Memoising it permanently (as `lru_cache` would) lets one transient timeout
-# disable the diagnostic for the process — indistinguishable from the store being healthy.
-# Not caching it at all is worse: `_latest_available` reopens the store for every period, so a
-# store that fsspec can read while these separate requests time out costs up to 30 s *per
-# period*, making an optional diagnostic the bottleneck during exactly the transient failure
-# it exists to tolerate. A short TTL bounds the cost and still self-heals.
-_EDH_UNKNOWN_FORMAT_TTL_SECONDS = 300.0
-_edh_zarr_format_unknown_until: dict[str, float] = {}
-# One warning per store per process. `_latest_available` reopens the store for every period,
-# so without this a multi-year ingest emits the same line thousands of times and buries it.
-_edh_superseded_warned: set[str] = set()
+# A confirmed verdict never changes for a given URL, so it is cached for the process.
+_edh_is_v3_cache: dict[str, bool] = {}
+# An *undeterminable* verdict is cached only briefly — a deliberate middle course. Memoising it
+# permanently would let one transient timeout disable the check for the process. Not caching it
+# at all is worse: `_latest_available` reopens the store for every period, so a store fsspec can
+# read while this separate request times out would cost a 15 s probe *per period*. A short TTL
+# bounds the cost and still recovers on its own.
+_EDH_UNKNOWN_TTL_SECONDS = 300.0
+_edh_unknown_until: dict[str, float] = {}
 
 
-def _zarr_format_of(document: object) -> int | None:
-    """Read the Zarr format out of a ``zarr.json`` or a ``.zmetadata`` document.
+def _edh_is_zarr_v3(url: str) -> bool | None:
+    """Whether an EDH store is Zarr v3. None when the question cannot be answered.
 
-    OCS reads only v3 stores; it still *recognises* an older one, which is not the same thing.
-    Checking ``zarr.json`` alone would answer "not v3" for a superseded store and for a
-    mistyped URL alike, and those want opposite responses. Reading ``.zmetadata`` as well
-    confirms the target really is a Zarr store and names the version it found, so the warning
-    can say what is wrong rather than that something is.
+    A v3 store answers ``zarr.json``; anything else does not. That single probe is the whole
+    test — OCS reads only v3, so there is nothing to learn from identifying *which* older
+    format a store uses.
 
-    Every level is shape-checked rather than assumed. A 200 carrying valid JSON of an
-    unexpected shape — ``[]``, or ``{"metadata": []}`` — would otherwise raise past the
-    caller's handler and take down an open that had already succeeded, turning a diagnostic
-    into an outage.
+    The three-way result matters. A definite 404 means the store is not v3 and the caller
+    should refuse. A timeout or a 5xx means we do not know, and a transient network fault must
+    never be turned into a refusal of a store that reads perfectly well.
     """
-    if not isinstance(document, dict):
-        return None
-    inline = document.get("zarr_format")
-    if isinstance(inline, int):
-        return inline
-    metadata = document.get("metadata")
-    if isinstance(metadata, dict):
-        group = metadata.get(".zgroup")
-        if isinstance(group, dict) and isinstance(group.get("zarr_format"), int):
-            return int(group["zarr_format"])
-    return None
-
-
-def _edh_zarr_format(url: str) -> int | None:
-    """Return the Zarr format of an EDH store, or None when it cannot be determined.
-
-    Probed rather than inferred: a v3 store answers ``zarr.json`` and a v2 store answers
-    ``.zmetadata``. Reading it off the opened ``xr.Dataset`` is not reliable — xarray does not
-    surface the store's format — and inferring it from the URL would go stale the moment a
-    store is migrated in place, which is exactly the case this is meant to catch.
-    """
-    cached = _edh_zarr_format_cache.get(url)
+    cached = _edh_is_v3_cache.get(url)
     if cached is not None:
         return cached
-    if monotonic() < _edh_zarr_format_unknown_until.get(url, 0.0):
+    if monotonic() < _edh_unknown_until.get(url, 0.0):
         return None  # probed recently and could not tell; do not re-probe per period
-    headers = _edh_auth_header(url)
-    for probe in ("zarr.json", ".zmetadata"):
-        try:
-            # The credential-free URL plus an explicit header: `urlopen` does not turn
-            # `user:pass@host` userinfo into Basic Auth the way fsspec does, so probing the
-            # authenticated URL fails for anyone using EDH_API_KEY.
-            request = Request(f"{url}/{probe}", headers=headers)
-            with urlopen(request, timeout=15) as response:  # noqa: S310  # fixed https EDH host
-                zarr_format = _zarr_format_of(json.loads(response.read()))
-        except Exception:  # noqa: BLE001 — a failed probe must never stop a working read
-            continue
-        if zarr_format is not None:
-            _edh_zarr_format_cache[url] = zarr_format
-            _edh_zarr_format_unknown_until.pop(url, None)
-            return zarr_format
-    _edh_zarr_format_unknown_until[url] = monotonic() + _EDH_UNKNOWN_FORMAT_TTL_SECONDS
-    return None
+    verdict: bool | None = None
+    try:
+        # The credential-free URL plus an explicit header: `urlopen` does not turn
+        # `user:pass@host` userinfo into Basic Auth the way fsspec does, so probing the
+        # authenticated URL fails for anyone using EDH_API_KEY.
+        request = Request(f"{url}/zarr.json", headers=_edh_auth_header(url))
+        with urlopen(request, timeout=15) as response:  # noqa: S310  # fixed https EDH host
+            document = json.loads(response.read())
+        # Only a document that actually states its format is evidence. A 200 of an unexpected
+        # shape — `[]`, or a proxy's JSON error page — says nothing about the store, so it is
+        # unknown rather than non-v3: refusing on it would break a store that reads fine.
+        declared = document.get("zarr_format") if isinstance(document, dict) else None
+        verdict = declared >= 3 if isinstance(declared, int) else None
+    except HTTPError as error:
+        # 404 is an answer: there is no v3 metadata document here. Any other status is not.
+        verdict = False if error.code == 404 else None
+    except Exception:  # noqa: BLE001 — an unreachable store is unknown, not non-v3
+        verdict = None
+    if verdict is None:
+        _edh_unknown_until[url] = monotonic() + _EDH_UNKNOWN_TTL_SECONDS
+        return None
+    _edh_is_v3_cache[url] = verdict
+    _edh_unknown_until.pop(url, None)
+    return verdict
 
 
-def _warn_if_superseded(url: str, ds: xr.Dataset) -> None:
-    """Warn when an EDH store is not Zarr v3, because it is no longer being updated.
+def _require_zarr_v3(url: str, ds: xr.Dataset) -> None:
+    """Refuse a store that is not Zarr v3, closing it first.
 
-    EDH keeps superseded stores readable, so a v2 store does not fail — it silently stops
-    advancing. An ingest against one then reports no new periods, which is indistinguishable
-    from "nothing has been published yet" (the same shape as CLIM-952). This makes the stall
-    visible, and reports the store's own latest timestamp so the gap is concrete rather than
-    theoretical.
+    OCS reads only Zarr v3. EDH keeps superseded stores readable and applies updates only to
+    the v3 ones, so an older store does not fail — it silently stops advancing, and an ingest
+    against it reports no new periods, which is indistinguishable from "nothing has been
+    published yet" (the same shape as CLIM-952). Refusing is what makes that visible.
+
+    Only a *confirmed* non-v3 store is refused. An undeterminable probe leaves the store
+    usable, because a network fault is not evidence about the store's format.
     """
-    zarr_format = _edh_zarr_format(url)
-    if zarr_format is None or zarr_format >= 3:
+    if _edh_is_zarr_v3(url) is not False:
         return
-    # Once per store per process: `_latest_available` reopens the store for every period, so a
-    # multi-year ingest would otherwise repeat this line thousands of times and bury it.
-    if url in _edh_superseded_warned:
-        return
-    _edh_superseded_warned.add(url)
     latest = ""
     time_dim = next((name for name in ("valid_time", "time") if name in ds.coords), None)
     if time_dim and ds.sizes.get(time_dim):
         try:
-            # A lazy remote read: the coordinate chunk still has to be fetched and decoded, and
-            # that can fail on its own. The timestamp only sharpens the message, so losing it
-            # must not turn a store that opened successfully into a failed ingest.
-            latest = f"; its latest timestamp is {str(ds[time_dim].isel({time_dim: -1}).values)[:16]}"
-        except Exception:  # noqa: BLE001 — enrichment is optional, the warning is not
-            logger.debug("Could not read the latest timestamp of %s for the warning", url, exc_info=True)
-    logger.warning(
-        "Earth Data Hub store %s is Zarr v%d, not v3. EDH applies updates only to its Zarr v3 "
-        "stores, so this one no longer advances%s. See CLIM-955.",
-        url,
-        zarr_format,
-        latest,
+            # A lazy remote read, which can fail on its own. It only sharpens the message.
+            latest = f" Its latest timestamp is {str(ds[time_dim].isel({time_dim: -1}).values)[:16]}."
+        except Exception:  # noqa: BLE001 — enrichment is optional, the refusal is not
+            logger.debug("Could not read the latest timestamp of %s", url, exc_info=True)
+    ds.close()
+    raise RuntimeError(
+        f"Earth Data Hub store {url} is not Zarr v3, and OCS reads only v3 stores. EDH applies "
+        f"updates only to its Zarr v3 stores, so this one no longer advances.{latest} "
+        f"Repoint it at the v3 store for this dataset. See CLIM-955."
     )
 
 
@@ -490,14 +461,14 @@ def _edh_open_zarr(url: str) -> xr.Dataset:
 
     Every store OCS pins is Zarr v3, which carries its metadata inline, so nothing here has to
     say how to find it — the `consolidated` switch that older stores needed is gone with them.
-    `_warn_if_superseded` is what keeps that assumption honest: EDH leaves superseded stores
+    `_require_zarr_v3` is what keeps that assumption honest: EDH leaves superseded stores
     readable, and they fail by going quiet rather than by erroring (CLIM-955).
     """
     opened = xr.open_zarr(
         _edh_authenticated_url(url),
         storage_options={"client_kwargs": {"trust_env": True}},
     )
-    _warn_if_superseded(url, opened)
+    _require_zarr_v3(url, opened)
     return opened  # type: ignore[no-any-return]
 
 

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -387,7 +387,13 @@ _edh_superseded_warned: set[str] = set()
 
 
 def _zarr_format_of(document: object) -> int | None:
-    """Read the Zarr format out of a ``zarr.json`` (v3) or ``.zmetadata`` (v2) document.
+    """Read the Zarr format out of a ``zarr.json`` or a ``.zmetadata`` document.
+
+    OCS reads only v3 stores; it still *recognises* an older one, which is not the same thing.
+    Checking ``zarr.json`` alone would answer "not v3" for a superseded store and for a
+    mistyped URL alike, and those want opposite responses. Reading ``.zmetadata`` as well
+    confirms the target really is a Zarr store and names the version it found, so the warning
+    can say what is wrong rather than that something is.
 
     Every level is shape-checked rather than assumed. A 200 carrying valid JSON of an
     unexpected shape — ``[]``, or ``{"metadata": []}`` — would otherwise raise past the
@@ -482,14 +488,13 @@ def _edh_open_zarr(url: str) -> xr.Dataset:
     (username ``edh``, password = key).  Falls back to netrc when the
     variable is not set.
 
-    Every store OCS pins is Zarr v3, which carries its metadata inline — so there is no
-    consolidated-metadata switch to set. `_warn_if_superseded` is the guard that this stays
-    true: EDH keeps superseded v2 stores readable, and they fail by going quiet, not by
-    erroring (CLIM-955).
+    Every store OCS pins is Zarr v3, which carries its metadata inline, so nothing here has to
+    say how to find it — the `consolidated` switch that older stores needed is gone with them.
+    `_warn_if_superseded` is what keeps that assumption honest: EDH leaves superseded stores
+    readable, and they fail by going quiet rather than by erroring (CLIM-955).
     """
     opened = xr.open_zarr(
         _edh_authenticated_url(url),
-        consolidated=None,
         storage_options={"client_kwargs": {"trust_env": True}},
     )
     _warn_if_superseded(url, opened)

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -11,7 +11,6 @@ import netrc
 import os
 import tempfile
 from datetime import date, datetime, timedelta
-from functools import lru_cache
 from pathlib import Path
 from threading import Lock
 from typing import Any, cast
@@ -370,7 +369,36 @@ _EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v
 _EDH_API_KEY_ENV = "EDH_API_KEY"
 
 
-@lru_cache(maxsize=16)
+# Only *confirmed* formats are cached. `lru_cache` would also memoise a None, so a single
+# transient timeout or 401 would disable the diagnostic for that store until the process
+# restarts — in a long-running worker that is indistinguishable from the store being fine.
+_edh_zarr_format_cache: dict[str, int] = {}
+# One warning per store per process. `_latest_available` reopens the store for every period,
+# so without this a multi-year ingest emits the same line thousands of times and buries it.
+_edh_superseded_warned: set[str] = set()
+
+
+def _zarr_format_of(document: object) -> int | None:
+    """Read the Zarr format out of a ``zarr.json`` (v3) or ``.zmetadata`` (v2) document.
+
+    Every level is shape-checked rather than assumed. A 200 carrying valid JSON of an
+    unexpected shape — ``[]``, or ``{"metadata": []}`` — would otherwise raise past the
+    caller's handler and take down an open that had already succeeded, turning a diagnostic
+    into an outage.
+    """
+    if not isinstance(document, dict):
+        return None
+    inline = document.get("zarr_format")
+    if isinstance(inline, int):
+        return inline
+    metadata = document.get("metadata")
+    if isinstance(metadata, dict):
+        group = metadata.get(".zgroup")
+        if isinstance(group, dict) and isinstance(group.get("zarr_format"), int):
+            return int(group["zarr_format"])
+    return None
+
+
 def _edh_zarr_format(url: str) -> int | None:
     """Return the Zarr format of an EDH store, or None when it cannot be determined.
 
@@ -378,22 +406,24 @@ def _edh_zarr_format(url: str) -> int | None:
     ``.zmetadata``. Reading it off the opened ``xr.Dataset`` is not reliable — xarray does not
     surface the store's format — and inferring it from the URL would go stale the moment a
     store is migrated in place, which is exactly the case this is meant to catch.
-
-    Cached per URL, since it is one extra request per distinct store per process.
     """
-    headers = _edh_basic_auth_header(url)
-    for probe, key in (("zarr.json", "zarr_format"), (".zmetadata", None)):
+    cached = _edh_zarr_format_cache.get(url)
+    if cached is not None:
+        return cached
+    headers = _edh_auth_header(url)
+    for probe in ("zarr.json", ".zmetadata"):
         try:
-            request = Request(f"{_edh_authenticated_url(url)}/{probe}", headers=headers)
+            # The credential-free URL plus an explicit header: `urlopen` does not turn
+            # `user:pass@host` userinfo into Basic Auth the way fsspec does, so probing the
+            # authenticated URL fails for anyone using EDH_API_KEY.
+            request = Request(f"{url}/{probe}", headers=headers)
             with urlopen(request, timeout=15) as response:  # noqa: S310  # fixed https EDH host
-                document = json.loads(response.read())
+                zarr_format = _zarr_format_of(json.loads(response.read()))
         except Exception:  # noqa: BLE001 — a failed probe must never stop a working read
             continue
-        if key and isinstance(document.get(key), int):
-            return int(document[key])
-        nested = document.get("metadata", {}).get(".zgroup", {})
-        if isinstance(nested.get("zarr_format"), int):
-            return int(nested["zarr_format"])
+        if zarr_format is not None:
+            _edh_zarr_format_cache[url] = zarr_format
+            return zarr_format
     return None
 
 
@@ -409,6 +439,11 @@ def _warn_if_superseded(url: str, ds: xr.Dataset) -> None:
     zarr_format = _edh_zarr_format(url)
     if zarr_format is None or zarr_format >= 3:
         return
+    # Once per store per process: `_latest_available` reopens the store for every period, so a
+    # multi-year ingest would otherwise repeat this line thousands of times and bury it.
+    if url in _edh_superseded_warned:
+        return
+    _edh_superseded_warned.add(url)
     latest = ""
     time_dim = next((name for name in ("valid_time", "time") if name in ds.coords), None)
     if time_dim and ds.sizes.get(time_dim):
@@ -452,16 +487,19 @@ def _edh_authenticated_url(url: str) -> str:
     return urlunparse(parts._replace(netloc=f"edh:{token}@{parts.netloc}"))
 
 
-def _edh_basic_auth_header(url: str) -> dict[str, str]:
-    """Basic Auth from netrc, for the plain ``urlopen`` probe.
+def _edh_auth_header(url: str) -> dict[str, str]:
+    """Basic Auth for the plain ``urlopen`` probe, from either credential source.
 
-    Only needed when ``EDH_API_KEY`` is unset and credentials live in netrc: xarray reaches EDH
-    through fsspec with ``trust_env=True``, which reads netrc itself, but ``urlopen`` does not.
-    Without this the probe gets a 401, returns None, and the superseded-store warning silently
-    never fires — which is exactly the failure it exists to prevent.
+    Needed because ``urlopen`` authenticates like neither of the paths that work elsewhere:
+    it does not read netrc (fsspec does, via ``trust_env=True``) and it does not turn
+    ``user:pass@host`` userinfo into an Authorization header (fsspec does that too). So both
+    of the documented ways to give OCS an EDH credential leave the probe unauthenticated, it
+    takes a 401, returns None, and the superseded-store warning silently never fires — the
+    exact failure it exists to prevent.
     """
-    if os.environ.get(_EDH_API_KEY_ENV):
-        return {}  # already carried in the URL
+    token = os.environ.get(_EDH_API_KEY_ENV, "")
+    if token:
+        return _basic_auth("edh", token)
     try:
         host = urlparse(url).hostname or ""
         credentials = netrc.netrc().authenticators(host)
@@ -470,8 +508,12 @@ def _edh_basic_auth_header(url: str) -> dict[str, str]:
     if not credentials:
         return {}
     login, _, password = credentials
-    token = base64.b64encode(f"{login}:{password or ''}".encode()).decode()
-    return {"Authorization": f"Basic {token}"}
+    return _basic_auth(login, password or "")
+
+
+def _basic_auth(login: str, password: str) -> dict[str, str]:
+    encoded = base64.b64encode(f"{login}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {encoded}"}
 
 
 class _ERA5LandEDHBase(BaseDatasetPlugin):

--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import calendar
+import json
+import logging
+import netrc
 import os
 import tempfile
 from datetime import date, datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
 from threading import Lock
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
+from urllib.request import Request, urlopen
 
 import numpy as np
 import xarray as xr
@@ -25,6 +31,8 @@ from open_climate_service.shared.time import (
 from open_climate_service.streaming import BaseDatasetPlugin, monthly_period_ids
 from open_climate_service.transforms.climatology import circular_rolling_mean
 from open_climate_service.transforms.unit_conversion import kelvin_to_celsius, metres_to_mm
+
+logger = logging.getLogger(__name__)
 
 # CDS API long-name variables for reanalysis-era5-land-monthly-means
 _CDS_VARIABLE_NAMES: dict[str, str] = {
@@ -351,11 +359,67 @@ def _deaccumulate_tp(tp: xr.DataArray, time_dim: str = "valid_time") -> xr.DataA
 # Earth Data Hub (EDH) plugins — lazy Zarr access, no per-period downloads
 # ---------------------------------------------------------------------------
 
-# Hourly ERA5-Land: Zarr v2
+# Hourly ERA5-Land: Zarr v2, and **no longer updated** — see the version warning below and
+# CLIM-955. EDH has migrated its ERA5 datasets to Zarr v3 and applies future updates only to
+# the v3 stores. Measured 2026-08-29: this store ends 2026-05-31 while the v3 daily store
+# below reaches 2026-07-31. Repointing needs the v3 URL, which is not discoverable from the
+# API (no catalogue endpoint) and must come from EDH rather than a guess.
 _EDH_HOURLY_URL = "https://api.earthdatahub.destine.eu/era5/reanalysis-era5-land-no-antartica-v0.zarr"
 # Daily ERA5-Land: new DestinE API, Zarr v3, requires an additional subscription
 _EDH_DAILY_URL = "https://api.earthdatahub.destine.eu/era5/era5-land-daily-utc-v1.zarr"
 _EDH_API_KEY_ENV = "EDH_API_KEY"
+
+
+@lru_cache(maxsize=16)
+def _edh_zarr_format(url: str) -> int | None:
+    """Return the Zarr format of an EDH store, or None when it cannot be determined.
+
+    Probed rather than inferred: a v3 store answers ``zarr.json`` and a v2 store answers
+    ``.zmetadata``. Reading it off the opened ``xr.Dataset`` is not reliable — xarray does not
+    surface the store's format — and inferring it from the URL would go stale the moment a
+    store is migrated in place, which is exactly the case this is meant to catch.
+
+    Cached per URL, since it is one extra request per distinct store per process.
+    """
+    headers = _edh_basic_auth_header(url)
+    for probe, key in (("zarr.json", "zarr_format"), (".zmetadata", None)):
+        try:
+            request = Request(f"{_edh_authenticated_url(url)}/{probe}", headers=headers)
+            with urlopen(request, timeout=15) as response:  # noqa: S310  # fixed https EDH host
+                document = json.loads(response.read())
+        except Exception:  # noqa: BLE001 — a failed probe must never stop a working read
+            continue
+        if key and isinstance(document.get(key), int):
+            return int(document[key])
+        nested = document.get("metadata", {}).get(".zgroup", {})
+        if isinstance(nested.get("zarr_format"), int):
+            return int(nested["zarr_format"])
+    return None
+
+
+def _warn_if_superseded(url: str, ds: xr.Dataset) -> None:
+    """Warn when an EDH store is not Zarr v3, because it is no longer being updated.
+
+    EDH keeps superseded stores readable, so a v2 store does not fail — it silently stops
+    advancing. An ingest against one then reports no new periods, which is indistinguishable
+    from "nothing has been published yet" (the same shape as CLIM-952). This makes the stall
+    visible, and reports the store's own latest timestamp so the gap is concrete rather than
+    theoretical.
+    """
+    zarr_format = _edh_zarr_format(url)
+    if zarr_format is None or zarr_format >= 3:
+        return
+    latest = ""
+    time_dim = next((name for name in ("valid_time", "time") if name in ds.coords), None)
+    if time_dim and ds.sizes.get(time_dim):
+        latest = f"; its latest timestamp is {str(ds[time_dim].isel({time_dim: -1}).values)[:16]}"
+    logger.warning(
+        "Earth Data Hub store %s is Zarr v%d, not v3. EDH applies updates only to its Zarr v3 "
+        "stores, so this one no longer advances%s. See CLIM-955.",
+        url,
+        zarr_format,
+        latest,
+    )
 
 
 def _edh_open_zarr(url: str, *, consolidated: bool | None = None) -> xr.Dataset:
@@ -367,15 +431,44 @@ def _edh_open_zarr(url: str, *, consolidated: bool | None = None) -> xr.Dataset:
 
     Pass ``consolidated=True`` for Zarr v2 stores (the hourly ERA5-Land store).
     """
-    token = os.environ.get(_EDH_API_KEY_ENV, "")
-    if token:
-        parts = urlparse(url)
-        url = urlunparse(parts._replace(netloc=f"edh:{token}@{parts.netloc}"))
-    return xr.open_zarr(  # type: ignore[no-any-return]
-        url,
+    opened = xr.open_zarr(
+        _edh_authenticated_url(url),
         consolidated=consolidated,
         storage_options={"client_kwargs": {"trust_env": True}},
     )
+    _warn_if_superseded(url, opened)
+    return opened  # type: ignore[no-any-return]
+
+
+def _edh_authenticated_url(url: str) -> str:
+    """Inject ``EDH_API_KEY`` as HTTP Basic Auth, leaving netrc to handle it when unset."""
+    token = os.environ.get(_EDH_API_KEY_ENV, "")
+    if not token:
+        return url
+    parts = urlparse(url)
+    return urlunparse(parts._replace(netloc=f"edh:{token}@{parts.netloc}"))
+
+
+def _edh_basic_auth_header(url: str) -> dict[str, str]:
+    """Basic Auth from netrc, for the plain ``urlopen`` probe.
+
+    Only needed when ``EDH_API_KEY`` is unset and credentials live in netrc: xarray reaches EDH
+    through fsspec with ``trust_env=True``, which reads netrc itself, but ``urlopen`` does not.
+    Without this the probe gets a 401, returns None, and the superseded-store warning silently
+    never fires — which is exactly the failure it exists to prevent.
+    """
+    if os.environ.get(_EDH_API_KEY_ENV):
+        return {}  # already carried in the URL
+    try:
+        host = urlparse(url).hostname or ""
+        credentials = netrc.netrc().authenticators(host)
+    except (OSError, netrc.NetrcParseError):
+        return {}
+    if not credentials:
+        return {}
+    login, _, password = credentials
+    token = base64.b64encode(f"{login}:{password or ''}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
 
 
 class _ERA5LandEDHBase(BaseDatasetPlugin):

--- a/tests/test_edh_store_version.py
+++ b/tests/test_edh_store_version.py
@@ -1,0 +1,181 @@
+"""Superseded Earth Data Hub stores must announce themselves (CLIM-955)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+import xarray as xr
+
+from open_climate_service.plugins.datasets import era5_land
+
+
+@pytest.fixture(autouse=True)
+def _capturable_logging() -> Any:
+    """Let `caplog` see these records, and start each test with a cold probe cache.
+
+    `startup.py` sets `propagate = False` on the `open_climate_service` logger so the package
+    owns its own handler and does not double-log under uvicorn. That also means caplog, which
+    attaches at the root, never sees a thing — the warning is emitted and the assertion still
+    fails. Re-enabled for the duration of each test rather than weakened in the package.
+    """
+    package_logger = logging.getLogger("open_climate_service")
+    previous = package_logger.propagate
+    package_logger.propagate = True
+    era5_land._edh_zarr_format.cache_clear()
+    yield
+    package_logger.propagate = previous
+    era5_land._edh_zarr_format.cache_clear()
+
+
+def _dataset_with_time(last: str = "2026-05-31T23:00") -> xr.Dataset:
+    import numpy as np
+
+    times = np.array(["2026-05-31T22:00", last], dtype="datetime64[ns]")
+    return xr.Dataset({"t2m": (("valid_time",), [1.0, 2.0])}, coords={"valid_time": times})
+
+
+def test_a_v2_store_warns_and_names_its_latest_timestamp(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The whole point: a superseded store stops advancing without failing.
+
+    An ingest against it reports no new periods, which reads exactly like "nothing has been
+    published yet". The warning is the only thing distinguishing the two.
+    """
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
+
+    assert "Zarr v2, not v3" in caplog.text
+    assert "no longer advances" in caplog.text
+    assert "2026-05-31T23:00" in caplog.text, "the operator needs the gap, not just the version"
+    assert "CLIM-955" in caplog.text
+
+
+def test_a_v3_store_is_silent(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 3)
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
+
+    assert caplog.text == ""
+
+
+def test_an_undeterminable_version_is_silent(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """A failed probe must not cry wolf: unknown is not the same as superseded."""
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: None)
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
+
+    assert caplog.text == ""
+
+
+def test_a_store_with_no_time_axis_still_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        era5_land._warn_if_superseded("https://example.invalid/store.zarr", xr.Dataset({"t2m": 1.0}))
+
+    assert "Zarr v2, not v3" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("document", "probe", "expected"),
+    [
+        ({"zarr_format": 3}, "zarr.json", 3),
+        ({"metadata": {".zgroup": {"zarr_format": 2}}}, ".zmetadata", 2),
+    ],
+)
+def test_the_version_is_probed_from_the_store_not_the_url(
+    monkeypatch: pytest.MonkeyPatch, document: dict[str, Any], probe: str, expected: int
+) -> None:
+    """Inferring from the URL would go stale exactly when a store is migrated in place."""
+    import io
+    import json
+
+    class _Response:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return self._payload
+
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
+        if not request.full_url.endswith(probe):
+            raise OSError("not this one")
+        return _Response(json.dumps(document).encode())
+
+    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
+    assert io  # keep the import meaningful for readers of the fake above
+
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == expected
+
+
+def test_a_probe_that_fails_entirely_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed probe must never stop a working read — the store still opens."""
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> None:
+        raise OSError("network down")
+
+    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
+
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+
+
+def test_the_probe_authenticates_from_netrc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gap the mocked tests missed, and that only a live run exposed.
+
+    xarray reaches EDH through fsspec with `trust_env=True`, which reads netrc itself.
+    `urlopen` does not, so without an explicit header the probe gets a 401, returns None, and
+    the warning silently never fires — the exact failure it exists to prevent.
+    """
+    import json
+
+    monkeypatch.delenv("EDH_API_KEY", raising=False)
+
+    class _Netrc:
+        @staticmethod
+        def authenticators(host: str) -> tuple[str, str, str] | None:
+            return ("edh", "", "secret-key") if host == "api.earthdatahub.destine.eu" else None
+
+    monkeypatch.setattr(era5_land.netrc, "netrc", lambda: _Netrc())
+
+    seen: dict[str, str] = {}
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps({"zarr_format": 3}).encode()
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
+        seen.update(request.headers)
+        return _Response()
+
+    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
+
+    assert era5_land._edh_zarr_format("https://api.earthdatahub.destine.eu/era5/store.zarr") == 3
+    assert any(k.lower() == "authorization" for k in seen), "the probe sent no credentials"
+
+
+def test_no_credentials_anywhere_sends_no_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EDH_API_KEY", raising=False)
+    monkeypatch.setattr(era5_land.netrc, "netrc", lambda: (_ for _ in ()).throw(OSError("no netrc")))
+
+    assert era5_land._edh_basic_auth_header("https://api.earthdatahub.destine.eu/x.zarr") == {}

--- a/tests/test_edh_store_version.py
+++ b/tests/test_edh_store_version.py
@@ -1,373 +1,318 @@
-"""Superseded Earth Data Hub stores must announce themselves (CLIM-955)."""
+"""OCS reads only Zarr v3 Earth Data Hub stores (CLIM-955).
+
+EDH leaves superseded stores readable and applies updates only to its v3 ones, so an older
+store does not fail — it silently stops advancing, and an ingest against it reports no new
+periods. That is indistinguishable from "nothing has been published yet", the same shape as
+CLIM-952. Refusing is what makes it visible.
+
+The three-way verdict is the crux of these tests: *not v3* and *cannot tell* must not be
+confused, or a transient network fault becomes a refused ingest.
+"""
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
+from urllib.error import HTTPError
 
+import numpy as np
 import pytest
 import xarray as xr
 
 from open_climate_service.plugins.datasets import era5_land
 
+_STORE = "https://api.earthdatahub.destine.eu/era5/store.zarr"
+
 
 @pytest.fixture(autouse=True)
-def _capturable_logging() -> Any:
-    """Let `caplog` see these records, and start each test with a cold probe cache.
+def _clean_probe_state() -> Any:
+    """Start each test with cold caches, and let `caplog` see the package logger.
 
     `startup.py` sets `propagate = False` on the `open_climate_service` logger so the package
-    owns its own handler and does not double-log under uvicorn. That also means caplog, which
-    attaches at the root, never sees a thing — the warning is emitted and the assertion still
-    fails. Re-enabled for the duration of each test rather than weakened in the package.
+    owns its handler and does not double-log under uvicorn. That also means caplog, which
+    attaches at the root, sees nothing — the record is emitted and the assertion still fails.
+    Re-enabled per test rather than weakened in the package.
     """
     package_logger = logging.getLogger("open_climate_service")
     previous = package_logger.propagate
     package_logger.propagate = True
-    era5_land._edh_zarr_format_cache.clear()
-    era5_land._edh_zarr_format_unknown_until.clear()
-    era5_land._edh_superseded_warned.clear()
+    era5_land._edh_is_v3_cache.clear()
+    era5_land._edh_unknown_until.clear()
     yield
     package_logger.propagate = previous
-    era5_land._edh_zarr_format_cache.clear()
-    era5_land._edh_zarr_format_unknown_until.clear()
-    era5_land._edh_superseded_warned.clear()
+    era5_land._edh_is_v3_cache.clear()
+    era5_land._edh_unknown_until.clear()
 
 
-def _dataset_with_time(last: str = "2026-05-31T23:00") -> xr.Dataset:
-    import numpy as np
-
+def _dataset(last: str = "2026-05-31T23:00") -> xr.Dataset:
     times = np.array(["2026-05-31T22:00", last], dtype="datetime64[ns]")
     return xr.Dataset({"t2m": (("valid_time",), [1.0, 2.0])}, coords={"valid_time": times})
 
 
-def test_a_v2_store_warns_and_names_its_latest_timestamp(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """The whole point: a superseded store stops advancing without failing.
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self._payload = json.dumps(payload).encode()
 
-    An ingest against it reports no new periods, which reads exactly like "nothing has been
-    published yet". The warning is the only thing distinguishing the two.
-    """
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
+    def read(self) -> bytes:
+        return self._payload
 
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
+    def __enter__(self) -> _Response:
+        return self
 
-    assert "Zarr v2, not v3" in caplog.text
-    assert "no longer advances" in caplog.text
-    assert "2026-05-31T23:00" in caplog.text, "the operator needs the gap, not just the version"
-    assert "CLIM-955" in caplog.text
+    def __exit__(self, *args: object) -> None:
+        return None
 
 
-def test_a_v3_store_is_silent(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 3)
-
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
-
-    assert caplog.text == ""
-
-
-def test_an_undeterminable_version_is_silent(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-    """A failed probe must not cry wolf: unknown is not the same as superseded."""
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: None)
-
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
-
-    assert caplog.text == ""
-
-
-def test_a_store_with_no_time_axis_still_warns(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
-
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        era5_land._warn_if_superseded("https://example.invalid/store.zarr", xr.Dataset({"t2m": 1.0}))
-
-    assert "Zarr v2, not v3" in caplog.text
-
-
-@pytest.mark.parametrize(
-    ("document", "probe", "expected"),
-    [
-        ({"zarr_format": 3}, "zarr.json", 3),
-        ({"metadata": {".zgroup": {"zarr_format": 2}}}, ".zmetadata", 2),
-    ],
-)
-def test_the_version_is_probed_from_the_store_not_the_url(
-    monkeypatch: pytest.MonkeyPatch, document: dict[str, Any], probe: str, expected: int
-) -> None:
-    """Inferring from the URL would go stale exactly when a store is migrated in place."""
-    import io
-    import json
-
-    class _Response:
-        def __init__(self, payload: bytes) -> None:
-            self._payload = payload
-
-        def read(self) -> bytes:
-            return self._payload
-
-        def __enter__(self) -> _Response:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
+def _serving(payload: object) -> Any:
     def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
-        if not request.full_url.endswith(probe):
-            raise OSError("not this one")
-        return _Response(json.dumps(document).encode())
+        return _Response(payload)
 
-    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
-    assert io  # keep the import meaningful for readers of the fake above
-
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == expected
+    return fake_urlopen
 
 
-def test_a_probe_that_fails_entirely_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A failed probe must never stop a working read — the store still opens."""
+def _raising(error: BaseException) -> Any:
+    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
+        raise error
 
-    def fake_urlopen(request: Any, timeout: int = 0) -> None:
-        raise OSError("network down")
-
-    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
-
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+    return fake_urlopen
 
 
-def test_the_probe_authenticates_from_netrc(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The gap the mocked tests missed, and that only a live run exposed.
+def _http_error(code: int) -> HTTPError:
+    return HTTPError(_STORE, code, "nope", {}, None)  # type: ignore[arg-type]
 
-    xarray reaches EDH through fsspec with `trust_env=True`, which reads netrc itself.
-    `urlopen` does not, so without an explicit header the probe gets a 401, returns None, and
-    the warning silently never fires — the exact failure it exists to prevent.
+
+# --- the verdict ------------------------------------------------------------------------
+
+
+def test_a_v3_store_is_recognised(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(era5_land, "urlopen", _serving({"zarr_format": 3}))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is True
+
+
+def test_a_missing_metadata_document_means_not_v3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 on `zarr.json` is an answer: there is no v3 metadata here."""
+    monkeypatch.setattr(era5_land, "urlopen", _raising(_http_error(404)))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is False
+
+
+def test_an_older_declared_format_means_not_v3(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(era5_land, "urlopen", _serving({"zarr_format": 2}))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is False
+
+
+@pytest.mark.parametrize("error", [_http_error(500), _http_error(429), _http_error(401), OSError("timeout")])
+def test_an_unreachable_store_is_unknown_not_non_v3(monkeypatch: pytest.MonkeyPatch, error: BaseException) -> None:
+    """The distinction that matters: a network fault is not evidence about the format.
+
+    Collapsing it into "not v3" would refuse a store that reads perfectly well, every time
+    the network hiccups.
     """
-    import json
+    monkeypatch.setattr(era5_land, "urlopen", _raising(error))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is None
+
+
+@pytest.mark.parametrize("payload", [[], {"metadata": []}, "a string", None, {"zarr_format": "three"}])
+def test_a_response_that_declares_nothing_is_unknown(monkeypatch: pytest.MonkeyPatch, payload: Any) -> None:
+    """A 200 of an unexpected shape — a proxy error page, say — says nothing about the store."""
+    monkeypatch.setattr(era5_land, "urlopen", _serving(payload))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is None
+
+
+# --- refusing ---------------------------------------------------------------------------
+
+
+class _ClosableDataset:
+    """Stands in for an opened store so the close can be observed.
+
+    `xr.Dataset` uses `__slots__`, so `close` cannot be monkeypatched onto a real one. This
+    exposes only what `_require_zarr_v3` touches.
+    """
+
+    def __init__(self, last: str = "2026-05-31T23:00") -> None:
+        self._inner = _dataset(last)
+        self.closed = False
+
+    @property
+    def coords(self) -> Any:
+        return self._inner.coords
+
+    @property
+    def sizes(self) -> Any:
+        return self._inner.sizes
+
+    def __getitem__(self, key: str) -> Any:
+        return self._inner[key]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_a_non_v3_store_is_refused_and_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A refused store must not be left open — the handle would leak on every period."""
+    monkeypatch.setattr(era5_land, "_edh_is_zarr_v3", lambda _url: False)
+    ds = _ClosableDataset()
+
+    with pytest.raises(RuntimeError) as raised:
+        era5_land._require_zarr_v3(_STORE, ds)  # type: ignore[arg-type]
+
+    assert "not Zarr v3" in str(raised.value)
+    assert "2026-05-31T23:00" in str(raised.value), "the operator needs the gap, not just the verdict"
+    assert "CLIM-955" in str(raised.value)
+    assert ds.closed, "the refused store was left open"
+
+
+def test_a_v3_store_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(era5_land, "_edh_is_zarr_v3", lambda _url: True)
+
+    era5_land._require_zarr_v3(_STORE, _dataset())
+
+
+def test_an_undeterminable_store_is_not_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown must never become a refusal — that is a working store broken by a hiccup."""
+    monkeypatch.setattr(era5_land, "_edh_is_zarr_v3", lambda _url: None)
+
+    era5_land._require_zarr_v3(_STORE, _dataset())
+
+
+def test_a_failing_timestamp_read_still_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enrichment is optional; the refusal is not.
+
+    Reading the latest timestamp is a lazy remote fetch that can fail on its own. Losing it
+    must cost the timestamp and nothing else.
+    """
+    monkeypatch.setattr(era5_land, "_edh_is_zarr_v3", lambda _url: False)
+
+    class _Exploding:
+        def isel(self, *args: object, **kwargs: object) -> Any:
+            raise OSError("coordinate chunk could not be fetched")
+
+    ds = _dataset()
+    monkeypatch.setitem(ds._variables, "valid_time", _Exploding())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError) as raised:
+        era5_land._require_zarr_v3(_STORE, ds)
+
+    assert "not Zarr v3" in str(raised.value)
+    assert "latest timestamp" not in str(raised.value)
+
+
+def test_a_store_with_no_time_axis_is_still_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(era5_land, "_edh_is_zarr_v3", lambda _url: False)
+
+    with pytest.raises(RuntimeError, match="not Zarr v3"):
+        era5_land._require_zarr_v3(_STORE, xr.Dataset({"t2m": 1.0}))
+
+
+# --- probe cost -------------------------------------------------------------------------
+
+
+def test_an_unknown_verdict_is_not_reprobed_on_every_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_latest_available` reopens the store for every period.
+
+    Without a negative cache, a store fsspec can read while this probe times out costs 15 s
+    *per period* — the check becomes the bottleneck during exactly the transient failure it
+    is meant to tolerate.
+    """
+    calls = {"n": 0}
+
+    def counting(request: Any, timeout: int = 0) -> _Response:
+        calls["n"] += 1
+        raise OSError("timeout")
+
+    monkeypatch.setattr(era5_land, "urlopen", counting)
+
+    for _ in range(100):
+        assert era5_land._edh_is_zarr_v3(_STORE) is None
+
+    assert calls["n"] == 1, f"probed {calls['n']} times across 100 opens"
+
+
+def test_the_negative_cache_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bounded, not permanent: the check must return without a process restart."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(era5_land, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(era5_land, "urlopen", _raising(OSError("down")))
+    assert era5_land._edh_is_zarr_v3(_STORE) is None
+
+    clock["t"] += era5_land._EDH_UNKNOWN_TTL_SECONDS + 1
+    monkeypatch.setattr(era5_land, "urlopen", _serving({"zarr_format": 3}))
+
+    assert era5_land._edh_is_zarr_v3(_STORE) is True, "the negative cache never expired"
+
+
+def test_a_confirmed_verdict_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def counting(request: Any, timeout: int = 0) -> _Response:
+        calls["n"] += 1
+        return _Response({"zarr_format": 3})
+
+    monkeypatch.setattr(era5_land, "urlopen", counting)
+    for _ in range(10):
+        assert era5_land._edh_is_zarr_v3(_STORE) is True
+
+    assert calls["n"] == 1
+
+
+# --- authentication ---------------------------------------------------------------------
+
+
+def test_the_env_key_path_authenticates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`urlopen` does not turn `user:pass@host` userinfo into Basic Auth the way fsspec does.
+
+    Probing the authenticated URL therefore 401s for anyone using EDH_API_KEY — the whole
+    documented environment-variable path — and the check silently never runs.
+    """
+    import base64
+
+    monkeypatch.setenv("EDH_API_KEY", "mytoken")
+
+    header = era5_land._edh_auth_header(_STORE)
+
+    assert base64.b64decode(header["Authorization"].split()[1]).decode() == "edh:mytoken"
+
+
+def test_the_netrc_path_authenticates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`urlopen` does not read netrc either, though fsspec does via `trust_env=True`."""
+    import base64
 
     monkeypatch.delenv("EDH_API_KEY", raising=False)
 
     class _Netrc:
         @staticmethod
         def authenticators(host: str) -> tuple[str, str, str] | None:
-            return ("edh", "", "secret-key") if host == "api.earthdatahub.destine.eu" else None
+            return ("edh", "", "secret") if host == "api.earthdatahub.destine.eu" else None
 
     monkeypatch.setattr(era5_land.netrc, "netrc", lambda: _Netrc())
 
-    seen: dict[str, str] = {}
+    header = era5_land._edh_auth_header(_STORE)
 
-    class _Response:
-        def read(self) -> bytes:
-            return json.dumps({"zarr_format": 3}).encode()
-
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
-        seen.update(request.headers)
-        return _Response()
-
-    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
-
-    assert era5_land._edh_zarr_format("https://api.earthdatahub.destine.eu/era5/store.zarr") == 3
-    assert any(k.lower() == "authorization" for k in seen), "the probe sent no credentials"
+    assert base64.b64decode(header["Authorization"].split()[1]).decode() == "edh:secret"
 
 
 def test_no_credentials_anywhere_sends_no_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EDH_API_KEY", raising=False)
     monkeypatch.setattr(era5_land.netrc, "netrc", lambda: (_ for _ in ()).throw(OSError("no netrc")))
 
-    assert era5_land._edh_auth_header("https://api.earthdatahub.destine.eu/x.zarr") == {}
+    assert era5_land._edh_auth_header(_STORE) == {}
 
 
-def test_the_env_key_path_also_authenticates(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`urlopen` does not turn `user:pass@host` userinfo into Basic Auth the way fsspec does.
-
-    Probing the authenticated URL therefore 401s for anyone using EDH_API_KEY — the whole
-    documented environment-variable path — and the warning silently never fires. Verified
-    against the live store: the probe returned None with the key set and 2 without it.
-    """
-    monkeypatch.setenv("EDH_API_KEY", "mytoken")
-
-    header = era5_land._edh_auth_header("https://api.earthdatahub.destine.eu/era5/x.zarr")
-
-    assert header["Authorization"].startswith("Basic ")
-    import base64
-
-    assert base64.b64decode(header["Authorization"].split()[1]).decode() == "edh:mytoken"
-
-
-def test_the_probe_never_sends_credentials_in_the_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Userinfo in the probe URL is both useless to urlopen and a credential leak into logs."""
-    import json
-
+def test_the_probe_never_puts_credentials_in_the_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Userinfo in the probe URL is both useless to urlopen and a leak into anything logging."""
     monkeypatch.setenv("EDH_API_KEY", "mytoken")
     seen: list[str] = []
 
-    class _Response:
-        def read(self) -> bytes:
-            return json.dumps({"zarr_format": 3}).encode()
-
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
+    def capturing(request: Any, timeout: int = 0) -> _Response:
         seen.append(request.full_url)
-        return _Response()
+        return _Response({"zarr_format": 3})
 
-    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
-    era5_land._edh_zarr_format("https://api.earthdatahub.destine.eu/era5/x.zarr")
+    monkeypatch.setattr(era5_land, "urlopen", capturing)
+    era5_land._edh_is_zarr_v3(_STORE)
 
     assert seen and all("mytoken" not in url and "@" not in url for url in seen)
-
-
-@pytest.mark.parametrize("document", [[], {"metadata": []}, "a string", None, {"metadata": {".zgroup": []}}])
-def test_a_valid_json_response_of_the_wrong_shape_yields_none(monkeypatch: pytest.MonkeyPatch, document: Any) -> None:
-    """A 200 of an unexpected shape must not raise past the probe.
-
-    It would propagate out of `_edh_open_zarr` and take down a store that had already opened
-    successfully — turning a diagnostic into an outage.
-    """
-    import json
-
-    class _Response:
-        def read(self) -> bytes:
-            return json.dumps(document).encode()
-
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-    monkeypatch.setattr(era5_land, "urlopen", lambda *a, **k: _Response())
-
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-
-
-def test_an_unknown_result_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A transient failure must not permanently disable the check in a long-running worker."""
-    import json
-
-    calls = {"n": 0}
-
-    class _Response:
-        def read(self) -> bytes:
-            return json.dumps({"zarr_format": 2}).encode()
-
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-    def flaky_urlopen(request: Any, timeout: int = 0) -> _Response:
-        calls["n"] += 1
-        if calls["n"] <= 2:  # both probes fail on the first attempt
-            raise OSError("transient")
-        return _Response()
-
-    monkeypatch.setattr(era5_land, "urlopen", flaky_urlopen)
-
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-    # Within the TTL the failure is remembered, so the per-period call path does not re-probe.
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-    assert calls["n"] == 2, "the store was re-probed inside the negative-cache window"
-    # Past it, the check recovers on its own rather than staying off for the process.
-    era5_land._edh_zarr_format_unknown_until.clear()
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == 2
-
-
-def test_the_warning_is_emitted_once_per_store(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """`_latest_available` reopens the store per period; a multi-year ingest would flood."""
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
-
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        for _ in range(50):
-            era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
-
-    assert caplog.text.count("no longer advances") == 1
-
-
-def test_an_unknown_result_is_not_reprobed_on_every_open(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The regression the negative-cache TTL exists to prevent (Copilot, second review).
-
-    `_latest_available` reopens the store for every period. With no negative cache, a store
-    fsspec can read while these separate requests time out costs up to 30 s *per period* —
-    making an optional diagnostic the bottleneck during exactly the transient failure it was
-    written to tolerate.
-    """
-    calls = {"n": 0}
-
-    def always_fails(request: Any, timeout: int = 0) -> None:
-        calls["n"] += 1
-        raise OSError("timeout")
-
-    monkeypatch.setattr(era5_land, "urlopen", always_fails)
-
-    for _ in range(100):
-        assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-
-    assert calls["n"] == 2, f"probed {calls['n']} times across 100 opens; expected one round of 2"
-
-
-def test_the_negative_cache_expires(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bounded, not permanent: the check must come back without a process restart."""
-    clock = {"t": 1000.0}
-    monkeypatch.setattr(era5_land, "monotonic", lambda: clock["t"])
-
-    def always_fails(request: Any, timeout: int = 0) -> None:
-        raise OSError("timeout")
-
-    monkeypatch.setattr(era5_land, "urlopen", always_fails)
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-
-    clock["t"] += era5_land._EDH_UNKNOWN_FORMAT_TTL_SECONDS + 1
-    probed = {"n": 0}
-
-    def counts(request: Any, timeout: int = 0) -> None:
-        probed["n"] += 1
-        raise OSError("still down")
-
-    monkeypatch.setattr(era5_land, "urlopen", counts)
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-    assert probed["n"] > 0, "the negative cache never expired"
-
-
-def test_a_failing_timestamp_read_still_warns(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A diagnostic must not turn a usable store into a failed ingest (Copilot, second review).
-
-    Reading the latest timestamp is a lazy remote fetch that can fail on its own. It only
-    sharpens the message, so losing it must cost the timestamp and nothing else.
-    """
-    import numpy as np
-
-    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
-
-    class _Exploding:
-        def isel(self, *args: object, **kwargs: object) -> Any:
-            raise OSError("coordinate chunk could not be fetched")
-
-    ds = xr.Dataset(
-        {"t2m": (("valid_time",), [1.0])},
-        coords={"valid_time": np.array(["2026-05-31"], dtype="datetime64[ns]")},
-    )
-    monkeypatch.setitem(ds._variables, "valid_time", _Exploding())  # type: ignore[arg-type]
-
-    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
-        era5_land._warn_if_superseded("https://example.invalid/store.zarr", ds)
-
-    assert "Zarr v2, not v3" in caplog.text, "the warning was lost with the timestamp"
-    assert "latest timestamp" not in caplog.text

--- a/tests/test_edh_store_version.py
+++ b/tests/test_edh_store_version.py
@@ -24,10 +24,12 @@ def _capturable_logging() -> Any:
     previous = package_logger.propagate
     package_logger.propagate = True
     era5_land._edh_zarr_format_cache.clear()
+    era5_land._edh_zarr_format_unknown_until.clear()
     era5_land._edh_superseded_warned.clear()
     yield
     package_logger.propagate = previous
     era5_land._edh_zarr_format_cache.clear()
+    era5_land._edh_zarr_format_unknown_until.clear()
     era5_land._edh_superseded_warned.clear()
 
 
@@ -276,7 +278,12 @@ def test_an_unknown_result_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(era5_land, "urlopen", flaky_urlopen)
 
     assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
-    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == 2, "None was cached"
+    # Within the TTL the failure is remembered, so the per-period call path does not re-probe.
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+    assert calls["n"] == 2, "the store was re-probed inside the negative-cache window"
+    # Past it, the check recovers on its own rather than staying off for the process.
+    era5_land._edh_zarr_format_unknown_until.clear()
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == 2
 
 
 def test_the_warning_is_emitted_once_per_store(
@@ -290,3 +297,77 @@ def test_the_warning_is_emitted_once_per_store(
             era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
 
     assert caplog.text.count("no longer advances") == 1
+
+
+def test_an_unknown_result_is_not_reprobed_on_every_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regression the negative-cache TTL exists to prevent (Copilot, second review).
+
+    `_latest_available` reopens the store for every period. With no negative cache, a store
+    fsspec can read while these separate requests time out costs up to 30 s *per period* —
+    making an optional diagnostic the bottleneck during exactly the transient failure it was
+    written to tolerate.
+    """
+    calls = {"n": 0}
+
+    def always_fails(request: Any, timeout: int = 0) -> None:
+        calls["n"] += 1
+        raise OSError("timeout")
+
+    monkeypatch.setattr(era5_land, "urlopen", always_fails)
+
+    for _ in range(100):
+        assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+
+    assert calls["n"] == 2, f"probed {calls['n']} times across 100 opens; expected one round of 2"
+
+
+def test_the_negative_cache_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bounded, not permanent: the check must come back without a process restart."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(era5_land, "monotonic", lambda: clock["t"])
+
+    def always_fails(request: Any, timeout: int = 0) -> None:
+        raise OSError("timeout")
+
+    monkeypatch.setattr(era5_land, "urlopen", always_fails)
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+
+    clock["t"] += era5_land._EDH_UNKNOWN_FORMAT_TTL_SECONDS + 1
+    probed = {"n": 0}
+
+    def counts(request: Any, timeout: int = 0) -> None:
+        probed["n"] += 1
+        raise OSError("still down")
+
+    monkeypatch.setattr(era5_land, "urlopen", counts)
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+    assert probed["n"] > 0, "the negative cache never expired"
+
+
+def test_a_failing_timestamp_read_still_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A diagnostic must not turn a usable store into a failed ingest (Copilot, second review).
+
+    Reading the latest timestamp is a lazy remote fetch that can fail on its own. It only
+    sharpens the message, so losing it must cost the timestamp and nothing else.
+    """
+    import numpy as np
+
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
+
+    class _Exploding:
+        def isel(self, *args: object, **kwargs: object) -> Any:
+            raise OSError("coordinate chunk could not be fetched")
+
+    ds = xr.Dataset(
+        {"t2m": (("valid_time",), [1.0])},
+        coords={"valid_time": np.array(["2026-05-31"], dtype="datetime64[ns]")},
+    )
+    monkeypatch.setitem(ds._variables, "valid_time", _Exploding())  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        era5_land._warn_if_superseded("https://example.invalid/store.zarr", ds)
+
+    assert "Zarr v2, not v3" in caplog.text, "the warning was lost with the timestamp"
+    assert "latest timestamp" not in caplog.text

--- a/tests/test_edh_store_version.py
+++ b/tests/test_edh_store_version.py
@@ -23,10 +23,12 @@ def _capturable_logging() -> Any:
     package_logger = logging.getLogger("open_climate_service")
     previous = package_logger.propagate
     package_logger.propagate = True
-    era5_land._edh_zarr_format.cache_clear()
+    era5_land._edh_zarr_format_cache.clear()
+    era5_land._edh_superseded_warned.clear()
     yield
     package_logger.propagate = previous
-    era5_land._edh_zarr_format.cache_clear()
+    era5_land._edh_zarr_format_cache.clear()
+    era5_land._edh_superseded_warned.clear()
 
 
 def _dataset_with_time(last: str = "2026-05-31T23:00") -> xr.Dataset:
@@ -178,4 +180,113 @@ def test_no_credentials_anywhere_sends_no_header(monkeypatch: pytest.MonkeyPatch
     monkeypatch.delenv("EDH_API_KEY", raising=False)
     monkeypatch.setattr(era5_land.netrc, "netrc", lambda: (_ for _ in ()).throw(OSError("no netrc")))
 
-    assert era5_land._edh_basic_auth_header("https://api.earthdatahub.destine.eu/x.zarr") == {}
+    assert era5_land._edh_auth_header("https://api.earthdatahub.destine.eu/x.zarr") == {}
+
+
+def test_the_env_key_path_also_authenticates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`urlopen` does not turn `user:pass@host` userinfo into Basic Auth the way fsspec does.
+
+    Probing the authenticated URL therefore 401s for anyone using EDH_API_KEY — the whole
+    documented environment-variable path — and the warning silently never fires. Verified
+    against the live store: the probe returned None with the key set and 2 without it.
+    """
+    monkeypatch.setenv("EDH_API_KEY", "mytoken")
+
+    header = era5_land._edh_auth_header("https://api.earthdatahub.destine.eu/era5/x.zarr")
+
+    assert header["Authorization"].startswith("Basic ")
+    import base64
+
+    assert base64.b64decode(header["Authorization"].split()[1]).decode() == "edh:mytoken"
+
+
+def test_the_probe_never_sends_credentials_in_the_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Userinfo in the probe URL is both useless to urlopen and a credential leak into logs."""
+    import json
+
+    monkeypatch.setenv("EDH_API_KEY", "mytoken")
+    seen: list[str] = []
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps({"zarr_format": 3}).encode()
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> _Response:
+        seen.append(request.full_url)
+        return _Response()
+
+    monkeypatch.setattr(era5_land, "urlopen", fake_urlopen)
+    era5_land._edh_zarr_format("https://api.earthdatahub.destine.eu/era5/x.zarr")
+
+    assert seen and all("mytoken" not in url and "@" not in url for url in seen)
+
+
+@pytest.mark.parametrize("document", [[], {"metadata": []}, "a string", None, {"metadata": {".zgroup": []}}])
+def test_a_valid_json_response_of_the_wrong_shape_yields_none(monkeypatch: pytest.MonkeyPatch, document: Any) -> None:
+    """A 200 of an unexpected shape must not raise past the probe.
+
+    It would propagate out of `_edh_open_zarr` and take down a store that had already opened
+    successfully — turning a diagnostic into an outage.
+    """
+    import json
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(document).encode()
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(era5_land, "urlopen", lambda *a, **k: _Response())
+
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+
+
+def test_an_unknown_result_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient failure must not permanently disable the check in a long-running worker."""
+    import json
+
+    calls = {"n": 0}
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps({"zarr_format": 2}).encode()
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def flaky_urlopen(request: Any, timeout: int = 0) -> _Response:
+        calls["n"] += 1
+        if calls["n"] <= 2:  # both probes fail on the first attempt
+            raise OSError("transient")
+        return _Response()
+
+    monkeypatch.setattr(era5_land, "urlopen", flaky_urlopen)
+
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") is None
+    assert era5_land._edh_zarr_format("https://example.invalid/store.zarr") == 2, "None was cached"
+
+
+def test_the_warning_is_emitted_once_per_store(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`_latest_available` reopens the store per period; a multi-year ingest would flood."""
+    monkeypatch.setattr(era5_land, "_edh_zarr_format", lambda _url: 2)
+
+    with caplog.at_level(logging.WARNING, logger=era5_land.logger.name):
+        for _ in range(50):
+            era5_land._warn_if_superseded("https://example.invalid/store.zarr", _dataset_with_time())
+
+    assert caplog.text.count("no longer advances") == 1

--- a/tests/test_edh_store_version.py
+++ b/tests/test_edh_store_version.py
@@ -287,7 +287,10 @@ def test_the_netrc_path_authenticates(monkeypatch: pytest.MonkeyPatch) -> None:
     class _Netrc:
         @staticmethod
         def authenticators(host: str) -> tuple[str, str, str] | None:
-            return ("edh", "", "secret") if host == "api.earthdatahub.destine.eu" else None
+            # The shape a real netrc yields for the entry EDH documents: a password and no
+            # login. The previous fixture returned ("edh", "", "secret"), which netrc never
+            # produces for that entry, and it hid the empty-login case entirely.
+            return ("", "", "secret") if host == "api.earthdatahub.destine.eu" else None
 
     monkeypatch.setattr(era5_land.netrc, "netrc", lambda: _Netrc())
 
@@ -316,3 +319,21 @@ def test_the_probe_never_puts_credentials_in_the_url(monkeypatch: pytest.MonkeyP
     era5_land._edh_is_zarr_v3(_STORE)
 
     assert seen and all("mytoken" not in url and "@" not in url for url in seen)
+
+
+def test_an_explicit_netrc_login_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaulting an empty login must not override one that was actually given."""
+    import base64
+
+    monkeypatch.delenv("EDH_API_KEY", raising=False)
+
+    class _Netrc:
+        @staticmethod
+        def authenticators(host: str) -> tuple[str, str, str] | None:
+            return ("someone", "", "secret")
+
+    monkeypatch.setattr(era5_land.netrc, "netrc", lambda: _Netrc())
+
+    header = era5_land._edh_auth_header(_STORE)
+
+    assert base64.b64decode(header["Authorization"].split()[1]).decode() == "someone:secret"

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -344,6 +344,10 @@ def test_edh_open_zarr_injects_api_key_in_url(monkeypatch: pytest.MonkeyPatch) -
         return MagicMock()
 
     monkeypatch.setenv("EDH_API_KEY", "mytoken")
+    # `_edh_open_zarr` also probes the store's Zarr version on open. Stubbed, or this unit
+    # test reaches the real EDH host: the probe swallows its own failures, so it would still
+    # pass while depending on DNS and spending up to two 15-second timeouts.
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._edh_zarr_format", lambda _url: 3)
     with patch("open_climate_service.plugins.datasets.era5_land.xr.open_zarr", fake_open_zarr):
         _edh_open_zarr("https://api.earthdatahub.destine.eu/era5/test.zarr")
 

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -347,7 +347,7 @@ def test_edh_open_zarr_injects_api_key_in_url(monkeypatch: pytest.MonkeyPatch) -
     # `_edh_open_zarr` also probes the store's Zarr version on open. Stubbed, or this unit
     # test reaches the real EDH host: the probe swallows its own failures, so it would still
     # pass while depending on DNS and spending up to two 15-second timeouts.
-    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._edh_zarr_format", lambda _url: 3)
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._edh_is_zarr_v3", lambda _url: True)
     with patch("open_climate_service.plugins.datasets.era5_land.xr.open_zarr", fake_open_zarr):
         _edh_open_zarr("https://api.earthdatahub.destine.eu/era5/test.zarr")
 


### PR DESCRIPTION
[CLIM-955](https://dhis2.atlassian.net/browse/CLIM-955)

[EDH has migrated its ERA5 datasets to Zarr v3](https://earthdatahub.destine.eu/) and applies future updates **only to the v3 stores**. Superseded stores stay readable, so nothing errors — they just stop advancing. Our pinned hourly store had already stalled at **2026-05-31** while the daily one reached **2026-07-31**.

`era5land_temperature_daily_from_hourly` reads it, so it silently capped while its daily sibling kept moving — and an ingest reports no new periods, which is indistinguishable from "nothing has been published yet". Same shape as CLIM-952.

## What this does

**Repoints the hourly store to Zarr v3.** The dataset slug is `era5-land`, not `era5-land-hourly`, so the store is `era5-land-v0.zarr` — which is why every name I tried first 404'd.

Verified identical in every respect the plugins depend on, before repointing rather than after:

| | v2 (was) | v3 (now) |
| --- | --- | --- |
| longitude | 0–360 | 0–360, so `_edh_lon_360` stays correct |
| latitude | −57.1 … 90.0 | identical |
| time axis | `valid_time` | identical |
| variables | 50, incl. `t2m`, `tp` | identical |
| **latest** | **2026-05-31T23:00** | **2026-07-31T23:00** |

**Drops v2 support entirely.** `_edh_consolidated`, the `consolidated=` parameter and the `.zmetadata` probe are gone — a v3 store carries its metadata inline, so there is nothing to configure and nothing to detect.

**Refuses a store that is not v3.** Reading a superseded store and merely warning about it is still supporting it. The check is now one question: does this store answer `zarr.json` with a `zarr_format` of 3 or more.

## The part worth reviewing closely

**The verdict is three-way, and that is deliberate.** A 404 means there is no v3 metadata and the store is refused. A timeout, a 5xx, or a 200 of an unexpected shape mean the question was not *answered* — and an unanswered question must never become a refusal, or a network hiccup (or a proxy returning its own JSON error page) breaks a store that reads perfectly well.

An unknown verdict is cached for 300 s. Bounded, because `_latest_available` reopens the store for every period and an uncached failure would cost a probe per period; self-healing, because a permanent cache would let one blip disable the check for the process.

A refused store is closed before raising, since that path runs once per period and would otherwise leak handles.

## Measured through the plugin, not just the store

`ERA5LandTempDailyFromHourlyPlugin` against the live source:

- **newest reachable day: 2026-05-31 → 2026-08-23** — nearly three months recovered. Past 2026-07-31 that is the CDS fallback filling the tail beyond EDH, as designed.
- 2024-07-15 (monsoon): mean 18.83 °C across 0.0…31.4 — Himalaya to Terai
- 2024-01-15 (winter): mean 1.67 °C across −20.6…17.4

## Two things the tests hid, both found by running it for real

**The probe was unauthenticated.** `urlopen` authenticates like neither path that works elsewhere: it does not read netrc (fsspec does, via `trust_env=True`) and it does not turn `user:pass@host` userinfo into Basic Auth. So both documented ways of giving OCS an EDH credential left the probe taking a 401, and the check silently never ran. It now sends an explicit header and probes the credential-free URL, which also keeps the key out of anything logging request URLs.

**The netrc fixture was not a shape netrc produces.** It returned `("edh", "", "secret")`; a real netrc for the entry EDH documents yields `("", "", key)` — an empty login — so the code built `:key` while the env-var path built `edh:key`. EDH tolerates both today, so this was not a live failure, but two auth paths disagreeing means one works only by the service's tolerance. Both now send `edh`.

## Tests

25 covering: the three-way verdict across four transport errors and five malformed payloads, that unknown is not refused, that a failing timestamp read still refuses without the timestamp, that a refused store is closed, that 100 opens against a dead probe cost one request, that the negative cache expires, both auth paths, an explicit netrc login, and that credentials never reach the probe URL.

`make lint` clean, **1153 passed, 1 skipped**.

## Also recorded in the ticket

EDH now publishes **ERA5 monthly** as Zarr v3 (1940–present, includes `t2m`, 0.25°). There is still **no ERA5-Land monthly** dataset, which is why `ERA5LandMonthlyPlugin` uses the CDS API. That store is a viable fast path for anyone wanting ERA5 rather than ERA5-Land, but it is a different product — 0.25° and no land-surface model — so it belongs as a separate dataset, not a substitution.


[CLIM-955]: https://dhis2.atlassian.net/browse/CLIM-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ