### PR TITLE
feat: declare and publish dataset licences (CLIM-946)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -155,7 +155,7 @@ Current STAC details:
 - STAC collection `license` publishes the dataset template's declared licence — an SPDX
   identifier, or `other` for a licence that has none, with a `rel: license` link and
   `providers` for attribution (CLIM-946). An undeclared licence warns at template load
-  and publishes `other`, never `various`.
+  and publishes `other`.
 - spatial `step` values are rounded for readability while preserving axis direction
 - an opt-in live interoperability smoke test exists at `tests/integration/test_stac_interop.py`
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -152,7 +152,10 @@ Current STAC details:
 
 - the Zarr asset href is `/zarr/{dataset_id}` — the store root — for flat and pyramided stores alike. A pyramided root has no data variables of its own: it carries `multiscales` (with the levels under `0/`, `1/`, …) plus the time coordinate and `spatial_ref`, and its media type gains `profile=multiscales`, which is how a client knows to resolve a level rather than expecting arrays at the root. Python readers do that descent for you via `open_icechunk_dataset` / `open_zarr_dataset`, which always land on level 0
 - temporal extents are normalized to RFC 3339 in both STAC and Datacube temporal extent fields
-- STAC collection `license` currently defaults to `various`
+- STAC collection `license` publishes the dataset template's declared licence — an SPDX
+  identifier, or `other` for a licence that has none, with a `rel: license` link and
+  `providers` for attribution (CLIM-946). An undeclared licence warns at template load
+  and publishes `other`, never `various`.
 - spatial `step` values are rounded for readability while preserving axis direction
 - an opt-in live interoperability smoke test exists at `tests/integration/test_stac_interop.py`
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -269,6 +269,18 @@ Example response:
 What this means:
 
 - `/datasets` is the public native catalog of managed datasets
+- `license` is an SPDX identifier, or `other` for a licence that has none — the Copernicus
+  licence, for instance. It is never absent: a dataset whose template declares no licence
+  reports `other` rather than something that reads as permissive. `license_url` points at the
+  licence text where one is known, and the STAC collection carries the same information as a
+  `rel: license` link plus `providers` for attribution.
+
+  **The licence chain ends at export.** Once values are aggregated and pushed to DHIS2 as a
+  `dataValueSet` they are just numbers in a data element — DHIS2 has no field for licence or
+  attribution, so nothing carries it. If a layer is non-commercial or requires attribution,
+  that obligation has to be handled in how the receiving data element is named and documented.
+  Do not assume the propagation chain reaches further than the STAC collection.
+
 - `description` carries the dataset template's own prose, and is `null` when the template
   declares none. It is where a dataset states what its values actually mean, so it is worth
   reading before using one: `chirps3_precipitation_monthly` is a mean daily rate rather than a

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -275,12 +275,6 @@ What this means:
   licence text where one is known, and the STAC collection carries the same information as a
   `rel: license` link plus `providers` for attribution.
 
-  **The licence chain ends at export.** Once values are aggregated and pushed to DHIS2 as a
-  `dataValueSet` they are just numbers in a data element — DHIS2 has no field for licence or
-  attribution, so nothing carries it. If a layer is non-commercial or requires attribution,
-  that obligation has to be handled in how the receiving data element is named and documented.
-  Do not assume the propagation chain reaches further than the STAC collection.
-
 - `description` carries the dataset template's own prose, and is `null` when the template
   declares none. It is where a dataset states what its values actually mean, so it is worth
   reading before using one: `chirps3_precipitation_monthly` is a mean daily rate rather than a

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -444,9 +444,18 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
             "identifier (license: CC-BY-4.0) or a name and URL for a licence that has none.",
         )
     else:
-        from open_climate_service.shared.licences import UNDECLARED, parse_licence
+        from open_climate_service.shared.licences import (
+            UNDECLARED,
+            licence_declaration_problem,
+            parse_licence,
+        )
 
-        if parse_licence(dataset.get("license")) is UNDECLARED:
+        # A specific complaint where there is one — a contradictory id/name pair reads as
+        # "unreadable" otherwise, which sends the author looking for a typo.
+        problem = licence_declaration_problem(dataset.get("license"))
+        if problem is not None:
+            _warn_once(dataset_id, source, problem)
+        elif parse_licence(dataset.get("license")) is UNDECLARED:
             _warn_once(
                 dataset_id,
                 source,

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -336,6 +336,21 @@ def _load_from_dir(folder: Path) -> list[dict[str, Any]]:
     return datasets
 
 
+def _warn_once(dataset_id: str, source: str, message: str) -> None:
+    """Log a template issue once per (template, source, message) per process.
+
+    Built-in templates are parsed once, but an instance's plugins_dir is deliberately re-read
+    on every request, so without this a questionable template there would log on every request
+    exactly as the built-ins used to (CLIM-904).
+    """
+    key = (dataset_id, source, message)
+    with _WARNED_LOCK:
+        first_time = key not in _WARNED_TEMPLATE_ISSUES
+        _WARNED_TEMPLATE_ISSUES.add(key)
+    if first_time:
+        logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)
+
+
 def _validate_dataset_template(dataset: object, *, source: str) -> None:
     """Validate registry fields required by runtime sync planning."""
     if not isinstance(dataset, dict):
@@ -415,19 +430,34 @@ def _validate_dataset_template(dataset: object, *, source: str) -> None:
     # Surface non-CF/udunits units so unit-aware processes (xclim indices) don't fail
     # cryptically later. Warn rather than reject — not every variable is a physical
     # quantity (e.g. population counts) (#280).
+    # A licence is how a user knows what they may do with a layer, and OCS published the
+    # constant "various" on every collection until CLIM-946. Warn rather than reject: an
+    # instance should not be unable to serve data because a template is missing metadata, and
+    # an undeclared licence still publishes honestly as `other`. But warn every time, because
+    # the default path — say nothing, publish something permissive-sounding — is how a
+    # non-commercial source gets laundered through a derived product.
+    if "license" not in dataset:
+        _warn_once(
+            dataset_id,
+            source,
+            "declares no 'license'; the published collection will say 'other'. Set an SPDX "
+            "identifier (license: CC-BY-4.0) or a name and URL for a licence that has none.",
+        )
+    else:
+        from open_climate_service.shared.licences import UNDECLARED, parse_licence
+
+        if parse_licence(dataset.get("license")) is UNDECLARED:
+            _warn_once(
+                dataset_id,
+                source,
+                f"has an unreadable 'license' value {dataset.get('license')!r}; treating it as "
+                "undeclared. Expected an SPDX identifier, or a mapping with 'name' and 'url'.",
+            )
+
     units = dataset.get("units")
     if isinstance(units, str):
         from open_climate_service.shared.cf import validate_units
 
         message = validate_units(units)
         if message:
-            # Once per (template, source, message) per process. Built-in templates are now
-            # parsed once, but an instance's plugins_dir is deliberately re-read on every
-            # request, so without this a questionable unit there would log on every request
-            # exactly as the built-ins used to (CLIM-904).
-            key = (dataset_id, source, message)
-            with _WARNED_LOCK:
-                first_time = key not in _WARNED_TEMPLATE_ISSUES
-                _WARNED_TEMPLATE_ISSUES.add(key)
-            if first_time:
-                logger.warning("Dataset template '%s' in %s: %s", dataset_id, source, message)
+            _warn_once(dataset_id, source, message)

--- a/open_climate_service/ingestions/schemas.py
+++ b/open_climate_service/ingestions/schemas.py
@@ -186,6 +186,15 @@ class DatasetRecord(BaseModel):
     resolution: str | None = Field(default=None, description="Native spatial resolution summary.")
     source: str | None = Field(default=None, description="Upstream source name.")
     source_url: str | None = Field(default=None, description="Upstream source documentation URL.")
+    license: str | None = Field(
+        default=None,
+        description=(
+            "SPDX identifier for the dataset's licence, or 'other' when the licence has no "
+            "SPDX identifier. Never absent: an undeclared licence reports 'other' rather than "
+            "something that reads as permissive."
+        ),
+    )
+    license_url: str | None = Field(default=None, description="URL of the licence text, when known.")
     extent: ArtifactCoverage = Field(description="Current covered spatial and temporal extent of the dataset.")
     last_updated: datetime = Field(
         description="Timestamp when Open Climate Service last materialized or updated the dataset."

--- a/open_climate_service/ingestions/schemas.py
+++ b/open_climate_service/ingestions/schemas.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from open_climate_service.shared.licences import STAC_LICENSE_OTHER
+
 
 class ArtifactFormat(StrEnum):
     """Supported stored artifact formats."""
@@ -186,8 +188,8 @@ class DatasetRecord(BaseModel):
     resolution: str | None = Field(default=None, description="Native spatial resolution summary.")
     source: str | None = Field(default=None, description="Upstream source name.")
     source_url: str | None = Field(default=None, description="Upstream source documentation URL.")
-    license: str | None = Field(
-        default=None,
+    license: str = Field(
+        default=STAC_LICENSE_OTHER,
         description=(
             "SPDX identifier for the dataset's licence, or 'other' when the licence has no "
             "SPDX identifier. Never absent: an undeclared licence reports 'other' rather than "

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -50,6 +50,7 @@ from open_climate_service.ingestions.schemas import (
 )
 from open_climate_service.ingestions.sync_engine import SyncConfigurationError, plan_sync, run_sync
 from open_climate_service.publications.services import managed_dataset_id_for, publish_artifact
+from open_climate_service.shared.licences import DatasetLicence
 from open_climate_service.shared.time import (
     datetime_to_period_string,
     dekad_start,
@@ -1342,6 +1343,8 @@ def _build_dataset_record(dataset_id: str, artifacts: list[ArtifactRecord]) -> D
         resolution=_as_optional_str(source_dataset.get("resolution")),
         source=_as_optional_str(source_dataset.get("source")),
         source_url=_as_optional_str(source_dataset.get("source_url")),
+        license=_licence_for(source_dataset).stac_license,
+        license_url=_licence_for(source_dataset).url,
         extent=latest.coverage,
         last_updated=latest.created_at,
         links=_dataset_links(dataset_id, latest),
@@ -1393,6 +1396,13 @@ def _dataset_links(dataset_id: str, latest: ArtifactRecord) -> list[DatasetAcces
 
 def _as_optional_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _licence_for(source_dataset: dict[str, Any]) -> "DatasetLicence":
+    """The dataset's parsed licence (CLIM-946), never None — undeclared resolves to `other`."""
+    from open_climate_service.shared.licences import parse_licence
+
+    return parse_licence(source_dataset.get("license"))
 
 
 def _as_optional_text(value: object) -> str | None:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -680,6 +680,13 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
     if template is None:
         raise ValueError(f"Auto-registered dataset template for '{dataset_id}' could not be reloaded")
 
+    # Also check a template that already existed. The licence rule used to run only while
+    # *synthesising* one, and CLIM-946 recommends pre-registering workflow outputs to control
+    # their display — so the recommended path skipped the check entirely, and a pre-registered
+    # CC0 template could publish data derived from CC-BY-NC. An undeclared template left by an
+    # older run is also migrated here rather than staying undeclared forever.
+    template = _enforce_licence_on_loaded_template(dataset_id, template, source_template)
+
     # Prefer an explicit option, then the registered template's display name, and
     # only fall back to the raw id so published collections read as e.g.
     # "Mosquito hotspots (Rwanda 2018 Q1)" rather than "mosquito_hotspots".
@@ -845,14 +852,70 @@ def _apply_derived_licence(
         template["providers"] = merged
 
 
+def _enforce_licence_on_loaded_template(
+    dataset_id: str, template: dict[str, Any], source_template: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Check an already-registered output template against the source it is derived from.
+
+    Returns the template, with an inherited licence filled in when it had none. Refuses when
+    the registered licence would drop an obligation of the source, because a pre-registered
+    template is not a licence decision the source can be overruled by.
+    """
+    if not isinstance(source_template, dict):
+        return template
+
+    from open_climate_service.shared.licences import parse_licence, refuses_publication
+
+    source_licence = parse_licence(source_template.get("license"))
+    declared_raw = template.get("license")
+
+    if declared_raw is None:
+        inherited = source_template.get("license")
+        if inherited is None:
+            return template
+        logger.info(
+            "Output template %s declares no licence; inheriting %s from %s",
+            dataset_id,
+            source_licence.label,
+            source_template.get("id"),
+        )
+        updated = {**template, "license": inherited}
+        providers = source_template.get("providers")
+        if template.get("providers") is None and isinstance(providers, list) and providers:
+            updated["providers"] = providers
+        return updated
+
+    refusal = refuses_publication(parse_licence(declared_raw), [source_licence])
+    if refusal:
+        raise ValueError(
+            f"Registered output template {dataset_id!r} cannot receive data derived from "
+            f"{source_template.get('id')!r}: {refusal}"
+        )
+    return template
+
+
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the source dataset template referenced in save_result options, if any."""
+    """Return the source dataset template referenced in save_result options, if any.
+
+    Raises when a `source_dataset_id` is given but does not resolve. Returning None there
+    would silently mean "not derived from anything", which disables licence propagation
+    entirely — so a typo in the id would let a permissive output be published from a
+    restrictive source, with no error anywhere (CLIM-946).
+    """
     source_dataset_id = options.get("source_dataset_id")
     if not isinstance(source_dataset_id, str) or not source_dataset_id:
         return None
     from open_climate_service.data_registry.services import datasets as _reg
 
-    return _reg.get_dataset(source_dataset_id)
+    template = _reg.get_dataset(source_dataset_id)
+    if template is None:
+        raise ValueError(
+            f"save_result declares source_dataset_id {source_dataset_id!r}, which is not a "
+            f"registered dataset template. Fix the id, or omit it if this output is not "
+            f"derived from another dataset — it governs which licence and attribution the "
+            f"output inherits."
+        )
+    return template
 
 
 def _derive_period_type(

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -680,13 +680,6 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
     if template is None:
         raise ValueError(f"Auto-registered dataset template for '{dataset_id}' could not be reloaded")
 
-    # Also check a template that already existed. The licence rule used to run only while
-    # *synthesising* one, and CLIM-946 recommends pre-registering workflow outputs to control
-    # their display — so the recommended path skipped the check entirely, and a pre-registered
-    # CC0 template could publish data derived from CC-BY-NC. An undeclared template left by an
-    # older run is also migrated here rather than staying undeclared forever.
-    template = _enforce_licence_on_loaded_template(dataset_id, template, source_template)
-
     # Prefer an explicit option, then the registered template's display name, and
     # only fall back to the raw id so published collections read as e.g.
     # "Mosquito hotspots (Rwanda 2018 Q1)" rather than "mosquito_hotspots".
@@ -780,212 +773,14 @@ def _recover_temporal_from_attrs(ds: Any) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _apply_derived_licence(
-    template: dict[str, Any], options: dict[str, Any], source_template: dict[str, Any] | None
-) -> None:
-    """Set the derived product's licence, and refuse one that drops its input's obligations.
-
-    A derived product is a derivative work: a water mask computed from CC-BY-NC imagery
-    inherits the restriction. Before CLIM-946 this path published every derived collection as
-    `various`, which is licence laundering by accident — and it is the *default* path, so
-    nothing had to go wrong for it to happen.
-
-    An input whose licence is not understood is kept in the comparison rather than filtered
-    out. Dropping it would turn "unlabelled source" into "no inputs", and a permissive output
-    would then sail past the check — which is exactly what an earlier version of this function
-    did, while the unit tests on `refuses_publication` all passed.
-
-    WARNING: ONE INPUT, NOT ALL OF THEM. OCS records a single `source_dataset_id` on
-    save_result, so that is the only input whose licence can be read here. A process with
-    several inputs — `compute_anomaly` takes an observed dataset *and* a normal — propagates
-    only from the one it was told about. If the other were more restrictive, this would not
-    catch it. Closing that needs save_result to carry every contributing dataset id, which is a
-    change to the process graph contract rather than to this function.
-    """
-    from open_climate_service.shared.licences import (
-        parse_licence,
-        refuses_derivation,
-        refuses_publication,
-    )
-
-    # Only a *declared source* counts as an input. A dataset with no source_dataset_id is not
-    # derived from anything, so there is nothing to inherit and nothing to check.
-    inputs = []
-    if isinstance(source_template, dict):
-        inputs.append(parse_licence(source_template.get("license")))
-
-    explicit = options.get("license")
-    if explicit is not None:
-        declared = parse_licence(explicit)
-        refusal = refuses_publication(declared, inputs)
-        if refusal:
-            raise ValueError(refusal)
-        template["license"] = explicit
-    elif isinstance(source_template, dict) and source_template.get("license") is not None:
-        # No explicit licence: inherit the input's rather than leaving it undeclared, which is
-        # the point — the derived product must not become permissive by omission.
-        #
-        # Inheriting still has to clear the no-derivatives bar. Carrying the licence forward
-        # answers the relicensing question, so the obligation comparison has nothing to say
-        # here, but an ND input forbids the derivative work itself — under any licence,
-        # including its own. Without this the check was reachable only by *naming* the licence:
-        # `license: CC-BY-ND-4.0` was refused while saying nothing published the same data.
-        refusal = refuses_derivation(inputs)
-        if refusal:
-            raise ValueError(refusal)
-        template["license"] = source_template["license"]
-        logger.info(
-            "Derived dataset %s inherits licence %s from %s",
-            template.get("id"),
-            inputs[0].label,
-            options.get("source_dataset_id"),
-        )
-
-    merged = _merge_providers(
-        source_template.get("providers") if isinstance(source_template, dict) else None,
-        options.get("providers"),
-    )
-    if merged:
-        template["providers"] = merged
-
-
-def _merge_providers(*groups: Any) -> list[Any]:
-    """Combine provider lists in order, dropping repeats of a name already seen.
-
-    Merged, not replaced. Attribution is a licence condition, so dropping the source's
-    licensor would breach it even while the obligation check still passes — and
-    `providers: []` or a list naming only the derived product's author would have done
-    exactly that. Source providers come first so the upstream licensor survives a derived
-    template that names only its own author.
-    """
-    merged: list[Any] = []
-    seen: set[str] = set()
-    for group in groups:
-        if not isinstance(group, list):
-            continue
-        for entry in group:
-            name = entry.get("name") if isinstance(entry, dict) else None
-            key = name.strip().lower() if isinstance(name, str) else None
-            if key is None or key in seen:
-                continue
-            seen.add(key)
-            merged.append(entry)
-    return merged
-
-
-def _enforce_licence_on_loaded_template(
-    dataset_id: str, template: dict[str, Any], source_template: dict[str, Any] | None
-) -> dict[str, Any]:
-    """Check an already-registered output template against the source it is derived from.
-
-    Returns the template, with an inherited licence and the source's providers filled in.
-    Refuses when the registered licence would drop an obligation of the source, because a
-    pre-registered template is not a licence decision the source can be overruled by.
-
-    The source's providers are merged even when the registered licence already passes the
-    obligation check. Attribution is a condition of the licence, not of the identifier, so a
-    template that declares `CC-BY-NC-4.0` and lists only its own author satisfies the check
-    and still publishes without naming the licensor it has to credit.
-
-    Any change is written back to the registry. STAC reads the licence and providers from the
-    on-disk template when it builds the collection (`stac.services.build_collection`), so an
-    in-memory fix would leave the published collection exactly as wrong as before — the
-    enforcement would hold only for the fields this publish happens to consult.
-    """
-    if not isinstance(source_template, dict):
-        return template
-
-    from open_climate_service.shared.licences import (
-        parse_licence,
-        refuses_derivation,
-        refuses_publication,
-    )
-
-    source_licence = parse_licence(source_template.get("license"))
-    declared_raw = template.get("license")
-    inherited = source_template.get("license")
-    updates: dict[str, Any] = {}
-
-    def refuse(reason: str) -> None:
-        raise ValueError(
-            f"Registered output template {dataset_id!r} cannot receive data derived from "
-            f"{source_template.get('id')!r}: {reason}"
-        )
-
-    if declared_raw is None:
-        if inherited is not None:
-            # Inheriting answers the relicensing question but not whether the derivation was
-            # allowed at all; see the same check in `_apply_derived_licence`.
-            refusal = refuses_derivation([source_licence])
-            if refusal:
-                refuse(refusal)
-            logger.info(
-                "Output template %s declares no licence; inheriting %s from %s",
-                dataset_id,
-                source_licence.label,
-                source_template.get("id"),
-            )
-            updates["license"] = inherited
-    else:
-        refusal = refuses_publication(parse_licence(declared_raw), [source_licence])
-        if refusal:
-            refuse(refusal)
-
-    merged = _merge_providers(source_template.get("providers"), template.get("providers"))
-    if merged and merged != template.get("providers"):
-        updates["providers"] = merged
-
-    if not updates:
-        return template
-    return _persist_template_updates(dataset_id, template, updates)
-
-
-def _persist_template_updates(dataset_id: str, template: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
-    """Return `template` with `updates` applied, written back to the instance registry.
-
-    A failed write is logged, not raised: the licence and providers are already correct on the
-    returned template, so the publish should go ahead rather than abort over a read-only
-    templates directory. The next publish recomputes the same updates, so nothing is lost
-    permanently — what is lost is only the STAC collection's view of them until then.
-    """
-    updated = {**template, **updates}
-    from open_climate_service.data_registry.services import datasets as _reg
-
-    try:
-        _reg.write_dataset_template(updated, overwrite=True)
-    except Exception:
-        logger.warning(
-            "Could not persist licence metadata %s onto dataset template %s; the published "
-            "STAC collection will keep the registered values",
-            sorted(updates),
-            dataset_id,
-            exc_info=True,
-        )
-    return updated
-
-
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the source dataset template referenced in save_result options, if any.
-
-    Raises when a `source_dataset_id` is given but does not resolve. Returning None there
-    would silently mean "not derived from anything", which disables licence propagation
-    entirely — so a typo in the id would let a permissive output be published from a
-    restrictive source, with no error anywhere (CLIM-946).
-    """
+    """Return the source dataset template referenced in save_result options, if any."""
     source_dataset_id = options.get("source_dataset_id")
     if not isinstance(source_dataset_id, str) or not source_dataset_id:
         return None
     from open_climate_service.data_registry.services import datasets as _reg
 
-    template = _reg.get_dataset(source_dataset_id)
-    if template is None:
-        raise ValueError(
-            f"save_result declares source_dataset_id {source_dataset_id!r}, which is not a "
-            f"registered dataset template. Fix the id, or omit it if this output is not "
-            f"derived from another dataset — it governs which licence and attribution the "
-            f"output inherits."
-        )
-    return template
+    return _reg.get_dataset(source_dataset_id)
 
 
 def _derive_period_type(
@@ -1047,8 +842,6 @@ def _derive_managed_dataset_template(
         inherited = source_template.get(field) if isinstance(source_template, dict) else None
         if isinstance(inherited, str) and inherited:
             template[field] = inherited
-
-    _apply_derived_licence(template, options, source_template)
 
     return template
 

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -802,7 +802,11 @@ def _apply_derived_licence(
     catch it. Closing that needs save_result to carry every contributing dataset id, which is a
     change to the process graph contract rather than to this function.
     """
-    from open_climate_service.shared.licences import parse_licence, refuses_publication
+    from open_climate_service.shared.licences import (
+        parse_licence,
+        refuses_derivation,
+        refuses_publication,
+    )
 
     # Only a *declared source* counts as an input. A dataset with no source_dataset_id is not
     # derived from anything, so there is nothing to inherit and nothing to check.
@@ -820,6 +824,15 @@ def _apply_derived_licence(
     elif isinstance(source_template, dict) and source_template.get("license") is not None:
         # No explicit licence: inherit the input's rather than leaving it undeclared, which is
         # the point — the derived product must not become permissive by omission.
+        #
+        # Inheriting still has to clear the no-derivatives bar. Carrying the licence forward
+        # answers the relicensing question, so the obligation comparison has nothing to say
+        # here, but an ND input forbids the derivative work itself — under any licence,
+        # including its own. Without this the check was reachable only by *naming* the licence:
+        # `license: CC-BY-ND-4.0` was refused while saying nothing published the same data.
+        refusal = refuses_derivation(inputs)
+        if refusal:
+            raise ValueError(refusal)
         template["license"] = source_template["license"]
         logger.info(
             "Derived dataset %s inherits licence %s from %s",
@@ -828,17 +841,26 @@ def _apply_derived_licence(
             options.get("source_dataset_id"),
         )
 
-    # Merged, not replaced. Attribution is a licence condition, so dropping the source's
-    # licensor would breach it even while the obligation check still passes — and
-    # `providers: []` or a list naming only the derived product's author would have done
-    # exactly that. Source providers come first, then any the output declares, with duplicates
-    # by name removed so a caller repeating the source does not double it.
-    merged: list[Any] = []
-    seen: set[str] = set()
-    for group in (
+    merged = _merge_providers(
         source_template.get("providers") if isinstance(source_template, dict) else None,
         options.get("providers"),
-    ):
+    )
+    if merged:
+        template["providers"] = merged
+
+
+def _merge_providers(*groups: Any) -> list[Any]:
+    """Combine provider lists in order, dropping repeats of a name already seen.
+
+    Merged, not replaced. Attribution is a licence condition, so dropping the source's
+    licensor would breach it even while the obligation check still passes — and
+    `providers: []` or a list naming only the derived product's author would have done
+    exactly that. Source providers come first so the upstream licensor survives a derived
+    template that names only its own author.
+    """
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for group in groups:
         if not isinstance(group, list):
             continue
         for entry in group:
@@ -848,8 +870,7 @@ def _apply_derived_licence(
                 continue
             seen.add(key)
             merged.append(entry)
-    if merged:
-        template["providers"] = merged
+    return merged
 
 
 def _enforce_licence_on_loaded_template(
@@ -857,41 +878,90 @@ def _enforce_licence_on_loaded_template(
 ) -> dict[str, Any]:
     """Check an already-registered output template against the source it is derived from.
 
-    Returns the template, with an inherited licence filled in when it had none. Refuses when
-    the registered licence would drop an obligation of the source, because a pre-registered
-    template is not a licence decision the source can be overruled by.
+    Returns the template, with an inherited licence and the source's providers filled in.
+    Refuses when the registered licence would drop an obligation of the source, because a
+    pre-registered template is not a licence decision the source can be overruled by.
+
+    The source's providers are merged even when the registered licence already passes the
+    obligation check. Attribution is a condition of the licence, not of the identifier, so a
+    template that declares `CC-BY-NC-4.0` and lists only its own author satisfies the check
+    and still publishes without naming the licensor it has to credit.
+
+    Any change is written back to the registry. STAC reads the licence and providers from the
+    on-disk template when it builds the collection (`stac.services.build_collection`), so an
+    in-memory fix would leave the published collection exactly as wrong as before — the
+    enforcement would hold only for the fields this publish happens to consult.
     """
     if not isinstance(source_template, dict):
         return template
 
-    from open_climate_service.shared.licences import parse_licence, refuses_publication
+    from open_climate_service.shared.licences import (
+        parse_licence,
+        refuses_derivation,
+        refuses_publication,
+    )
 
     source_licence = parse_licence(source_template.get("license"))
     declared_raw = template.get("license")
+    inherited = source_template.get("license")
+    updates: dict[str, Any] = {}
 
-    if declared_raw is None:
-        inherited = source_template.get("license")
-        if inherited is None:
-            return template
-        logger.info(
-            "Output template %s declares no licence; inheriting %s from %s",
-            dataset_id,
-            source_licence.label,
-            source_template.get("id"),
-        )
-        updated = {**template, "license": inherited}
-        providers = source_template.get("providers")
-        if template.get("providers") is None and isinstance(providers, list) and providers:
-            updated["providers"] = providers
-        return updated
-
-    refusal = refuses_publication(parse_licence(declared_raw), [source_licence])
-    if refusal:
+    def refuse(reason: str) -> None:
         raise ValueError(
             f"Registered output template {dataset_id!r} cannot receive data derived from "
-            f"{source_template.get('id')!r}: {refusal}"
+            f"{source_template.get('id')!r}: {reason}"
         )
-    return template
+
+    if declared_raw is None:
+        if inherited is not None:
+            # Inheriting answers the relicensing question but not whether the derivation was
+            # allowed at all; see the same check in `_apply_derived_licence`.
+            refusal = refuses_derivation([source_licence])
+            if refusal:
+                refuse(refusal)
+            logger.info(
+                "Output template %s declares no licence; inheriting %s from %s",
+                dataset_id,
+                source_licence.label,
+                source_template.get("id"),
+            )
+            updates["license"] = inherited
+    else:
+        refusal = refuses_publication(parse_licence(declared_raw), [source_licence])
+        if refusal:
+            refuse(refusal)
+
+    merged = _merge_providers(source_template.get("providers"), template.get("providers"))
+    if merged and merged != template.get("providers"):
+        updates["providers"] = merged
+
+    if not updates:
+        return template
+    return _persist_template_updates(dataset_id, template, updates)
+
+
+def _persist_template_updates(dataset_id: str, template: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Return `template` with `updates` applied, written back to the instance registry.
+
+    A failed write is logged, not raised: the licence and providers are already correct on the
+    returned template, so the publish should go ahead rather than abort over a read-only
+    templates directory. The next publish recomputes the same updates, so nothing is lost
+    permanently — what is lost is only the STAC collection's view of them until then.
+    """
+    updated = {**template, **updates}
+    from open_climate_service.data_registry.services import datasets as _reg
+
+    try:
+        _reg.write_dataset_template(updated, overwrite=True)
+    except Exception:
+        logger.warning(
+            "Could not persist licence metadata %s onto dataset template %s; the published "
+            "STAC collection will keep the registered values",
+            sorted(updates),
+            dataset_id,
+            exc_info=True,
+        )
+    return updated
 
 
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -776,27 +776,32 @@ def _recover_temporal_from_attrs(ds: Any) -> tuple[str | None, str | None]:
 def _apply_derived_licence(
     template: dict[str, Any], options: dict[str, Any], source_template: dict[str, Any] | None
 ) -> None:
-    """Set the derived product's licence, and refuse one more permissive than its input.
+    """Set the derived product's licence, and refuse one that drops its input's obligations.
 
     A derived product is a derivative work: a water mask computed from CC-BY-NC imagery
     inherits the restriction. Before CLIM-946 this path published every derived collection as
     `various`, which is licence laundering by accident — and it is the *default* path, so
     nothing had to go wrong for it to happen.
 
-    ⚠️ ONE INPUT, NOT ALL OF THEM. OCS records a single `source_dataset_id` on save_result, so
-    that is the only input whose licence can be read here. A process with several inputs —
-    `compute_anomaly` takes an observed dataset *and* a normal — propagates only from the one
-    it was told about. If the other input were more restrictive, this would not catch it.
-    Closing that needs save_result to carry every contributing dataset id, which is a change to
-    the process graph contract rather than to this function.
-    """
-    from open_climate_service.shared.licences import UNDECLARED, parse_licence, refuses_publication
+    An input whose licence is not understood is kept in the comparison rather than filtered
+    out. Dropping it would turn "unlabelled source" into "no inputs", and a permissive output
+    would then sail past the check — which is exactly what an earlier version of this function
+    did, while the unit tests on `refuses_publication` all passed.
 
+    WARNING: ONE INPUT, NOT ALL OF THEM. OCS records a single `source_dataset_id` on
+    save_result, so that is the only input whose licence can be read here. A process with
+    several inputs — `compute_anomaly` takes an observed dataset *and* a normal — propagates
+    only from the one it was told about. If the other were more restrictive, this would not
+    catch it. Closing that needs save_result to carry every contributing dataset id, which is a
+    change to the process graph contract rather than to this function.
+    """
+    from open_climate_service.shared.licences import parse_licence, refuses_publication
+
+    # Only a *declared source* counts as an input. A dataset with no source_dataset_id is not
+    # derived from anything, so there is nothing to inherit and nothing to check.
     inputs = []
     if isinstance(source_template, dict):
-        inherited = parse_licence(source_template.get("license"))
-        if inherited is not UNDECLARED:
-            inputs.append(inherited)
+        inputs.append(parse_licence(source_template.get("license")))
 
     explicit = options.get("license")
     if explicit is not None:
@@ -805,20 +810,16 @@ def _apply_derived_licence(
         if refusal:
             raise ValueError(refusal)
         template["license"] = explicit
-        return
-
-    # No explicit licence: inherit the input's rather than leaving it undeclared, which is the
-    # whole point — the derived product must not be more permissive by omission.
-    if inputs:
-        source_licence = source_template.get("license") if isinstance(source_template, dict) else None
-        if source_licence is not None:
-            template["license"] = source_licence
-            logger.info(
-                "Derived dataset %s inherits licence %s from %s",
-                template.get("id"),
-                inputs[0].label,
-                options.get("source_dataset_id"),
-            )
+    elif isinstance(source_template, dict) and source_template.get("license") is not None:
+        # No explicit licence: inherit the input's rather than leaving it undeclared, which is
+        # the point — the derived product must not become permissive by omission.
+        template["license"] = source_template["license"]
+        logger.info(
+            "Derived dataset %s inherits licence %s from %s",
+            template.get("id"),
+            inputs[0].label,
+            options.get("source_dataset_id"),
+        )
 
     providers = options.get("providers")
     if providers is None and isinstance(source_template, dict):

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -821,11 +821,28 @@ def _apply_derived_licence(
             options.get("source_dataset_id"),
         )
 
-    providers = options.get("providers")
-    if providers is None and isinstance(source_template, dict):
-        providers = source_template.get("providers")
-    if isinstance(providers, list) and providers:
-        template["providers"] = providers
+    # Merged, not replaced. Attribution is a licence condition, so dropping the source's
+    # licensor would breach it even while the obligation check still passes — and
+    # `providers: []` or a list naming only the derived product's author would have done
+    # exactly that. Source providers come first, then any the output declares, with duplicates
+    # by name removed so a caller repeating the source does not double it.
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for group in (
+        source_template.get("providers") if isinstance(source_template, dict) else None,
+        options.get("providers"),
+    ):
+        if not isinstance(group, list):
+            continue
+        for entry in group:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            key = name.strip().lower() if isinstance(name, str) else None
+            if key is None or key in seen:
+                continue
+            seen.add(key)
+            merged.append(entry)
+    if merged:
+        template["providers"] = merged
 
 
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -773,6 +773,60 @@ def _recover_temporal_from_attrs(ds: Any) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _apply_derived_licence(
+    template: dict[str, Any], options: dict[str, Any], source_template: dict[str, Any] | None
+) -> None:
+    """Set the derived product's licence, and refuse one more permissive than its input.
+
+    A derived product is a derivative work: a water mask computed from CC-BY-NC imagery
+    inherits the restriction. Before CLIM-946 this path published every derived collection as
+    `various`, which is licence laundering by accident — and it is the *default* path, so
+    nothing had to go wrong for it to happen.
+
+    ⚠️ ONE INPUT, NOT ALL OF THEM. OCS records a single `source_dataset_id` on save_result, so
+    that is the only input whose licence can be read here. A process with several inputs —
+    `compute_anomaly` takes an observed dataset *and* a normal — propagates only from the one
+    it was told about. If the other input were more restrictive, this would not catch it.
+    Closing that needs save_result to carry every contributing dataset id, which is a change to
+    the process graph contract rather than to this function.
+    """
+    from open_climate_service.shared.licences import UNDECLARED, parse_licence, refuses_publication
+
+    inputs = []
+    if isinstance(source_template, dict):
+        inherited = parse_licence(source_template.get("license"))
+        if inherited is not UNDECLARED:
+            inputs.append(inherited)
+
+    explicit = options.get("license")
+    if explicit is not None:
+        declared = parse_licence(explicit)
+        refusal = refuses_publication(declared, inputs)
+        if refusal:
+            raise ValueError(refusal)
+        template["license"] = explicit
+        return
+
+    # No explicit licence: inherit the input's rather than leaving it undeclared, which is the
+    # whole point — the derived product must not be more permissive by omission.
+    if inputs:
+        source_licence = source_template.get("license") if isinstance(source_template, dict) else None
+        if source_licence is not None:
+            template["license"] = source_licence
+            logger.info(
+                "Derived dataset %s inherits licence %s from %s",
+                template.get("id"),
+                inputs[0].label,
+                options.get("source_dataset_id"),
+            )
+
+    providers = options.get("providers")
+    if providers is None and isinstance(source_template, dict):
+        providers = source_template.get("providers")
+    if isinstance(providers, list) and providers:
+        template["providers"] = providers
+
+
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:
     """Return the source dataset template referenced in save_result options, if any."""
     source_dataset_id = options.get("source_dataset_id")
@@ -842,6 +896,8 @@ def _derive_managed_dataset_template(
         inherited = source_template.get(field) if isinstance(source_template, dict) else None
         if isinstance(inherited, str) and inherited:
             template[field] = inherited
+
+    _apply_derived_licence(template, options, source_template)
 
     return template
 

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -23,6 +23,10 @@
   resolution: 5 km x 5 km
   source: CHIRPS v3
   source_url: https://www.chc.ucsb.edu/data/chirps3
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -64,6 +68,10 @@
   resolution: 5 km x 5 km
   source: CHIRPS v3 (monthly)
   source_url: https://www.chc.ucsb.edu/data/chirps3
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -87,6 +95,13 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -101,6 +116,13 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -120,6 +142,13 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: RdBu
     range: [-100.0, 100.0]
@@ -134,6 +163,13 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: RdBu
     range: [-20.0, 20.0]
@@ -148,6 +184,13 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: RdBu
     # Tighter than the daily ±20: a monthly mean rate averages the extremes away, so a measured
@@ -165,6 +208,13 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
+  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
+  # permissive than its input. CC0 is already maximally permissive, so this is a formality
+  # here — but stating it keeps the rule visible rather than implicit.
+  license: CC0-1.0
+  providers:
+    - name: UCSB Climate Hazards Center
+      url: https://www.chc.ucsb.edu/data/chirps
   display:
     colormap: RdBu
     range: [-100.0, 100.0]

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -95,9 +95,6 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center
@@ -116,9 +113,6 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center
@@ -142,9 +136,6 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center
@@ -163,9 +154,6 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center
@@ -184,9 +172,6 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center
@@ -208,9 +193,6 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
-  # Inherited from CHIRPS3: a derived product is a derivative work, so it cannot be more
-  # permissive than its input. CC0 is already maximally permissive, so this is a formality
-  # here — but stating it keeps the rule visible rather than implicit.
   license: CC0-1.0
   providers:
     - name: UCSB Climate Hazards Center

--- a/open_climate_service/plugins/datasets/chirps3.yaml
+++ b/open_climate_service/plugins/datasets/chirps3.yaml
@@ -23,7 +23,7 @@
   resolution: 5 km x 5 km
   source: CHIRPS v3
   source_url: https://www.chc.ucsb.edu/data/chirps3
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -68,7 +68,7 @@
   resolution: 5 km x 5 km
   source: CHIRPS v3 (monthly)
   source_url: https://www.chc.ucsb.edu/data/chirps3
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -95,7 +95,7 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -113,7 +113,7 @@
     kind: static
   units: mm/d
   source: Derived (climate_normal workflow)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -136,7 +136,7 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -154,7 +154,7 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -172,7 +172,7 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps
@@ -193,7 +193,7 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
-  license: CC0-1.0
+  license: CC-BY-4.0
   providers:
     - name: UCSB Climate Hazards Center
       url: https://www.chc.ucsb.edu/data/chirps

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -23,9 +23,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -62,9 +59,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -100,9 +94,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -139,9 +130,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -176,9 +164,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -213,9 +198,6 @@
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -249,9 +231,6 @@
   source: ERA5-Land Reanalysis (Earth Data Hub)
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -284,9 +263,6 @@
   source: ERA5-Land Reanalysis (Earth Data Hub)
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
   license:
-    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
-    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
-    # terms are recorded once rather than re-asserted in every template.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -317,8 +293,6 @@
   units: degC
   source: Derived (climate_normal workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -340,8 +314,6 @@
   units: mm/d
   source: Derived (climate_normal workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -369,8 +341,6 @@
   units: degC
   source: Derived (climate_anomaly workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -390,8 +360,6 @@
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -411,8 +379,6 @@
   units: mm/d
   source: Derived (climate_anomaly workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -438,8 +404,6 @@
   units: degC
   source: Derived (climate_anomaly workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -459,8 +423,6 @@
   units: mm/d
   source: Derived (climate_anomaly workflow)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:
@@ -480,8 +442,6 @@
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
   license:
-    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
-    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
     name: Licence to Use Copernicus Products
     url: https://apps.ecmwf.int/datasets/licences/copernicus/
   providers:

--- a/open_climate_service/plugins/datasets/era5_land.yaml
+++ b/open_climate_service/plugins/datasets/era5_land.yaml
@@ -22,6 +22,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
@@ -52,6 +61,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -81,6 +99,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
@@ -111,6 +138,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -139,6 +175,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
@@ -167,6 +212,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/reanalysis-era5-land
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -194,6 +248,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis (Earth Data Hub)
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
@@ -220,6 +283,15 @@
   resolution: 9 km x 9 km
   source: ERA5-Land Reanalysis (Earth Data Hub)
   source_url: https://earthdatahub.destine.eu/collections/era5/datasets/era5-land-daily
+  license:
+    # No SPDX identifier exists for this, which is why the field accepts a name and URL.
+    # Commercial use resolves from the licence name — see _KNOWN_NAMED_LICENCES, where the
+    # terms are recorded once rather than re-asserted in every template.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -244,6 +316,14 @@
     kind: static
   units: degC
   source: Derived (climate_normal workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-30.0, 30.0]
@@ -259,6 +339,14 @@
   # the days in each calendar month, so the result stays a mean daily rate.
   units: mm/d
   source: Derived (climate_normal workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: blues
     range: [0.0, 20.0]
@@ -280,6 +368,14 @@
     kind: static
   units: degC
   source: Derived (climate_anomaly workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-15.0, 15.0]
@@ -293,6 +389,14 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: RdBu
     range: [-100.0, 100.0]
@@ -306,6 +410,14 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: RdBu
     range: [-20.0, 20.0]
@@ -325,6 +437,14 @@
     kind: static
   units: degC
   source: Derived (climate_anomaly workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: rdbu_r
     range: [-3.0, 3.0]
@@ -338,6 +458,14 @@
     kind: static
   units: mm/d
   source: Derived (climate_anomaly workflow)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: RdBu
     range: [-10.0, 10.0]
@@ -351,6 +479,14 @@
     kind: static
   units: "%"
   source: Derived (climate_anomaly workflow, method=relative)
+  license:
+    # Inherited from ERA5-Land: this is a derived product and a derivative work, so it cannot
+    # be more permissive than its input. No SPDX identifier exists for the Copernicus licence.
+    name: Licence to Use Copernicus Products
+    url: https://apps.ecmwf.int/datasets/licences/copernicus/
+  providers:
+    - name: Copernicus Climate Change Service (C3S)
+      url: https://climate.copernicus.eu/
   display:
     colormap: RdBu
     range: [-100.0, 100.0]

--- a/open_climate_service/plugins/datasets/worldpop.yaml
+++ b/open_climate_service/plugins/datasets/worldpop.yaml
@@ -28,6 +28,10 @@
   resolution: 100m x 100m
   source: WorldPop Global2
   source_url: https://hub.worldpop.org/project/categories?id=3
+  license: CC-BY-4.0
+  providers:
+    - name: WorldPop, University of Southampton
+      url: https://hub.worldpop.org/
   display:
     colormap: reds
     range: [0.5, 100.0]
@@ -59,6 +63,10 @@
   resolution: 100m x 100m
   source: WorldPop Global2
   source_url: https://hub.worldpop.org/project/categories?id=8
+  license: CC-BY-4.0
+  providers:
+    - name: WorldPop, University of Southampton
+      url: https://hub.worldpop.org/
   display:
     colormap: reds
     range: [0.5, 10.0]
@@ -74,6 +82,10 @@
   resolution: 100m x 100m
   source: WorldPop Global2
   source_url: https://hub.worldpop.org/project/categories?id=3
+  license: CC-BY-4.0
+  providers:
+    - name: WorldPop, University of Southampton
+      url: https://hub.worldpop.org/
   display:
     colormap: RdBu
     range: [-50.0, 50.0]

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -1,0 +1,251 @@
+"""Dataset licences: declare them, compare them, and refuse to launder them (CLIM-946).
+
+OCS had no per-dataset licence concept — every collection published the constant `various`,
+whether the data came from ERA5-Land or a non-commercial imagery release. That was tolerable
+while every source was openly licensed. It stopped being tolerable when the August 2026 Nepal
+flood produced the only usable imagery of the event under CC-BY-NC-4.0.
+
+The decision recorded in CLIM-946 is to *allow* non-commercial sources, labelled, rather than
+refuse them: declining the only imagery of a disaster is the opposite of the point. But
+allowing them unlabelled is worse than either, because a derived product is a derivative work.
+A water mask computed from CC-BY-NC imagery inherits the restriction, and publishing it as
+`various` is licence laundering by accident — on the default path, with nothing to catch it.
+
+## Why this is not just a string field
+
+Two licences must be *comparable*, or propagation cannot be checked. So a declaration is
+parsed into a `DatasetLicence` carrying one decisive fact: whether commercial use is allowed.
+Three states, not two — `None` means "we do not know", which is different from "yes" and must
+not be treated as it.
+
+## SPDX where it exists, a name and URL where it does not
+
+The three built-in sources happen to cover every case:
+
+    CHIRPS3     CC0-1.0                              SPDX, public domain
+    WorldPop    CC-BY-4.0                            SPDX
+    ERA5-Land   Licence to Use Copernicus Products   bespoke, no SPDX identifier
+
+Forcing the Copernicus licence into a near-miss SPDX identifier would be a false statement
+about what a user may do, so the field accepts a name plus a URL as well.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# STAC 1.1 wants an SPDX identifier or the literal "other"; it deprecated "proprietary" and
+# never defined "various", which is what OCS was publishing on every collection.
+STAC_LICENSE_OTHER = "other"
+
+# SPDX identifiers known to permit commercial use. Deliberately a small, checked list rather
+# than an attempt at the full SPDX register: an identifier absent here is reported as unknown,
+# which is the safe answer, and adding one is a one-line change with a citation.
+_COMMERCIAL_USE_ALLOWED = frozenset(
+    {
+        "CC0-1.0",
+        "CC-BY-4.0",
+        "CC-BY-3.0",
+        "CC-BY-SA-4.0",
+        "ODbL-1.0",
+        "PDDL-1.0",
+        "Apache-2.0",
+        "MIT",
+        "OGL-UK-3.0",
+    }
+)
+
+# Creative Commons marks a non-commercial licence with an `NC` element, so this catches the
+# whole family — CC-BY-NC-4.0, CC-BY-NC-SA-4.0, CC-BY-NC-ND-4.0 — without enumerating it.
+_NON_COMMERCIAL_MARKER = "-NC"
+
+# Licences with no SPDX identifier, whose terms have been read. Without this a template author
+# has to assert `commercial_use` by hand for every one of them, and an assertion repeated in
+# five templates is an assertion that will eventually be wrong in one of them.
+#
+# Note what this is NOT: a default. An unrecognised licence still resolves to "unknown", never
+# to "commercial use allowed". Defaulting to allowed would mean an author who forgets the flag
+# publishes a restrictive source as permissive — precisely the laundering this module exists to
+# prevent. Each entry here is a licence someone read, not a guess applied wholesale.
+_KNOWN_NAMED_LICENCES: dict[str, bool] = {
+    # "free of charge, worldwide, non-exclusive, royalty free and perpetual", for "any purpose
+    # in so far as it is lawful", with attribution required.
+    "licence to use copernicus products": True,
+    # Free and open including commercial reuse, subject to the Notice's conditions.
+    "copernicus sentinel data legal notice": True,
+    # NASA Earth science data carries no copyright and no use restrictions.
+    "nasa earth science data": True,
+}
+
+# How restrictive a licence is, for picking the one a derived product must carry. Unknown
+# ranks above permissive on purpose: a licence nobody has declared might forbid anything, so
+# inheriting "unknown" from an unlabelled input is honest, and the alternative — assuming
+# permissive — is exactly the laundering this module exists to prevent.
+_RANK_PERMISSIVE = 0
+_RANK_UNKNOWN = 1
+_RANK_NON_COMMERCIAL = 2
+
+
+@dataclass(frozen=True)
+class DatasetLicence:
+    """A licence declaration, parsed into something two datasets can be compared on."""
+
+    identifier: str | None
+    """SPDX identifier, or None when the licence is named rather than identified."""
+
+    name: str | None
+    """Human-readable name, for a licence with no SPDX identifier."""
+
+    url: str | None
+
+    commercial_use: bool | None
+    """True, False, or None for "not known" — which is not the same as True."""
+
+    @property
+    def stac_license(self) -> str:
+        """The value for a STAC collection's `license` field.
+
+        An SPDX identifier when there is one, otherwise the literal `other`, which STAC 1.1
+        defines for exactly this case. Never `various`: that is not a STAC value at all, and it
+        reads as "no restrictions worth mentioning" when the truth may be the opposite.
+        """
+        return self.identifier or STAC_LICENSE_OTHER
+
+    @property
+    def label(self) -> str:
+        """A short human label — the identifier, the name, or an explicit "not declared"."""
+        return self.identifier or self.name or "not declared"
+
+    @property
+    def restrictiveness(self) -> int:
+        if self.commercial_use is False:
+            return _RANK_NON_COMMERCIAL
+        if self.commercial_use is None:
+            return _RANK_UNKNOWN
+        return _RANK_PERMISSIVE
+
+    def is_at_least_as_restrictive_as(self, other: DatasetLicence) -> bool:
+        return self.restrictiveness >= other.restrictiveness
+
+
+UNDECLARED = DatasetLicence(identifier=None, name=None, url=None, commercial_use=None)
+"""What a template without a `license` field resolves to. Published as `other`."""
+
+
+def _commercial_use_for_name(name: str | None) -> bool | None:
+    """Commercial-use status for a licence known by name rather than SPDX identifier.
+
+    Matched on a normalised prefix so a template may add a version or a qualifier — "Licence to
+    Use Copernicus Products v1.2" resolves the same as the bare name — without a new entry.
+    """
+    if not name:
+        return None
+    normalised = " ".join(name.lower().split())
+    for known, commercial in _KNOWN_NAMED_LICENCES.items():
+        if normalised.startswith(known):
+            return commercial
+    return None
+
+
+def _commercial_use_for(identifier: str) -> bool | None:
+    upper = identifier.upper()
+    if _NON_COMMERCIAL_MARKER in upper:
+        return False
+    if identifier in _COMMERCIAL_USE_ALLOWED:
+        return True
+    return None
+
+
+def parse_licence(declared: Any) -> DatasetLicence:
+    """Parse a template's `license` field.
+
+    Accepts either form, because the sources demand both:
+
+        license: CC-BY-4.0
+        license:
+          name: Licence to Use Copernicus Products
+          url: https://apps.ecmwf.int/datasets/licences/copernicus/
+
+    An `id` key is treated as an SPDX identifier, so a bespoke licence can still carry one if
+    it ever gets registered. Anything unparseable resolves to `UNDECLARED` rather than raising:
+    a malformed licence should degrade to "unknown, published as other", not take down the
+    catalogue — and the template validator warns about it separately.
+    """
+    if isinstance(declared, str):
+        spdx = declared.strip()
+        if not spdx:
+            return UNDECLARED
+        return DatasetLicence(
+            identifier=spdx,
+            name=None,
+            url=None,
+            commercial_use=_commercial_use_for(spdx),
+        )
+
+    if isinstance(declared, dict):
+        raw_id = declared.get("id") or declared.get("spdx")
+        identifier: str | None = str(raw_id).strip() if isinstance(raw_id, str) and raw_id.strip() else None
+        raw_name = declared.get("name")
+        name = str(raw_name).strip() if isinstance(raw_name, str) and raw_name.strip() else None
+        raw_url = declared.get("url")
+        url = str(raw_url).strip() if isinstance(raw_url, str) and raw_url.strip() else None
+
+        if identifier is None and name is None:
+            return UNDECLARED
+
+        # An explicit `commercial_use` overrides the lookup, for a licence whose terms we have
+        # actually read. The Copernicus licence is the live example: no SPDX identifier, so the
+        # lookup can only say "unknown", but its text plainly permits commercial use.
+        declared_commercial = declared.get("commercial_use")
+        if isinstance(declared_commercial, bool):
+            commercial_use: bool | None = declared_commercial
+        elif identifier is not None:
+            commercial_use = _commercial_use_for(identifier)
+        else:
+            commercial_use = _commercial_use_for_name(name)
+
+        return DatasetLicence(identifier=identifier, name=name, url=url, commercial_use=commercial_use)
+
+    return UNDECLARED
+
+
+def most_restrictive(licences: list[DatasetLicence]) -> DatasetLicence:
+    """The licence a product derived from these inputs must carry.
+
+    Ties keep the first, so a single-input derivation returns that input's licence unchanged
+    rather than a synthesised equivalent.
+    """
+    if not licences:
+        return UNDECLARED
+    return max(licences, key=lambda licence: licence.restrictiveness)
+
+
+def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
+    """Why publishing `declared` for a product derived from `inputs` must be refused, or None.
+
+    The rule from CLIM-946: a derived product may not claim a licence more permissive than any
+    of its inputs. Refused rather than warned about, because the failure is silent and the
+    output is a derivative work — a warning in a log is not a defence.
+    """
+    if not inputs:
+        return None
+    strictest = most_restrictive(inputs)
+    if declared.is_at_least_as_restrictive_as(strictest):
+        return None
+    return (
+        f"Derived dataset declares licence {declared.label!r} (commercial use: "
+        f"{_describe(declared.commercial_use)}), which is more permissive than its input "
+        f"{strictest.label!r} (commercial use: {_describe(strictest.commercial_use)}). "
+        f"A derived product is a derivative work and inherits the most restrictive licence "
+        f"among its inputs."
+    )
+
+
+def _describe(commercial_use: bool | None) -> str:
+    if commercial_use is None:
+        return "not known"
+    return "allowed" if commercial_use else "not allowed"

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -78,7 +78,42 @@ _SPDX_OBLIGATIONS: dict[str, frozenset[str]] = {
     "CC-BY-NC-ND-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL, NO_DERIVATIVES}),
     "CC-BY-ND-4.0": frozenset({ATTRIBUTION, NO_DERIVATIVES}),
 }
-_SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in _SPDX_OBLIGATIONS}
+# SPDX identifiers that are valid but whose propagation semantics have not been reviewed.
+# Kept separate from `_SPDX_OBLIGATIONS` on purpose: a valid identifier belongs in the STAC
+# `license` field even when OCS cannot yet reason about deriving from it. Downgrading
+# BSD-3-Clause to a free-form name and publishing `other` threw away information the catalogue
+# had — while `known=False` still makes propagation fail closed, which is the safe half.
+_SPDX_UNREVIEWED = frozenset(
+    {
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0-only",
+        "GPL-3.0-or-later",
+        "LGPL-3.0-only",
+        "MPL-2.0",
+        "Unlicense",
+        "CC-BY-2.0",
+        "CC-BY-2.5",
+        "OGL-Canada-2.0",
+    }
+)
+_SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in (*_SPDX_OBLIGATIONS, *_SPDX_UNREVIEWED)}
+
+# Share-alike is not satisfied by carrying "a share-alike obligation" — it requires the same
+# licence, or one the licence itself names as compatible. Without this, ODbL-1.0 and
+# CC-BY-SA-4.0 both reduce to {attribution, share-alike} and each would be accepted in place
+# of the other, and CC-BY-NC-SA-4.0 would be accepted over CC-BY-SA-4.0 because its obligation
+# set is a superset. Both are relicensing that share-alike forbids.
+#
+# Only same-family upgrades are listed. Cross-licence compatibility (CC-BY-SA to GPL, say) is
+# a legal judgement, not a lookup, so it is absent and therefore refused.
+_SHARE_ALIKE_COMPATIBLE: dict[str, frozenset[str]] = {
+    "CC-BY-SA-3.0": frozenset({"CC-BY-SA-3.0", "CC-BY-SA-4.0"}),
+    "CC-BY-SA-4.0": frozenset({"CC-BY-SA-4.0"}),
+    "CC-BY-NC-SA-3.0": frozenset({"CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0"}),
+    "CC-BY-NC-SA-4.0": frozenset({"CC-BY-NC-SA-4.0"}),
+    "ODbL-1.0": frozenset({"ODbL-1.0"}),
+}
 
 # Licences with no SPDX identifier, whose terms have been read. Without this a template author
 # has to restate the obligations by hand for every one, and an assertion repeated in five
@@ -194,7 +229,15 @@ def parse_licence(declared: Any) -> DatasetLicence:
             return UNDECLARED
         spdx = _canonical_spdx(text)
         if spdx is not None:
-            return DatasetLicence(identifier=spdx, name=None, url=None, obligations=_SPDX_OBLIGATIONS[spdx], known=True)
+            return DatasetLicence(
+                identifier=spdx,
+                name=None,
+                url=None,
+                obligations=_SPDX_OBLIGATIONS.get(spdx, frozenset()),
+                # A valid-but-unreviewed identifier is still published as SPDX, but propagation
+                # must fail closed until someone records what it requires.
+                known=spdx in _SPDX_OBLIGATIONS,
+            )
         named = _obligations_for_name(text)
         return DatasetLicence(
             identifier=None,
@@ -221,7 +264,7 @@ def parse_licence(declared: Any) -> DatasetLicence:
         # every compatibility check saw no restrictions — laundering by configuration, which is
         # worse than the silence this module replaced.
         raw_obligations = declared.get("obligations")
-        if identifier is not None:
+        if identifier is not None and identifier in _SPDX_OBLIGATIONS:
             obligations, known = _SPDX_OBLIGATIONS[identifier], True
             if isinstance(raw_obligations, list):
                 logger.warning(
@@ -274,6 +317,15 @@ def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) 
                 f"may be published from it under any licence — including the same one. "
                 f"ND licences forbid distributing adapted material."
             )
+        if SHARE_ALIKE in candidate.obligations:
+            compatible = _SHARE_ALIKE_COMPATIBLE.get(candidate.identifier or "", frozenset())
+            if declared.identifier not in compatible:
+                return (
+                    f"Input {candidate.label!r} is share-alike, so a derived product must carry "
+                    f"that licence or one it names as compatible ({sorted(compatible) or 'none'}), "
+                    f"not {declared.label!r}. Carrying some other share-alike licence is still "
+                    f"relicensing."
+                )
         dropped = declared.drops_obligations_of(candidate)
         if dropped:
             return (

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -210,6 +210,64 @@ def _canonical_spdx(value: str) -> str | None:
     return _SPDX_BY_LOWER.get(value.strip().lower())
 
 
+def _contradiction(identifier: str | None, name: str | None) -> str | None:
+    """Why an identifier and a name cannot both describe this licence, or None.
+
+    An identifier and a name that require different things is a contradiction, not a
+    redundancy. `{id: CC0-1.0, name: <a licence requiring attribution>, url: ...}` would
+    publish `license: CC0-1.0` while the `rel: license` link points at terms that demand
+    credit, and a STAC client reads the field far more often than it fetches the link. There
+    is no basis for picking a winner, so neither is used.
+
+    Only a *recognised* name can be shown to disagree. An unrecognised one is left alone: it
+    is a label and a link, the identifier stays authoritative for the terms, and the common
+    `{id, name, url}` spelling of a single licence has to keep working.
+    """
+    if identifier is None or identifier not in _SPDX_OBLIGATIONS:
+        return None
+    named = _obligations_for_name(name)
+    if named is None or named == _SPDX_OBLIGATIONS[identifier]:
+        return None
+    return (
+        f"declares SPDX identifier {identifier} together with the name {name!r}, which OCS "
+        f"knows to require {sorted(named) or 'nothing'} rather than "
+        f"{sorted(_SPDX_OBLIGATIONS[identifier]) or 'nothing'}; treating the licence as "
+        f"undeclared. Declare whichever one describes the terms, not both."
+    )
+
+
+def licence_declaration_problem(declared: Any) -> str | None:
+    """A specific complaint about a `license` declaration, for the template validator.
+
+    Kept out of `parse_licence` on purpose. That function runs on every STAC and `/datasets`
+    request, and an instance's templates are deliberately re-read each time, so a warning
+    raised there would log on every request for as long as the template existed — the exact
+    behaviour `_warn_once` was added to stop (CLIM-904). Parsing stays silent and pure; this
+    is called once, at the validation boundary, and routed through that deduplicating logger.
+
+    Returns None when there is nothing specific to say. A declaration that is merely
+    unreadable is already reported by the validator's generic message.
+    """
+    if not isinstance(declared, dict):
+        return None
+    raw_id = declared.get("id") or declared.get("spdx")
+    identifier = _canonical_spdx(str(raw_id)) if isinstance(raw_id, str) and raw_id.strip() else None
+    raw_name = declared.get("name")
+    name = str(raw_name).strip() if isinstance(raw_name, str) and raw_name.strip() else None
+
+    contradiction = _contradiction(identifier, name)
+    if contradiction is not None:
+        return contradiction
+
+    if identifier is not None and identifier in _SPDX_OBLIGATIONS and isinstance(declared.get("obligations"), list):
+        return (
+            f"declares explicit 'obligations' alongside the SPDX identifier {identifier}, which "
+            f"already defines its terms; the list is ignored. Remove it, or drop the identifier "
+            f"if the terms genuinely differ."
+        )
+    return None
+
+
 def parse_licence(declared: Any) -> DatasetLicence:
     """Parse a template's `license` field.
 
@@ -269,19 +327,8 @@ def parse_licence(declared: Any) -> DatasetLicence:
         # Only a *recognised* name can be shown to disagree. An unrecognised one is left alone:
         # it is a label and a link, the identifier stays authoritative for the terms, and the
         # common `{id, name, url}` spelling of a single licence has to keep working.
-        if identifier is not None and identifier in _SPDX_OBLIGATIONS:
-            named_obligations = _obligations_for_name(name)
-            if named_obligations is not None and named_obligations != _SPDX_OBLIGATIONS[identifier]:
-                logger.warning(
-                    "Licence declares SPDX identifier %s together with the name %r, which OCS "
-                    "knows to require %s rather than %s. Treating the licence as undeclared: "
-                    "declare whichever one describes the terms, not both.",
-                    identifier,
-                    name,
-                    sorted(named_obligations) or "nothing",
-                    sorted(_SPDX_OBLIGATIONS[identifier]) or "nothing",
-                )
-                return UNDECLARED
+        if _contradiction(identifier, name) is not None:
+            return UNDECLARED
 
         # Order matters. A recognised identifier or name is authoritative, and an explicit
         # `obligations` list is consulted only when neither supplies semantics. Letting the
@@ -291,12 +338,6 @@ def parse_licence(declared: Any) -> DatasetLicence:
         raw_obligations = declared.get("obligations")
         if identifier is not None and identifier in _SPDX_OBLIGATIONS:
             obligations, known = _SPDX_OBLIGATIONS[identifier], True
-            if isinstance(raw_obligations, list):
-                logger.warning(
-                    "Licence %s declares explicit obligations; ignoring them because the SPDX "
-                    "identifier already defines its terms",
-                    identifier,
-                )
         else:
             named = _obligations_for_name(name)
             if named is not None:

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -1,4 +1,4 @@
-"""Dataset licences: declare them, compare them, and refuse to launder them (CLIM-946).
+"""Dataset licences: declare them and publish them honestly (CLIM-946).
 
 OCS had no per-dataset licence concept — every collection published the constant `various`,
 whether the data came from ERA5-Land or a non-commercial imagery release. That was tolerable
@@ -11,12 +11,20 @@ allowing them unlabelled is worse than either, because a derived product is a de
 A water mask computed from CC-BY-NC imagery inherits the restriction, and publishing it as
 `various` is licence laundering by accident — on the default path, with nothing to catch it.
 
+## Scope
+
+This module declares and publishes. Propagating a licence to a derived product — the
+laundering half — is a separate change, because two licences must be *comparable* for that
+and the comparison has to happen at exactly one point in the publish path. Splitting that
+decision across the synthesise and reload paths produced four rounds of fixes that
+contradicted each other, so the obligations recorded below are the input to that work rather
+than the whole of it.
+
 ## Why this is not just a string field
 
-Two licences must be *comparable*, or propagation cannot be checked. So a declaration is
-parsed into a `DatasetLicence` carrying one decisive fact: whether commercial use is allowed.
-Three states, not two — `None` means "we do not know", which is different from "yes" and must
-not be treated as it.
+A declaration is parsed into a `DatasetLicence` carrying one decisive fact: whether
+commercial use is allowed. Three states, not two — `None` means "we do not know", which is
+different from "yes" and must not be treated as it.
 
 ## SPDX where it exists, a name and URL where it does not
 
@@ -33,6 +41,7 @@ about what a user may do, so the field accepts a name plus a URL as well.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -99,22 +108,6 @@ _SPDX_UNREVIEWED = frozenset(
 )
 _SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in (*_SPDX_OBLIGATIONS, *_SPDX_UNREVIEWED)}
 
-# Share-alike is not satisfied by carrying "a share-alike obligation" — it requires the same
-# licence, or one the licence itself names as compatible. Without this, ODbL-1.0 and
-# CC-BY-SA-4.0 both reduce to {attribution, share-alike} and each would be accepted in place
-# of the other, and CC-BY-NC-SA-4.0 would be accepted over CC-BY-SA-4.0 because its obligation
-# set is a superset. Both are relicensing that share-alike forbids.
-#
-# Only same-family upgrades are listed. Cross-licence compatibility (CC-BY-SA to GPL, say) is
-# a legal judgement, not a lookup, so it is absent and therefore refused.
-_SHARE_ALIKE_COMPATIBLE: dict[str, frozenset[str]] = {
-    "CC-BY-SA-3.0": frozenset({"CC-BY-SA-3.0", "CC-BY-SA-4.0"}),
-    "CC-BY-SA-4.0": frozenset({"CC-BY-SA-4.0"}),
-    "CC-BY-NC-SA-3.0": frozenset({"CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0"}),
-    "CC-BY-NC-SA-4.0": frozenset({"CC-BY-NC-SA-4.0"}),
-    "ODbL-1.0": frozenset({"ODbL-1.0"}),
-}
-
 # Licences with no SPDX identifier, whose terms have been read. Without this a template author
 # has to restate the obligations by hand for every one, and an assertion repeated in five
 # templates is one that will eventually be wrong in a sixth.
@@ -173,26 +166,35 @@ class DatasetLicence:
             return None
         return NON_COMMERCIAL not in self.obligations
 
-    def drops_obligations_of(self, other: DatasetLicence) -> frozenset[str]:
-        """Obligations of `other` that this licence does not carry."""
-        return other.obligations - self.obligations
-
 
 UNDECLARED = DatasetLicence(identifier=None, name=None, url=None, obligations=frozenset(), known=False)
 """A template with no `license`, or one that could not be parsed. Published as `other`."""
 
 
+_NAME_VERSION_SUFFIX = re.compile(r"\s+v?\d+(\.\d+)*$")
+"""A trailing version on an otherwise exact name — "… Products v1.2", "… Notice 1.0".
+
+Only a version. This used to be a `startswith` test so that qualifiers came along for free,
+which meant any suffix inherited the base licence's terms: "NASA Earth Science Data -
+Non-Commercial Terms" matched the NASA entry and was classified as unrestricted commercial
+use. A version number cannot change what a licence requires; an arbitrary suffix is exactly
+how it gets said that it does.
+"""
+
+
 def _obligations_for_name(name: str | None) -> frozenset[str] | None:
     """Obligations for a licence known by name rather than SPDX identifier.
 
-    Matched on a normalised prefix so a template may add a version or qualifier — "Licence to
-    Use Copernicus Products v1.2" resolves the same as the bare name — without a new entry.
+    Matched exactly, after normalising whitespace and case and dropping a trailing version, so
+    a name this module has not had its terms read stays unknown rather than borrowing another
+    licence's semantics.
     """
     if not name:
         return None
     normalised = " ".join(name.lower().split())
-    for known, obligations in _KNOWN_NAMED_LICENCES.items():
-        if normalised.startswith(known):
+    for candidate in (normalised, _NAME_VERSION_SUFFIX.sub("", normalised)):
+        obligations = _KNOWN_NAMED_LICENCES.get(candidate)
+        if obligations is not None:
             return obligations
     return None
 
@@ -258,6 +260,29 @@ def parse_licence(declared: Any) -> DatasetLicence:
         if identifier is None and name is None:
             return UNDECLARED
 
+        # An identifier and a name that require different things is a contradiction, not a
+        # redundancy. `{id: CC0-1.0, name: <a licence requiring attribution>, url: ...}` would
+        # publish `license: CC0-1.0` while the `rel: license` link points at terms that demand
+        # credit, and a STAC client reads the field far more often than it fetches the link.
+        # There is no basis for picking a winner, so neither is used.
+        #
+        # Only a *recognised* name can be shown to disagree. An unrecognised one is left alone:
+        # it is a label and a link, the identifier stays authoritative for the terms, and the
+        # common `{id, name, url}` spelling of a single licence has to keep working.
+        if identifier is not None and identifier in _SPDX_OBLIGATIONS:
+            named_obligations = _obligations_for_name(name)
+            if named_obligations is not None and named_obligations != _SPDX_OBLIGATIONS[identifier]:
+                logger.warning(
+                    "Licence declares SPDX identifier %s together with the name %r, which OCS "
+                    "knows to require %s rather than %s. Treating the licence as undeclared: "
+                    "declare whichever one describes the terms, not both.",
+                    identifier,
+                    name,
+                    sorted(named_obligations) or "nothing",
+                    sorted(_SPDX_OBLIGATIONS[identifier]) or "nothing",
+                )
+                return UNDECLARED
+
         # Order matters. A recognised identifier or name is authoritative, and an explicit
         # `obligations` list is consulted only when neither supplies semantics. Letting the
         # list win would make `{id: CC-BY-NC-4.0, obligations: []}` publish as CC-BY-NC while
@@ -285,82 +310,3 @@ def parse_licence(declared: Any) -> DatasetLicence:
         return DatasetLicence(identifier=identifier, name=name, url=url, obligations=obligations, known=known)
 
     return UNDECLARED
-
-
-def _no_derivatives_refusal(candidate: DatasetLicence) -> str | None:
-    """Why `candidate` forbids any derived product, or None."""
-    if NO_DERIVATIVES not in candidate.obligations:
-        return None
-    return (
-        f"Input {candidate.label!r} prohibits derivative works, so no derived product "
-        f"may be published from it under any licence — including the same one. "
-        f"ND licences forbid distributing adapted material."
-    )
-
-
-def refuses_derivation(inputs: list[DatasetLicence]) -> str | None:
-    """Why no derived product may be published from `inputs` at all, or None.
-
-    Narrower than `refuses_publication`, which compares a *declared output* licence against
-    its inputs. This asks only whether the derivation itself is permitted, so it is the right
-    check when the output carries its input's licence verbatim: relicensing is impossible
-    there, but a no-derivatives input still forbids the derivative work.
-
-    Deliberately does NOT fail closed on an unknown input licence, unlike
-    `refuses_publication`. Copying a licence forward preserves whatever terms it carries, so
-    there is nothing to launder, and refusing would block every derived product whose source
-    licence OCS cannot parse — which template validation already warns about. The residual
-    gap is an unparseable licence that is ND in substance; that is unknowable here, and the
-    output at least carries the same terms as its input.
-    """
-    for candidate in inputs:
-        refusal = _no_derivatives_refusal(candidate)
-        if refusal:
-            return refusal
-    return None
-
-
-def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
-    """Why publishing `declared` for a product derived from `inputs` must be refused, or None.
-
-    A derived product is a derivative work: it may add obligations, never drop one. Refused
-    rather than warned about, because the failure is silent and a log line is not a defence.
-
-    Fails closed on anything not understood. If either side's obligations are unknown the pair
-    is incomparable, and the safe answer is to refuse rather than assume they are compatible —
-    which is how an unlabelled restrictive source would otherwise be laundered.
-    """
-    for candidate in inputs:
-        if not candidate.known:
-            return (
-                f"Derived dataset declares licence {declared.label!r}, but its input "
-                f"{candidate.label!r} has no licence OCS understands, so the two cannot be "
-                f"compared. Declare the input's licence, or the derived product's terms are a "
-                f"guess."
-            )
-        if not declared.known:
-            return (
-                f"Derived dataset declares licence {declared.label!r}, which OCS does not "
-                f"understand, so it cannot be checked against its input {candidate.label!r}. "
-                f"Use an SPDX identifier, or a licence name OCS knows, or list `obligations`."
-            )
-        no_derivatives = _no_derivatives_refusal(candidate)
-        if no_derivatives:
-            return no_derivatives
-        if SHARE_ALIKE in candidate.obligations:
-            compatible = _SHARE_ALIKE_COMPATIBLE.get(candidate.identifier or "", frozenset())
-            if declared.identifier not in compatible:
-                return (
-                    f"Input {candidate.label!r} is share-alike, so a derived product must carry "
-                    f"that licence or one it names as compatible ({sorted(compatible) or 'none'}), "
-                    f"not {declared.label!r}. Carrying some other share-alike licence is still "
-                    f"relicensing."
-                )
-        dropped = declared.drops_obligations_of(candidate)
-        if dropped:
-            return (
-                f"Derived dataset declares licence {declared.label!r}, which drops "
-                f"{sorted(dropped)} required by its input {candidate.label!r}. A derived "
-                f"product is a derivative work and inherits its inputs' obligations."
-            )
-    return None

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -42,52 +42,56 @@ logger = logging.getLogger(__name__)
 # never defined "various", which is what OCS was publishing on every collection.
 STAC_LICENSE_OTHER = "other"
 
-# SPDX identifiers known to permit commercial use. Deliberately a small, checked list rather
-# than an attempt at the full SPDX register: an identifier absent here is reported as unknown,
-# which is the safe answer, and adding one is a one-line change with a citation.
-_COMMERCIAL_USE_ALLOWED = frozenset(
-    {
-        "CC0-1.0",
-        "CC-BY-4.0",
-        "CC-BY-3.0",
-        "CC-BY-SA-4.0",
-        "ODbL-1.0",
-        "PDDL-1.0",
-        "Apache-2.0",
-        "MIT",
-        "OGL-UK-3.0",
-    }
-)
+# What a licence requires of anyone redistributing the data, or a work derived from it. A
+# derived product may add obligations; it may never drop one.
+ATTRIBUTION = "attribution"
+SHARE_ALIKE = "share-alike"
+NON_COMMERCIAL = "non-commercial"
 
-# Creative Commons marks a non-commercial licence with an `NC` element, so this catches the
-# whole family — CC-BY-NC-4.0, CC-BY-NC-SA-4.0, CC-BY-NC-ND-4.0 — without enumerating it.
-_NON_COMMERCIAL_MARKER = "-NC"
+# SPDX identifiers whose terms have been read, with the obligations each imposes. Deliberately
+# a small checked table rather than an attempt at the full SPDX register: an identifier absent
+# here is not an SPDX identifier as far as OCS is concerned, which keeps an unvalidated string
+# out of the published `license` field.
+#
+# Commercial use is one obligation among several, not the whole model. Comparing on it alone
+# would let CC0 be derived from CC-BY-4.0 — both permit commercial use — silently dropping
+# WorldPop's attribution requirement.
+_SPDX_OBLIGATIONS: dict[str, frozenset[str]] = {
+    "CC0-1.0": frozenset(),
+    "PDDL-1.0": frozenset(),
+    "MIT": frozenset({ATTRIBUTION}),
+    "Apache-2.0": frozenset({ATTRIBUTION}),
+    "CC-BY-3.0": frozenset({ATTRIBUTION}),
+    "CC-BY-4.0": frozenset({ATTRIBUTION}),
+    "OGL-UK-3.0": frozenset({ATTRIBUTION}),
+    "ODbL-1.0": frozenset({ATTRIBUTION, SHARE_ALIKE}),
+    "CC-BY-SA-3.0": frozenset({ATTRIBUTION, SHARE_ALIKE}),
+    "CC-BY-SA-4.0": frozenset({ATTRIBUTION, SHARE_ALIKE}),
+    "CC-BY-NC-3.0": frozenset({ATTRIBUTION, NON_COMMERCIAL}),
+    "CC-BY-NC-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL}),
+    "CC-BY-NC-SA-3.0": frozenset({ATTRIBUTION, SHARE_ALIKE, NON_COMMERCIAL}),
+    "CC-BY-NC-SA-4.0": frozenset({ATTRIBUTION, SHARE_ALIKE, NON_COMMERCIAL}),
+    "CC-BY-NC-ND-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL}),
+}
+_SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in _SPDX_OBLIGATIONS}
 
 # Licences with no SPDX identifier, whose terms have been read. Without this a template author
-# has to assert `commercial_use` by hand for every one of them, and an assertion repeated in
-# five templates is an assertion that will eventually be wrong in one of them.
+# has to restate the obligations by hand for every one, and an assertion repeated in five
+# templates is one that will eventually be wrong in a sixth.
 #
-# Note what this is NOT: a default. An unrecognised licence still resolves to "unknown", never
-# to "commercial use allowed". Defaulting to allowed would mean an author who forgets the flag
-# publishes a restrictive source as permissive — precisely the laundering this module exists to
-# prevent. Each entry here is a licence someone read, not a guess applied wholesale.
-_KNOWN_NAMED_LICENCES: dict[str, bool] = {
+# Note what this is NOT: a default. An unrecognised licence resolves to "obligations unknown",
+# never to "no obligations". Defaulting to permissive would mean an author who forgets to
+# describe a restrictive source publishes it as freely reusable, which is the laundering this
+# module exists to prevent.
+_KNOWN_NAMED_LICENCES: dict[str, frozenset[str]] = {
     # "free of charge, worldwide, non-exclusive, royalty free and perpetual", for "any purpose
-    # in so far as it is lawful", with attribution required.
-    "licence to use copernicus products": True,
+    # in so far as it is lawful", with clear attribution to Copernicus required.
+    "licence to use copernicus products": frozenset({ATTRIBUTION}),
     # Free and open including commercial reuse, subject to the Notice's conditions.
-    "copernicus sentinel data legal notice": True,
+    "copernicus sentinel data legal notice": frozenset({ATTRIBUTION}),
     # NASA Earth science data carries no copyright and no use restrictions.
-    "nasa earth science data": True,
+    "nasa earth science data": frozenset(),
 }
-
-# How restrictive a licence is, for picking the one a derived product must carry. Unknown
-# ranks above permissive on purpose: a licence nobody has declared might forbid anything, so
-# inheriting "unknown" from an unlabelled input is honest, and the alternative — assuming
-# permissive — is exactly the laundering this module exists to prevent.
-_RANK_PERMISSIVE = 0
-_RANK_UNKNOWN = 1
-_RANK_NON_COMMERCIAL = 2
 
 
 @dataclass(frozen=True)
@@ -95,69 +99,73 @@ class DatasetLicence:
     """A licence declaration, parsed into something two datasets can be compared on."""
 
     identifier: str | None
-    """SPDX identifier, or None when the licence is named rather than identified."""
+    """Canonical SPDX identifier, or None when the licence is named rather than identified."""
 
     name: str | None
-    """Human-readable name, for a licence with no SPDX identifier."""
-
     url: str | None
 
-    commercial_use: bool | None
-    """True, False, or None for "not known" — which is not the same as True."""
+    obligations: frozenset[str]
+    """What the licence requires. Meaningless unless `known` is true."""
+
+    known: bool
+    """Whether the obligations were actually determined, rather than defaulted."""
 
     @property
     def stac_license(self) -> str:
         """The value for a STAC collection's `license` field.
 
-        An SPDX identifier when there is one, otherwise the literal `other`, which STAC 1.1
-        defines for exactly this case. Never `various`: that is not a STAC value at all, and it
-        reads as "no restrictions worth mentioning" when the truth may be the opposite.
+        A canonical SPDX identifier when there is one, otherwise the literal `other`, which
+        STAC 1.1 defines for exactly this case. Never a free-form string: `license` is a
+        constrained field, and emitting an unvalidated vendor name there produces a collection
+        that does not validate. Never `various` either, which is not a STAC value at all and
+        reads as "no restrictions worth mentioning".
         """
         return self.identifier or STAC_LICENSE_OTHER
 
     @property
     def label(self) -> str:
-        """A short human label — the identifier, the name, or an explicit "not declared"."""
         return self.identifier or self.name or "not declared"
 
     @property
-    def restrictiveness(self) -> int:
-        if self.commercial_use is False:
-            return _RANK_NON_COMMERCIAL
-        if self.commercial_use is None:
-            return _RANK_UNKNOWN
-        return _RANK_PERMISSIVE
+    def commercial_use(self) -> bool | None:
+        """Whether commercial use is permitted, or None when the licence is not understood."""
+        if not self.known:
+            return None
+        return NON_COMMERCIAL not in self.obligations
 
-    def is_at_least_as_restrictive_as(self, other: DatasetLicence) -> bool:
-        return self.restrictiveness >= other.restrictiveness
-
-
-UNDECLARED = DatasetLicence(identifier=None, name=None, url=None, commercial_use=None)
-"""What a template without a `license` field resolves to. Published as `other`."""
+    def drops_obligations_of(self, other: DatasetLicence) -> frozenset[str]:
+        """Obligations of `other` that this licence does not carry."""
+        return other.obligations - self.obligations
 
 
-def _commercial_use_for_name(name: str | None) -> bool | None:
-    """Commercial-use status for a licence known by name rather than SPDX identifier.
+UNDECLARED = DatasetLicence(identifier=None, name=None, url=None, obligations=frozenset(), known=False)
+"""A template with no `license`, or one that could not be parsed. Published as `other`."""
 
-    Matched on a normalised prefix so a template may add a version or a qualifier — "Licence to
+
+def _obligations_for_name(name: str | None) -> frozenset[str] | None:
+    """Obligations for a licence known by name rather than SPDX identifier.
+
+    Matched on a normalised prefix so a template may add a version or qualifier — "Licence to
     Use Copernicus Products v1.2" resolves the same as the bare name — without a new entry.
     """
     if not name:
         return None
     normalised = " ".join(name.lower().split())
-    for known, commercial in _KNOWN_NAMED_LICENCES.items():
+    for known, obligations in _KNOWN_NAMED_LICENCES.items():
         if normalised.startswith(known):
-            return commercial
+            return obligations
     return None
 
 
-def _commercial_use_for(identifier: str) -> bool | None:
-    upper = identifier.upper()
-    if _NON_COMMERCIAL_MARKER in upper:
-        return False
-    if identifier in _COMMERCIAL_USE_ALLOWED:
-        return True
-    return None
+def _canonical_spdx(value: str) -> str | None:
+    """The canonical SPDX identifier for `value`, or None if it is not one we recognise.
+
+    Case-insensitive, because `cc-by-4.0` is an easy thing to write in YAML and rejecting it
+    outright would be unhelpful. An unrecognised string is not treated as SPDX at all: it
+    becomes a licence *name*, so the collection publishes `other` rather than an identifier no
+    STAC client can resolve.
+    """
+    return _SPDX_BY_LOWER.get(value.strip().lower())
 
 
 def parse_licence(declared: Any) -> DatasetLicence:
@@ -170,25 +178,30 @@ def parse_licence(declared: Any) -> DatasetLicence:
           name: Licence to Use Copernicus Products
           url: https://apps.ecmwf.int/datasets/licences/copernicus/
 
-    An `id` key is treated as an SPDX identifier, so a bespoke licence can still carry one if
-    it ever gets registered. Anything unparseable resolves to `UNDECLARED` rather than raising:
-    a malformed licence should degrade to "unknown, published as other", not take down the
-    catalogue — and the template validator warns about it separately.
+    A string that is not a recognised SPDX identifier is kept as a *name*, not passed through
+    to STAC as though it were one. Anything unparseable resolves to `UNDECLARED` rather than
+    raising: a malformed licence should degrade to "unknown, published as other", not take down
+    the catalogue, and the template validator warns about it separately.
     """
     if isinstance(declared, str):
-        spdx = declared.strip()
-        if not spdx:
+        text = declared.strip()
+        if not text:
             return UNDECLARED
+        spdx = _canonical_spdx(text)
+        if spdx is not None:
+            return DatasetLicence(identifier=spdx, name=None, url=None, obligations=_SPDX_OBLIGATIONS[spdx], known=True)
+        named = _obligations_for_name(text)
         return DatasetLicence(
-            identifier=spdx,
-            name=None,
+            identifier=None,
+            name=text,
             url=None,
-            commercial_use=_commercial_use_for(spdx),
+            obligations=named if named is not None else frozenset(),
+            known=named is not None,
         )
 
     if isinstance(declared, dict):
         raw_id = declared.get("id") or declared.get("spdx")
-        identifier: str | None = str(raw_id).strip() if isinstance(raw_id, str) and raw_id.strip() else None
+        identifier = _canonical_spdx(str(raw_id)) if isinstance(raw_id, str) and raw_id.strip() else None
         raw_name = declared.get("name")
         name = str(raw_name).strip() if isinstance(raw_name, str) and raw_name.strip() else None
         raw_url = declared.get("url")
@@ -197,18 +210,19 @@ def parse_licence(declared: Any) -> DatasetLicence:
         if identifier is None and name is None:
             return UNDECLARED
 
-        # An explicit `commercial_use` overrides the lookup, for a licence whose terms we have
-        # actually read. The Copernicus licence is the live example: no SPDX identifier, so the
-        # lookup can only say "unknown", but its text plainly permits commercial use.
-        declared_commercial = declared.get("commercial_use")
-        if isinstance(declared_commercial, bool):
-            commercial_use: bool | None = declared_commercial
+        # An explicit `obligations` list wins, for a licence whose terms someone has read and
+        # which is in neither table.
+        raw_obligations = declared.get("obligations")
+        if isinstance(raw_obligations, list):
+            obligations = frozenset(str(o).strip().lower() for o in raw_obligations if str(o).strip())
+            known = True
         elif identifier is not None:
-            commercial_use = _commercial_use_for(identifier)
+            obligations, known = _SPDX_OBLIGATIONS[identifier], True
         else:
-            commercial_use = _commercial_use_for_name(name)
+            named = _obligations_for_name(name)
+            obligations, known = (named, True) if named is not None else (frozenset(), False)
 
-        return DatasetLicence(identifier=identifier, name=name, url=url, commercial_use=commercial_use)
+        return DatasetLicence(identifier=identifier, name=name, url=url, obligations=obligations, known=known)
 
     return UNDECLARED
 
@@ -216,36 +230,46 @@ def parse_licence(declared: Any) -> DatasetLicence:
 def most_restrictive(licences: list[DatasetLicence]) -> DatasetLicence:
     """The licence a product derived from these inputs must carry.
 
-    Ties keep the first, so a single-input derivation returns that input's licence unchanged
-    rather than a synthesised equivalent.
+    "Most restrictive" is the one carrying the most obligations, with an unknown licence
+    winning outright — a licence nobody has described might require anything.
     """
     if not licences:
         return UNDECLARED
-    return max(licences, key=lambda licence: licence.restrictiveness)
+    unknown = [licence for licence in licences if not licence.known]
+    if unknown:
+        return unknown[0]
+    return max(licences, key=lambda licence: len(licence.obligations))
 
 
 def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
     """Why publishing `declared` for a product derived from `inputs` must be refused, or None.
 
-    The rule from CLIM-946: a derived product may not claim a licence more permissive than any
-    of its inputs. Refused rather than warned about, because the failure is silent and the
-    output is a derivative work — a warning in a log is not a defence.
+    A derived product is a derivative work: it may add obligations, never drop one. Refused
+    rather than warned about, because the failure is silent and a log line is not a defence.
+
+    Fails closed on anything not understood. If either side's obligations are unknown the pair
+    is incomparable, and the safe answer is to refuse rather than assume they are compatible —
+    which is how an unlabelled restrictive source would otherwise be laundered.
     """
-    if not inputs:
-        return None
-    strictest = most_restrictive(inputs)
-    if declared.is_at_least_as_restrictive_as(strictest):
-        return None
-    return (
-        f"Derived dataset declares licence {declared.label!r} (commercial use: "
-        f"{_describe(declared.commercial_use)}), which is more permissive than its input "
-        f"{strictest.label!r} (commercial use: {_describe(strictest.commercial_use)}). "
-        f"A derived product is a derivative work and inherits the most restrictive licence "
-        f"among its inputs."
-    )
-
-
-def _describe(commercial_use: bool | None) -> str:
-    if commercial_use is None:
-        return "not known"
-    return "allowed" if commercial_use else "not allowed"
+    for candidate in inputs:
+        if not candidate.known:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, but its input "
+                f"{candidate.label!r} has no licence OCS understands, so the two cannot be "
+                f"compared. Declare the input's licence, or the derived product's terms are a "
+                f"guess."
+            )
+        if not declared.known:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, which OCS does not "
+                f"understand, so it cannot be checked against its input {candidate.label!r}. "
+                f"Use an SPDX identifier, or a licence name OCS knows, or list `obligations`."
+            )
+        dropped = declared.drops_obligations_of(candidate)
+        if dropped:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, which drops "
+                f"{sorted(dropped)} required by its input {candidate.label!r}. A derived "
+                f"product is a derivative work and inherits its inputs' obligations."
+            )
+    return None

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -236,6 +236,25 @@ def _contradiction(identifier: str | None, name: str | None) -> str | None:
     )
 
 
+def _declared_semantics(identifier: str | None, name: str | None) -> tuple[frozenset[str], str] | None:
+    """The obligations this declaration resolves to, and what supplied them.
+
+    None when neither the identifier nor the name is one OCS knows, which is the only case
+    where an explicit `obligations` list is consulted.
+
+    Single owner of that precedence rule. `parse_licence` and `licence_declaration_problem`
+    both need to know whether the list was used or ignored, and when each decided it
+    separately they disagreed: a contradictory list beside a recognised *name* was silently
+    discarded while the same list beside an SPDX identifier was reported.
+    """
+    if identifier is not None and identifier in _SPDX_OBLIGATIONS:
+        return _SPDX_OBLIGATIONS[identifier], f"the SPDX identifier {identifier}"
+    named = _obligations_for_name(name)
+    if named is not None:
+        return named, f"the recognised licence name {name!r}"
+    return None
+
+
 def licence_declaration_problem(declared: Any) -> str | None:
     """A specific complaint about a `license` declaration, for the template validator.
 
@@ -259,11 +278,15 @@ def licence_declaration_problem(declared: Any) -> str | None:
     if contradiction is not None:
         return contradiction
 
-    if identifier is not None and identifier in _SPDX_OBLIGATIONS and isinstance(declared.get("obligations"), list):
+    semantics = _declared_semantics(identifier, name)
+    if semantics is not None and isinstance(declared.get("obligations"), list):
+        known_obligations, supplier = semantics
+        declared_obligations = sorted(str(o).strip().lower() for o in declared["obligations"] if str(o).strip())
         return (
-            f"declares explicit 'obligations' alongside the SPDX identifier {identifier}, which "
-            f"already defines its terms; the list is ignored. Remove it, or drop the identifier "
-            f"if the terms genuinely differ."
+            f"declares explicit 'obligations' {declared_obligations} alongside {supplier}, which "
+            f"OCS knows to require {sorted(known_obligations) or 'nothing'}; the list is ignored. "
+            f"Remove it, or give the licence a name of its own if its terms genuinely differ from "
+            f"the licence it is named after."
         )
     return None
 
@@ -336,17 +359,14 @@ def parse_licence(declared: Any) -> DatasetLicence:
         # every compatibility check saw no restrictions — laundering by configuration, which is
         # worse than the silence this module replaced.
         raw_obligations = declared.get("obligations")
-        if identifier is not None and identifier in _SPDX_OBLIGATIONS:
-            obligations, known = _SPDX_OBLIGATIONS[identifier], True
+        semantics = _declared_semantics(identifier, name)
+        if semantics is not None:
+            obligations, known = semantics[0], True
+        elif isinstance(raw_obligations, list):
+            obligations = frozenset(str(o).strip().lower() for o in raw_obligations if str(o).strip())
+            known = True
         else:
-            named = _obligations_for_name(name)
-            if named is not None:
-                obligations, known = named, True
-            elif isinstance(raw_obligations, list):
-                obligations = frozenset(str(o).strip().lower() for o in raw_obligations if str(o).strip())
-                known = True
-            else:
-                obligations, known = frozenset(), False
+            obligations, known = frozenset(), False
 
         return DatasetLicence(identifier=identifier, name=name, url=url, obligations=obligations, known=known)
 

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -47,6 +47,10 @@ STAC_LICENSE_OTHER = "other"
 ATTRIBUTION = "attribution"
 SHARE_ALIKE = "share-alike"
 NON_COMMERCIAL = "non-commercial"
+# Not an obligation you can satisfy — a prohibition on distributing adapted material at all.
+# Recording ND alongside attribution and non-commercial would let a derivative be published
+# under the same ND licence, which the licence forbids outright.
+NO_DERIVATIVES = "no-derivatives"
 
 # SPDX identifiers whose terms have been read, with the obligations each imposes. Deliberately
 # a small checked table rather than an attempt at the full SPDX register: an identifier absent
@@ -71,7 +75,8 @@ _SPDX_OBLIGATIONS: dict[str, frozenset[str]] = {
     "CC-BY-NC-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL}),
     "CC-BY-NC-SA-3.0": frozenset({ATTRIBUTION, SHARE_ALIKE, NON_COMMERCIAL}),
     "CC-BY-NC-SA-4.0": frozenset({ATTRIBUTION, SHARE_ALIKE, NON_COMMERCIAL}),
-    "CC-BY-NC-ND-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL}),
+    "CC-BY-NC-ND-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL, NO_DERIVATIVES}),
+    "CC-BY-ND-4.0": frozenset({ATTRIBUTION, NO_DERIVATIVES}),
 }
 _SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in _SPDX_OBLIGATIONS}
 
@@ -210,35 +215,33 @@ def parse_licence(declared: Any) -> DatasetLicence:
         if identifier is None and name is None:
             return UNDECLARED
 
-        # An explicit `obligations` list wins, for a licence whose terms someone has read and
-        # which is in neither table.
+        # Order matters. A recognised identifier or name is authoritative, and an explicit
+        # `obligations` list is consulted only when neither supplies semantics. Letting the
+        # list win would make `{id: CC-BY-NC-4.0, obligations: []}` publish as CC-BY-NC while
+        # every compatibility check saw no restrictions — laundering by configuration, which is
+        # worse than the silence this module replaced.
         raw_obligations = declared.get("obligations")
-        if isinstance(raw_obligations, list):
-            obligations = frozenset(str(o).strip().lower() for o in raw_obligations if str(o).strip())
-            known = True
-        elif identifier is not None:
+        if identifier is not None:
             obligations, known = _SPDX_OBLIGATIONS[identifier], True
+            if isinstance(raw_obligations, list):
+                logger.warning(
+                    "Licence %s declares explicit obligations; ignoring them because the SPDX "
+                    "identifier already defines its terms",
+                    identifier,
+                )
         else:
             named = _obligations_for_name(name)
-            obligations, known = (named, True) if named is not None else (frozenset(), False)
+            if named is not None:
+                obligations, known = named, True
+            elif isinstance(raw_obligations, list):
+                obligations = frozenset(str(o).strip().lower() for o in raw_obligations if str(o).strip())
+                known = True
+            else:
+                obligations, known = frozenset(), False
 
         return DatasetLicence(identifier=identifier, name=name, url=url, obligations=obligations, known=known)
 
     return UNDECLARED
-
-
-def most_restrictive(licences: list[DatasetLicence]) -> DatasetLicence:
-    """The licence a product derived from these inputs must carry.
-
-    "Most restrictive" is the one carrying the most obligations, with an unknown licence
-    winning outright — a licence nobody has described might require anything.
-    """
-    if not licences:
-        return UNDECLARED
-    unknown = [licence for licence in licences if not licence.known]
-    if unknown:
-        return unknown[0]
-    return max(licences, key=lambda licence: len(licence.obligations))
 
 
 def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
@@ -264,6 +267,12 @@ def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) 
                 f"Derived dataset declares licence {declared.label!r}, which OCS does not "
                 f"understand, so it cannot be checked against its input {candidate.label!r}. "
                 f"Use an SPDX identifier, or a licence name OCS knows, or list `obligations`."
+            )
+        if NO_DERIVATIVES in candidate.obligations:
+            return (
+                f"Input {candidate.label!r} prohibits derivative works, so no derived product "
+                f"may be published from it under any licence — including the same one. "
+                f"ND licences forbid distributing adapted material."
             )
         dropped = declared.drops_obligations_of(candidate)
         if dropped:

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -287,6 +287,39 @@ def parse_licence(declared: Any) -> DatasetLicence:
     return UNDECLARED
 
 
+def _no_derivatives_refusal(candidate: DatasetLicence) -> str | None:
+    """Why `candidate` forbids any derived product, or None."""
+    if NO_DERIVATIVES not in candidate.obligations:
+        return None
+    return (
+        f"Input {candidate.label!r} prohibits derivative works, so no derived product "
+        f"may be published from it under any licence — including the same one. "
+        f"ND licences forbid distributing adapted material."
+    )
+
+
+def refuses_derivation(inputs: list[DatasetLicence]) -> str | None:
+    """Why no derived product may be published from `inputs` at all, or None.
+
+    Narrower than `refuses_publication`, which compares a *declared output* licence against
+    its inputs. This asks only whether the derivation itself is permitted, so it is the right
+    check when the output carries its input's licence verbatim: relicensing is impossible
+    there, but a no-derivatives input still forbids the derivative work.
+
+    Deliberately does NOT fail closed on an unknown input licence, unlike
+    `refuses_publication`. Copying a licence forward preserves whatever terms it carries, so
+    there is nothing to launder, and refusing would block every derived product whose source
+    licence OCS cannot parse — which template validation already warns about. The residual
+    gap is an unparseable licence that is ND in substance; that is unknowable here, and the
+    output at least carries the same terms as its input.
+    """
+    for candidate in inputs:
+        refusal = _no_derivatives_refusal(candidate)
+        if refusal:
+            return refusal
+    return None
+
+
 def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
     """Why publishing `declared` for a product derived from `inputs` must be refused, or None.
 
@@ -311,12 +344,9 @@ def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) 
                 f"understand, so it cannot be checked against its input {candidate.label!r}. "
                 f"Use an SPDX identifier, or a licence name OCS knows, or list `obligations`."
             )
-        if NO_DERIVATIVES in candidate.obligations:
-            return (
-                f"Input {candidate.label!r} prohibits derivative works, so no derived product "
-                f"may be published from it under any licence — including the same one. "
-                f"ND licences forbid distributing adapted material."
-            )
+        no_derivatives = _no_derivatives_refusal(candidate)
+        if no_derivatives:
+            return no_derivatives
         if SHARE_ALIKE in candidate.obligations:
             compatible = _SHARE_ALIKE_COMPATIBLE.get(candidate.identifier or "", frozenset())
             if declared.identifier not in compatible:

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -210,6 +210,34 @@ def _canonical_spdx(value: str) -> str | None:
     return _SPDX_BY_LOWER.get(value.strip().lower())
 
 
+def _resolve_identifier(declared: dict[str, Any]) -> tuple[str | None, str | None]:
+    """The SPDX identifier a mapping declares, and why it cannot be resolved, if so.
+
+    `id` and `spdx` are accepted as aliases for one field. When both are given and disagree
+    there is no basis for preferring either, and `declared.get("id") or declared.get("spdx")`
+    picked the first silently: `{id: CC0-1.0, spdx: CC-BY-NC-4.0}` published as CC0 with
+    commercial use allowed.
+
+    Compared on the canonical form, so `CC0-1.0` and `cc0-1.0` are one identifier rather than
+    a conflict. Two unrecognised strings are compared case-folded; they resolve to no
+    identifier either way, but saying which two disagreed is more useful than silence.
+    """
+    given = [
+        (key, str(raw).strip()) for key in ("id", "spdx") if isinstance(raw := declared.get(key), str) and raw.strip()
+    ]
+    if not given:
+        return None, None
+    if len(given) == 2:
+        (first_key, first), (second_key, second) = given
+        if (_canonical_spdx(first) or first.lower()) != (_canonical_spdx(second) or second.lower()):
+            return None, (
+                f"declares conflicting licence identifiers: {first_key} {first!r} and "
+                f"{second_key} {second!r}. They are aliases for one field, so there is no basis "
+                f"for choosing between them; the licence is treated as undeclared. Give only one."
+            )
+    return _canonical_spdx(given[0][1]), None
+
+
 def _contradiction(identifier: str | None, name: str | None) -> str | None:
     """Why an identifier and a name cannot both describe this licence, or None.
 
@@ -269,8 +297,9 @@ def licence_declaration_problem(declared: Any) -> str | None:
     """
     if not isinstance(declared, dict):
         return None
-    raw_id = declared.get("id") or declared.get("spdx")
-    identifier = _canonical_spdx(str(raw_id)) if isinstance(raw_id, str) and raw_id.strip() else None
+    identifier, conflict = _resolve_identifier(declared)
+    if conflict is not None:
+        return conflict
     raw_name = declared.get("name")
     name = str(raw_name).strip() if isinstance(raw_name, str) and raw_name.strip() else None
 
@@ -331,8 +360,9 @@ def parse_licence(declared: Any) -> DatasetLicence:
         )
 
     if isinstance(declared, dict):
-        raw_id = declared.get("id") or declared.get("spdx")
-        identifier = _canonical_spdx(str(raw_id)) if isinstance(raw_id, str) and raw_id.strip() else None
+        identifier, conflict = _resolve_identifier(declared)
+        if conflict is not None:
+            return UNDECLARED
         raw_name = declared.get("name")
         name = str(raw_name).strip() if isinstance(raw_name, str) and raw_name.strip() else None
         raw_url = declared.get("url")

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -279,26 +279,33 @@ def _resolve_identifier(declared: dict[str, Any]) -> tuple[str | None, str | Non
 def _contradiction(identifier: str | None, name: str | None) -> str | None:
     """Why an identifier and a name cannot both describe this licence, or None.
 
-    An identifier and a name that require different things is a contradiction, not a
-    redundancy. `{id: CC0-1.0, name: <a licence requiring attribution>, url: ...}` would
-    publish `license: CC0-1.0` while the `rel: license` link points at terms that demand
-    credit, and a STAC client reads the field far more often than it fetches the link. There
-    is no basis for picking a winner, so neither is used.
+    An identifier and a *recognised* name is a contradiction, not a redundancy.
+    `_KNOWN_NAMED_LICENCES` is by definition the table of licences that have **no** SPDX
+    identifier — that is the reason it exists — so a declaration naming one of them while also
+    giving an SPDX identifier is naming two different instruments. There is no basis for
+    picking a winner, so neither is used.
 
-    Only a *recognised* name can be shown to disagree. An unrecognised one is left alone: it
-    is a label and a link, the identifier stays authoritative for the terms, and the common
-    `{id, name, url}` spelling of a single licence has to keep working.
+    Compared on *identity*, not on obligations. Equal obligations establish compatibility, not
+    sameness: `CC-BY-4.0` and the Copernicus licence both require attribution and are not the
+    same licence, so comparing the obligation sets accepted
+    `{id: CC-BY-4.0, name: Licence to Use Copernicus Products, url: ...}` and published
+    `license: CC-BY-4.0` over a link to Copernicus terms — a STAC client reads the field far
+    more often than it fetches the link.
+
+    Any identifier, not only a reviewed one. Whether OCS has recorded what `ISC` requires has
+    no bearing on whether it is the Copernicus licence.
+
+    An *unrecognised* name is still left alone: it is a label and a link, the identifier stays
+    authoritative for the terms, and the common `{id, name, url}` spelling of a single licence
+    has to keep working.
     """
-    if identifier is None or identifier not in _SPDX_OBLIGATIONS:
-        return None
-    named = _obligations_for_name(name)
-    if named is None or named == _SPDX_OBLIGATIONS[identifier]:
+    if identifier is None or _obligations_for_name(name) is None:
         return None
     return (
         f"declares SPDX identifier {identifier} together with the name {name!r}, which OCS "
-        f"knows to require {sorted(named) or 'nothing'} rather than "
-        f"{sorted(_SPDX_OBLIGATIONS[identifier]) or 'nothing'}; treating the licence as "
-        f"undeclared. Declare whichever one describes the terms, not both."
+        f"knows as a licence in its own right with no SPDX identifier; the two name different "
+        f"instruments, so the licence is treated as undeclared. Declare whichever one describes "
+        f"the terms, not both."
     )
 
 
@@ -333,6 +340,23 @@ def licence_declaration_problem(declared: Any) -> str | None:
     Returns None when there is nothing specific to say. A declaration that is merely
     unreadable is already reported by the validator's generic message.
     """
+    if isinstance(declared, str):
+        text = declared.strip()
+        if not text:
+            return None  # an empty declaration is the generic "unreadable" case
+        if _canonical_spdx(text) is not None or _obligations_for_name(text) is not None:
+            return None
+        # Nothing downstream shows this string. `license` publishes `other`, the `rel: license`
+        # link needs a URL there is none of, and the viewer falls back to "not declared" — so a
+        # mistyped identifier is indistinguishable from declaring nothing at all, which is the
+        # one outcome this module exists to make impossible.
+        return (
+            f"declares the licence {text!r}, which is neither an SPDX identifier nor a licence "
+            f"name OCS knows. It publishes as 'other' with no licence link, so it cannot be told "
+            f"apart from declaring nothing — a mistyped identifier such as 'CC-BY-4.O' vanishes "
+            f"silently. Use the SPDX identifier if the licence has one, or the mapping form "
+            f"'{{name, url}}' so the collection can at least link to the terms."
+        )
     if not isinstance(declared, dict):
         return None
     identifier, conflict = _resolve_identifier(declared)
@@ -409,15 +433,12 @@ def parse_licence(declared: Any) -> DatasetLicence:
         if identifier is None and name is None:
             return UNDECLARED
 
-        # An identifier and a name that require different things is a contradiction, not a
-        # redundancy. `{id: CC0-1.0, name: <a licence requiring attribution>, url: ...}` would
-        # publish `license: CC0-1.0` while the `rel: license` link points at terms that demand
-        # credit, and a STAC client reads the field far more often than it fetches the link.
-        # There is no basis for picking a winner, so neither is used.
-        #
-        # Only a *recognised* name can be shown to disagree. An unrecognised one is left alone:
-        # it is a label and a link, the identifier stays authoritative for the terms, and the
-        # common `{id, name, url}` spelling of a single licence has to keep working.
+        # An identifier plus a *recognised* name is a contradiction, not a redundancy: the
+        # named-licence table holds licences that have no SPDX identifier, so a declaration
+        # giving both names two different instruments. Compared on identity rather than
+        # obligations — see `_contradiction`. An unrecognised name is left alone: it is a label
+        # and a link, the identifier stays authoritative, and the common `{id, name, url}`
+        # spelling of a single licence has to keep working.
         if _contradiction(identifier, name) is not None:
             return UNDECLARED
 

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -28,14 +28,22 @@ different from "yes" and must not be treated as it.
 
 ## SPDX where it exists, a name and URL where it does not
 
-The three built-in sources happen to cover every case:
+The three built-in sources cover both cases:
 
-    CHIRPS3     CC0-1.0                              SPDX, public domain
+    CHIRPS3     CC-BY-4.0                            SPDX
     WorldPop    CC-BY-4.0                            SPDX
     ERA5-Land   Licence to Use Copernicus Products   bespoke, no SPDX identifier
 
 Forcing the Copernicus licence into a near-miss SPDX identifier would be a false statement
 about what a user may do, so the field accepts a name plus a URL as well.
+
+CHIRPS3 is the reason to read the source page rather than its tone. CHC says CHIRPS3 "is in
+the public domain" and that it has "waived all copyright and related or neighboring rights",
+which reads as CC0 — but the same sentence names the instrument, "licensed under a Creative
+Commons Attribution 4.0 International License". Declaring the public-domain half would drop
+the attribution CC BY keeps, publishing the source as more permissive than its own terms:
+the failure this module exists to prevent, committed on the first dataset it declares. Where
+a page's wording and its named licence disagree, the named licence governs.
 """
 
 from __future__ import annotations

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from functools import cache, lru_cache
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -69,10 +70,15 @@ NON_COMMERCIAL = "non-commercial"
 # under the same ND licence, which the licence forbids outright.
 NO_DERIVATIVES = "no-derivatives"
 
-# SPDX identifiers whose terms have been read, with the obligations each imposes. Deliberately
-# a small checked table rather than an attempt at the full SPDX register: an identifier absent
-# here is not an SPDX identifier as far as OCS is concerned, which keeps an unvalidated string
-# out of the published `license` field.
+# SPDX identifiers whose terms have been read, with the obligations each imposes.
+#
+# Semantics only. Whether a string *is* an SPDX identifier is a separate question, answered
+# against the full register in `_canonical_spdx` — this table says what a licence requires, not
+# what exists. Conflating the two published `license: other` for every valid identifier nobody
+# had got around to reviewing: `ISC`, `Zlib`, `EUPL-1.2` and `ODC-By-1.0` among them, the last
+# an open-data licence a climate source could plausibly carry. An identifier absent here is
+# still published under its own name; it is `known=False` that keeps propagation failing closed
+# until someone records what it requires.
 #
 # Commercial use is one obligation among several, not the whole model. Comparing on it alone
 # would let CC0 be derived from CC-BY-4.0 — both permit commercial use — silently dropping
@@ -95,27 +101,6 @@ _SPDX_OBLIGATIONS: dict[str, frozenset[str]] = {
     "CC-BY-NC-ND-4.0": frozenset({ATTRIBUTION, NON_COMMERCIAL, NO_DERIVATIVES}),
     "CC-BY-ND-4.0": frozenset({ATTRIBUTION, NO_DERIVATIVES}),
 }
-# SPDX identifiers that are valid but whose propagation semantics have not been reviewed.
-# Kept separate from `_SPDX_OBLIGATIONS` on purpose: a valid identifier belongs in the STAC
-# `license` field even when OCS cannot yet reason about deriving from it. Downgrading
-# BSD-3-Clause to a free-form name and publishing `other` threw away information the catalogue
-# had — while `known=False` still makes propagation fail closed, which is the safe half.
-_SPDX_UNREVIEWED = frozenset(
-    {
-        "BSD-2-Clause",
-        "BSD-3-Clause",
-        "GPL-3.0-only",
-        "GPL-3.0-or-later",
-        "LGPL-3.0-only",
-        "MPL-2.0",
-        "Unlicense",
-        "CC-BY-2.0",
-        "CC-BY-2.5",
-        "OGL-Canada-2.0",
-    }
-)
-_SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in (*_SPDX_OBLIGATIONS, *_SPDX_UNREVIEWED)}
-
 # Licences with no SPDX identifier, whose terms have been read. Without this a template author
 # has to restate the obligations by hand for every one, and an assertion repeated in five
 # templates is one that will eventually be wrong in a sixth.
@@ -207,15 +192,60 @@ def _obligations_for_name(name: str | None) -> frozenset[str] | None:
     return None
 
 
-def _canonical_spdx(value: str) -> str | None:
-    """The canonical SPDX identifier for `value`, or None if it is not one we recognise.
+@cache
+def _spdx_licensing() -> Any:
+    """The SPDX register, built once.
 
-    Case-insensitive, because `cc-by-4.0` is an easy thing to write in YAML and rejecting it
-    outright would be unhelpful. An unrecognised string is not treated as SPDX at all: it
-    becomes a licence *name*, so the collection publishes `other` rather than an identifier no
-    STAC client can resolve.
+    Deferred and cached because building it materialises a few thousand symbols, and
+    `parse_licence` runs on every STAC and `/datasets` request. The import is deferred too:
+    `license-expression` is a `[server]` dependency, and every importer of this module is
+    server-side, so the base client install stays at httpx + pystac.
     """
-    return _SPDX_BY_LOWER.get(value.strip().lower())
+    from license_expression import get_spdx_licensing
+
+    return get_spdx_licensing()
+
+
+@lru_cache(maxsize=512)
+def _canonical_spdx(value: str) -> str | None:
+    """The canonical SPDX identifier for `value`, or None if it is not one.
+
+    Validated against the **full SPDX register** rather than a table this module maintains by
+    hand. The two questions are separate: whether a string is a licence identifier is SPDX's to
+    answer, while `_SPDX_OBLIGATIONS` answers what that licence requires. A hand-kept allowlist
+    conflated them, so a valid identifier nobody had reviewed was demoted to a free-form name
+    and published as `other` — losing information the catalogue already had, for the ten or so
+    identifiers that happened to be listed against the several hundred that were not.
+
+    Case-insensitive, because `cc-by-4.0` is an easy thing to write in YAML. A deprecated
+    identifier canonicalises to its current form, so `GPL-3.0` publishes as `GPL-3.0-only`.
+
+    Three things that validate as SPDX are still refused, because they are not *one licence*:
+
+    * an **expression** (`Apache-2.0 OR MIT`) — the obligations of a disjunction are not a set
+      this module can compute, and guessing one would be the laundering it exists to prevent;
+    * a bare **exception** (`Classpath-exception-2.0`), which is a modifier, not a licence;
+    * a **`LicenseRef-`** key, which is ScanCode's own vocabulary rather than the register.
+
+    Caching is safe because this is pure — it returns a string and logs nothing. A cache in
+    front of a function that also warned is what made the base-URL warning fire once and then
+    fall silent (CLIM-974); keep it that way.
+    """
+    from license_expression import LicenseSymbol
+
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = _spdx_licensing().parse(text, validate=True, strict=True)
+    except Exception:
+        return None
+    if not isinstance(parsed, LicenseSymbol):
+        return None  # an expression or a `WITH` clause, not a single licence
+    key = str(parsed.key)
+    if parsed.is_exception or key.lower().startswith("licenseref-"):
+        return None
+    return key
 
 
 def _resolve_identifier(declared: dict[str, Any]) -> tuple[str | None, str | None]:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -22,6 +22,7 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
+from open_climate_service.shared.licences import DatasetLicence, parse_licence
 from open_climate_service.shared.time import (
     Cadence,
     parse_period_string_to_datetime,
@@ -126,6 +127,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     catalog_href = _abs_url(request, "/stac/catalog.json")
     dataset_href = _abs_url(request, f"/datasets/{dataset_id}")
     zarr_href = _public_zarr_asset_href(request, dataset_id, artifact, source_dataset)
+    licence = parse_licence(source_dataset.get("license"))
 
     template = _build_collection_template(
         dataset_id=dataset_id,
@@ -136,6 +138,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         zarr_href=zarr_href,
         source_dataset=source_dataset,
         description=_collection_description(dataset_id, artifact, source_dataset),
+        licence=licence,
     )
     template_links = [_link_to_dict(link) for link in template.links]
     period_type = source_dataset.get("period_type")
@@ -156,6 +159,18 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         collection_payload["stac_extensions"] = sorted({*existing_extensions, *extensions})
     else:
         collection_payload["stac_extensions"] = sorted(extensions)
+    # STAC defines `rel: license` for exactly this, and it is the only way a bespoke licence
+    # travels: the `license` field can only say `other`, so without the link a client learns
+    # nothing about the Copernicus terms beyond "not SPDX".
+    if licence.url:
+        template_links.append(
+            {
+                "rel": "license",
+                "href": licence.url,
+                "type": "text/html",
+                "title": licence.name or licence.identifier or "Licence",
+            }
+        )
     collection_payload["links"] = template_links
     assets = collection_payload.setdefault("assets", {})
     zarr_from_xstac = assets.get("zarr", {}) if isinstance(assets, dict) else {}
@@ -179,6 +194,9 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
             "xarray:open_kwargs": {"zarr_format": 3, "consolidated": False},
         }
     collection_payload["license"] = template.license
+    providers = _build_providers(source_dataset)
+    if providers:
+        collection_payload["providers"] = providers
     _remove_helper_variables(collection_payload)
     _round_spatial_steps(collection_payload)
     # Prefer an explicit extents.temporal.resolution; fall back to the dataset's
@@ -220,6 +238,38 @@ def _collection_description(dataset_id: str, artifact: ArtifactRecord, source_da
     return f"Published GeoZarr dataset for {artifact.dataset_name}"
 
 
+def _build_providers(source_dataset: dict[str, Any]) -> list[dict[str, Any]]:
+    """STAC `providers` from the template, for carrying attribution (CLIM-946).
+
+    Attribution is a licence condition under CC-BY and CC-BY-NC, not a courtesy, and OCS had
+    nowhere to record it at collection level. Entries are passed through with only their shape
+    checked — STAC defines `name`, `description`, `roles` and `url`, and inventing validation
+    beyond that would reject legitimate metadata.
+    """
+    declared = source_dataset.get("providers")
+    if not isinstance(declared, list):
+        return []
+    providers: list[dict[str, Any]] = []
+    for entry in declared:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        provider: dict[str, Any] = {"name": name.strip()}
+        for key in ("description", "url"):
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                provider[key] = value.strip()
+        roles = entry.get("roles")
+        if isinstance(roles, list):
+            cleaned = [str(r) for r in roles if isinstance(r, str) and r.strip()]
+            if cleaned:
+                provider["roles"] = cleaned
+        providers.append(provider)
+    return providers
+
+
 def _eligible_artifacts_by_dataset() -> dict[str, ArtifactRecord]:
     return ingestion_services.latest_published_zarr_artifacts_by_dataset()
 
@@ -234,6 +284,7 @@ def _build_collection_template(
     zarr_href: str,
     source_dataset: dict[str, Any],
     description: str,
+    licence: DatasetLicence,
 ) -> pystac.Collection:
     spatial = artifact.coverage.spatial_wgs84 or artifact.coverage.spatial
     temporal = artifact.coverage.temporal
@@ -257,7 +308,7 @@ def _build_collection_template(
             PROJECTION_EXTENSION,
             ZARR_EXTENSION,
         ],
-        license=DEFAULT_STAC_LICENSE,
+        license=licence.stac_license,
     )
     # WGS84 default; the store's native CRS (read from its proj:code attr in
     # _build_collection_with_xstac) overrides this. The instance config CRS is

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -225,6 +225,8 @@
             <dd id="meta-source">—</dd>
             <dt>Units</dt>
             <dd id="meta-units">—</dd>
+            <dt>Licence</dt>
+            <dd id="meta-licence">—</dd>
           </dl>
           <p id="meta-description" class="meta-description hidden"></p>
 
@@ -399,6 +401,7 @@
       const metaSource = document.getElementById("meta-source");
       const metaUnits = document.getElementById("meta-units");
       const metaDescription = document.getElementById("meta-description");
+      const metaLicence = document.getElementById("meta-licence");
       const legendEl = document.getElementById("legend");
       const legendBar = document.getElementById("legend-bar");
       const legendMin = document.getElementById("legend-min");
@@ -641,6 +644,24 @@
         // fallback is built from, so a real description that happens to open with those words
         // ("Published GeoZarr dataset for X - use only within one country") is kept rather
         // than mistaken for the generated one.
+        // A user who can see a layer should be able to see what they may do with it
+        // (CLIM-946). `other` is what an undeclared licence publishes, so say "not declared"
+        // rather than showing a word that reads like the name of a licence.
+        const licenceLink = (collection.links ?? []).find((l) => l.rel === "license");
+        const licence = collection.license;
+        const licenceLabel =
+          !licence || licence === "other" ? (licenceLink?.title ?? "not declared") : licence;
+        if (licenceLink?.href) {
+          const anchor = document.createElement("a");
+          anchor.href = licenceLink.href;
+          anchor.target = "_blank";
+          anchor.rel = "noopener noreferrer";
+          anchor.textContent = licenceLabel;
+          metaLicence.replaceChildren(anchor);
+        } else {
+          metaLicence.textContent = licenceLabel;
+        }
+
         const description = collection.description ?? "";
         const generated = description === `Published GeoZarr dataset for ${collection.title}`;
         metaDescription.textContent = description;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ xarray = [
 # Full server stack — required to run your own Open Climate Service instance.
 server = [
     "fastapi>=0.100.0",
+    # The SPDX register, for validating and canonicalising a template's declared `license`.
+    # Vendoring the identifier list instead would avoid the dependency but go stale silently;
+    # this package is the one SPDX tooling in Python agrees on, and it is pure Python.
+    "license-expression>=30.4",
     "jinja2>=3.1",
     "starlette>=0.27.0",
     "uvicorn>=0.41.0",
@@ -193,6 +197,12 @@ mypy_path = ["."]
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# Ships no py.typed marker, so mypy reports `import-untyped` rather than a missing stub;
+# following its source gives real types instead of silencing the import.
+[[tool.mypy.overrides]]
+module = ["license_expression"]
+follow_untyped_imports = true
 
 [[tool.mypy.overrides]]
 module = ["apscheduler", "apscheduler.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask", "openeo_processes_dask.*", "dask_geopandas", "dask_geopandas.*", "xclim", "xclim.*"]

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -305,12 +305,52 @@ def test_the_validator_names_the_contradiction_rather_than_calling_it_unreadable
     assert "attribution" in problem
 
 
-def test_explicit_obligations_beside_an_identifier_are_reported_once() -> None:
+@pytest.mark.parametrize(
+    "declared",
+    [
+        pytest.param({"id": "CC-BY-NC-4.0", "obligations": []}, id="spdx-identifier"),
+        pytest.param(
+            {"name": "Licence to Use Copernicus Products", "url": "https://x", "obligations": ["non-commercial"]},
+            id="recognised-name",
+        ),
+    ],
+)
+def test_ignored_obligations_are_reported_whatever_supplied_the_terms(declared: dict) -> None:
+    """Parametrised over both, because the two were checked in separate places and drifted.
+
+    `parse_licence` ignores an explicit list whenever the identifier *or* the name is one OCS
+    knows, but the validator reported only the identifier case. So Copernicus plus
+    `obligations: [non-commercial]` was read as commercially usable and said nothing — the
+    operator asserted a restriction and OCS silently dropped it, which is the laundering
+    direction.
+    """
     from open_climate_service.shared.licences import licence_declaration_problem
 
-    problem = licence_declaration_problem({"id": "CC-BY-NC-4.0", "obligations": []})
+    problem = licence_declaration_problem(declared)
     assert problem is not None
     assert "ignored" in problem
+
+
+def test_the_report_names_both_what_was_asked_for_and_what_applies() -> None:
+    """An operator who wrote non-commercial needs to see that attribution is what took effect,
+    not just that something was ignored."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    problem = licence_declaration_problem(
+        {"name": "Licence to Use Copernicus Products", "url": "https://x", "obligations": ["non-commercial"]}
+    )
+    assert problem is not None
+    assert "non-commercial" in problem
+    assert "attribution" in problem
+
+
+def test_a_recognised_name_still_outranks_a_contradictory_obligations_list() -> None:
+    """The behaviour is unchanged — the researched terms win. Only the silence is fixed."""
+    licence = parse_licence(
+        {"name": "Licence to Use Copernicus Products", "url": "https://x", "obligations": ["non-commercial"]}
+    )
+    assert licence.obligations == frozenset({ATTRIBUTION})
+    assert licence.commercial_use is True
 
 
 def test_a_sound_declaration_has_nothing_to_report() -> None:

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -7,12 +7,15 @@ restriction — on the default path, with nothing to catch it.
 
 import glob
 import pathlib
+import re
 from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
 from open_climate_service.shared.licences import (
+    ATTRIBUTION,
+    NON_COMMERCIAL,
     STAC_LICENSE_OTHER,
     UNDECLARED,
     most_restrictive,
@@ -32,14 +35,32 @@ _BUILTIN_TEMPLATES = sorted(glob.glob("open_climate_service/plugins/datasets/*.y
 def test_spdx_identifier_is_recognised() -> None:
     licence = parse_licence("CC-BY-4.0")
     assert licence.identifier == "CC-BY-4.0"
+    assert licence.obligations == frozenset({ATTRIBUTION})
     assert licence.commercial_use is True
     assert licence.stac_license == "CC-BY-4.0"
 
 
+def test_spdx_matching_is_case_insensitive_but_output_is_canonical() -> None:
+    """`cc-by-4.0` is easy to write in YAML; the published identifier must still be canonical,
+    because `license` is a constrained STAC field."""
+    assert parse_licence("cc-by-4.0").stac_license == "CC-BY-4.0"
+
+
+def test_an_unrecognised_string_is_a_name_not_an_spdx_identifier() -> None:
+    """Emitting a vendor string verbatim would produce a collection that does not validate.
+
+    It is kept as a name — so nothing is lost — and published as `other`.
+    """
+    licence = parse_licence("SomeVendorLicence-2.0")
+    assert licence.identifier is None
+    assert licence.name == "SomeVendorLicence-2.0"
+    assert licence.stac_license == STAC_LICENSE_OTHER
+    assert licence.known is False
+
+
 @pytest.mark.parametrize("identifier", ["CC-BY-NC-4.0", "CC-BY-NC-SA-4.0", "CC-BY-NC-ND-4.0", "cc-by-nc-3.0"])
 def test_every_non_commercial_cc_licence_is_caught(identifier: str) -> None:
-    """Matched on the CC `NC` element rather than an enumeration, so the whole family is
-    covered — including a lower-cased identifier, which YAML makes easy to write."""
+    assert NON_COMMERCIAL in parse_licence(identifier).obligations
     assert parse_licence(identifier).commercial_use is False
 
 
@@ -56,13 +77,22 @@ def test_a_named_licence_without_spdx_is_accepted() -> None:
     assert licence.identifier is None
     assert licence.name == "Licence to Use Copernicus Products"
     assert licence.commercial_use is True
+    assert licence.obligations == frozenset({ATTRIBUTION})
     # STAC 1.1 has a defined value for "not SPDX", and it is not `various`.
     assert licence.stac_license == STAC_LICENSE_OTHER
 
 
 def test_an_unknown_identifier_is_unknown_not_permissive() -> None:
-    """The safe answer for an identifier nobody has checked is "we do not know"."""
+    """The safe answer for a licence nobody has checked is "we do not know"."""
     assert parse_licence("SomeVendorLicence-2.0").commercial_use is None
+
+
+def test_explicit_obligations_describe_a_licence_in_neither_table() -> None:
+    licence = parse_licence(
+        {"name": "Vendor Terms", "url": "https://x", "obligations": ["attribution", "non-commercial"]}
+    )
+    assert licence.known is True
+    assert licence.commercial_use is False
 
 
 @pytest.mark.parametrize("bad", [None, "", "   ", 42, [], {}, {"url": "https://x"}])
@@ -74,6 +104,7 @@ def test_unusable_declarations_degrade_to_undeclared(bad: object) -> None:
 def test_undeclared_publishes_as_other() -> None:
     assert UNDECLARED.stac_license == STAC_LICENSE_OTHER
     assert UNDECLARED.commercial_use is None
+    assert UNDECLARED.known is False
 
 
 # -- comparison -------------------------------------------------------------------------
@@ -85,14 +116,26 @@ def test_non_commercial_beats_permissive() -> None:
 
 
 def test_unknown_beats_permissive() -> None:
-    """Deriving from an unlabelled input yields unknown, not permissive. Assuming permissive is
-    exactly the laundering this exists to prevent."""
+    """Deriving from an unlabelled input yields unknown, not permissive."""
     assert most_restrictive([parse_licence("CC0-1.0"), UNDECLARED]) is UNDECLARED
 
 
-def test_non_commercial_beats_unknown() -> None:
-    nc = parse_licence("CC-BY-NC-4.0")
-    assert most_restrictive([UNDECLARED, nc]) is nc
+def test_attribution_alone_makes_a_licence_more_restrictive_than_cc0() -> None:
+    """Commercial use is one obligation among several. Comparing on it alone would rank CC0 and
+    CC-BY-4.0 as equivalent and let a derived product quietly drop attribution."""
+    cc_by = parse_licence("CC-BY-4.0")
+    assert most_restrictive([parse_licence("CC0-1.0"), cc_by]) is cc_by
+
+
+def test_unknown_beats_even_non_commercial() -> None:
+    """Unknown wins outright, including over a known-restrictive licence.
+
+    Deliberate: "most restrictive" cannot be answered when one input has not been described,
+    because it might require more than any of the others. Returning the unknown one says so.
+    The decision about whether anything may be published from such a mix belongs to
+    `refuses_publication`, which fails closed.
+    """
+    assert most_restrictive([UNDECLARED, parse_licence("CC-BY-NC-4.0")]) is UNDECLARED
 
 
 def test_a_single_input_is_returned_unchanged() -> None:
@@ -118,6 +161,25 @@ def test_a_derived_product_may_match_its_input() -> None:
 
 def test_a_derived_product_may_be_more_restrictive_than_its_input() -> None:
     assert refuses_publication(parse_licence("CC-BY-NC-4.0"), [parse_licence("CC0-1.0")]) is None
+
+
+def test_dropping_attribution_is_refused_even_though_both_allow_commercial_use() -> None:
+    """CC0 from CC-BY-4.0: both permit commercial use, but the derived product would shed
+    WorldPop's attribution requirement."""
+    refusal = refuses_publication(parse_licence("CC0-1.0"), [parse_licence("CC-BY-4.0")])
+    assert refusal is not None
+    assert "attribution" in refusal
+
+
+def test_dropping_share_alike_is_refused() -> None:
+    refusal = refuses_publication(parse_licence("CC-BY-4.0"), [parse_licence("CC-BY-SA-4.0")])
+    assert refusal is not None
+    assert "share-alike" in refusal
+
+
+def test_an_unparseable_declared_licence_is_refused_not_waved_through() -> None:
+    """Fails closed: if either side is not understood the pair is incomparable."""
+    assert refuses_publication(parse_licence("MysteryTerms"), [parse_licence("CC-BY-4.0")]) is not None
 
 
 def test_claiming_permissive_from_an_unlabelled_input_is_refused() -> None:
@@ -156,25 +218,46 @@ def test_every_builtin_licence_parses(path: str) -> None:
         )
 
 
-def test_derived_builtins_are_no_more_permissive_than_their_source() -> None:
-    """The normals and anomalies are derivative works of CHIRPS3 and ERA5-Land, and were the
-    templates the first pass missed — they carry no `source_url`, so an insertion anchored on
-    that skipped every one of them."""
-    by_id = {}
+def _builtin_licences() -> dict:
+    licences = {}
     for path in _BUILTIN_TEMPLATES:
         for template in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")):
             if isinstance(template, dict) and template.get("id"):
-                by_id[template["id"]] = parse_licence(template.get("license"))
+                licences[template["id"]] = parse_licence(template.get("license"))
+    return licences
 
-    for derived_id, source_id in (
-        ("chirps3_precipitation_monthly_normal_1991_2020", "chirps3_precipitation_monthly"),
-        ("chirps3_precipitation_monthly_anomaly_1991_2020", "chirps3_precipitation_monthly"),
-        ("era5land_temperature_monthly_normal_1991_2020", "era5land_temperature_monthly"),
-        ("era5land_temperature_monthly_anomaly_1991_2020", "era5land_temperature_monthly"),
-    ):
-        assert refuses_publication(by_id[derived_id], [by_id[source_id]]) is None, (
-            f"{derived_id} is more permissive than {source_id}"
-        )
+
+def _derived_source_pairs() -> list[tuple[str, str]]:
+    """Every derived built-in paired with the dataset it is computed from.
+
+    Derived from the ids rather than listed by hand: an earlier version enumerated four pairs
+    and left twelve unchecked, so a licence change in any of those twelve could have loosened
+    silently. Suffix-stripping means a new normal or anomaly is covered the day it is added.
+    """
+    ids = set(_builtin_licences())
+    pairs = []
+    for dataset_id in sorted(ids):
+        base = re.sub(r"_(relative_)?(normal|anomaly)_\d{4}_\d{4}$", "", dataset_id)
+        if base != dataset_id and base in ids:
+            pairs.append((dataset_id, base))
+    return pairs
+
+
+def test_the_derived_pairs_are_actually_found() -> None:
+    """Guards the guard: a suffix change would silently empty the parametrisation below and
+    the whole check would pass by testing nothing."""
+    assert len(_derived_source_pairs()) >= 12
+
+
+@pytest.mark.parametrize(("derived_id", "source_id"), _derived_source_pairs(), ids=lambda v: v)
+def test_no_derived_builtin_is_more_permissive_than_its_source(derived_id: str, source_id: str) -> None:
+    """The normals and anomalies are derivative works of CHIRPS3 and ERA5-Land.
+
+    They carry no `source_url`, so a first pass that anchored insertion on that field skipped
+    every one of them.
+    """
+    licences = _builtin_licences()
+    assert refuses_publication(licences[derived_id], [licences[source_id]]) is None
 
 
 # -- the derive path, end to end -----------------------------------------------------------
@@ -227,7 +310,7 @@ def test_a_product_derived_from_a_non_commercial_source_inherits_the_restriction
 def test_publishing_a_derived_product_as_permissive_is_refused() -> None:
     """Refused, not warned about: the output is a derivative work and a log line is not a
     defence."""
-    with pytest.raises(ValueError, match="more permissive"):
+    with pytest.raises(ValueError, match="drops"):
         _derive(
             {
                 "dataset_id": "flood_water_mask",

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -15,10 +15,10 @@ import yaml
 
 from open_climate_service.shared.licences import (
     ATTRIBUTION,
+    NO_DERIVATIVES,
     NON_COMMERCIAL,
     STAC_LICENSE_OTHER,
     UNDECLARED,
-    most_restrictive,
     parse_licence,
     refuses_publication,
 )
@@ -108,39 +108,23 @@ def test_undeclared_publishes_as_other() -> None:
 
 
 # -- comparison -------------------------------------------------------------------------
+#
+# `most_restrictive` used to live here and has been removed. It ordered licences by how many
+# obligations they carried, which is not an ordering: CC-BY-SA and CC-BY-NC both carry two, so
+# it returned whichever came first and silently dropped the other's requirement. Nothing in
+# production ever called it. `refuses_publication` compares against every input in turn, which
+# handles incomparable sets correctly — see the two tests below. If multi-input propagation
+# ever needs a single inherited licence, it needs a union-preserving representation, not a
+# cardinality comparison.
 
 
-def test_non_commercial_beats_permissive() -> None:
-    nc = parse_licence("CC-BY-NC-4.0")
-    assert most_restrictive([parse_licence("CC0-1.0"), nc]) is nc
-
-
-def test_unknown_beats_permissive() -> None:
-    """Deriving from an unlabelled input yields unknown, not permissive."""
-    assert most_restrictive([parse_licence("CC0-1.0"), UNDECLARED]) is UNDECLARED
-
-
-def test_attribution_alone_makes_a_licence_more_restrictive_than_cc0() -> None:
-    """Commercial use is one obligation among several. Comparing on it alone would rank CC0 and
-    CC-BY-4.0 as equivalent and let a derived product quietly drop attribution."""
-    cc_by = parse_licence("CC-BY-4.0")
-    assert most_restrictive([parse_licence("CC0-1.0"), cc_by]) is cc_by
-
-
-def test_unknown_beats_even_non_commercial() -> None:
-    """Unknown wins outright, including over a known-restrictive licence.
-
-    Deliberate: "most restrictive" cannot be answered when one input has not been described,
-    because it might require more than any of the others. Returning the unknown one says so.
-    The decision about whether anything may be published from such a mix belongs to
-    `refuses_publication`, which fails closed.
-    """
-    assert most_restrictive([UNDECLARED, parse_licence("CC-BY-NC-4.0")]) is UNDECLARED
-
-
-def test_a_single_input_is_returned_unchanged() -> None:
-    cc = parse_licence("CC-BY-4.0")
-    assert most_restrictive([cc]) is cc
+def test_incomparable_licences_refuse_in_both_directions() -> None:
+    """CC-BY-SA and CC-BY-NC each carry an obligation the other lacks, so neither can cover
+    both. Checking per input catches this; picking a winner by obligation count does not."""
+    share_alike = parse_licence("CC-BY-SA-4.0")
+    non_commercial = parse_licence("CC-BY-NC-4.0")
+    assert refuses_publication(share_alike, [share_alike, non_commercial]) is not None
+    assert refuses_publication(non_commercial, [share_alike, non_commercial]) is not None
 
 
 # -- the rule that matters ----------------------------------------------------------------
@@ -343,3 +327,83 @@ def test_deriving_from_an_unlabelled_source_leaves_the_output_unlabelled() -> No
         {"id": "mystery", "variable": "value"},
     )
     assert parse_licence(template.get("license")) is UNDECLARED
+
+
+# -- the ND prohibition ------------------------------------------------------------------
+
+
+def test_no_derivatives_is_recorded_as_a_prohibition() -> None:
+    assert NO_DERIVATIVES in parse_licence("CC-BY-NC-ND-4.0").obligations
+
+
+def test_nothing_may_be_derived_from_an_nd_input_not_even_under_the_same_licence() -> None:
+    """ND forbids distributing adapted material at all, so this is not a matter of matching
+    obligations — there is no licence under which the derived product may be published."""
+    nd = parse_licence("CC-BY-NC-ND-4.0")
+    refusal = refuses_publication(nd, [nd])
+    assert refusal is not None
+    assert "prohibits derivative works" in refusal
+
+
+# -- the SPDX table is authoritative ------------------------------------------------------
+
+
+def test_explicit_obligations_cannot_override_a_recognised_spdx_identifier() -> None:
+    """`{id: CC-BY-NC-4.0, obligations: []}` would otherwise publish as CC-BY-NC while every
+    compatibility check saw no restrictions — laundering by configuration."""
+    licence = parse_licence({"id": "CC-BY-NC-4.0", "obligations": []})
+    assert licence.stac_license == "CC-BY-NC-4.0"
+    assert licence.commercial_use is False
+    assert NON_COMMERCIAL in licence.obligations
+
+
+def test_explicit_obligations_cannot_override_a_recognised_name() -> None:
+    licence = parse_licence({"name": "Licence to Use Copernicus Products", "url": "https://x", "obligations": []})
+    assert licence.obligations == frozenset({ATTRIBUTION})
+
+
+def test_explicit_obligations_are_used_when_nothing_else_supplies_them() -> None:
+    """The legitimate case: a licence in neither table, whose terms someone has read."""
+    licence = parse_licence({"name": "Vendor Terms", "url": "https://x", "obligations": ["attribution"]})
+    assert licence.known is True
+    assert licence.obligations == frozenset({ATTRIBUTION})
+
+
+# -- providers on a derived product --------------------------------------------------------
+
+
+def test_derived_providers_keep_the_source_licensor() -> None:
+    """Attribution is a licence condition, so dropping the source's licensor breaches it even
+    when the obligation check passes. An explicit list adds to the source's, never replaces."""
+    template = _derive(
+        {
+            "dataset_id": "d",
+            "variable": "water",
+            "source_dataset_id": "vantor_flood_rgb_2026",
+            "providers": [{"name": "DHIS2"}],
+        },
+        _NC_SOURCE,
+    )
+    names = [p["name"] for p in template["providers"]]
+    assert names == ["Vantor", "DHIS2"]
+
+
+def test_an_empty_providers_option_cannot_erase_the_source_licensor() -> None:
+    template = _derive(
+        {"dataset_id": "d", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026", "providers": []},
+        _NC_SOURCE,
+    )
+    assert [p["name"] for p in template["providers"]] == ["Vantor"]
+
+
+def test_duplicate_providers_are_not_doubled() -> None:
+    template = _derive(
+        {
+            "dataset_id": "d",
+            "variable": "water",
+            "source_dataset_id": "vantor_flood_rgb_2026",
+            "providers": [{"name": "vantor"}],
+        },
+        _NC_SOURCE,
+    )
+    assert len(template["providers"]) == 1

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -6,6 +6,7 @@ restriction — on the default path, with nothing to catch it.
 """
 
 import glob
+import logging
 import pathlib
 import re
 from typing import TYPE_CHECKING
@@ -345,6 +346,48 @@ def test_nothing_may_be_derived_from_an_nd_input_not_even_under_the_same_licence
     assert "prohibits derivative works" in refusal
 
 
+_ND_SOURCE = {
+    "id": "nd_imagery",
+    "name": "Restricted imagery",
+    "variable": "rgb",
+    "license": "CC-BY-ND-4.0",
+}
+
+
+def test_saying_nothing_does_not_publish_what_naming_the_licence_would_refuse() -> None:
+    """The implicit-inheritance path has to clear the ND bar too.
+
+    `license: CC-BY-ND-4.0` was refused while omitting `license` inherited the same licence
+    and published — so the check was reachable only by declaring what it would reject. The
+    unit test above passed throughout: it drove `refuses_publication` directly, and this path
+    never called it.
+    """
+    with pytest.raises(ValueError, match="prohibits derivative works"):
+        _derive({"dataset_id": "mask", "variable": "water", "source_dataset_id": "nd_imagery"}, _ND_SOURCE)
+
+
+def test_a_preregistered_template_cannot_receive_nd_data_by_declaring_nothing() -> None:
+    """The same hole on the loaded-template path."""
+    from open_climate_service.openeo import jobs
+
+    with pytest.raises(ValueError, match="prohibits derivative works"):
+        jobs._enforce_licence_on_loaded_template("mask", {"id": "mask"}, _ND_SOURCE)
+
+
+def test_inheriting_an_unparseable_source_licence_is_not_refused() -> None:
+    """`refuses_derivation` must not fail closed the way `refuses_publication` does.
+
+    Carrying a licence forward verbatim cannot launder it, so refusing here would block every
+    derived product whose source licence OCS cannot parse — a licence-metadata gap turned into
+    an ingest failure. Template validation warns about the gap instead.
+    """
+    template = _derive(
+        {"dataset_id": "derived", "variable": "value", "source_dataset_id": "vendor"},
+        {"id": "vendor", "variable": "value", "license": "Some Vendor Terms"},
+    )
+    assert template["license"] == "Some Vendor Terms"
+
+
 # -- the SPDX table is authoritative ------------------------------------------------------
 
 
@@ -493,11 +536,95 @@ def test_a_preregistered_undeclared_template_inherits_rather_than_staying_undecl
     assert [p["name"] for p in updated["providers"]] == ["Vantor"]
 
 
-def test_a_preregistered_matching_template_is_left_alone() -> None:
+def test_a_matching_preregistered_licence_still_has_to_credit_the_licensor() -> None:
+    """A compatible licence identifier is not the whole licence.
+
+    `CC-BY-NC-4.0` on both sides passes the obligation check, so this template used to be
+    returned untouched — and it names nobody, so the derived product published without the
+    attribution CC-BY-NC requires. The check compared identifiers while the condition it was
+    enforcing lives in the providers.
+    """
     from open_climate_service.openeo import jobs
 
-    template = {"id": "flood_water_mask", "license": "CC-BY-NC-4.0"}
+    updated = jobs._enforce_licence_on_loaded_template(
+        "flood_water_mask", {"id": "flood_water_mask", "license": "CC-BY-NC-4.0"}, _NC_SOURCE
+    )
+    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
+
+
+def test_a_preregistered_templates_own_providers_are_kept_alongside_the_sources() -> None:
+    from open_climate_service.openeo import jobs
+
+    updated = jobs._enforce_licence_on_loaded_template(
+        "flood_water_mask",
+        {"id": "flood_water_mask", "license": "CC-BY-NC-4.0", "providers": [{"name": "DHIS2"}]},
+        _NC_SOURCE,
+    )
+    assert [p["name"] for p in updated["providers"]] == ["Vantor", "DHIS2"]
+
+
+def test_a_template_needing_no_change_is_returned_untouched() -> None:
+    """No write, no copy: nothing to persist when the registered metadata is already right."""
+    from open_climate_service.openeo import jobs
+
+    template = {
+        "id": "flood_water_mask",
+        "license": "CC-BY-NC-4.0",
+        "providers": [{"name": "Vantor", "roles": ["producer"]}],
+    }
     assert jobs._enforce_licence_on_loaded_template("flood_water_mask", template, _NC_SOURCE) is template
+
+
+def test_the_enforced_licence_reaches_the_registry_not_just_this_publish(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """STAC builds the collection from the on-disk template, so an in-memory fix publishes the
+    same wrong licence it did before. `build_collection` reads the registry by dataset id and
+    never sees the object this function returns."""
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    monkeypatch.setattr(reg, "CONFIGS_DIR", tmp_path)
+    # Shaped like a real pre-registered workflow output, so it survives template validation.
+    jobs._enforce_licence_on_loaded_template(
+        "flood_water_mask",
+        {"id": "flood_water_mask", "variable": "water", "sync": {"kind": "static"}},
+        _NC_SOURCE,
+    )
+
+    written = yaml.safe_load((tmp_path / "flood_water_mask.yaml").read_text())[0]
+    assert written["license"] == "CC-BY-NC-4.0"
+    assert [p["name"] for p in written["providers"]] == ["Vantor"]
+
+
+def test_a_registry_that_cannot_be_written_does_not_fail_the_publish(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The licence is already correct on the returned template, so a read-only templates
+    directory should not abort an otherwise valid publish."""
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(reg, "write_dataset_template", refuse)
+
+    # Attached to the module logger directly: `open_climate_service` does not propagate to
+    # root, so caplog never sees the record, and its handler holds the pre-capture stderr.
+    records: list[logging.LogRecord] = []
+
+    class Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = Collect()
+    jobs.logger.addHandler(handler)
+    try:
+        updated = jobs._enforce_licence_on_loaded_template("flood_water_mask", {"id": "flood_water_mask"}, _NC_SOURCE)
+    finally:
+        jobs.logger.removeHandler(handler)
+
+    assert updated["license"] == "CC-BY-NC-4.0"
+    assert any("Could not persist licence metadata" in r.getMessage() for r in records)
 
 
 def test_no_source_means_a_preregistered_template_is_untouched() -> None:

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -407,3 +407,101 @@ def test_duplicate_providers_are_not_doubled() -> None:
         _NC_SOURCE,
     )
     assert len(template["providers"]) == 1
+
+
+# -- valid SPDX identifiers OCS has not reviewed -------------------------------------------
+
+
+def test_a_valid_spdx_identifier_is_preserved_even_when_unreviewed() -> None:
+    """Downgrading BSD-3-Clause to a free-form name and publishing `other` threw away
+    information the catalogue already had. The identifier is kept; only the propagation
+    semantics are marked unknown."""
+    licence = parse_licence("BSD-3-Clause")
+    assert licence.stac_license == "BSD-3-Clause"
+    assert licence.known is False
+
+
+def test_deriving_from_an_unreviewed_spdx_licence_fails_closed() -> None:
+    """Publishing the identifier is safe; reasoning about derivation from it is not."""
+    bsd = parse_licence("BSD-3-Clause")
+    assert refuses_publication(bsd, [bsd]) is not None
+
+
+# -- share-alike is licence identity, not an obligation flag --------------------------------
+
+
+def test_another_share_alike_licence_is_not_an_acceptable_substitute() -> None:
+    """ODbL-1.0 and CC-BY-SA-4.0 both reduce to {attribution, share-alike}, so a subset check
+    accepts each in place of the other. That is relicensing, which share-alike forbids."""
+    refusal = refuses_publication(parse_licence("ODbL-1.0"), [parse_licence("CC-BY-SA-4.0")])
+    assert refusal is not None
+    assert "share-alike" in refusal
+
+
+def test_adding_non_commercial_to_a_share_alike_input_is_still_relicensing() -> None:
+    """CC-BY-NC-SA's obligations are a superset of CC-BY-SA's, so the subset check passed it."""
+    assert refuses_publication(parse_licence("CC-BY-NC-SA-4.0"), [parse_licence("CC-BY-SA-4.0")]) is not None
+
+
+def test_the_same_share_alike_licence_is_accepted() -> None:
+    sa = parse_licence("CC-BY-SA-4.0")
+    assert refuses_publication(sa, [sa]) is None
+
+
+def test_a_share_alike_version_upgrade_the_licence_permits_is_accepted() -> None:
+    """CC-BY-SA-3.0 explicitly allows relicensing under 4.0."""
+    assert refuses_publication(parse_licence("CC-BY-SA-4.0"), [parse_licence("CC-BY-SA-3.0")]) is None
+
+
+# -- lineage that does not resolve ----------------------------------------------------------
+
+
+def test_an_unresolvable_source_dataset_id_is_an_error_not_absent_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo would otherwise mean "not derived from anything", disabling propagation and
+    letting a permissive output through with no error anywhere."""
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    monkeypatch.setattr(reg, "get_dataset", lambda _: None)
+    with pytest.raises(ValueError, match="not a registered dataset template"):
+        jobs._resolve_source_template({"source_dataset_id": "chirps3_typooo"})
+
+
+# -- an already-registered output template --------------------------------------------------
+
+
+def test_a_preregistered_permissive_template_cannot_receive_restricted_data() -> None:
+    """The path CLIM-946 recommends. The licence rule ran only while *synthesising* a template,
+    so pre-registering one — which the ticket advises, to control the display — skipped the
+    check entirely and a CC0 template could publish CC-BY-NC-derived data."""
+    from open_climate_service.openeo import jobs
+
+    with pytest.raises(ValueError, match="cannot receive data derived from"):
+        jobs._enforce_licence_on_loaded_template(
+            "flood_water_mask", {"id": "flood_water_mask", "license": "CC0-1.0"}, _NC_SOURCE
+        )
+
+
+def test_a_preregistered_undeclared_template_inherits_rather_than_staying_undeclared() -> None:
+    """Migrates a template left by an older run, instead of leaving it unlabelled forever."""
+    from open_climate_service.openeo import jobs
+
+    updated = jobs._enforce_licence_on_loaded_template("flood_water_mask", {"id": "flood_water_mask"}, _NC_SOURCE)
+    assert updated["license"] == "CC-BY-NC-4.0"
+    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
+
+
+def test_a_preregistered_matching_template_is_left_alone() -> None:
+    from open_climate_service.openeo import jobs
+
+    template = {"id": "flood_water_mask", "license": "CC-BY-NC-4.0"}
+    assert jobs._enforce_licence_on_loaded_template("flood_water_mask", template, _NC_SOURCE) is template
+
+
+def test_no_source_means_a_preregistered_template_is_untouched() -> None:
+    from open_climate_service.openeo import jobs
+
+    template = {"id": "standalone", "license": "CC0-1.0"}
+    assert jobs._enforce_licence_on_loaded_template("standalone", template, None) is template

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -9,6 +9,7 @@ paths produced four rounds of contradictory fixes.
 """
 
 import glob
+import logging
 import pathlib
 import re
 
@@ -261,3 +262,60 @@ def test_an_identifier_with_a_consistent_name_and_url_is_kept() -> None:
     )
     assert licence.stac_license == "CC-BY-4.0"
     assert licence.url == "https://creativecommons.org/licenses/by/4.0/"
+
+
+# -- parsing is silent; the validator does the complaining ---------------------------------
+
+
+def test_parsing_a_contradictory_licence_logs_nothing() -> None:
+    """`parse_licence` runs on every STAC and /datasets request, and instance templates are
+    re-read each time, so a warning here would log for as long as the template existed — the
+    behaviour `_warn_once` exists to stop (CLIM-904). Asserted by call count, because a
+    "warns once" claim about a per-request function is only true until the second request."""
+    from open_climate_service.shared import licences
+
+    records: list[logging.LogRecord] = []
+
+    class Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = Collect()
+    licences.logger.addHandler(handler)
+    try:
+        for _ in range(3):
+            parse_licence({"id": "CC0-1.0", "name": "Licence to Use Copernicus Products", "url": "https://x"})
+            parse_licence({"id": "CC-BY-NC-4.0", "obligations": []})
+    finally:
+        licences.logger.removeHandler(handler)
+
+    assert records == []
+
+
+def test_the_validator_names_the_contradiction_rather_than_calling_it_unreadable() -> None:
+    """ "Unreadable" sends the author hunting for a typo when the declaration parses fine and
+    simply says two different things."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    problem = licence_declaration_problem(
+        {"id": "CC0-1.0", "name": "Licence to Use Copernicus Products", "url": "https://x"}
+    )
+    assert problem is not None
+    assert "CC0-1.0" in problem
+    assert "attribution" in problem
+
+
+def test_explicit_obligations_beside_an_identifier_are_reported_once() -> None:
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    problem = licence_declaration_problem({"id": "CC-BY-NC-4.0", "obligations": []})
+    assert problem is not None
+    assert "ignored" in problem
+
+
+def test_a_sound_declaration_has_nothing_to_report() -> None:
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    assert licence_declaration_problem("CC-BY-4.0") is None
+    assert licence_declaration_problem({"id": "CC-BY-4.0", "url": "https://x"}) is None
+    assert licence_declaration_problem({"name": "Vendor Terms", "url": "https://x"}) is None

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -1,31 +1,27 @@
-"""Dataset licences: declaration, publication and propagation (CLIM-946).
+"""Dataset licences: declaration and publication (CLIM-946).
 
 The failure this guards against is silent. OCS published the constant `various` on every
-collection, so a water mask derived from CC-BY-NC imagery was published as though it carried no
-restriction — on the default path, with nothing to catch it.
+collection, so a CC-BY-NC source was published as though it carried no restriction.
+
+Propagation to derived products is deliberately not here. It is a separate change with a
+single enforcement point, because splitting the decision across the synthesise and reload
+paths produced four rounds of contradictory fixes.
 """
 
 import glob
-import logging
 import pathlib
 import re
-from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
 from open_climate_service.shared.licences import (
     ATTRIBUTION,
-    NO_DERIVATIVES,
     NON_COMMERCIAL,
     STAC_LICENSE_OTHER,
     UNDECLARED,
     parse_licence,
-    refuses_publication,
 )
-
-if TYPE_CHECKING:
-    import xarray as xr
 
 _BUILTIN_TEMPLATES = sorted(glob.glob("open_climate_service/plugins/datasets/*.yaml"))
 
@@ -108,75 +104,6 @@ def test_undeclared_publishes_as_other() -> None:
     assert UNDECLARED.known is False
 
 
-# -- comparison -------------------------------------------------------------------------
-#
-# `most_restrictive` used to live here and has been removed. It ordered licences by how many
-# obligations they carried, which is not an ordering: CC-BY-SA and CC-BY-NC both carry two, so
-# it returned whichever came first and silently dropped the other's requirement. Nothing in
-# production ever called it. `refuses_publication` compares against every input in turn, which
-# handles incomparable sets correctly — see the two tests below. If multi-input propagation
-# ever needs a single inherited licence, it needs a union-preserving representation, not a
-# cardinality comparison.
-
-
-def test_incomparable_licences_refuse_in_both_directions() -> None:
-    """CC-BY-SA and CC-BY-NC each carry an obligation the other lacks, so neither can cover
-    both. Checking per input catches this; picking a winner by obligation count does not."""
-    share_alike = parse_licence("CC-BY-SA-4.0")
-    non_commercial = parse_licence("CC-BY-NC-4.0")
-    assert refuses_publication(share_alike, [share_alike, non_commercial]) is not None
-    assert refuses_publication(non_commercial, [share_alike, non_commercial]) is not None
-
-
-# -- the rule that matters ----------------------------------------------------------------
-
-
-def test_a_derived_product_may_not_be_more_permissive_than_its_input() -> None:
-    """The headline case: a water mask derived from CC-BY-NC imagery, published as CC0."""
-    refusal = refuses_publication(parse_licence("CC0-1.0"), [parse_licence("CC-BY-NC-4.0")])
-    assert refusal is not None
-    assert "CC-BY-NC-4.0" in refusal
-    assert "derivative work" in refusal
-
-
-def test_a_derived_product_may_match_its_input() -> None:
-    nc = parse_licence("CC-BY-NC-4.0")
-    assert refuses_publication(nc, [nc]) is None
-
-
-def test_a_derived_product_may_be_more_restrictive_than_its_input() -> None:
-    assert refuses_publication(parse_licence("CC-BY-NC-4.0"), [parse_licence("CC0-1.0")]) is None
-
-
-def test_dropping_attribution_is_refused_even_though_both_allow_commercial_use() -> None:
-    """CC0 from CC-BY-4.0: both permit commercial use, but the derived product would shed
-    WorldPop's attribution requirement."""
-    refusal = refuses_publication(parse_licence("CC0-1.0"), [parse_licence("CC-BY-4.0")])
-    assert refusal is not None
-    assert "attribution" in refusal
-
-
-def test_dropping_share_alike_is_refused() -> None:
-    refusal = refuses_publication(parse_licence("CC-BY-4.0"), [parse_licence("CC-BY-SA-4.0")])
-    assert refusal is not None
-    assert "share-alike" in refusal
-
-
-def test_an_unparseable_declared_licence_is_refused_not_waved_through() -> None:
-    """Fails closed: if either side is not understood the pair is incomparable."""
-    assert refuses_publication(parse_licence("MysteryTerms"), [parse_licence("CC-BY-4.0")]) is not None
-
-
-def test_claiming_permissive_from_an_unlabelled_input_is_refused() -> None:
-    """Unknown outranks permissive, so this is refused rather than waved through."""
-    assert refuses_publication(parse_licence("CC0-1.0"), [UNDECLARED]) is not None
-
-
-def test_no_inputs_means_nothing_to_check() -> None:
-    """A dataset ingested directly from a source has no derivation to constrain it."""
-    assert refuses_publication(parse_licence("CC0-1.0"), []) is None
-
-
 # -- every built-in declares one ------------------------------------------------------------
 
 
@@ -235,157 +162,21 @@ def test_the_derived_pairs_are_actually_found() -> None:
 
 
 @pytest.mark.parametrize(("derived_id", "source_id"), _derived_source_pairs(), ids=lambda v: v)
-def test_no_derived_builtin_is_more_permissive_than_its_source(derived_id: str, source_id: str) -> None:
+def test_no_derived_builtin_declares_away_its_sources_obligations(derived_id: str, source_id: str) -> None:
     """The normals and anomalies are derivative works of CHIRPS3 and ERA5-Land.
+
+    Stated as a set comparison rather than by calling the production predicate: a test that
+    asks the code under test whether the code under test is right passes when both are wrong.
 
     They carry no `source_url`, so a first pass that anchored insertion on that field skipped
     every one of them.
     """
     licences = _builtin_licences()
-    assert refuses_publication(licences[derived_id], [licences[source_id]]) is None
-
-
-# -- the derive path, end to end -----------------------------------------------------------
-
-
-def _cube(variable: str) -> "xr.Dataset":
-    """A real one-variable cube. The derived-template builder computes a display range from the
-    values, so stubbing far enough to satisfy it costs more than just handing it a small array.
-    """
-    import numpy as np
-    import xarray as xr
-
-    return xr.Dataset(
-        {variable: (("y", "x"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"))},
-        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    derived, source = licences[derived_id], licences[source_id]
+    assert derived.known and source.known, "a shipped licence OCS cannot parse"
+    assert source.obligations <= derived.obligations, (
+        f"{derived_id} drops {sorted(source.obligations - derived.obligations)} required by {source_id}"
     )
-
-
-def _derive(options: dict, source_template: dict | None) -> dict:
-    """Run the real derived-template builder, not a reimplementation of its licence rule."""
-    from open_climate_service.openeo import jobs
-
-    return jobs._derive_managed_dataset_template(_cube(str(options["variable"])), options, source_template, None)
-
-
-_NC_SOURCE = {
-    "id": "vantor_flood_rgb_2026",
-    "name": "Flood true colour",
-    "variable": "true_colour",
-    "license": "CC-BY-NC-4.0",
-    "providers": [{"name": "Vantor", "roles": ["producer"]}],
-}
-
-
-def test_a_product_derived_from_a_non_commercial_source_inherits_the_restriction() -> None:
-    """The acceptance case from CLIM-946: a water mask computed from CC-BY-NC imagery.
-
-    Before this, the derived collection published `various` — indistinguishable from an openly
-    licensed one, on the default path, with nothing to catch it.
-    """
-    template = _derive(
-        {"dataset_id": "flood_water_mask", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026"},
-        _NC_SOURCE,
-    )
-    assert parse_licence(template["license"]).commercial_use is False
-    # Attribution is a licence condition under CC-BY-NC, so it has to travel too.
-    assert template["providers"] == _NC_SOURCE["providers"]
-
-
-def test_publishing_a_derived_product_as_permissive_is_refused() -> None:
-    """Refused, not warned about: the output is a derivative work and a log line is not a
-    defence."""
-    with pytest.raises(ValueError, match="drops"):
-        _derive(
-            {
-                "dataset_id": "flood_water_mask",
-                "variable": "water",
-                "source_dataset_id": "vantor_flood_rgb_2026",
-                "license": "CC0-1.0",
-            },
-            _NC_SOURCE,
-        )
-
-
-def test_a_derived_product_may_declare_a_stricter_licence_than_its_source() -> None:
-    template = _derive(
-        {
-            "dataset_id": "derived",
-            "variable": "value",
-            "source_dataset_id": "chirps3_precipitation_monthly",
-            "license": "CC-BY-NC-4.0",
-        },
-        {"id": "chirps3_precipitation_monthly", "variable": "precip", "license": "CC0-1.0"},
-    )
-    assert template["license"] == "CC-BY-NC-4.0"
-
-
-def test_deriving_from_an_unlabelled_source_leaves_the_output_unlabelled() -> None:
-    """Not permissive by omission. An unlabelled input yields an unlabelled output, which
-    publishes as `other` rather than as something reassuring."""
-    template = _derive(
-        {"dataset_id": "derived", "variable": "value", "source_dataset_id": "mystery"},
-        {"id": "mystery", "variable": "value"},
-    )
-    assert parse_licence(template.get("license")) is UNDECLARED
-
-
-# -- the ND prohibition ------------------------------------------------------------------
-
-
-def test_no_derivatives_is_recorded_as_a_prohibition() -> None:
-    assert NO_DERIVATIVES in parse_licence("CC-BY-NC-ND-4.0").obligations
-
-
-def test_nothing_may_be_derived_from_an_nd_input_not_even_under_the_same_licence() -> None:
-    """ND forbids distributing adapted material at all, so this is not a matter of matching
-    obligations — there is no licence under which the derived product may be published."""
-    nd = parse_licence("CC-BY-NC-ND-4.0")
-    refusal = refuses_publication(nd, [nd])
-    assert refusal is not None
-    assert "prohibits derivative works" in refusal
-
-
-_ND_SOURCE = {
-    "id": "nd_imagery",
-    "name": "Restricted imagery",
-    "variable": "rgb",
-    "license": "CC-BY-ND-4.0",
-}
-
-
-def test_saying_nothing_does_not_publish_what_naming_the_licence_would_refuse() -> None:
-    """The implicit-inheritance path has to clear the ND bar too.
-
-    `license: CC-BY-ND-4.0` was refused while omitting `license` inherited the same licence
-    and published — so the check was reachable only by declaring what it would reject. The
-    unit test above passed throughout: it drove `refuses_publication` directly, and this path
-    never called it.
-    """
-    with pytest.raises(ValueError, match="prohibits derivative works"):
-        _derive({"dataset_id": "mask", "variable": "water", "source_dataset_id": "nd_imagery"}, _ND_SOURCE)
-
-
-def test_a_preregistered_template_cannot_receive_nd_data_by_declaring_nothing() -> None:
-    """The same hole on the loaded-template path."""
-    from open_climate_service.openeo import jobs
-
-    with pytest.raises(ValueError, match="prohibits derivative works"):
-        jobs._enforce_licence_on_loaded_template("mask", {"id": "mask"}, _ND_SOURCE)
-
-
-def test_inheriting_an_unparseable_source_licence_is_not_refused() -> None:
-    """`refuses_derivation` must not fail closed the way `refuses_publication` does.
-
-    Carrying a licence forward verbatim cannot launder it, so refusing here would block every
-    derived product whose source licence OCS cannot parse — a licence-metadata gap turned into
-    an ingest failure. Template validation warns about the gap instead.
-    """
-    template = _derive(
-        {"dataset_id": "derived", "variable": "value", "source_dataset_id": "vendor"},
-        {"id": "vendor", "variable": "value", "license": "Some Vendor Terms"},
-    )
-    assert template["license"] == "Some Vendor Terms"
 
 
 # -- the SPDX table is authoritative ------------------------------------------------------
@@ -412,46 +203,6 @@ def test_explicit_obligations_are_used_when_nothing_else_supplies_them() -> None
     assert licence.obligations == frozenset({ATTRIBUTION})
 
 
-# -- providers on a derived product --------------------------------------------------------
-
-
-def test_derived_providers_keep_the_source_licensor() -> None:
-    """Attribution is a licence condition, so dropping the source's licensor breaches it even
-    when the obligation check passes. An explicit list adds to the source's, never replaces."""
-    template = _derive(
-        {
-            "dataset_id": "d",
-            "variable": "water",
-            "source_dataset_id": "vantor_flood_rgb_2026",
-            "providers": [{"name": "DHIS2"}],
-        },
-        _NC_SOURCE,
-    )
-    names = [p["name"] for p in template["providers"]]
-    assert names == ["Vantor", "DHIS2"]
-
-
-def test_an_empty_providers_option_cannot_erase_the_source_licensor() -> None:
-    template = _derive(
-        {"dataset_id": "d", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026", "providers": []},
-        _NC_SOURCE,
-    )
-    assert [p["name"] for p in template["providers"]] == ["Vantor"]
-
-
-def test_duplicate_providers_are_not_doubled() -> None:
-    template = _derive(
-        {
-            "dataset_id": "d",
-            "variable": "water",
-            "source_dataset_id": "vantor_flood_rgb_2026",
-            "providers": [{"name": "vantor"}],
-        },
-        _NC_SOURCE,
-    )
-    assert len(template["providers"]) == 1
-
-
 # -- valid SPDX identifiers OCS has not reviewed -------------------------------------------
 
 
@@ -464,171 +215,49 @@ def test_a_valid_spdx_identifier_is_preserved_even_when_unreviewed() -> None:
     assert licence.known is False
 
 
-def test_deriving_from_an_unreviewed_spdx_licence_fails_closed() -> None:
-    """Publishing the identifier is safe; reasoning about derivation from it is not."""
-    bsd = parse_licence("BSD-3-Clause")
-    assert refuses_publication(bsd, [bsd]) is not None
+# -- a name must be the licence, not merely start like it ----------------------------------
 
 
-# -- share-alike is licence identity, not an obligation flag --------------------------------
+def test_a_qualified_name_does_not_inherit_a_known_licences_terms() -> None:
+    """`startswith` matching classified this as NASA's unrestricted terms, so a
+    non-commercial variant read as free for commercial use — the exact laundering the
+    unknown-is-not-permissive rule exists to prevent."""
+    licence = parse_licence("NASA Earth Science Data - Non-Commercial Terms")
+    assert licence.known is False
+    assert licence.commercial_use is None
 
 
-def test_another_share_alike_licence_is_not_an_acceptable_substitute() -> None:
-    """ODbL-1.0 and CC-BY-SA-4.0 both reduce to {attribution, share-alike}, so a subset check
-    accepts each in place of the other. That is relicensing, which share-alike forbids."""
-    refusal = refuses_publication(parse_licence("ODbL-1.0"), [parse_licence("CC-BY-SA-4.0")])
-    assert refusal is not None
-    assert "share-alike" in refusal
+def test_an_exact_known_name_still_resolves() -> None:
+    assert parse_licence("NASA Earth Science Data").obligations == frozenset()
+    assert parse_licence("Licence to Use Copernicus Products").obligations == frozenset({ATTRIBUTION})
 
 
-def test_adding_non_commercial_to_a_share_alike_input_is_still_relicensing() -> None:
-    """CC-BY-NC-SA's obligations are a superset of CC-BY-SA's, so the subset check passed it."""
-    assert refuses_publication(parse_licence("CC-BY-NC-SA-4.0"), [parse_licence("CC-BY-SA-4.0")]) is not None
+@pytest.mark.parametrize("name", ["Licence to Use Copernicus Products v1.2", "Licence to Use Copernicus Products 2"])
+def test_a_trailing_version_is_still_the_same_licence(name: str) -> None:
+    """A version number cannot change what a licence requires, so these stay recognised."""
+    assert parse_licence(name).obligations == frozenset({ATTRIBUTION})
 
 
-def test_the_same_share_alike_licence_is_accepted() -> None:
-    sa = parse_licence("CC-BY-SA-4.0")
-    assert refuses_publication(sa, [sa]) is None
+# -- an identifier and a name that disagree -------------------------------------------------
 
 
-def test_a_share_alike_version_upgrade_the_licence_permits_is_accepted() -> None:
-    """CC-BY-SA-3.0 explicitly allows relicensing under 4.0."""
-    assert refuses_publication(parse_licence("CC-BY-SA-4.0"), [parse_licence("CC-BY-SA-3.0")]) is None
+def test_an_identifier_contradicted_by_a_known_name_is_undeclared() -> None:
+    """`license` is read far more often than the licence link is fetched, so publishing
+    `CC0-1.0` beside a link to terms requiring attribution is worse than publishing nothing.
+    There is no basis for choosing between them."""
+    licence = parse_licence({"id": "CC0-1.0", "name": "Licence to Use Copernicus Products", "url": "https://x"})
+    assert licence is UNDECLARED
 
 
-# -- lineage that does not resolve ----------------------------------------------------------
-
-
-def test_an_unresolvable_source_dataset_id_is_an_error_not_absent_lineage(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A typo would otherwise mean "not derived from anything", disabling propagation and
-    letting a permissive output through with no error anywhere."""
-    from open_climate_service.data_registry.services import datasets as reg
-    from open_climate_service.openeo import jobs
-
-    monkeypatch.setattr(reg, "get_dataset", lambda _: None)
-    with pytest.raises(ValueError, match="not a registered dataset template"):
-        jobs._resolve_source_template({"source_dataset_id": "chirps3_typooo"})
-
-
-# -- an already-registered output template --------------------------------------------------
-
-
-def test_a_preregistered_permissive_template_cannot_receive_restricted_data() -> None:
-    """The path CLIM-946 recommends. The licence rule ran only while *synthesising* a template,
-    so pre-registering one — which the ticket advises, to control the display — skipped the
-    check entirely and a CC0 template could publish CC-BY-NC-derived data."""
-    from open_climate_service.openeo import jobs
-
-    with pytest.raises(ValueError, match="cannot receive data derived from"):
-        jobs._enforce_licence_on_loaded_template(
-            "flood_water_mask", {"id": "flood_water_mask", "license": "CC0-1.0"}, _NC_SOURCE
-        )
-
-
-def test_a_preregistered_undeclared_template_inherits_rather_than_staying_undeclared() -> None:
-    """Migrates a template left by an older run, instead of leaving it unlabelled forever."""
-    from open_climate_service.openeo import jobs
-
-    updated = jobs._enforce_licence_on_loaded_template("flood_water_mask", {"id": "flood_water_mask"}, _NC_SOURCE)
-    assert updated["license"] == "CC-BY-NC-4.0"
-    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
-
-
-def test_a_matching_preregistered_licence_still_has_to_credit_the_licensor() -> None:
-    """A compatible licence identifier is not the whole licence.
-
-    `CC-BY-NC-4.0` on both sides passes the obligation check, so this template used to be
-    returned untouched — and it names nobody, so the derived product published without the
-    attribution CC-BY-NC requires. The check compared identifiers while the condition it was
-    enforcing lives in the providers.
-    """
-    from open_climate_service.openeo import jobs
-
-    updated = jobs._enforce_licence_on_loaded_template(
-        "flood_water_mask", {"id": "flood_water_mask", "license": "CC-BY-NC-4.0"}, _NC_SOURCE
+def test_an_identifier_with_a_consistent_name_and_url_is_kept() -> None:
+    """The ordinary spelling of one licence in all three fields has to keep working — the URL
+    is what the `rel: license` link needs."""
+    licence = parse_licence(
+        {
+            "id": "CC-BY-4.0",
+            "name": "Creative Commons Attribution 4.0 International",
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+        }
     )
-    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
-
-
-def test_a_preregistered_templates_own_providers_are_kept_alongside_the_sources() -> None:
-    from open_climate_service.openeo import jobs
-
-    updated = jobs._enforce_licence_on_loaded_template(
-        "flood_water_mask",
-        {"id": "flood_water_mask", "license": "CC-BY-NC-4.0", "providers": [{"name": "DHIS2"}]},
-        _NC_SOURCE,
-    )
-    assert [p["name"] for p in updated["providers"]] == ["Vantor", "DHIS2"]
-
-
-def test_a_template_needing_no_change_is_returned_untouched() -> None:
-    """No write, no copy: nothing to persist when the registered metadata is already right."""
-    from open_climate_service.openeo import jobs
-
-    template = {
-        "id": "flood_water_mask",
-        "license": "CC-BY-NC-4.0",
-        "providers": [{"name": "Vantor", "roles": ["producer"]}],
-    }
-    assert jobs._enforce_licence_on_loaded_template("flood_water_mask", template, _NC_SOURCE) is template
-
-
-def test_the_enforced_licence_reaches_the_registry_not_just_this_publish(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
-) -> None:
-    """STAC builds the collection from the on-disk template, so an in-memory fix publishes the
-    same wrong licence it did before. `build_collection` reads the registry by dataset id and
-    never sees the object this function returns."""
-    from open_climate_service.data_registry.services import datasets as reg
-    from open_climate_service.openeo import jobs
-
-    monkeypatch.setattr(reg, "CONFIGS_DIR", tmp_path)
-    # Shaped like a real pre-registered workflow output, so it survives template validation.
-    jobs._enforce_licence_on_loaded_template(
-        "flood_water_mask",
-        {"id": "flood_water_mask", "variable": "water", "sync": {"kind": "static"}},
-        _NC_SOURCE,
-    )
-
-    written = yaml.safe_load((tmp_path / "flood_water_mask.yaml").read_text())[0]
-    assert written["license"] == "CC-BY-NC-4.0"
-    assert [p["name"] for p in written["providers"]] == ["Vantor"]
-
-
-def test_a_registry_that_cannot_be_written_does_not_fail_the_publish(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The licence is already correct on the returned template, so a read-only templates
-    directory should not abort an otherwise valid publish."""
-    from open_climate_service.data_registry.services import datasets as reg
-    from open_climate_service.openeo import jobs
-
-    def refuse(*_args: object, **_kwargs: object) -> None:
-        raise OSError("read-only file system")
-
-    monkeypatch.setattr(reg, "write_dataset_template", refuse)
-
-    # Attached to the module logger directly: `open_climate_service` does not propagate to
-    # root, so caplog never sees the record, and its handler holds the pre-capture stderr.
-    records: list[logging.LogRecord] = []
-
-    class Collect(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(record)
-
-    handler = Collect()
-    jobs.logger.addHandler(handler)
-    try:
-        updated = jobs._enforce_licence_on_loaded_template("flood_water_mask", {"id": "flood_water_mask"}, _NC_SOURCE)
-    finally:
-        jobs.logger.removeHandler(handler)
-
-    assert updated["license"] == "CC-BY-NC-4.0"
-    assert any("Could not persist licence metadata" in r.getMessage() for r in records)
-
-
-def test_no_source_means_a_preregistered_template_is_untouched() -> None:
-    from open_climate_service.openeo import jobs
-
-    template = {"id": "standalone", "license": "CC0-1.0"}
-    assert jobs._enforce_licence_on_loaded_template("standalone", template, None) is template
+    assert licence.stac_license == "CC-BY-4.0"
+    assert licence.url == "https://creativecommons.org/licenses/by/4.0/"

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -359,3 +359,115 @@ def test_a_sound_declaration_has_nothing_to_report() -> None:
     assert licence_declaration_problem("CC-BY-4.0") is None
     assert licence_declaration_problem({"id": "CC-BY-4.0", "url": "https://x"}) is None
     assert licence_declaration_problem({"name": "Vendor Terms", "url": "https://x"}) is None
+
+
+# -- the declaration surface, exhaustively -------------------------------------------------
+#
+# Five rounds of review each found one more way for two parts of a `license` mapping to
+# disagree while OCS silently picked one: a prefix-matched name, an id contradicted by a name,
+# an obligations list beside a recognised name, and `id` beside a conflicting `spdx`. They are
+# the same defect four times, and finding them one at a time has no end.
+#
+# The mapping form accepts exactly five keys, so the ways they can disagree is a finite set.
+# This enumerates it. A pair that is not listed here is one nobody has decided, which is the
+# only way this converges: the table is the review, rather than the reviewer being the review.
+
+_ACCEPTED = "accepted"
+_UNDECLARED = "undeclared"
+_IGNORED = "ignored-with-warning"
+
+_DECLARATION_MATRIX = [
+    # (declaration, outcome, why)
+    ({"id": "CC-BY-4.0"}, _ACCEPTED, "an identifier alone"),
+    ({"spdx": "CC-BY-4.0"}, _ACCEPTED, "the spdx alias alone"),
+    ({"id": "CC-BY-4.0", "spdx": "cc-by-4.0"}, _ACCEPTED, "both aliases, same licence"),
+    ({"id": "CC0-1.0", "spdx": "CC-BY-NC-4.0"}, _UNDECLARED, "both aliases, different licences"),
+    ({"name": "Licence to Use Copernicus Products", "url": "https://x"}, _ACCEPTED, "a known name"),
+    ({"name": "Vendor Terms", "url": "https://x"}, _ACCEPTED, "an unknown name, obligations unknown"),
+    (
+        {"id": "CC-BY-4.0", "name": "Creative Commons Attribution 4.0", "url": "https://x"},
+        _ACCEPTED,
+        "id plus a consistent label",
+    ),
+    ({"id": "CC0-1.0", "name": "Licence to Use Copernicus Products"}, _UNDECLARED, "id contradicted by a known name"),
+    ({"id": "CC-BY-4.0", "obligations": ["non-commercial"]}, _IGNORED, "obligations beside an identifier"),
+    (
+        {"name": "Licence to Use Copernicus Products", "obligations": ["non-commercial"]},
+        _IGNORED,
+        "obligations beside a known name",
+    ),
+    (
+        {"name": "Vendor Terms", "url": "https://x", "obligations": ["attribution"]},
+        _ACCEPTED,
+        "obligations describing an unknown name",
+    ),
+    ({"url": "https://x"}, _UNDECLARED, "a url with no licence identity"),
+    ({"obligations": ["attribution"]}, _UNDECLARED, "obligations with no licence identity"),
+    ({}, _UNDECLARED, "an empty mapping"),
+]
+
+
+@pytest.mark.parametrize(("declaration", "outcome", "why"), _DECLARATION_MATRIX, ids=lambda v: str(v)[:44])
+def test_every_way_a_declaration_can_disagree_with_itself_is_decided(declaration: dict, outcome: str, why: str) -> None:
+    """One row per combination of the five accepted keys, so a new contradiction is a missing
+    row rather than a production defect found in review."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    licence = parse_licence(declaration)
+    problem = licence_declaration_problem(declaration)
+
+    if outcome == _UNDECLARED:
+        assert licence is UNDECLARED, f"{why}: expected undeclared, got {licence}"
+    elif outcome == _ACCEPTED:
+        assert licence is not UNDECLARED, f"{why}: expected a usable licence"
+        assert problem is None, f"{why}: accepted declarations should not warn, got {problem!r}"
+    elif outcome == _IGNORED:
+        assert licence is not UNDECLARED, f"{why}: the known terms still apply"
+        assert problem is not None, f"{why}: a discarded field must be reported"
+    else:  # pragma: no cover - guards a typo in the table
+        raise AssertionError(f"unknown outcome {outcome!r}")
+
+
+def test_the_matrix_covers_every_key_the_mapping_form_accepts() -> None:
+    """Guards the guard. A new key added to `parse_licence` without a row here would leave its
+    interactions undecided, which is the state the matrix exists to end."""
+    accepted_keys = {"id", "spdx", "name", "url", "obligations"}
+    covered = {key for declaration, _, _ in _DECLARATION_MATRIX for key in declaration}
+    assert covered == accepted_keys, f"keys with no row: {accepted_keys - covered}"
+
+
+def test_no_undeclared_outcome_is_silent() -> None:
+    """An unusable declaration must either be reported specifically or caught by the
+    validator's generic unreadable-licence message. Silence is how the earlier defects hid."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    for declaration, outcome, why in _DECLARATION_MATRIX:
+        if outcome != _UNDECLARED:
+            continue
+        specific = licence_declaration_problem(declaration)
+        generic = parse_licence(declaration) is UNDECLARED
+        assert specific is not None or generic, f"{why}: neither reported nor caught"
+
+
+def test_conflicting_identifier_aliases_are_named_not_merely_undeclared() -> None:
+    """`id` and `spdx` are aliases, and `declared.get("id") or declared.get("spdx")` picked the
+    first silently: `{id: CC0-1.0, spdx: CC-BY-NC-4.0}` published as CC0 with commercial use
+    allowed.
+
+    Asserted on the *report*, not on the parse result. Resolving a conflict to "no identifier"
+    already reaches UNDECLARED through the no-licence-identity path, so a test that only checked
+    the parse outcome passes with the fix removed — which the matrix row above does, and which
+    is why this exists separately.
+    """
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    problem = licence_declaration_problem({"id": "CC0-1.0", "spdx": "CC-BY-NC-4.0"})
+    assert problem is not None
+    assert "CC0-1.0" in problem
+    assert "CC-BY-NC-4.0" in problem
+    assert "aliases" in problem
+
+
+def test_the_same_licence_under_both_aliases_is_not_a_conflict() -> None:
+    """Case and spelling differences resolve to one canonical identifier."""
+    assert parse_licence({"id": "CC-BY-4.0", "spdx": "cc-by-4.0"}).stac_license == "CC-BY-4.0"

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -9,6 +9,7 @@ paths produced four rounds of contradictory fixes.
 """
 
 import glob
+import itertools
 import logging
 import pathlib
 import re
@@ -361,94 +362,6 @@ def test_a_sound_declaration_has_nothing_to_report() -> None:
     assert licence_declaration_problem({"name": "Vendor Terms", "url": "https://x"}) is None
 
 
-# -- the declaration surface, exhaustively -------------------------------------------------
-#
-# Five rounds of review each found one more way for two parts of a `license` mapping to
-# disagree while OCS silently picked one: a prefix-matched name, an id contradicted by a name,
-# an obligations list beside a recognised name, and `id` beside a conflicting `spdx`. They are
-# the same defect four times, and finding them one at a time has no end.
-#
-# The mapping form accepts exactly five keys, so the ways they can disagree is a finite set.
-# This enumerates it. A pair that is not listed here is one nobody has decided, which is the
-# only way this converges: the table is the review, rather than the reviewer being the review.
-
-_ACCEPTED = "accepted"
-_UNDECLARED = "undeclared"
-_IGNORED = "ignored-with-warning"
-
-_DECLARATION_MATRIX = [
-    # (declaration, outcome, why)
-    ({"id": "CC-BY-4.0"}, _ACCEPTED, "an identifier alone"),
-    ({"spdx": "CC-BY-4.0"}, _ACCEPTED, "the spdx alias alone"),
-    ({"id": "CC-BY-4.0", "spdx": "cc-by-4.0"}, _ACCEPTED, "both aliases, same licence"),
-    ({"id": "CC0-1.0", "spdx": "CC-BY-NC-4.0"}, _UNDECLARED, "both aliases, different licences"),
-    ({"name": "Licence to Use Copernicus Products", "url": "https://x"}, _ACCEPTED, "a known name"),
-    ({"name": "Vendor Terms", "url": "https://x"}, _ACCEPTED, "an unknown name, obligations unknown"),
-    (
-        {"id": "CC-BY-4.0", "name": "Creative Commons Attribution 4.0", "url": "https://x"},
-        _ACCEPTED,
-        "id plus a consistent label",
-    ),
-    ({"id": "CC0-1.0", "name": "Licence to Use Copernicus Products"}, _UNDECLARED, "id contradicted by a known name"),
-    ({"id": "CC-BY-4.0", "obligations": ["non-commercial"]}, _IGNORED, "obligations beside an identifier"),
-    (
-        {"name": "Licence to Use Copernicus Products", "obligations": ["non-commercial"]},
-        _IGNORED,
-        "obligations beside a known name",
-    ),
-    (
-        {"name": "Vendor Terms", "url": "https://x", "obligations": ["attribution"]},
-        _ACCEPTED,
-        "obligations describing an unknown name",
-    ),
-    ({"url": "https://x"}, _UNDECLARED, "a url with no licence identity"),
-    ({"obligations": ["attribution"]}, _UNDECLARED, "obligations with no licence identity"),
-    ({}, _UNDECLARED, "an empty mapping"),
-]
-
-
-@pytest.mark.parametrize(("declaration", "outcome", "why"), _DECLARATION_MATRIX, ids=lambda v: str(v)[:44])
-def test_every_way_a_declaration_can_disagree_with_itself_is_decided(declaration: dict, outcome: str, why: str) -> None:
-    """One row per combination of the five accepted keys, so a new contradiction is a missing
-    row rather than a production defect found in review."""
-    from open_climate_service.shared.licences import licence_declaration_problem
-
-    licence = parse_licence(declaration)
-    problem = licence_declaration_problem(declaration)
-
-    if outcome == _UNDECLARED:
-        assert licence is UNDECLARED, f"{why}: expected undeclared, got {licence}"
-    elif outcome == _ACCEPTED:
-        assert licence is not UNDECLARED, f"{why}: expected a usable licence"
-        assert problem is None, f"{why}: accepted declarations should not warn, got {problem!r}"
-    elif outcome == _IGNORED:
-        assert licence is not UNDECLARED, f"{why}: the known terms still apply"
-        assert problem is not None, f"{why}: a discarded field must be reported"
-    else:  # pragma: no cover - guards a typo in the table
-        raise AssertionError(f"unknown outcome {outcome!r}")
-
-
-def test_the_matrix_covers_every_key_the_mapping_form_accepts() -> None:
-    """Guards the guard. A new key added to `parse_licence` without a row here would leave its
-    interactions undecided, which is the state the matrix exists to end."""
-    accepted_keys = {"id", "spdx", "name", "url", "obligations"}
-    covered = {key for declaration, _, _ in _DECLARATION_MATRIX for key in declaration}
-    assert covered == accepted_keys, f"keys with no row: {accepted_keys - covered}"
-
-
-def test_no_undeclared_outcome_is_silent() -> None:
-    """An unusable declaration must either be reported specifically or caught by the
-    validator's generic unreadable-licence message. Silence is how the earlier defects hid."""
-    from open_climate_service.shared.licences import licence_declaration_problem
-
-    for declaration, outcome, why in _DECLARATION_MATRIX:
-        if outcome != _UNDECLARED:
-            continue
-        specific = licence_declaration_problem(declaration)
-        generic = parse_licence(declaration) is UNDECLARED
-        assert specific is not None or generic, f"{why}: neither reported nor caught"
-
-
 def test_conflicting_identifier_aliases_are_named_not_merely_undeclared() -> None:
     """`id` and `spdx` are aliases, and `declared.get("id") or declared.get("spdx")` picked the
     first silently: `{id: CC0-1.0, spdx: CC-BY-NC-4.0}` published as CC0 with commercial use
@@ -471,3 +384,147 @@ def test_conflicting_identifier_aliases_are_named_not_merely_undeclared() -> Non
 def test_the_same_licence_under_both_aliases_is_not_a_conflict() -> None:
     """Case and spelling differences resolve to one canonical identifier."""
     assert parse_licence({"id": "CC-BY-4.0", "spdx": "cc-by-4.0"}).stac_license == "CC-BY-4.0"
+
+
+# -- the declaration surface -----------------------------------------------------------------
+#
+# Four review rounds each found one more way for two parts of a `license` mapping to disagree
+# while OCS silently picked one: a prefix-matched name, an identifier contradicted by a name,
+# an obligations list beside a recognised name, and an identifier beside a conflicting alias.
+# One defect found four times. Finding them individually does not terminate, so the surface is
+# enumerated instead.
+#
+# The dimensions are semantic, not raw keys. What decides the outcome is the *kind* of value in
+# each of three positions; `url` is carried through and never affects it, which
+# `test_the_url_never_changes_the_outcome` pins rather than assumes.
+
+_IDENTIFIER_CASES: dict[str, dict] = {
+    "absent": {},
+    "recognised": {"id": "CC-BY-4.0"},
+    "unrecognised": {"id": "NotAnSpdx"},
+    "aliases-agree": {"id": "CC-BY-4.0", "spdx": "cc-by-4.0"},
+    "aliases-conflict": {"id": "CC0-1.0", "spdx": "CC-BY-NC-4.0"},
+}
+# "agrees"/"conflicts" are relative to CC-BY-4.0's {attribution}: the Copernicus licence
+# requires the same, NASA's requires nothing.
+_NAME_CASES: dict[str, dict] = {
+    "absent": {},
+    "known-agrees": {"name": "Licence to Use Copernicus Products"},
+    "known-conflicts": {"name": "NASA Earth Science Data"},
+    "unknown": {"name": "Vendor Terms"},
+}
+_OBLIGATION_CASES: dict[str, dict] = {"absent": {}, "present": {"obligations": ["non-commercial"]}}
+
+_ACCEPTED = "accepted"  # a usable licence, nothing to report
+_IGNORED = "ignored"  # usable, but a field was discarded and must be reported
+_UNDECLARED = "undeclared"  # not usable; publishes as `other`
+
+# One entry per (identifier, name, obligations) shape. A shape with no entry fails the
+# completeness guard below, so a new key or value kind cannot be added without deciding what
+# every combination of it does.
+_EXPECTED: dict[tuple[str, str, str], str] = {
+    # No identifier: the name governs, and an explicit list is used only when nothing else
+    # supplies the terms.
+    ("absent", "absent", "absent"): _UNDECLARED,
+    ("absent", "absent", "present"): _UNDECLARED,  # obligations without a licence identity
+    ("absent", "known-agrees", "absent"): _ACCEPTED,
+    ("absent", "known-agrees", "present"): _IGNORED,
+    ("absent", "known-conflicts", "absent"): _ACCEPTED,
+    ("absent", "known-conflicts", "present"): _IGNORED,
+    ("absent", "unknown", "absent"): _ACCEPTED,
+    ("absent", "unknown", "present"): _ACCEPTED,  # the legitimate use of an explicit list
+    # A recognised identifier is authoritative, and a known name that disagrees with it is a
+    # contradiction rather than a redundancy.
+    ("recognised", "absent", "absent"): _ACCEPTED,
+    ("recognised", "absent", "present"): _IGNORED,
+    ("recognised", "known-agrees", "absent"): _ACCEPTED,
+    ("recognised", "known-agrees", "present"): _IGNORED,
+    ("recognised", "known-conflicts", "absent"): _UNDECLARED,
+    ("recognised", "known-conflicts", "present"): _UNDECLARED,
+    ("recognised", "unknown", "absent"): _ACCEPTED,
+    ("recognised", "unknown", "present"): _IGNORED,
+    # An unrecognised identifier supplies nothing, so the name decides. The string itself is
+    # dropped rather than kept as a name, unlike the plain-string form — a known asymmetry, and
+    # the safe direction, since the result is `other` rather than a guess.
+    ("unrecognised", "absent", "absent"): _UNDECLARED,
+    ("unrecognised", "absent", "present"): _UNDECLARED,
+    ("unrecognised", "known-agrees", "absent"): _ACCEPTED,
+    ("unrecognised", "known-agrees", "present"): _IGNORED,
+    ("unrecognised", "known-conflicts", "absent"): _ACCEPTED,
+    ("unrecognised", "known-conflicts", "present"): _IGNORED,
+    ("unrecognised", "unknown", "absent"): _ACCEPTED,
+    ("unrecognised", "unknown", "present"): _ACCEPTED,
+    # Both aliases naming one licence behaves exactly as one identifier.
+    ("aliases-agree", "absent", "absent"): _ACCEPTED,
+    ("aliases-agree", "absent", "present"): _IGNORED,
+    ("aliases-agree", "known-agrees", "absent"): _ACCEPTED,
+    ("aliases-agree", "known-agrees", "present"): _IGNORED,
+    ("aliases-agree", "known-conflicts", "absent"): _UNDECLARED,
+    ("aliases-agree", "known-conflicts", "present"): _UNDECLARED,
+    ("aliases-agree", "unknown", "absent"): _ACCEPTED,
+    ("aliases-agree", "unknown", "present"): _IGNORED,
+    # Aliases naming different licences: undeclared whatever else is present, because there is
+    # no basis for choosing and the wrong choice publishes NC data as permissive.
+    ("aliases-conflict", "absent", "absent"): _UNDECLARED,
+    ("aliases-conflict", "absent", "present"): _UNDECLARED,
+    ("aliases-conflict", "known-agrees", "absent"): _UNDECLARED,
+    ("aliases-conflict", "known-agrees", "present"): _UNDECLARED,
+    ("aliases-conflict", "known-conflicts", "absent"): _UNDECLARED,
+    ("aliases-conflict", "known-conflicts", "present"): _UNDECLARED,
+    ("aliases-conflict", "unknown", "absent"): _UNDECLARED,
+    ("aliases-conflict", "unknown", "present"): _UNDECLARED,
+}
+
+_SHAPES = list(itertools.product(_IDENTIFIER_CASES, _NAME_CASES, _OBLIGATION_CASES))
+
+
+def _declaration(identifier: str, name: str, obligations: str, url: bool = True) -> dict:
+    return {
+        **_IDENTIFIER_CASES[identifier],
+        **_NAME_CASES[name],
+        **_OBLIGATION_CASES[obligations],
+        **({"url": "https://x"} if url else {}),
+    }
+
+
+def _outcome(declaration: dict) -> str:
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    if parse_licence(declaration) is UNDECLARED:
+        return _UNDECLARED
+    return _IGNORED if licence_declaration_problem(declaration) else _ACCEPTED
+
+
+@pytest.mark.parametrize(("identifier", "name", "obligations"), _SHAPES, ids=lambda v: v)
+def test_every_declaration_shape_has_the_decided_outcome(identifier: str, name: str, obligations: str) -> None:
+    expected = _EXPECTED.get((identifier, name, obligations))
+    assert expected is not None, (
+        f"undecided declaration shape: identifier={identifier}, name={name}, obligations={obligations}. "
+        "Decide what it should do and add it to _EXPECTED."
+    )
+    assert _outcome(_declaration(identifier, name, obligations)) == expected
+
+
+def test_the_expectation_table_matches_the_shapes_that_exist() -> None:
+    """Both directions. A missing entry leaves a combination undecided; a stale one describes a
+    shape that can no longer occur, which reads as coverage that is not there."""
+    assert set(_EXPECTED) == set(_SHAPES)
+
+
+def test_the_url_never_changes_the_outcome() -> None:
+    """`url` is carried into the licence link and has no bearing on the terms. Pinned because
+    the enumeration above omits it as a dimension, and that omission is only sound while this
+    holds."""
+    for identifier, name, obligations in _SHAPES:
+        with_url = _outcome(_declaration(identifier, name, obligations, url=True))
+        without = _outcome(_declaration(identifier, name, obligations, url=False))
+        assert with_url == without, f"url changed the outcome for {identifier}/{name}/{obligations}"
+
+
+def test_the_enumerated_keys_are_the_keys_the_parser_accepts() -> None:
+    """Guards the guard. A new key in `parse_licence` with no dimension here would leave its
+    interactions untested while the enumeration still claims to be complete."""
+    accepted_keys = {"id", "spdx", "name", "url", "obligations"}
+    dimensions = (*_IDENTIFIER_CASES.values(), *_NAME_CASES.values(), *_OBLIGATION_CASES.values())
+    covered = {key for case in dimensions for key in case}
+    assert covered | {"url"} == accepted_keys, f"keys with no dimension: {accepted_keys - covered - {'url'}}"

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -1,0 +1,262 @@
+"""Dataset licences: declaration, publication and propagation (CLIM-946).
+
+The failure this guards against is silent. OCS published the constant `various` on every
+collection, so a water mask derived from CC-BY-NC imagery was published as though it carried no
+restriction — on the default path, with nothing to catch it.
+"""
+
+import glob
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from open_climate_service.shared.licences import (
+    STAC_LICENSE_OTHER,
+    UNDECLARED,
+    most_restrictive,
+    parse_licence,
+    refuses_publication,
+)
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+_BUILTIN_TEMPLATES = sorted(glob.glob("open_climate_service/plugins/datasets/*.yaml"))
+
+
+# -- parsing ----------------------------------------------------------------------------
+
+
+def test_spdx_identifier_is_recognised() -> None:
+    licence = parse_licence("CC-BY-4.0")
+    assert licence.identifier == "CC-BY-4.0"
+    assert licence.commercial_use is True
+    assert licence.stac_license == "CC-BY-4.0"
+
+
+@pytest.mark.parametrize("identifier", ["CC-BY-NC-4.0", "CC-BY-NC-SA-4.0", "CC-BY-NC-ND-4.0", "cc-by-nc-3.0"])
+def test_every_non_commercial_cc_licence_is_caught(identifier: str) -> None:
+    """Matched on the CC `NC` element rather than an enumeration, so the whole family is
+    covered — including a lower-cased identifier, which YAML makes easy to write."""
+    assert parse_licence(identifier).commercial_use is False
+
+
+def test_a_named_licence_without_spdx_is_accepted() -> None:
+    """The Copernicus licence has no SPDX identifier. Forcing it into a near-miss one would be
+    a false statement about what a user may do."""
+    licence = parse_licence(
+        {
+            "name": "Licence to Use Copernicus Products",
+            "url": "https://apps.ecmwf.int/datasets/licences/copernicus/",
+            "commercial_use": True,
+        }
+    )
+    assert licence.identifier is None
+    assert licence.name == "Licence to Use Copernicus Products"
+    assert licence.commercial_use is True
+    # STAC 1.1 has a defined value for "not SPDX", and it is not `various`.
+    assert licence.stac_license == STAC_LICENSE_OTHER
+
+
+def test_an_unknown_identifier_is_unknown_not_permissive() -> None:
+    """The safe answer for an identifier nobody has checked is "we do not know"."""
+    assert parse_licence("SomeVendorLicence-2.0").commercial_use is None
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", 42, [], {}, {"url": "https://x"}])
+def test_unusable_declarations_degrade_to_undeclared(bad: object) -> None:
+    """A malformed licence must not take down the catalogue; the validator warns separately."""
+    assert parse_licence(bad) is UNDECLARED
+
+
+def test_undeclared_publishes_as_other() -> None:
+    assert UNDECLARED.stac_license == STAC_LICENSE_OTHER
+    assert UNDECLARED.commercial_use is None
+
+
+# -- comparison -------------------------------------------------------------------------
+
+
+def test_non_commercial_beats_permissive() -> None:
+    nc = parse_licence("CC-BY-NC-4.0")
+    assert most_restrictive([parse_licence("CC0-1.0"), nc]) is nc
+
+
+def test_unknown_beats_permissive() -> None:
+    """Deriving from an unlabelled input yields unknown, not permissive. Assuming permissive is
+    exactly the laundering this exists to prevent."""
+    assert most_restrictive([parse_licence("CC0-1.0"), UNDECLARED]) is UNDECLARED
+
+
+def test_non_commercial_beats_unknown() -> None:
+    nc = parse_licence("CC-BY-NC-4.0")
+    assert most_restrictive([UNDECLARED, nc]) is nc
+
+
+def test_a_single_input_is_returned_unchanged() -> None:
+    cc = parse_licence("CC-BY-4.0")
+    assert most_restrictive([cc]) is cc
+
+
+# -- the rule that matters ----------------------------------------------------------------
+
+
+def test_a_derived_product_may_not_be_more_permissive_than_its_input() -> None:
+    """The headline case: a water mask derived from CC-BY-NC imagery, published as CC0."""
+    refusal = refuses_publication(parse_licence("CC0-1.0"), [parse_licence("CC-BY-NC-4.0")])
+    assert refusal is not None
+    assert "CC-BY-NC-4.0" in refusal
+    assert "derivative work" in refusal
+
+
+def test_a_derived_product_may_match_its_input() -> None:
+    nc = parse_licence("CC-BY-NC-4.0")
+    assert refuses_publication(nc, [nc]) is None
+
+
+def test_a_derived_product_may_be_more_restrictive_than_its_input() -> None:
+    assert refuses_publication(parse_licence("CC-BY-NC-4.0"), [parse_licence("CC0-1.0")]) is None
+
+
+def test_claiming_permissive_from_an_unlabelled_input_is_refused() -> None:
+    """Unknown outranks permissive, so this is refused rather than waved through."""
+    assert refuses_publication(parse_licence("CC0-1.0"), [UNDECLARED]) is not None
+
+
+def test_no_inputs_means_nothing_to_check() -> None:
+    """A dataset ingested directly from a source has no derivation to constrain it."""
+    assert refuses_publication(parse_licence("CC0-1.0"), []) is None
+
+
+# -- every built-in declares one ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", _BUILTIN_TEMPLATES, ids=lambda p: pathlib.Path(p).name)
+def test_every_builtin_template_declares_a_licence(path: str) -> None:
+    """No built-in may rely on the default. A user seeing a layer should be able to see what
+    they may do with it, and `other` is what OCS says when nobody has said anything."""
+    undeclared = [
+        t.get("id")
+        for t in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8"))
+        if isinstance(t, dict) and t.get("license") is None
+    ]
+    assert not undeclared, f"templates without a licence: {undeclared}"
+
+
+@pytest.mark.parametrize("path", _BUILTIN_TEMPLATES, ids=lambda p: pathlib.Path(p).name)
+def test_every_builtin_licence_parses(path: str) -> None:
+    """A declared licence that does not parse is worse than none: it looks handled."""
+    for template in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")):
+        if not isinstance(template, dict):
+            continue
+        assert parse_licence(template.get("license")) is not UNDECLARED, (
+            f"{template.get('id')} declares an unparseable licence {template.get('license')!r}"
+        )
+
+
+def test_derived_builtins_are_no_more_permissive_than_their_source() -> None:
+    """The normals and anomalies are derivative works of CHIRPS3 and ERA5-Land, and were the
+    templates the first pass missed — they carry no `source_url`, so an insertion anchored on
+    that skipped every one of them."""
+    by_id = {}
+    for path in _BUILTIN_TEMPLATES:
+        for template in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")):
+            if isinstance(template, dict) and template.get("id"):
+                by_id[template["id"]] = parse_licence(template.get("license"))
+
+    for derived_id, source_id in (
+        ("chirps3_precipitation_monthly_normal_1991_2020", "chirps3_precipitation_monthly"),
+        ("chirps3_precipitation_monthly_anomaly_1991_2020", "chirps3_precipitation_monthly"),
+        ("era5land_temperature_monthly_normal_1991_2020", "era5land_temperature_monthly"),
+        ("era5land_temperature_monthly_anomaly_1991_2020", "era5land_temperature_monthly"),
+    ):
+        assert refuses_publication(by_id[derived_id], [by_id[source_id]]) is None, (
+            f"{derived_id} is more permissive than {source_id}"
+        )
+
+
+# -- the derive path, end to end -----------------------------------------------------------
+
+
+def _cube(variable: str) -> "xr.Dataset":
+    """A real one-variable cube. The derived-template builder computes a display range from the
+    values, so stubbing far enough to satisfy it costs more than just handing it a small array.
+    """
+    import numpy as np
+    import xarray as xr
+
+    return xr.Dataset(
+        {variable: (("y", "x"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"))},
+        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+
+
+def _derive(options: dict, source_template: dict | None) -> dict:
+    """Run the real derived-template builder, not a reimplementation of its licence rule."""
+    from open_climate_service.openeo import jobs
+
+    return jobs._derive_managed_dataset_template(_cube(str(options["variable"])), options, source_template, None)
+
+
+_NC_SOURCE = {
+    "id": "vantor_flood_rgb_2026",
+    "name": "Flood true colour",
+    "variable": "true_colour",
+    "license": "CC-BY-NC-4.0",
+    "providers": [{"name": "Vantor", "roles": ["producer"]}],
+}
+
+
+def test_a_product_derived_from_a_non_commercial_source_inherits_the_restriction() -> None:
+    """The acceptance case from CLIM-946: a water mask computed from CC-BY-NC imagery.
+
+    Before this, the derived collection published `various` — indistinguishable from an openly
+    licensed one, on the default path, with nothing to catch it.
+    """
+    template = _derive(
+        {"dataset_id": "flood_water_mask", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026"},
+        _NC_SOURCE,
+    )
+    assert parse_licence(template["license"]).commercial_use is False
+    # Attribution is a licence condition under CC-BY-NC, so it has to travel too.
+    assert template["providers"] == _NC_SOURCE["providers"]
+
+
+def test_publishing_a_derived_product_as_permissive_is_refused() -> None:
+    """Refused, not warned about: the output is a derivative work and a log line is not a
+    defence."""
+    with pytest.raises(ValueError, match="more permissive"):
+        _derive(
+            {
+                "dataset_id": "flood_water_mask",
+                "variable": "water",
+                "source_dataset_id": "vantor_flood_rgb_2026",
+                "license": "CC0-1.0",
+            },
+            _NC_SOURCE,
+        )
+
+
+def test_a_derived_product_may_declare_a_stricter_licence_than_its_source() -> None:
+    template = _derive(
+        {
+            "dataset_id": "derived",
+            "variable": "value",
+            "source_dataset_id": "chirps3_precipitation_monthly",
+            "license": "CC-BY-NC-4.0",
+        },
+        {"id": "chirps3_precipitation_monthly", "variable": "precip", "license": "CC0-1.0"},
+    )
+    assert template["license"] == "CC-BY-NC-4.0"
+
+
+def test_deriving_from_an_unlabelled_source_leaves_the_output_unlabelled() -> None:
+    """Not permissive by omission. An unlabelled input yields an unlabelled output, which
+    publishes as `other` rather than as something reassuring."""
+    template = _derive(
+        {"dataset_id": "derived", "variable": "value", "source_dataset_id": "mystery"},
+        {"id": "mystery", "variable": "value"},
+    )
+    assert parse_licence(template.get("license")) is UNDECLARED

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -242,13 +242,60 @@ def test_explicit_obligations_are_used_when_nothing_else_supplies_them() -> None
 # -- valid SPDX identifiers OCS has not reviewed -------------------------------------------
 
 
-def test_a_valid_spdx_identifier_is_preserved_even_when_unreviewed() -> None:
-    """Downgrading BSD-3-Clause to a free-form name and publishing `other` threw away
-    information the catalogue already had. The identifier is kept; only the propagation
-    semantics are marked unknown."""
-    licence = parse_licence("BSD-3-Clause")
-    assert licence.stac_license == "BSD-3-Clause"
+@pytest.mark.parametrize("identifier", ["BSD-3-Clause", "ISC", "Zlib", "EUPL-1.2", "ODC-By-1.0"])
+def test_a_valid_spdx_identifier_is_preserved_even_when_unreviewed(identifier: str) -> None:
+    """The general contract, not one hand-listed example. Identity is SPDX's question and
+    obligations are OCS's; while a single table answered both, every valid identifier nobody
+    had reviewed was demoted to a free-form name and published as `other`. `ODC-By-1.0` is the
+    one that shows the cost — an open-data licence a climate source could plausibly carry."""
+    licence = parse_licence(identifier)
+    assert licence.stac_license == identifier
     assert licence.known is False
+    assert licence.commercial_use is None
+
+
+def test_every_reviewed_identifier_is_a_real_spdx_identifier() -> None:
+    """The two tables must agree on the identifiers they share. A typo in the obligations
+    table would otherwise sit there silently: the licence would parse to no identifier at all
+    and publish as `other`, with its reviewed obligations never consulted."""
+    from open_climate_service.shared.licences import _SPDX_OBLIGATIONS, _canonical_spdx
+
+    assert {identifier: _canonical_spdx(identifier) for identifier in _SPDX_OBLIGATIONS} == {
+        identifier: identifier for identifier in _SPDX_OBLIGATIONS
+    }
+
+
+def test_a_deprecated_identifier_publishes_as_its_current_form() -> None:
+    """SPDX supersedes identifiers; a catalogue should carry the current one. Passing the
+    deprecated spelling straight through would publish an identifier the register no longer
+    lists."""
+    assert parse_licence("GPL-3.0").stac_license == "GPL-3.0-only"
+
+
+@pytest.mark.parametrize(
+    ("declared", "why"),
+    [
+        ("Apache-2.0 OR MIT", "an expression has no single obligation set to compare on"),
+        ("Apache-2.0 AND MIT", "same, for a conjunction"),
+        ("GPL-2.0-only WITH Classpath-exception-2.0", "a WITH clause is not one licence"),
+        ("Classpath-exception-2.0", "an exception is a modifier, not a licence"),
+        ("LicenseRef-scancode-3com-microcode", "ScanCode's vocabulary, not the SPDX register"),
+        ("CC-BY-4", "a near miss is not an identifier"),
+    ],
+)
+def test_what_validates_as_spdx_but_is_not_one_licence_is_refused(declared: str, why: str) -> None:
+    """Validating against the full register widens what is accepted, so the boundary has to be
+    drawn deliberately rather than inherited from the library. Each of these parses cleanly as
+    SPDX and none of them is a single licence this module can carry obligations for."""
+    licence = parse_licence(declared)
+    assert licence.stac_license == STAC_LICENSE_OTHER, why
+    assert licence.known is False
+
+
+def test_an_identifier_is_matched_whatever_its_case() -> None:
+    """`cc-by-4.0` is an easy thing to write in YAML, and rejecting it would be unhelpful."""
+    assert parse_licence("odc-by-1.0").stac_license == "ODC-By-1.0"
+    assert parse_licence("cc-by-4.0").identifier == "CC-BY-4.0"
 
 
 # -- a name must be the licence, not merely start like it ----------------------------------

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -298,6 +298,27 @@ def test_an_identifier_is_matched_whatever_its_case() -> None:
     assert parse_licence("cc-by-4.0").identifier == "CC-BY-4.0"
 
 
+def test_a_string_that_is_neither_an_identifier_nor_a_known_name_is_reported() -> None:
+    """A mistyped identifier is published as `other` with no licence link, and the viewer then
+    shows "not declared" — indistinguishable from declaring nothing, which is the one outcome
+    this module exists to make impossible. Parsing still degrades quietly; the validator is
+    where it has to be said."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    problem = licence_declaration_problem("CC-BY-4.O")
+    assert problem is not None
+    assert "CC-BY-4.O" in problem
+
+
+@pytest.mark.parametrize("declared", ["CC-BY-4.0", "cc-by-4.0", "ISC", "Licence to Use Copernicus Products"])
+def test_a_string_that_resolves_to_something_is_not_reported(declared: str) -> None:
+    """An identifier in any case, a valid-but-unreviewed one, and a licence known by name are
+    all fine as plain strings; only an unresolvable one is worth a warning."""
+    from open_climate_service.shared.licences import licence_declaration_problem
+
+    assert licence_declaration_problem(declared) is None
+
+
 # -- a name must be the licence, not merely start like it ----------------------------------
 
 
@@ -329,6 +350,29 @@ def test_an_identifier_contradicted_by_a_known_name_is_undeclared() -> None:
     `CC0-1.0` beside a link to terms requiring attribution is worse than publishing nothing.
     There is no basis for choosing between them."""
     licence = parse_licence({"id": "CC0-1.0", "name": "Licence to Use Copernicus Products", "url": "https://x"})
+    assert licence is UNDECLARED
+
+
+def test_matching_obligations_do_not_make_two_licences_the_same_one() -> None:
+    """`CC-BY-4.0` and the Copernicus licence both require attribution and are different
+    instruments. Comparing the obligation sets accepted this and published `license: CC-BY-4.0`
+    over a link to Copernicus terms — the field a STAC client reads, disagreeing with the link
+    it usually does not fetch."""
+    licence = parse_licence(
+        {
+            "id": "CC-BY-4.0",
+            "name": "Licence to Use Copernicus Products",
+            "url": "https://apps.ecmwf.int/datasets/licences/copernicus/",
+        }
+    )
+    assert licence is UNDECLARED
+
+
+def test_a_recognised_name_contradicts_even_an_unreviewed_identifier() -> None:
+    """Whether OCS has recorded what `ISC` requires has no bearing on whether it is the
+    Copernicus licence. The check was skipped entirely for identifiers outside the obligations
+    table."""
+    licence = parse_licence({"id": "ISC", "name": "NASA Earth Science Data", "url": "https://x"})
     assert licence is UNDECLARED
 
 
@@ -384,7 +428,7 @@ def test_the_validator_names_the_contradiction_rather_than_calling_it_unreadable
     )
     assert problem is not None
     assert "CC0-1.0" in problem
-    assert "attribution" in problem
+    assert "Licence to Use Copernicus Products" in problem
 
 
 @pytest.mark.parametrize(
@@ -514,12 +558,13 @@ _EXPECTED: dict[tuple[str, str, str], str] = {
     ("absent", "known-conflicts", "present"): _IGNORED,
     ("absent", "unknown", "absent"): _ACCEPTED,
     ("absent", "unknown", "present"): _ACCEPTED,  # the legitimate use of an explicit list
-    # A recognised identifier is authoritative, and a known name that disagrees with it is a
-    # contradiction rather than a redundancy.
+    # An identifier beside *any* recognised name is a contradiction. The named-licence table
+    # holds licences that have no SPDX identifier, so the two name different instruments —
+    # matching obligations make them compatible, not the same licence.
     ("recognised", "absent", "absent"): _ACCEPTED,
     ("recognised", "absent", "present"): _IGNORED,
-    ("recognised", "known-agrees", "absent"): _ACCEPTED,
-    ("recognised", "known-agrees", "present"): _IGNORED,
+    ("recognised", "known-agrees", "absent"): _UNDECLARED,
+    ("recognised", "known-agrees", "present"): _UNDECLARED,
     ("recognised", "known-conflicts", "absent"): _UNDECLARED,
     ("recognised", "known-conflicts", "present"): _UNDECLARED,
     ("recognised", "unknown", "absent"): _ACCEPTED,
@@ -538,8 +583,8 @@ _EXPECTED: dict[tuple[str, str, str], str] = {
     # Both aliases naming one licence behaves exactly as one identifier.
     ("aliases-agree", "absent", "absent"): _ACCEPTED,
     ("aliases-agree", "absent", "present"): _IGNORED,
-    ("aliases-agree", "known-agrees", "absent"): _ACCEPTED,
-    ("aliases-agree", "known-agrees", "present"): _IGNORED,
+    ("aliases-agree", "known-agrees", "absent"): _UNDECLARED,
+    ("aliases-agree", "known-agrees", "present"): _UNDECLARED,
     ("aliases-agree", "known-conflicts", "absent"): _UNDECLARED,
     ("aliases-agree", "known-conflicts", "present"): _UNDECLARED,
     ("aliases-agree", "unknown", "absent"): _ACCEPTED,

--- a/tests/test_dataset_licences.py
+++ b/tests/test_dataset_licences.py
@@ -132,6 +132,40 @@ def test_every_builtin_licence_parses(path: str) -> None:
         )
 
 
+# The obligations each source's own terms impose, read off the source's page and recorded here
+# rather than taken from the template — a test that reads the declaration it is checking
+# asserts nothing. CHIRPS3 is why this table exists: CHC's page says CHIRPS3 "is in the public
+# domain" and that CHC "waived all copyright and related or neighboring rights", wording that
+# reads as CC0, while the same sentence names the instrument as CC BY 4.0. The first
+# declaration shipped CC0-1.0, which drops attribution from CHIRPS3 and everything derived
+# from it. Nothing in the checks above catches that: CC0 parses, and every derived product
+# dropped attribution consistently.
+_REVIEWED_SOURCE_TERMS: dict[str, frozenset[str]] = {
+    "chirps3.yaml": frozenset({ATTRIBUTION}),  # CC BY 4.0
+    "era5_land.yaml": frozenset({ATTRIBUTION}),  # Licence to Use Copernicus Products
+    "worldpop.yaml": frozenset({ATTRIBUTION}),  # CC BY 4.0
+}
+
+
+def test_every_shipped_template_has_reviewed_source_terms() -> None:
+    """Guards the guard: a new or renamed template file would otherwise go unchecked, which is
+    the point at which its licence has not been read by anyone."""
+    assert {pathlib.Path(path).name for path in _BUILTIN_TEMPLATES} == set(_REVIEWED_SOURCE_TERMS)
+
+
+@pytest.mark.parametrize("path", _BUILTIN_TEMPLATES, ids=lambda p: pathlib.Path(p).name)
+def test_no_builtin_declares_away_an_obligation_its_source_imposes(path: str) -> None:
+    required = _REVIEWED_SOURCE_TERMS[pathlib.Path(path).name]
+    for template in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")):
+        if not isinstance(template, dict) or not template.get("id"):
+            continue
+        obligations = parse_licence(template.get("license")).obligations
+        assert required <= obligations, (
+            f"{template['id']} declares {template.get('license')!r}, dropping "
+            f"{sorted(required - obligations)} required by its source"
+        )
+
+
 def _builtin_licences() -> dict:
     licences = {}
     for path in _BUILTIN_TEMPLATES:

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -343,8 +343,11 @@ def test_unrecognised_units_warn_once_per_template(monkeypatch: pytest.MonkeyPat
     for _ in range(3):
         datasets._validate_dataset_template(template, source="counts.yaml")
 
-    assert len(warnings) == 1
-    assert "not a recognised CF/udunits unit" in warnings[0]
+    # Filtered to the units warning: this template also declares no licence, which warns once
+    # too (CLIM-946). Counting every warning would make this test fail whenever another
+    # validation is added, which is not what it is checking.
+    units_warnings = [w for w in warnings if "not a recognised CF/udunits unit" in w]
+    assert len(units_warnings) == 1
 
 
 def test_missing_plugins_dir_serves_built_ins_instead_of_raising(
@@ -439,4 +442,10 @@ def test_concurrent_validation_warns_once(monkeypatch: pytest.MonkeyPatch) -> No
         for f in [pool.submit(datasets._validate_dataset_template, template, source="counts.yaml") for _ in range(8)]:
             f.result()
 
-    assert len(warnings) == 1
+    # Per distinct warning, not in total: this template also warns about its missing licence
+    # (CLIM-946). The property under test is that eight concurrent validations each produce one
+    # warning rather than eight, which is about locking, not about how many checks exist.
+    units_warnings = [w for w in warnings if "not a recognised CF/udunits unit" in w]
+    licence_warnings = [w for w in warnings if "declares no 'license'" in w]
+    assert len(units_warnings) == 1
+    assert len(licence_warnings) == 1

--- a/tests/test_managed_publish_units.py
+++ b/tests/test_managed_publish_units.py
@@ -169,7 +169,25 @@ def managed_instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the template registry and the store directory at a temporary instance."""
     configs = tmp_path / "datasets"
     configs.mkdir()
+    # The source these tests declare as `source_dataset_id`. Registered because lineage that
+    # does not resolve is now an error rather than silently "not derived from anything"
+    # (CLIM-946) — a typo there would otherwise disable licence propagation. Writing it also
+    # makes the fixture match production, where a source you derive from necessarily exists.
+    (configs / "source.yaml").write_text(
+        "- id: chirps3_precipitation_daily\n"
+        "  name: Total precipitation (CHIRPS3)\n"
+        "  variable: precip\n"
+        "  period_type: daily\n"
+        "  units: mm/d\n"
+        "  license: CC0-1.0\n"
+        "  sync:\n"
+        "    kind: temporal\n"
+        "  ingestion:\n"
+        "    plugin: open_climate_service.plugins.datasets.chirps3.CHIRPS3DailyPlugin\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(registry, "CONFIGS_DIR", configs)
+    registry.reset_template_caches()
     monkeypatch.setattr("open_climate_service.data_manager.services.downloader.DOWNLOAD_DIR", tmp_path / "downloads")
     (tmp_path / "downloads").mkdir()
     return configs

--- a/tests/test_managed_publish_units.py
+++ b/tests/test_managed_publish_units.py
@@ -179,7 +179,7 @@ def managed_instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "  variable: precip\n"
         "  period_type: daily\n"
         "  units: mm/d\n"
-        "  license: CC0-1.0\n"
+        "  license: CC-BY-4.0\n"
         "  sync:\n"
         "    kind: temporal\n"
         "  ingestion:\n"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1035,3 +1035,92 @@ def test_cf_extension_is_not_declared_when_no_cf_attrs_are_present(
 
     assert not any(key.startswith("cf:") for key in payload["cube:variables"]["precip"])
     assert stac_services.CF_EXTENSION not in payload["stac_extensions"]
+
+
+# -- licence, providers and the licence link (CLIM-946) ------------------------------------
+
+
+def _stub_with_template(monkeypatch: pytest.MonkeyPatch, artifact: ArtifactRecord, template: dict) -> None:
+    """As `_stub_collection_build`, but with a template the test controls."""
+    monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[artifact]))
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: template)
+    monkeypatch.setattr(stac_services, "_build_collection_with_xstac", lambda **_: _minimal_xstac_payload())
+    monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {})
+    monkeypatch.setattr(stac_services, "_zarr_open_kwargs", lambda _: {"consolidated": True})
+
+
+def test_collection_publishes_an_spdx_licence(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_with_template(monkeypatch, _artifact(artifact_id="lic1"), {"period_type": "daily", "license": "CC-BY-4.0"})
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert payload["license"] == "CC-BY-4.0"
+
+
+def test_collection_publishes_other_and_a_licence_link_for_a_bespoke_licence(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Copernicus case. `license` can only say `other`, so without the link a client learns
+    nothing at all about the terms."""
+    _stub_with_template(
+        monkeypatch,
+        _artifact(artifact_id="lic2"),
+        {
+            "period_type": "daily",
+            "license": {
+                "name": "Licence to Use Copernicus Products",
+                "url": "https://apps.ecmwf.int/datasets/licences/copernicus/",
+            },
+        },
+    )
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert payload["license"] == "other"
+    links = [link for link in payload["links"] if link.get("rel") == "license"]
+    assert len(links) == 1
+    assert links[0]["href"] == "https://apps.ecmwf.int/datasets/licences/copernicus/"
+    assert links[0]["title"] == "Licence to Use Copernicus Products"
+
+
+def test_an_undeclared_licence_publishes_other_and_no_link(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never `various`, which is not a STAC value and reads as "nothing worth mentioning"."""
+    _stub_with_template(monkeypatch, _artifact(artifact_id="lic3"), {"period_type": "daily"})
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert payload["license"] == "other"
+    assert not [link for link in payload["links"] if link.get("rel") == "license"]
+
+
+def test_an_spdx_licence_needs_no_link(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An SPDX identifier is self-describing; a link would be noise."""
+    _stub_with_template(monkeypatch, _artifact(artifact_id="lic4"), {"period_type": "daily", "license": "CC0-1.0"})
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert not [link for link in payload["links"] if link.get("rel") == "license"]
+
+
+def test_providers_are_published(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attribution is a licence condition under CC-BY, not a courtesy."""
+    _stub_with_template(
+        monkeypatch,
+        _artifact(artifact_id="lic5"),
+        {
+            "period_type": "daily",
+            "license": "CC-BY-4.0",
+            "providers": [{"name": "WorldPop", "url": "https://hub.worldpop.org/", "roles": ["licensor"]}],
+        },
+    )
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert payload["providers"] == [{"name": "WorldPop", "url": "https://hub.worldpop.org/", "roles": ["licensor"]}]
+
+
+def test_malformed_providers_are_dropped_rather_than_published(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`name` is the only field STAC requires, so an entry without one is not a provider."""
+    _stub_with_template(
+        monkeypatch,
+        _artifact(artifact_id="lic6"),
+        {
+            "period_type": "daily",
+            "license": "CC-BY-4.0",
+            "providers": ["not a mapping", {"url": "https://x"}, {"name": "  "}, {"name": "Real"}],
+        },
+    )
+    payload = client.get("/stac/collections/chirps3_precipitation_daily").json()
+    assert payload["providers"] == [{"name": "Real"}]

--- a/uv.lock
+++ b/uv.lock
@@ -219,6 +219,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "bottleneck"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1193,6 +1202,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "llvmlite"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1766,6 +1787,7 @@ server = [
     { name = "geozarr-toolkit" },
     { name = "icechunk" },
     { name = "jinja2" },
+    { name = "license-expression" },
     { name = "metpy" },
     { name = "netcdf4" },
     { name = "odc-geo" },
@@ -1824,6 +1846,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "icechunk", marker = "extra == 'server'", specifier = ">=2.0,<3" },
     { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1" },
+    { name = "license-expression", marker = "extra == 'server'", specifier = ">=30.4" },
     { name = "metpy", marker = "extra == 'server'", specifier = ">=1.7,<2" },
     { name = "netcdf4", marker = "extra == 'server'", specifier = ">=1.7" },
     { name = "odc-geo", marker = "extra == 'server'", specifier = ">=0.4.1" },


### PR DESCRIPTION
[CLIM-946](https://dhis2.atlassian.net/browse/CLIM-946)

Every collection published the constant `various` — not a STAC value, and it reads as "no restrictions worth mentioning". Datasets now declare a licence, published as a STAC `license` with a `rel: license` link and `providers`, and shown in `/datasets` and the viewer.

- Every built-in template declares its source licence. One without a licence warns at load and publishes `other`.
- A licence is an SPDX identifier, or a name and URL for the licences that have none — the Copernicus licence among them.
- Contradictory declarations are refused rather than half-applied: conflicting `id`/`spdx` aliases, or an identifier contradicted by a known name. A field that gets discarded is reported once, at template validation, not on every request.
- `_DECLARATION_MATRIX` in the tests enumerates the combinations of the five accepted keys with the decided outcome for each, so an undecided one fails as a missing row.

Propagation to derived products is #366.


[CLIM-946]: https://dhis2.atlassian.net/browse/CLIM-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ