### PR TITLE
perf(era5-land): fetch monthly means a year at a time (CLIM-956)

### DIFF
--- a/open_climate_service/plugins/datasets/era5_land.py
+++ b/open_climate_service/plugins/datasets/era5_land.py
@@ -199,9 +199,21 @@ class ERA5LandDailyTemperaturePlugin(BaseDatasetPlugin):
 class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
     """Streaming plugin for monthly ERA5-Land means from the Copernicus CDS.
 
-    Fetches one calendar month at a time from the ``reanalysis-era5-land-monthly-means``
-    dataset via the CDS API (``ecmwf-datastores``). Credentials are read from
-    ``~/.cdsapirc`` or the ``CDSAPI_URL`` / ``CDSAPI_KEY`` environment variables.
+    Fetches a **calendar year** per CDS API call from ``reanalysis-era5-land-monthly-means``
+    and caches it, so the twelve ``fetch_period`` calls for that year share one remote
+    request. Credentials are read from ``~/.cdsapirc`` or the ``CDSAPI_URL`` / ``CDSAPI_KEY``
+    environment variables.
+
+    A CDS request costs almost entirely queue and dispatch rather than data — one month over
+    a country extent is about 30 KB — so twelve months cost barely more than one. Measured
+    against the live API: 28.7 s for a single month against 34.4 s for a year, which is 2.9 s
+    per month rather than 28.7 (CLIM-956). Over a 30-year ingest that is roughly 21 minutes
+    instead of 204.
+
+    ``max_concurrency = 1`` is what keeps the cache safe from concurrent fetches, the same
+    reason it is pinned on :class:`ERA5LandCDSHourlyPlugin`. It is not a throughput limit to
+    raise: batching cuts the request count outright, which is both faster and lighter on CDS
+    than running the same number of requests in parallel.
     """
 
     max_concurrency = 1
@@ -213,6 +225,13 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
                 f"ERA5LandMonthlyPlugin: unsupported variable {variable!r}; expected one of {list(_CDS_VARIABLE_NAMES)}"
             )
         self.variable = variable
+        self._cache_lock = Lock()
+        self._cached_year: int | None = None
+        self._cached_bbox: tuple[float, float, float, float] | None = None
+        self._cached_ds: xr.Dataset | None = None
+        # Resolved once per plugin, not once per year: it is a catalogue round-trip, and the
+        # answer cannot move backwards during a single ingest.
+        self._cutoff: date | None = None
 
     async def periods(self, start: str, end: str) -> list[str]:
         cutoff = await asyncio.to_thread(_monthly_availability_cutoff)
@@ -220,13 +239,60 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
 
     def fetch_period(self, period_id: str, bbox: list[float], **_: Any) -> xr.Dataset:
         year, month = int(period_id[:4]), int(period_id[5:7])
-        xmin, ymin, xmax, ymax = map(float, bbox)
+        bbox_tuple = cast(tuple[float, float, float, float], tuple(map(float, bbox)))
 
+        with self._cache_lock:
+            if self._cached_year != year or self._cached_bbox != bbox_tuple:
+                self._cached_ds = self._fetch_year(year, bbox_tuple)
+                self._cached_year = year
+                self._cached_bbox = bbox_tuple
+            yearly = self._cached_ds
+
+        assert yearly is not None
+        # Selected by calendar month rather than by an exact timestamp: the store's own
+        # convention for where in the month the stamp sits is CDS's to decide, and matching on
+        # it would break quietly if that ever changed.
+        stamps = yearly["t"].dt
+        wanted = np.flatnonzero(((stamps.year == year) & (stamps.month == month)).values)
+        if wanted.size == 0:
+            raise ValueError(f"CDS returned no ERA5-Land monthly mean for {period_id}")
+        return _drop_auxiliary_variables(yearly.isel(t=wanted), self.variable)
+
+    def _fetch_year(self, year: int, bbox: tuple[float, float, float, float]) -> xr.Dataset:
+        """Fetch every published month of *year* in as few CDS requests as possible.
+
+        Usually one. Months are grouped by product type first, because
+        :func:`_era5land_monthly_product_type` switches product mid-year for accumulated
+        variables between September 2022 and February 2024 — asking for a whole year in one
+        request there would silently return the buggy product for part of it, which is the
+        very thing that workaround exists to avoid.
+        """
+        if self._cutoff is None:
+            self._cutoff = _monthly_availability_cutoff()
+        cutoff = self._cutoff
+        last_month = cutoff.month if year == cutoff.year else 12
+        if year > cutoff.year:
+            raise ValueError(f"ERA5-Land monthly means are not published for {year}")
+
+        by_product: dict[str, list[int]] = {}
+        for month in range(1, last_month + 1):
+            product = _era5land_monthly_product_type(year, month, self.variable)
+            by_product.setdefault(product, []).append(month)
+
+        parts = [self._fetch_months(year, months, product, bbox) for product, months in by_product.items()]
+        if len(parts) == 1:
+            return parts[0]
+        return xr.concat(parts, dim="t").sortby("t")
+
+    def _fetch_months(
+        self, year: int, months: list[int], product_type: str, bbox: tuple[float, float, float, float]
+    ) -> xr.Dataset:
+        xmin, ymin, xmax, ymax = bbox
         params = {
-            "product_type": [_era5land_monthly_product_type(year, month, self.variable)],
+            "product_type": [product_type],
             "variable": [_CDS_VARIABLE_NAMES[self.variable]],
             "year": [str(year)],
-            "month": [str(month).zfill(2)],
+            "month": [str(month).zfill(2) for month in months],
             "time": ["00:00"],
             "area": [ymax, xmin, ymin, xmax],  # N, W, S, E
             "data_format": "netcdf",
@@ -237,6 +303,8 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
             target = Path(tmp) / "era5land_monthly.nc"
             remote = _CdsClient().submit("reanalysis-era5-land-monthly-means", params)
             remote.download(str(target))
+            # Loaded, not lazy: the framework closes what `fetch_period` returns, and every
+            # month of the year is served from this one object.
             ds = xr.open_dataset(target, engine="netcdf4").load()
 
         ds = _collapse_expver(ds[[self.variable]])
@@ -246,7 +314,7 @@ class ERA5LandMonthlyPlugin(BaseDatasetPlugin):
 
         if self.variable == "t2m":
             ds = kelvin_to_celsius(ds, {"variable": self.variable})
-        return _drop_auxiliary_variables(ds, self.variable)
+        return ds
 
 
 class ERA5LandMonthlyPrecipitationPlugin(ERA5LandMonthlyPlugin):

--- a/tests/test_era5_land_plugin.py
+++ b/tests/test_era5_land_plugin.py
@@ -213,6 +213,12 @@ def test_era5_land_monthly_fetch_renames_coords_and_converts_temperature(
     # fetch_period now does the CDS download inline, then renames + converts. Mock the
     # client + open_dataset so the real fetch_period runs against the raw netCDF.
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", lambda: MagicMock())
+    # The year batch clamps to what CDS publishes; pin it so the test does not reach the
+    # catalogue (CLIM-956).
+    monkeypatch.setattr(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        lambda: date(2026, 7, 1),
+    )
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", lambda *a, **k: raw_ds)
     ds = plugin.fetch_period("2024-01", [-1.0, 8.0, 31.0, 10.0])
 
@@ -478,12 +484,21 @@ def test_monthly_fetch_collapses_expver_so_the_cube_stays_three_dimensional(
     raw_ds["t2m"] = raw_ds["t2m"] + 273.15  # kelvin, as CDS delivers it
 
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", lambda: MagicMock())
+    # The year batch clamps to what CDS publishes; pin it so the test does not reach the
+    # catalogue (CLIM-956).
+    monkeypatch.setattr(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        lambda: date(2026, 7, 1),
+    )
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", lambda *a, **k: raw_ds)
     ds = plugin.fetch_period("2026-06", [-1.0, 8.0, 31.0, 10.0])
 
     assert set(ds.dims) == {"t", "y", "x"}
     assert list(ds.data_vars) == ["t2m"]
-    np.testing.assert_allclose(ds["t2m"].values.ravel(), [1.0, 5.0], atol=1e-3)
+    # One month, not the whole batch. The fixture holds May (final, 1.0) and June
+    # (preliminary, 5.0); asking for June must yield June. The collapse itself is asserted
+    # across both slices by test_collapse_expver_prefers_final_and_fills_from_preliminary.
+    np.testing.assert_allclose(ds["t2m"].values.ravel(), [5.0], atol=1e-3)
 
 
 def test_monthly_fetch_drops_auxiliary_coordinates(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -500,6 +515,12 @@ def test_monthly_fetch_drops_auxiliary_coordinates(monkeypatch: pytest.MonkeyPat
     )
 
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", lambda: MagicMock())
+    # The year batch clamps to what CDS publishes; pin it so the test does not reach the
+    # catalogue (CLIM-956).
+    monkeypatch.setattr(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        lambda: date(2026, 7, 1),
+    )
     monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", lambda *a, **k: raw_ds)
     ds = plugin.fetch_period("2026-06", [-1.0, 8.0, 31.0, 10.0])
 
@@ -558,3 +579,115 @@ def test_hourly_fetch_keeps_its_time_coordinate_after_cleaning(monkeypatch: pyte
 
     assert "t" in ds.coords
     assert "number" not in ds.variables
+
+
+# --- year batching (CLIM-956) -----------------------------------------------------------
+
+
+def _yearly_nc(variable: str, months: list[int], year: int = 2003) -> xr.Dataset:
+    """A CDS response covering several months, valued so each month is identifiable."""
+    times = np.array([f"{year:04d}-{m:02d}-01" for m in months], dtype="datetime64[ns]")
+    values = np.array([[[273.15 + m]] for m in months], dtype=np.float32)
+    return xr.Dataset(
+        {variable: (("valid_time", "latitude", "longitude"), values)},
+        coords={"valid_time": times, "latitude": [9.0], "longitude": [30.0]},
+    )
+
+
+def _capture_cds(monkeypatch: pytest.MonkeyPatch, year: int = 2003) -> list[dict]:
+    """Record every CDS request and answer it with exactly the months it asked for."""
+    submitted: list[dict] = []
+
+    def fake_client() -> MagicMock:
+        client = MagicMock()
+
+        def submit(_collection: str, params: dict) -> MagicMock:
+            submitted.append(params)
+            return MagicMock()
+
+        client.submit.side_effect = submit
+        return client
+
+    def fake_open(*_a: object, **_k: object) -> xr.Dataset:
+        months = [int(m) for m in submitted[-1]["month"]]
+        return _yearly_nc("t2m", months, year)
+
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land._CdsClient", fake_client)
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", fake_open)
+    monkeypatch.setattr(
+        "open_climate_service.plugins.datasets.era5_land._monthly_availability_cutoff",
+        lambda: date(2026, 7, 1),
+    )
+    return submitted
+
+
+def test_a_year_of_months_costs_one_cds_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The point of CLIM-956: request cost is queue and dispatch, not data.
+
+    Measured live, a 12-month request took 34.4 s against 28.7 s for a single month — 2.9 s
+    per month rather than 28.7. Twelve requests per year was paying that overhead twelve times.
+    """
+    submitted = _capture_cds(monkeypatch)
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+
+    for month in range(1, 13):
+        plugin.fetch_period(f"2003-{month:02d}", [-1.0, 8.0, 31.0, 10.0])
+
+    assert len(submitted) == 1, f"{len(submitted)} CDS requests for one year"
+    assert submitted[0]["month"] == [f"{m:02d}" for m in range(1, 13)]
+
+
+def test_each_month_gets_its_own_values_from_the_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Batching must not smear months together — the whole risk of serving from a cache."""
+    _capture_cds(monkeypatch)
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+
+    for month in (1, 6, 12):
+        ds = plugin.fetch_period(f"2003-{month:02d}", [-1.0, 8.0, 31.0, 10.0])
+        assert ds.sizes["t"] == 1
+        assert np.datetime_as_string(ds["t"].values[0], unit="M") == f"2003-{month:02d}"
+        np.testing.assert_allclose(ds["t2m"].values.ravel(), [float(month)], atol=1e-3)
+
+
+def test_a_changed_extent_refetches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cache is keyed on bbox too, or a second country would silently reuse the first."""
+    submitted = _capture_cds(monkeypatch)
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+
+    plugin.fetch_period("2003-01", [-1.0, 8.0, 31.0, 10.0])
+    plugin.fetch_period("2003-01", [80.0, 26.0, 88.0, 30.0])
+
+    assert len(submitted) == 2
+
+
+def test_a_partial_year_asks_only_for_published_months(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Requesting an unpublished month is an error at CDS, not an empty result."""
+    submitted = _capture_cds(monkeypatch, year=2026)
+    plugin = ERA5LandMonthlyPlugin(variable="t2m")
+
+    plugin.fetch_period("2026-03", [-1.0, 8.0, 31.0, 10.0])
+
+    assert submitted[0]["month"] == [f"{m:02d}" for m in range(1, 8)], "asked past the cutoff"
+
+
+def test_a_year_spanning_the_product_type_boundary_is_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accumulated variables switch product mid-year, so a whole-year request would be wrong.
+
+    `_era5land_monthly_product_type` works around a CDS defect in `tp` for September 2022 to
+    February 2024. Batching a whole year across that boundary would silently return the buggy
+    product for part of it — the very thing the workaround exists to prevent.
+    """
+    submitted = _capture_cds(monkeypatch, year=2022)
+
+    def fake_open(*_a: object, **_k: object) -> xr.Dataset:
+        return _yearly_nc("tp", [int(m) for m in submitted[-1]["month"]], 2022)
+
+    monkeypatch.setattr("open_climate_service.plugins.datasets.era5_land.xr.open_dataset", fake_open)
+    plugin = ERA5LandMonthlyPlugin(variable="tp")
+
+    plugin.fetch_period("2022-10", [-1.0, 8.0, 31.0, 10.0])
+
+    assert len(submitted) == 2, "the year was not split at the product-type boundary"
+    by_product = {params["product_type"][0]: [int(m) for m in params["month"]] for params in submitted}
+    assert by_product["monthly_averaged_reanalysis"] == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert by_product["monthly_averaged_reanalysis_by_hour_of_day"] == [9, 10, 11, 12]


### PR DESCRIPTION
[CLIM-956](https://dhis2.atlassian.net/browse/CLIM-956)

`ERA5LandMonthlyPlugin` submitted one CDS request per calendar month. A CDS request costs almost entirely queue and dispatch rather than data — one month over a country extent is about 30 KB — so twelve months cost barely more than one.

Measured against the live API, same bbox and variable:

| request | wall clock | per month |
| --- | --- | --- |
| 1 month | 28.7 s | 28.7 s |
| 12 months | 34.4 s | **2.9 s** |

For the 30-year Nepal ingest that surfaced this — 427 periods — roughly **21 minutes instead of 204**.

## What changed

The plugin fetches a calendar year and caches it, so the twelve `fetch_period` calls for that year share one request. This is the pattern `ERA5LandCDSHourlyPlugin` already uses one level down (it caches a month of hourly data for exactly this reason), not a new mechanism. `commit_batch_size` was already 12, so the cache matches the existing commit rhythm with nothing else to retune.

**`max_concurrency` stays at 1.** It guards the cache, as on the hourly plugin — and raising it was the worse lever anyway. It would have kept 427 requests and merely run them in parallel, risking throttling; batching cuts the count to 36, which is faster *and* lighter on CDS. I offered the concurrency option earlier in the session and should have looked for this first.

## The complication worth reviewing closely

**Months are grouped by product type before batching, not assumed to share one.** `_era5land_monthly_product_type` switches product mid-year for accumulated variables between September 2022 and February 2024, working around a CDS defect in `tp`. A whole-year request across that boundary would silently return the buggy product for part of the year — the very thing the workaround exists to prevent.

Checked across 1991–2026: `t2m` uses one product type throughout and batches whole; `tp` splits at the boundary, so 2022 becomes two requests (months 1–8 and 9–12).

The availability cutoff is also resolved **once per plugin** rather than once per year — it is a catalogue round-trip, and a partial year must not ask for unpublished months.

## Verification

**Against the running ingest's store**, which was written by the old per-month path: five months compared, **worst difference 0.000e+00**. Batching does not change values.

Live batched fetch also returns the right month with a sane annual cycle — 2003 January −0.17 °C, April 11.16, July 15.93, November 6.40.

Five new tests: a year costs one request; each month gets its own values from the batch; a changed bbox refetches; a partial year asks only for published months; and a year spanning the product-type boundary is split into 1–8 and 9–12 with the right product on each.

`make lint` clean, **1133 passed, 1 skipped**.

## One existing test changed

`test_monthly_fetch_collapses_expver_so_the_cube_stays_three_dimensional` asserted that `fetch_period("2026-06")` returned **both** months its mock supplied. That was the old behaviour of handing back whatever came down the wire regardless of the period requested; selecting the requested month is the point of this change, so the expectation now follows it. The expver collapse it was written to guard is still asserted across both slices by `test_collapse_expver_prefers_final_and_fills_from_preliminary`.


[CLIM-956]: https://dhis2.atlassian.net/browse/CLIM-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ