### PR TITLE
fix(urls): build absolute URLs from the configured base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,17 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # HOST=0.0.0.0
 # PORT=9000
 
-# Set when running behind a reverse proxy so that STAC hrefs and native dataset
-# links use the public address instead of the internal request URL.
-# Note: pygeoapi's OGC self/root links are controlled separately via server.url
-# in config/pygeoapi/base.yml and are not affected by this variable.
+# The public origin of this instance. Set it when running behind a reverse proxy
+# whose address OCS does not trust, so that absolute URLs name the public address
+# rather than the internal request URL. It governs every URL that leaves the
+# process: the STAC catalogue and collections, the openEO capabilities links, and
+# the /openeo editor redirect. Links inside served HTML pages do not use it -- they
+# are relative, so they follow whichever origin the page was reached on.
+# A proxy on loopback needs no setting: uvicorn already trusts its forwarded
+# headers, so the scheme and host are derived correctly without this.
+# Also read by the Python client as the instance to talk to, so exporting it for
+# the client changes what a locally-run server puts in its own links.
+# Must include a scheme: "ocs.example.org" produces broken links.
 # CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
 # Fallback used to derive the native API base URL when CLIMATE_SERVICE_BASE_URL is not set.

--- a/.env.example
+++ b/.env.example
@@ -30,43 +30,30 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # PORT=9000
 
 # Path prefix this instance is served under, when a reverse proxy puts it on a
-# sub-path and strips that prefix before forwarding. Set it and links inside served
-# pages resolve under the prefix. The proxy must strip the prefix; a non-stripping
-# proxy 404s every route before any URL is generated.
-# Prefer this over declaring the prefix only in the path of CLIMATE_SERVICE_BASE_URL.
-# That fallback exists for deployments that cannot set ROOT_PATH, and it cannot
-# distinguish a proxied request from a direct one, so it also prefixes links when you
-# reach the instance on a port-forward, where they then 404.
+# sub-path and strips that prefix before forwarding. Links inside served pages and the
+# absolute URLs in STAC and openEO documents then resolve under it. Read by the app,
+# so it works under make run, bare uvicorn and the climate-service entry point alike.
+# The proxy must strip the prefix: a non-stripping proxy 404s every route.
 # ROOT_PATH=/ocs
 
-# The public origin of this instance. Set it when running behind a reverse proxy
-# whose address OCS does not trust, so that absolute URLs name the public address
-# rather than the internal request URL. It governs the absolute URLs OCS puts into
-# documents it serves: the STAC catalogue, collections and asset hrefs, the openEO
-# capabilities, /processes, /collections and /.well-known/openeo, and the /openeo
-# editor redirect. Job, workflow and ingestion links are still bare paths (CLIM-995).
-# A path in this URL is the fallback mount prefix for links inside served pages when
-# ROOT_PATH is unset. Otherwise served HTML does not use this variable: its links are
-# mount-relative paths, so they follow whichever origin the page was reached on.
-# A host-installed proxy talking to a host-run uvicorn over loopback needs no
-# setting: uvicorn trusts forwarded headers from 127.0.0.1 by default, so the scheme
-# and host are derived correctly. That does not hold for the shipped compose.yml --
-# the app sits on a Docker bridge, so a same-host proxy reaches it from the bridge
-# gateway, X-Forwarded-Proto is ignored, and links come out http://. Either set this
-# variable or widen FORWARDED_ALLOW_IPS below.
-# Also read by the Python client as the instance to talk to, so exporting it for
-# the client changes what a locally-run server puts in its own links.
-# Must include a scheme and a host: "ocs.example.org" is rejected with a warning and
-# the request origin is used instead. Any query string or fragment is dropped.
+# The public origin of this instance, with a scheme and a host. Set it when running
+# behind a reverse proxy whose address OCS does not trust, so that the absolute URLs in
+# the STAC catalogue, the openEO capabilities and the /openeo editor redirect name the
+# public address rather than the internal one. Links inside served HTML never use it:
+# they are mount-relative paths, so they follow whichever origin the page was reached on.
+# A path here is the service root as the outside world addresses it; with no path,
+# ROOT_PATH is appended. Declaring the prefix only here, without ROOT_PATH, also works
+# but prefixes in-page links on a direct port-forward, where they then 404.
+# A same-host proxy talking to uvicorn over loopback needs no setting: uvicorn trusts
+# forwarded headers from 127.0.0.1 by default. The shipped compose.yml is not that case,
+# because the app sits on a Docker bridge; set this or widen FORWARDED_ALLOW_IPS.
+# Also read by the Python client as the instance to talk to.
 # CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
 # Proxy addresses whose X-Forwarded-* headers uvicorn will trust. Defaults to
-# 127.0.0.1, which excludes a proxy arriving over a Docker bridge. The general fix for
-# every site that derives a URL from the request rather than from
-# CLIMATE_SERVICE_BASE_URL.
-# The climate-service entry point reads it from this file. Running uvicorn directly
-# does not: uvicorn builds its config from the process environment before anything
-# loads .env, so pass --forwarded-allow-ips on the command line in that case.
+# 127.0.0.1, which excludes a proxy arriving over a Docker bridge. The climate-service
+# entry point reads it from this file; bare uvicorn reads it from the process
+# environment only, so export it or pass --forwarded-allow-ips in that case.
 # FORWARDED_ALLOW_IPS=172.16.0.0/12
 
 # Comma-separated list of origins used for extra browser/private-network headers

--- a/.env.example
+++ b/.env.example
@@ -31,21 +31,27 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 
 # The public origin of this instance. Set it when running behind a reverse proxy
 # whose address OCS does not trust, so that absolute URLs name the public address
-# rather than the internal request URL. It governs every URL that leaves the
-# process: the STAC catalogue and collections, the openEO capabilities links, and
-# the /openeo editor redirect. Links inside served HTML pages do not use it -- they
-# are relative, so they follow whichever origin the page was reached on.
-# A proxy on loopback needs no setting: uvicorn already trusts its forwarded
-# headers, so the scheme and host are derived correctly without this.
+# rather than the internal request URL. It governs three things: the STAC catalogue
+# and collections, the openEO capabilities links, and the /openeo editor redirect.
+# Job, workflow and ingestion links are still bare paths (CLIM-995).
+# Links inside served HTML pages do not use it -- they are mount-relative paths, so
+# they follow whichever origin the page was reached on.
+# A host-installed proxy talking to a host-run uvicorn over loopback needs no
+# setting: uvicorn trusts forwarded headers from 127.0.0.1 by default, so the scheme
+# and host are derived correctly. That does not hold for the shipped compose.yml --
+# the app sits on a Docker bridge, so a same-host proxy reaches it from the bridge
+# gateway, X-Forwarded-Proto is ignored, and links come out http://. Either set this
+# variable or widen FORWARDED_ALLOW_IPS below.
 # Also read by the Python client as the instance to talk to, so exporting it for
 # the client changes what a locally-run server puts in its own links.
 # Must include a scheme: "ocs.example.org" produces broken links.
 # CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
-# Fallback used to derive the native API base URL when CLIMATE_SERVICE_BASE_URL is not set.
-# Only needed if CLIMATE_SERVICE_BASE_URL is unset and the OGC API path is known.
-# Note: pygeoapi's server.url is controlled separately in config/pygeoapi/base.yml.
-# OGCAPI_BASE_URL=http://localhost:9000/ogcapi
+# Proxy addresses whose X-Forwarded-* headers uvicorn will trust. Defaults to
+# 127.0.0.1, which excludes a proxy arriving over a Docker bridge. Honoured by
+# uvicorn directly, and the general fix for every site that derives a URL from the
+# request rather than from CLIMATE_SERVICE_BASE_URL.
+# FORWARDED_ALLOW_IPS=172.16.0.0/12
 
 # Comma-separated list of origins used for extra browser/private-network headers
 # on Zarr responses (default: https://inspect.geozarr.org).

--- a/.env.example
+++ b/.env.example
@@ -29,16 +29,25 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # HOST=0.0.0.0
 # PORT=9000
 
+# Path prefix this instance is served under, when a reverse proxy puts it on a
+# sub-path and strips that prefix before forwarding. Set it and links inside served
+# pages resolve under the prefix. The proxy must strip the prefix; a non-stripping
+# proxy 404s every route before any URL is generated.
+# Prefer this over declaring the prefix only in the path of CLIMATE_SERVICE_BASE_URL.
+# That fallback exists for deployments that cannot set ROOT_PATH, and it cannot
+# distinguish a proxied request from a direct one, so it also prefixes links when you
+# reach the instance on a port-forward, where they then 404.
+# ROOT_PATH=/ocs
+
 # The public origin of this instance. Set it when running behind a reverse proxy
 # whose address OCS does not trust, so that absolute URLs name the public address
 # rather than the internal request URL. It governs the absolute URLs OCS puts into
 # documents it serves: the STAC catalogue, collections and asset hrefs, the openEO
 # capabilities, /processes, /collections and /.well-known/openeo, and the /openeo
 # editor redirect. Job, workflow and ingestion links are still bare paths (CLIM-995).
-# A path in this URL also supplies the mount prefix for links inside served pages
-# when the server is not started with --root-path, which no shipped entry point does.
-# Links inside served HTML pages do not use it -- they are mount-relative paths, so
-# they follow whichever origin the page was reached on.
+# A path in this URL is the fallback mount prefix for links inside served pages when
+# ROOT_PATH is unset. Otherwise served HTML does not use this variable: its links are
+# mount-relative paths, so they follow whichever origin the page was reached on.
 # A host-installed proxy talking to a host-run uvicorn over loopback needs no
 # setting: uvicorn trusts forwarded headers from 127.0.0.1 by default, so the scheme
 # and host are derived correctly. That does not hold for the shipped compose.yml --
@@ -47,7 +56,8 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # variable or widen FORWARDED_ALLOW_IPS below.
 # Also read by the Python client as the instance to talk to, so exporting it for
 # the client changes what a locally-run server puts in its own links.
-# Must include a scheme: "ocs.example.org" produces broken links.
+# Must include a scheme and a host: "ocs.example.org" is rejected with a warning and
+# the request origin is used instead. Any query string or fragment is dropped.
 # CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
 # Proxy addresses whose X-Forwarded-* headers uvicorn will trust. Defaults to

--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,12 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 
 # The public origin of this instance. Set it when running behind a reverse proxy
 # whose address OCS does not trust, so that absolute URLs name the public address
-# rather than the internal request URL. It governs three things: the STAC catalogue
-# and collections, the openEO capabilities links, and the /openeo editor redirect.
-# Job, workflow and ingestion links are still bare paths (CLIM-995).
+# rather than the internal request URL. It governs the absolute URLs OCS puts into
+# documents it serves: the STAC catalogue, collections and asset hrefs, the openEO
+# capabilities, /processes, /collections and /.well-known/openeo, and the /openeo
+# editor redirect. Job, workflow and ingestion links are still bare paths (CLIM-995).
+# A path in this URL also supplies the mount prefix for links inside served pages
+# when the server is not started with --root-path, which no shipped entry point does.
 # Links inside served HTML pages do not use it -- they are mount-relative paths, so
 # they follow whichever origin the page was reached on.
 # A host-installed proxy talking to a host-run uvicorn over loopback needs no
@@ -48,9 +51,12 @@ CLIMATE_SERVICE_CONFIG=./climate-service.yaml
 # CLIMATE_SERVICE_BASE_URL=http://localhost:9000
 
 # Proxy addresses whose X-Forwarded-* headers uvicorn will trust. Defaults to
-# 127.0.0.1, which excludes a proxy arriving over a Docker bridge. Honoured by
-# uvicorn directly, and the general fix for every site that derives a URL from the
-# request rather than from CLIMATE_SERVICE_BASE_URL.
+# 127.0.0.1, which excludes a proxy arriving over a Docker bridge. The general fix for
+# every site that derives a URL from the request rather than from
+# CLIMATE_SERVICE_BASE_URL.
+# The climate-service entry point reads it from this file. Running uvicorn directly
+# does not: uvicorn builds its config from the process environment before anything
+# loads .env, so pass --forwarded-allow-ips on the command line in that case.
 # FORWARDED_ALLOW_IPS=172.16.0.0/12
 
 # Comma-separated list of origins used for extra browser/private-network headers

--- a/open_climate_service/cli.py
+++ b/open_climate_service/cli.py
@@ -4,6 +4,8 @@ import os
 
 import uvicorn
 
+import open_climate_service.startup  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 9000
 
@@ -11,34 +13,23 @@ DEFAULT_PORT = 9000
 def main() -> None:
     """Start the Open Climate Service server.
 
-    Host, port, deployment prefix and trusted proxy addresses come from HOST, PORT, ROOT_PATH
-    and FORWARDED_ALLOW_IPS, defaulting to 0.0.0.0:9000, no prefix, and uvicorn's own
-    127.0.0.1.
+    Host, port and trusted proxy addresses come from HOST, PORT and FORWARDED_ALLOW_IPS,
+    defaulting to 0.0.0.0:9000 and uvicorn's own 127.0.0.1. ROOT_PATH is read by the app
+    itself (`create_app`), so it applies under every launcher, not only this one.
 
-    `.env` is loaded here, before the four are read, because uvicorn builds its config from the
-    process environment as `run()` is called — earlier than the app import that loads `.env` for
-    everything else. Without this, `FORWARDED_ALLOW_IPS` in `.env` is ignored and only compose's
-    `env_file` works, with no error to go on. `load_dotenv` does not overwrite variables already
-    set, so compose and the shell still win over the file.
-
-    `ROOT_PATH` is how a deployment prefix should be declared: it sets ASGI `root_path`, which
-    `shared.urls` prefers over its fallback of reading the path of `CLIMATE_SERVICE_BASE_URL` as
-    a mount. That fallback cannot distinguish a proxied request from a direct one, so it also
-    prefixes in-page links on a port-forward straight to the port.
+    `startup` is imported above, before the environment is read, because uvicorn builds its
+    config from the process environment as `run()` is called, earlier than the app import that
+    loads `.env` for everything else. Without it, `FORWARDED_ALLOW_IPS` in `.env` is silently
+    ignored. `load_dotenv` does not overwrite variables already set, so compose and the shell
+    still win over the file.
     """
-    from dotenv import load_dotenv
-
-    load_dotenv()
-
     host = os.environ.get("HOST", DEFAULT_HOST)
     port = int(os.environ.get("PORT", DEFAULT_PORT))
     forwarded_allow_ips = os.environ.get("FORWARDED_ALLOW_IPS")
-    root_path = os.environ.get("ROOT_PATH", "")
 
     uvicorn.run(
         "open_climate_service.main:app",
         host=host,
         port=port,
         forwarded_allow_ips=forwarded_allow_ips,
-        root_path=root_path,
     )

--- a/open_climate_service/cli.py
+++ b/open_climate_service/cli.py
@@ -11,9 +11,26 @@ DEFAULT_PORT = 9000
 def main() -> None:
     """Start the Open Climate Service server.
 
-    Host and port are read from the HOST and PORT environment variables,
-    defaulting to 0.0.0.0:9000.
+    Host, port and trusted proxy addresses are read from HOST, PORT and
+    FORWARDED_ALLOW_IPS, defaulting to 0.0.0.0:9000 and uvicorn's own 127.0.0.1.
+
+    `FORWARDED_ALLOW_IPS` is passed explicitly rather than left to uvicorn. Uvicorn reads it
+    from the process environment while building its config, which happens before the app
+    imports and calls `load_dotenv`, so a value in `.env` was silently ignored here and worked
+    only through compose's `env_file`. An operator who set it and still got `http://` links had
+    no error to go on.
     """
     host = os.environ.get("HOST", DEFAULT_HOST)
     port = int(os.environ.get("PORT", DEFAULT_PORT))
-    uvicorn.run("open_climate_service.main:app", host=host, port=port)
+
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    forwarded_allow_ips = os.environ.get("FORWARDED_ALLOW_IPS")
+
+    uvicorn.run(
+        "open_climate_service.main:app",
+        host=host,
+        port=port,
+        forwarded_allow_ips=forwarded_allow_ips,
+    )

--- a/open_climate_service/cli.py
+++ b/open_climate_service/cli.py
@@ -11,26 +11,34 @@ DEFAULT_PORT = 9000
 def main() -> None:
     """Start the Open Climate Service server.
 
-    Host, port and trusted proxy addresses are read from HOST, PORT and
-    FORWARDED_ALLOW_IPS, defaulting to 0.0.0.0:9000 and uvicorn's own 127.0.0.1.
+    Host, port, deployment prefix and trusted proxy addresses come from HOST, PORT, ROOT_PATH
+    and FORWARDED_ALLOW_IPS, defaulting to 0.0.0.0:9000, no prefix, and uvicorn's own
+    127.0.0.1.
 
-    `FORWARDED_ALLOW_IPS` is passed explicitly rather than left to uvicorn. Uvicorn reads it
-    from the process environment while building its config, which happens before the app
-    imports and calls `load_dotenv`, so a value in `.env` was silently ignored here and worked
-    only through compose's `env_file`. An operator who set it and still got `http://` links had
-    no error to go on.
+    `.env` is loaded here, before the four are read, because uvicorn builds its config from the
+    process environment as `run()` is called — earlier than the app import that loads `.env` for
+    everything else. Without this, `FORWARDED_ALLOW_IPS` in `.env` is ignored and only compose's
+    `env_file` works, with no error to go on. `load_dotenv` does not overwrite variables already
+    set, so compose and the shell still win over the file.
+
+    `ROOT_PATH` is how a deployment prefix should be declared: it sets ASGI `root_path`, which
+    `shared.urls` prefers over its fallback of reading the path of `CLIMATE_SERVICE_BASE_URL` as
+    a mount. That fallback cannot distinguish a proxied request from a direct one, so it also
+    prefixes in-page links on a port-forward straight to the port.
     """
-    host = os.environ.get("HOST", DEFAULT_HOST)
-    port = int(os.environ.get("PORT", DEFAULT_PORT))
-
     from dotenv import load_dotenv
 
     load_dotenv()
+
+    host = os.environ.get("HOST", DEFAULT_HOST)
+    port = int(os.environ.get("PORT", DEFAULT_PORT))
     forwarded_allow_ips = os.environ.get("FORWARDED_ALLOW_IPS")
+    root_path = os.environ.get("ROOT_PATH", "")
 
     uvicorn.run(
         "open_climate_service.main:app",
         host=host,
         port=port,
         forwarded_allow_ips=forwarded_allow_ips,
+        root_path=root_path,
     )

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -20,6 +20,7 @@ from open_climate_service.openeo.jobs import get_openeo_job_service
 from open_climate_service.read_only import read_only_middleware
 from open_climate_service.scheduler import routes as scheduler_routes
 from open_climate_service.scheduler.service import get_scheduler_service
+from open_climate_service.shared import urls
 from open_climate_service.stac import routes as stac_routes
 from open_climate_service.system import routes as system_routes
 
@@ -106,7 +107,12 @@ def create_app() -> FastAPI:
         from open_climate_service.main import create_app
         app = create_app()
     """
-    _app = FastAPI(lifespan=_lifespan)
+    # `root_path` from the environment here rather than only in `cli.py`, so a deployment
+    # prefix applies under `make run` and bare uvicorn as well as the `climate-service` entry
+    # point. Reading the base URL once at boot surfaces an unusable value in the startup log,
+    # instead of on the first request that builds a link.
+    _app = FastAPI(lifespan=_lifespan, root_path=urls.configured_root_path())
+    urls.configured_base()
 
     # Registered *before* CORS so it ends up innermost: Starlette applies the most recently
     # added middleware outermost, so CORS wraps this and a 403 still carries the headers a
@@ -170,7 +176,8 @@ def create_app() -> FastAPI:
 
         # Extra CORS + PNA headers for Zarr inspector origins on /zarr paths.
         allowed_zarr_origin = origin if origin in _zarr_browser_access_origins() else None
-        if allowed_zarr_origin and (request.url.path == "/zarr" or request.url.path.startswith("/zarr/")):
+        path = urls.route_path(request)
+        if allowed_zarr_origin and (path == "/zarr" or path.startswith("/zarr/")):
             response.headers["Access-Control-Allow-Origin"] = allowed_zarr_origin
             _append_vary_value(response, "Origin")
             response.headers.setdefault("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")

--- a/open_climate_service/openeo/collections.py
+++ b/open_climate_service/openeo/collections.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 from fastapi import HTTPException, Request
 
+from open_climate_service.shared.urls import absolute_base
 from open_climate_service.stac import services as stac_services
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def _normalize_cube_dimensions(collection: dict[str, Any]) -> dict[str, Any]:
 
 def _rewrite_collection_links(collection: dict[str, Any], request: Request) -> dict[str, Any]:
     """Replace /stac/collections links with /collections links."""
-    base_url = _abs_base(request)
+    base_url = absolute_base(request)
     links = collection.get("links", [])
     rewritten: list[dict[str, Any]] = []
     for link in links:
@@ -73,7 +73,7 @@ def list_collections(request: Request) -> dict[str, Any]:
             )
             continue
 
-    base_url = _abs_base(request)
+    base_url = absolute_base(request)
     return {
         "collections": collections,
         "links": [
@@ -88,10 +88,3 @@ def get_collection(dataset_id: str, request: Request) -> dict[str, Any]:
     collection = stac_services.build_collection(dataset_id, request)
     collection = _rewrite_collection_links(collection, request)
     return _normalize_cube_dimensions(collection)
-
-
-def _abs_base(request: Request) -> str:
-    base_url = os.getenv("CLIMATE_SERVICE_BASE_URL")
-    if base_url:
-        return base_url.rstrip("/")
-    return str(request.base_url).rstrip("/")

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any, Callable
 
 from fastapi import APIRouter, Body, HTTPException, Request, Response
@@ -22,6 +21,7 @@ from open_climate_service.openeo.schemas import (
     WorkflowListResponse,
     WorkflowRecord,
 )
+from open_climate_service.shared.urls import absolute_base
 
 capabilities_router = APIRouter(tags=["openEO"])
 collections_router = APIRouter(tags=["openEO"])
@@ -39,7 +39,7 @@ result_router = APIRouter(tags=["openEO"])
 
 def get_openeo_capabilities(request: Request) -> JSONResponse:
     """Return openEO capabilities when the client requests JSON."""
-    base_url = _abs_base(request)
+    base_url = absolute_base(request)
     caps = build_capabilities(base_url)
     return JSONResponse(caps.model_dump())
 
@@ -47,7 +47,7 @@ def get_openeo_capabilities(request: Request) -> JSONResponse:
 @capabilities_router.get("/.well-known/openeo")
 def well_known_openeo(request: Request) -> dict[str, Any]:
     """OpenEO service discovery — lets clients find the versioned API URL."""
-    base_url = _abs_base(request)
+    base_url = absolute_base(request)
     return {
         "versions": [
             {
@@ -192,7 +192,7 @@ def get_collection(collection_id: str, request: Request) -> dict[str, Any]:
 def list_processes(request: Request) -> dict[str, Any]:
     """Return all available openEO processes."""
     procs = processes_service.list_openeo_processes()
-    base_url = _abs_base(request)
+    base_url = absolute_base(request)
     return {
         "processes": procs,
         "links": [{"rel": "self", "href": f"{base_url}/processes", "type": "application/json"}],
@@ -557,13 +557,6 @@ def delete_workflow(process_graph_id: str) -> Response:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _abs_base(request: Request) -> str:
-    base_url = os.getenv("CLIMATE_SERVICE_BASE_URL")
-    if base_url:
-        return base_url.rstrip("/")
-    return str(request.base_url).rstrip("/")
 
 
 def _reserved_process_ids() -> set[str]:

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -10,7 +10,6 @@ from fastapi.responses import FileResponse, JSONResponse
 from open_climate_service.openeo import collections as collections_service
 from open_climate_service.openeo import processes as processes_service
 from open_climate_service.openeo import workflows as workflow_store
-from open_climate_service.openeo.capabilities import build_capabilities
 from open_climate_service.openeo.jobs import get_openeo_job_service
 from open_climate_service.openeo.schemas import (
     OpenEOJobCreate,
@@ -29,19 +28,6 @@ processes_router = APIRouter(tags=["openEO"])
 jobs_router = APIRouter(tags=["openEO"])
 udp_router = APIRouter(tags=["openEO"])
 result_router = APIRouter(tags=["openEO"])
-
-
-# ---------------------------------------------------------------------------
-# Capabilities  GET /
-# (registered without prefix in main.py so it overlays the system route)
-# ---------------------------------------------------------------------------
-
-
-def get_openeo_capabilities(request: Request) -> JSONResponse:
-    """Return openEO capabilities when the client requests JSON."""
-    base_url = absolute_base(request)
-    caps = build_capabilities(base_url)
-    return JSONResponse(caps.model_dump())
 
 
 @capabilities_router.get("/.well-known/openeo")

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -80,16 +80,16 @@ async def read_only_middleware(
 ) -> Response:
     """Refuse state-changing and admin requests when the instance is configured read-only.
 
-    The ASGI prefix is removed before the policy sees the path. `is_blocked` matches against
-    route paths as the app declares them, so under `--root-path /ocs` an unstripped
-    `/ocs/manage` matched no closed prefix and read-only mode **failed open** — the admin
-    console and the job listing were served, while `POST /ocs/result` was still refused because
-    that rule falls through to the method check.
+    The ASGI prefix is removed before the policy sees the path, because `is_blocked` matches
+    route paths as the app declares them. Left on, `/ocs/manage` under `--root-path /ocs`
+    matches no closed prefix and read-only mode **fails open**, serving the admin console and
+    the job listing while `POST /ocs/result` is still refused by the method check — a partial
+    failure that looks like a working configuration.
 
     `asgi_prefix`, never `mount_prefix`: the latter falls back to the path of
-    `CLIMATE_SERVICE_BASE_URL`, which is a statement about the public origin rather than about
-    the incoming path. With a base URL of `https://host/jobs` that fallback stripped `/jobs`
-    from the real route and served the job listing with a 200.
+    `CLIMATE_SERVICE_BASE_URL`, a statement about the public origin rather than the incoming
+    path. A base URL of `https://host/jobs` would strip `/jobs` off the real route and serve the
+    job listing with a 200.
     """
     path = strip_mount(request.url.path, asgi_prefix(request))
     if api_config.is_read_only() and is_blocked(request.method, path):

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -31,7 +31,7 @@ from fastapi import Request
 from starlette.responses import JSONResponse, Response
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.urls import asgi_prefix, strip_mount
+from open_climate_service.shared.urls import route_path
 
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
@@ -80,19 +80,16 @@ async def read_only_middleware(
 ) -> Response:
     """Refuse state-changing and admin requests when the instance is configured read-only.
 
-    The ASGI prefix is removed before the policy sees the path, because `is_blocked` matches
-    route paths as the app declares them. Left on, `/ocs/manage` under `--root-path /ocs`
-    matches no closed prefix and read-only mode **fails open**, serving the admin console and
-    the job listing while `POST /ocs/result` is still refused by the method check — a partial
-    failure that looks like a working configuration.
-
-    `asgi_prefix`, never `mount_prefix`: the latter falls back to the path of
-    `CLIMATE_SERVICE_BASE_URL`, a statement about the public origin rather than the incoming
-    path. A base URL of `https://host/jobs` would strip `/jobs` off the real route and serve the
-    job listing with a 200.
+    The policy is matched against the route path, with the ASGI prefix removed, because
+    `is_blocked` matches route paths as the app declares them. Matched against the raw request
+    path, `/ocs/manage` under `ROOT_PATH=/ocs` hits no closed prefix and read-only mode fails
+    open. `route_path` never consults `CLIMATE_SERVICE_BASE_URL`, whose path is a public-origin
+    statement rather than an incoming prefix.
     """
-    path = strip_mount(request.url.path, asgi_prefix(request))
-    if api_config.is_read_only() and is_blocked(request.method, path):
+    if not api_config.is_read_only():
+        return await call_next(request)
+    path = route_path(request)
+    if is_blocked(request.method, path):
         message = _MESSAGE.format(method=request.method, path=path)
         return JSONResponse(
             status_code=403,

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -31,6 +31,7 @@ from fastapi import Request
 from starlette.responses import JSONResponse, Response
 
 from open_climate_service import config as api_config
+from open_climate_service.shared.urls import mount_prefix, strip_mount
 
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
@@ -77,9 +78,17 @@ async def read_only_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
-    """Refuse state-changing and admin requests when the instance is configured read-only."""
-    if api_config.is_read_only() and is_blocked(request.method, request.url.path):
-        message = _MESSAGE.format(method=request.method, path=request.url.path)
+    """Refuse state-changing and admin requests when the instance is configured read-only.
+
+    The mount prefix is removed before the policy sees the path. `is_blocked` matches against
+    route paths as the app declares them, so under `--root-path /ocs` an unstripped
+    `/ocs/manage` matched no closed prefix and read-only mode **failed open** — the admin
+    console and the job listing were served, while `POST /ocs/result` was still refused because
+    that rule falls through to the method check.
+    """
+    path = strip_mount(request.url.path, mount_prefix(request))
+    if api_config.is_read_only() and is_blocked(request.method, path):
+        message = _MESSAGE.format(method=request.method, path=path)
         return JSONResponse(
             status_code=403,
             # `detail` matches FastAPI's HTTPException shape for ordinary HTTP clients;

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -31,7 +31,7 @@ from fastapi import Request
 from starlette.responses import JSONResponse, Response
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.urls import mount_prefix, strip_mount
+from open_climate_service.shared.urls import asgi_prefix, strip_mount
 
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
@@ -80,13 +80,18 @@ async def read_only_middleware(
 ) -> Response:
     """Refuse state-changing and admin requests when the instance is configured read-only.
 
-    The mount prefix is removed before the policy sees the path. `is_blocked` matches against
+    The ASGI prefix is removed before the policy sees the path. `is_blocked` matches against
     route paths as the app declares them, so under `--root-path /ocs` an unstripped
     `/ocs/manage` matched no closed prefix and read-only mode **failed open** — the admin
     console and the job listing were served, while `POST /ocs/result` was still refused because
     that rule falls through to the method check.
+
+    `asgi_prefix`, never `mount_prefix`: the latter falls back to the path of
+    `CLIMATE_SERVICE_BASE_URL`, which is a statement about the public origin rather than about
+    the incoming path. With a base URL of `https://host/jobs` that fallback stripped `/jobs`
+    from the real route and served the job listing with a 200.
     """
-    path = strip_mount(request.url.path, mount_prefix(request))
+    path = strip_mount(request.url.path, asgi_prefix(request))
     if api_config.is_read_only() and is_blocked(request.method, path):
         message = _MESSAGE.format(method=request.method, path=path)
         return JSONResponse(

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -47,6 +47,28 @@ def absolute_url(request: Request, path: str) -> str:
     return f"{absolute_base(request)}/{path.lstrip('/')}"
 
 
+def mount_prefix(request: Request) -> str:
+    """The path prefix this instance is served under, or `""` when it is at the root.
+
+    For links and form actions *within* a served page, which need to be same-origin but
+    mount-correct. A path carries no scheme and no host, so it inherits both from the page —
+    which is what fixes the mixed-content defect — while still resolving under a deployment
+    prefix.
+
+    The two wrong answers this sits between, both of which shipped in this file's history:
+
+    * `absolute_base()` names an origin, so an operator reaching the console through a
+      port-forward would submit forms to the configured *public* instance. Silently, since CORS
+      is `allow_origins=["*"]`.
+    * A bare leading slash resolves from the origin root, so under `--root-path /ocs` a page at
+      `/ocs/manage` posted to `/manage` and the proxy returned 404.
+
+    Returned without a trailing slash, so `f"{mount_prefix(request)}/manage"` is right whether
+    or not there is a prefix.
+    """
+    return str(request.scope.get("root_path", "")).rstrip("/")
+
+
 def self_url(request: Request) -> str:
     """The public URL of the document being requested.
 

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -30,19 +30,21 @@ BASE_URL_ENV = "CLIMATE_SERVICE_BASE_URL"
 
 
 def absolute_base(request: Request) -> str:
-    """The configured public origin, or the request's own, without a trailing slash."""
-    configured = os.getenv(BASE_URL_ENV, "").strip()
+    """The configured public origin, or the request's own, without a trailing slash.
+
+    Trailing slashes are stripped *before* the value is judged usable. Testing truthiness
+    first accepted `CLIMATE_SERVICE_BASE_URL="/"`, stripped it to the empty string and
+    returned that, so every href in every served document lost its origin.
+    """
+    configured = os.getenv(BASE_URL_ENV, "").strip().rstrip("/")
     if configured:
-        return configured.rstrip("/")
+        return configured
     return str(request.base_url).rstrip("/")
 
 
 def absolute_url(request: Request, path: str) -> str:
     """`path` resolved against the public origin."""
-    base = absolute_base(request)
-    if not path:
-        return base
-    return f"{base}/{path.lstrip('/')}"
+    return f"{absolute_base(request)}/{path.lstrip('/')}"
 
 
 def self_url(request: Request) -> str:
@@ -52,5 +54,15 @@ def self_url(request: Request) -> str:
     and each must name itself — while the origin comes from the configuration. The query
     string is deliberately dropped: no OCS document varies by it, and reflecting arbitrary
     client input back into a served document is not worth the trouble it invites.
+
+    `root_path` is removed before the path is appended. Mounted under a prefix, the fallback
+    origin (`request.base_url`) already ends with that prefix; a server that leaves the prefix
+    on `request.url.path` as well — a non-stripping proxy in front of `--root-path` — would
+    otherwise produce `/ocs/ocs/stac` for `self` while every other link stayed correct, and a
+    STAC client following `self` would 404.
     """
-    return absolute_url(request, request.url.path)
+    path = request.url.path
+    root_path = request.scope.get("root_path", "")
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :] or "/"
+    return absolute_url(request, path)

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -1,0 +1,56 @@
+"""The public origin for absolute URLs OCS puts into documents it serves.
+
+Behind a TLS-terminating reverse proxy, the request uvicorn sees is plain HTTP: the proxy
+speaks HTTPS to the client and forwards over HTTP. So `request.base_url` reports the `http`
+scheme even though every client reached the service over `https`, and any absolute URL built
+from the request carries a scheme that is wrong for the outside world (CLIM-974).
+
+`CLIMATE_SERVICE_BASE_URL` is the operator's statement of the public origin, so it wins.
+The request is the fallback for a direct deployment where nothing is configured, which is
+the local-development case.
+
+The failure this prevents is easy to misread. An HTTPS page fetching `http://` URLs is
+active mixed content, so the browser blocks the requests and the map viewer renders an empty
+catalogue — while curl against every endpoint still returns 200, because the endpoints were
+never the problem. HSTS masks it completely: the browser rewrites the scheme before the
+request leaves, so a deployment with HSTS at the edge looks correct and only clients that
+have not yet seen the HSTS header (and non-browser STAC clients, which do not implement it
+at all) see the defect.
+
+Use these helpers rather than `request.base_url` or `request.url` for anything that leaves
+the process. Reading the environment variable at each call site is the same one-line
+expression repeated, and the sites that forgot it are exactly the bug.
+"""
+
+import os
+
+from fastapi import Request
+
+BASE_URL_ENV = "CLIMATE_SERVICE_BASE_URL"
+
+
+def absolute_base(request: Request) -> str:
+    """The configured public origin, or the request's own, without a trailing slash."""
+    configured = os.getenv(BASE_URL_ENV, "").strip()
+    if configured:
+        return configured.rstrip("/")
+    return str(request.base_url).rstrip("/")
+
+
+def absolute_url(request: Request, path: str) -> str:
+    """`path` resolved against the public origin."""
+    base = absolute_base(request)
+    if not path:
+        return base
+    return f"{base}/{path.lstrip('/')}"
+
+
+def self_url(request: Request) -> str:
+    """The public URL of the document being requested.
+
+    The path comes from the request — `/stac` and `/stac/catalog.json` are the same document
+    and each must name itself — while the origin comes from the configuration. The query
+    string is deliberately dropped: no OCS document varies by it, and reflecting arbitrary
+    client input back into a served document is not worth the trouble it invites.
+    """
+    return absolute_url(request, request.url.path)

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -9,38 +9,89 @@ from the request carries a scheme that is wrong for the outside world (CLIM-974)
 The request is the fallback for a direct deployment where nothing is configured, which is
 the local-development case.
 
-The failure this prevents is easy to misread. An HTTPS page fetching `http://` URLs is
-active mixed content, so the browser blocks the requests and the map viewer renders an empty
-catalogue — while curl against every endpoint still returns 200, because the endpoints were
-never the problem. HSTS masks it completely: the browser rewrites the scheme before the
-request leaves, so a deployment with HSTS at the edge looks correct and only clients that
-have not yet seen the HSTS header (and non-browser STAC clients, which do not implement it
-at all) see the defect.
+The symptom is easy to misread. An HTTPS page fetching `http://` URLs is active mixed
+content, so the browser blocks the requests and the map viewer renders an empty catalogue,
+while curl against every endpoint returns 200 — the endpoints are not the problem. HSTS masks
+it entirely for clients that have already seen the header, so the deployment can look correct
+while non-browser STAC clients, which do not implement HSTS, still fail.
 
-Use these helpers rather than `request.base_url` or `request.url` for anything that leaves
-the process. Reading the environment variable at each call site is the same one-line
-expression repeated, and the sites that forgot it are exactly the bug.
+Use these helpers rather than `request.base_url` or `request.url` for anything that leaves the
+process, so the rule lives in one place instead of being repeated at each call site.
 """
 
+import functools
+import logging
 import os
 import urllib.parse
 
 from fastapi import Request
 
+logger = logging.getLogger(__name__)
+
 BASE_URL_ENV = "CLIMATE_SERVICE_BASE_URL"
 
 
-def absolute_base(request: Request) -> str:
-    """The configured public origin, or the request's own, without a trailing slash.
+@functools.lru_cache(maxsize=8)
+def _parse_configured_base(raw: str) -> str:
+    """Normalise `CLIMATE_SERVICE_BASE_URL`, or return `""` when it is unusable.
 
-    Trailing slashes are stripped *before* the value is judged usable. Testing truthiness
-    first accepted `CLIMATE_SERVICE_BASE_URL="/"`, stripped it to the empty string and
-    returned that, so every href in every served document lost its origin.
+    Parsed, not string-trimmed, because a path is appended to whatever comes back and every
+    consumer must read the value the same way. A surviving query string turns
+    `https://host/ocs?x=1` into `https://host/ocs?x=1/stac`.
+
+    A value with no scheme or no host is refused — `host.example` yields a schemeless
+    `host.example/stac`, which a browser resolves as a relative path, and `"/"` and `https://`
+    yield nothing to build on. Refusing falls back to the request origin: wrong in the way this
+    variable exists to fix, but well-formed and logged.
+
+    Cached on the raw string, so the warning appears once per distinct value rather than once
+    per request.
     """
-    configured = os.getenv(BASE_URL_ENV, "").strip().rstrip("/")
+    value = raw.strip()
+    if not value:
+        return ""
+    split = urllib.parse.urlsplit(value)
+    if not split.scheme or not split.netloc:
+        logger.warning(
+            "%s=%r is not a usable absolute URL (needs a scheme and a host); "
+            "falling back to the request origin, so absolute URLs will name the internal address",
+            BASE_URL_ENV,
+            value,
+        )
+        return ""
+    if split.query or split.fragment:
+        logger.warning(
+            "%s=%r carries a query string or fragment; ignoring them, since a path is appended to this value",
+            BASE_URL_ENV,
+            value,
+        )
+    return urllib.parse.urlunsplit((split.scheme, split.netloc, split.path.rstrip("/"), "", ""))
+
+
+def configured_base() -> str:
+    """The normalised configured public origin, or `""` when unset or unusable."""
+    return _parse_configured_base(os.getenv(BASE_URL_ENV, ""))
+
+
+def absolute_base(request: Request) -> str:
+    """The public service root — origin and mount prefix — without a trailing slash.
+
+    The root of this service *as the outside world addresses it*, so appending a route path
+    always yields a working URL. One rule for every caller, so no document can mix a prefixed
+    link with an unprefixed one.
+
+    `request.base_url` is the fallback when nothing is configured, and it needs the prefix added:
+    Starlette builds it from `app_root_path`, which under an embedding `Mount("/ocs", app)` is
+    the outer root with no prefix at all.
+    """
+    configured = configured_base()
     if configured:
         return configured
-    return str(request.base_url).rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    prefix = asgi_prefix(request)
+    if prefix and not base.endswith(prefix):
+        base += prefix
+    return base
 
 
 def absolute_url(request: Request, path: str) -> str:
@@ -56,11 +107,12 @@ def mount_prefix(request: Request) -> str:
     resolving under a deployment prefix. An origin would not, since an operator on a port-forward
     would then submit forms to the configured public instance.
 
-    Two places can carry the prefix and this reconciles them, so callers have one answer. ASGI
-    `root_path` wins when set. Nothing in the shipped entry points sets it — `cli.py` passes only
-    host and port — so the usual case is a proxy prefix declared solely in the path of
-    `CLIMATE_SERVICE_BASE_URL`, and that is the fallback. Without it, an instance behind
-    `https://host/ocs/` renders `/map`, which 404s at the proxy.
+    Two places can carry the prefix, and this reconciles them so callers have one answer. ASGI
+    `root_path` wins, which is what `ROOT_PATH` sets through `cli.py`. The fallback is the path
+    of `CLIMATE_SERVICE_BASE_URL`, for deployments that declare the prefix only there: without
+    it an instance behind `https://host/ocs/` renders `/map`, which 404s at the proxy. That
+    fallback cannot distinguish a proxied request from a direct one, so it prefixes links on a
+    port-forward too — a reason to prefer `ROOT_PATH`, not to drop the fallback.
 
     Returned without a trailing slash, so `f"{mount_prefix(request)}/manage"` is right whether
     or not there is a prefix.
@@ -68,21 +120,17 @@ def mount_prefix(request: Request) -> str:
     root_path = str(request.scope.get("root_path", "")).rstrip("/")
     if root_path:
         return root_path
-    configured = os.getenv(BASE_URL_ENV, "").strip().rstrip("/")
-    if not configured:
-        return ""
-    return urllib.parse.urlsplit(configured).path.rstrip("/")
+    return urllib.parse.urlsplit(configured_base()).path.rstrip("/")
 
 
 def asgi_prefix(request: Request) -> str:
     """The prefix the routing layer has put on `request.url.path`, or `""`.
 
-    Distinct from `mount_prefix`, and the two must not be swapped. This one describes the
+    Distinct from `mount_prefix`, and the two must not be swapped: this one describes the
     *incoming* path, so it is what to remove before matching a path against a route. It never
-    consults `CLIMATE_SERVICE_BASE_URL`: that variable states a public origin, and its path
-    component is not necessarily an ASGI mount. Using it here let a base URL of
-    `https://host/jobs` strip `/jobs` off the real route and turn read-only mode's `GET /jobs`
-    into a 200.
+    consults `CLIMATE_SERVICE_BASE_URL`, because that variable states a public origin and its
+    path is not necessarily an ASGI mount — a base URL of `https://host/jobs` would otherwise
+    strip `/jobs` off a real route and turn read-only mode's `GET /jobs` into a 200.
     """
     return str(request.scope.get("root_path", "")).rstrip("/")
 
@@ -91,8 +139,7 @@ def strip_mount(path: str, prefix: str) -> str:
     """`path` with `prefix` removed, only when it ends on a path-segment boundary.
 
     `startswith` alone would turn `/stac` under a `/st` prefix into `/ac`. Unreachable through
-    uvicorn, but the guard costs one comparison and mirrors what Starlette's own
-    `get_route_path` does.
+    uvicorn, but the guard costs one comparison and mirrors Starlette's own `get_route_path`.
     """
     if not prefix or not path.startswith(prefix):
         return path
@@ -110,31 +157,14 @@ def self_url(request: Request) -> str:
     string is deliberately dropped: no OCS document varies by it, and reflecting arbitrary
     client input back into a served document is not worth the trouble it invites.
 
-    `root_path` is removed before the path is appended, and this is **required in the ordinary
-    deployment** rather than a defensive measure. Uvicorn sets `scope["path"] = root_path + path`
-    (`uvicorn/protocols/http/h11_impl.py`), so behind a normal stripping proxy with
-    `--root-path /ocs` the request arrives as `/stac`, `request.url.path` becomes `/ocs/stac`,
-    and the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path
-    unstripped would give `/ocs/ocs/stac` for `self` while every other link stayed correct, and
-    a STAC client following `self` would 404.
+    The ASGI prefix comes off the path because `absolute_base` supplies it — one rule, whichever
+    origin is in play. It is **required in the ordinary deployment**, not defensive: uvicorn sets
+    `scope["path"] = root_path + path` (`uvicorn/protocols/http/h11_impl.py`), so behind a
+    stripping proxy with `--root-path /ocs` a request for `/stac` arrives with
+    `request.url.path == "/ocs/stac"`. Appending that unstripped gives `/ocs/ocs/stac` for `self`
+    while every other link stays correct, and a STAC client following `self` 404s.
 
-    `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, so
-    a test that wants this behaviour has to build the scope by hand and unset the configured
-    origin, or it will pass whether or not the strip is here.
+    `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, so a
+    test covering this has to build the scope by hand, or it passes either way.
     """
-    # How much to strip depends on which origin the path is about to be appended to, because the
-    # two origins already account for different amounts of the prefix.
-    #
-    # A configured `CLIMATE_SERVICE_BASE_URL` *is* the service root, path included, so the whole
-    # ASGI prefix comes off. `request.base_url`, by contrast, is built from `app_root_path` and
-    # so already carries exactly that much — removing more would delete a prefix it never added.
-    #
-    # The distinction is invisible in most shapes and load-bearing in two: an embedding
-    # `Mount("/ocs", app)` sets `root_path` while leaving `base_url` at the outer root, and
-    # uvicorn's `--root-path` puts the prefix on both the path and `base_url`.
-    scope = request.scope
-    if os.getenv(BASE_URL_ENV, "").strip().rstrip("/"):
-        prefix = str(scope.get("root_path", ""))
-    else:
-        prefix = str(scope.get("app_root_path", scope.get("root_path", "")))
-    return absolute_url(request, strip_mount(request.url.path, prefix))
+    return absolute_url(request, strip_mount(request.url.path, asgi_prefix(request)))

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -23,6 +23,7 @@ expression repeated, and the sites that forgot it are exactly the bug.
 """
 
 import os
+import urllib.parse
 
 from fastapi import Request
 
@@ -50,23 +51,42 @@ def absolute_url(request: Request, path: str) -> str:
 def mount_prefix(request: Request) -> str:
     """The path prefix this instance is served under, or `""` when it is at the root.
 
-    For links and form actions *within* a served page, which need to be same-origin but
-    mount-correct. A path carries no scheme and no host, so it inherits both from the page —
-    which is what fixes the mixed-content defect — while still resolving under a deployment
-    prefix.
+    For links and form actions *within* a served page: a path carries no scheme and no host, so
+    it inherits both from the page — which is what fixes the mixed-content defect — while still
+    resolving under a deployment prefix. An origin would not, since an operator on a port-forward
+    would then submit forms to the configured public instance.
 
-    The two wrong answers this sits between, both of which shipped in this file's history:
-
-    * `absolute_base()` names an origin, so an operator reaching the console through a
-      port-forward would submit forms to the configured *public* instance. Silently, since CORS
-      is `allow_origins=["*"]`.
-    * A bare leading slash resolves from the origin root, so under `--root-path /ocs` a page at
-      `/ocs/manage` posted to `/manage` and the proxy returned 404.
+    Two places can carry the prefix and this reconciles them, so callers have one answer. ASGI
+    `root_path` wins when set. Nothing in the shipped entry points sets it — `cli.py` passes only
+    host and port — so the usual case is a proxy prefix declared solely in the path of
+    `CLIMATE_SERVICE_BASE_URL`, and that is the fallback. Without it, an instance behind
+    `https://host/ocs/` renders `/map`, which 404s at the proxy.
 
     Returned without a trailing slash, so `f"{mount_prefix(request)}/manage"` is right whether
     or not there is a prefix.
     """
-    return str(request.scope.get("root_path", "")).rstrip("/")
+    root_path = str(request.scope.get("root_path", "")).rstrip("/")
+    if root_path:
+        return root_path
+    configured = os.getenv(BASE_URL_ENV, "").strip().rstrip("/")
+    if not configured:
+        return ""
+    return urllib.parse.urlsplit(configured).path.rstrip("/")
+
+
+def strip_mount(path: str, prefix: str) -> str:
+    """`path` with `prefix` removed, only when it ends on a path-segment boundary.
+
+    `startswith` alone would turn `/stac` under a `/st` prefix into `/ac`. Unreachable through
+    uvicorn, but the guard costs one comparison and mirrors what Starlette's own
+    `get_route_path` does.
+    """
+    if not prefix or not path.startswith(prefix):
+        return path
+    remainder = path[len(prefix) :]
+    if remainder and not remainder.startswith("/"):
+        return path
+    return remainder or "/"
 
 
 def self_url(request: Request) -> str:
@@ -83,16 +103,16 @@ def self_url(request: Request) -> str:
     `--root-path /ocs` the request arrives as `/stac`, `request.url.path` becomes `/ocs/stac`,
     and the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path
     unstripped would give `/ocs/ocs/stac` for `self` while every other link stayed correct, and
-    a STAC client following `self` would 404. Verified against uvicorn booted with
-    `root_path="/ocs"`: with the strip `self` is `.../ocs/stac`, without it `.../ocs/ocs/stac`.
+    a STAC client following `self` would 404.
 
     `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, so
-    the `mounted_client` tests cannot reproduce the doubling. The coverage lives in
-    `test_the_self_link_does_not_double_a_mount_prefix`, which builds the scope by hand and
-    unsets the configured origin so the fallback is exercised; removing the strip fails it.
+    a test that wants this behaviour has to build the scope by hand and unset the configured
+    origin, or it will pass whether or not the strip is here.
     """
-    path = request.url.path
-    root_path = request.scope.get("root_path", "")
-    if root_path and path.startswith(root_path):
-        path = path[len(root_path) :] or "/"
-    return absolute_url(request, path)
+    # `app_root_path` rather than `root_path`: `request.base_url` is built from the former, so
+    # the strip has to match it or the two disagree. Under `outer.mount("/ocs", create_app())`
+    # Starlette sets `root_path` on the inner app while `base_url` keeps the outer prefix, and
+    # stripping `root_path` there removed a prefix `base_url` had never added.
+    scope = request.scope
+    prefix = str(scope.get("app_root_path", scope.get("root_path", "")))
+    return absolute_url(request, strip_mount(request.url.path, prefix))

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -77,11 +77,19 @@ def self_url(request: Request) -> str:
     string is deliberately dropped: no OCS document varies by it, and reflecting arbitrary
     client input back into a served document is not worth the trouble it invites.
 
-    `root_path` is removed before the path is appended. Mounted under a prefix, the fallback
-    origin (`request.base_url`) already ends with that prefix; a server that leaves the prefix
-    on `request.url.path` as well — a non-stripping proxy in front of `--root-path` — would
-    otherwise produce `/ocs/ocs/stac` for `self` while every other link stayed correct, and a
-    STAC client following `self` would 404.
+    `root_path` is removed before the path is appended, and this is **required in the ordinary
+    deployment** rather than a defensive measure. Uvicorn sets `scope["path"] = root_path + path`
+    (`uvicorn/protocols/http/h11_impl.py`), so behind a normal stripping proxy with
+    `--root-path /ocs` the request arrives as `/stac`, `request.url.path` becomes `/ocs/stac`,
+    and the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path
+    unstripped would give `/ocs/ocs/stac` for `self` while every other link stayed correct, and
+    a STAC client following `self` would 404. Verified against uvicorn booted with
+    `root_path="/ocs"`: with the strip `self` is `.../ocs/stac`, without it `.../ocs/ocs/stac`.
+
+    `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, so
+    the `mounted_client` tests cannot reproduce the doubling. The coverage lives in
+    `test_the_self_link_does_not_double_a_mount_prefix`, which builds the scope by hand and
+    unsets the configured origin so the fallback is exercised; removing the strip fails it.
     """
     path = request.url.path
     root_path = request.scope.get("root_path", "")

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -74,6 +74,19 @@ def mount_prefix(request: Request) -> str:
     return urllib.parse.urlsplit(configured).path.rstrip("/")
 
 
+def asgi_prefix(request: Request) -> str:
+    """The prefix the routing layer has put on `request.url.path`, or `""`.
+
+    Distinct from `mount_prefix`, and the two must not be swapped. This one describes the
+    *incoming* path, so it is what to remove before matching a path against a route. It never
+    consults `CLIMATE_SERVICE_BASE_URL`: that variable states a public origin, and its path
+    component is not necessarily an ASGI mount. Using it here let a base URL of
+    `https://host/jobs` strip `/jobs` off the real route and turn read-only mode's `GET /jobs`
+    into a 200.
+    """
+    return str(request.scope.get("root_path", "")).rstrip("/")
+
+
 def strip_mount(path: str, prefix: str) -> str:
     """`path` with `prefix` removed, only when it ends on a path-segment boundary.
 
@@ -109,10 +122,19 @@ def self_url(request: Request) -> str:
     a test that wants this behaviour has to build the scope by hand and unset the configured
     origin, or it will pass whether or not the strip is here.
     """
-    # `app_root_path` rather than `root_path`: `request.base_url` is built from the former, so
-    # the strip has to match it or the two disagree. Under `outer.mount("/ocs", create_app())`
-    # Starlette sets `root_path` on the inner app while `base_url` keeps the outer prefix, and
-    # stripping `root_path` there removed a prefix `base_url` had never added.
+    # How much to strip depends on which origin the path is about to be appended to, because the
+    # two origins already account for different amounts of the prefix.
+    #
+    # A configured `CLIMATE_SERVICE_BASE_URL` *is* the service root, path included, so the whole
+    # ASGI prefix comes off. `request.base_url`, by contrast, is built from `app_root_path` and
+    # so already carries exactly that much — removing more would delete a prefix it never added.
+    #
+    # The distinction is invisible in most shapes and load-bearing in two: an embedding
+    # `Mount("/ocs", app)` sets `root_path` while leaving `base_url` at the outer root, and
+    # uvicorn's `--root-path` puts the prefix on both the path and `base_url`.
     scope = request.scope
-    prefix = str(scope.get("app_root_path", scope.get("root_path", "")))
+    if os.getenv(BASE_URL_ENV, "").strip().rstrip("/"):
+        prefix = str(scope.get("root_path", ""))
+    else:
+        prefix = str(scope.get("app_root_path", scope.get("root_path", "")))
     return absolute_url(request, strip_mount(request.url.path, prefix))

--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -1,55 +1,62 @@
-"""The public origin for absolute URLs OCS puts into documents it serves.
+"""The public origin and mount prefix for the URLs OCS puts into documents it serves.
 
-Behind a TLS-terminating reverse proxy, the request uvicorn sees is plain HTTP: the proxy
-speaks HTTPS to the client and forwards over HTTP. So `request.base_url` reports the `http`
-scheme even though every client reached the service over `https`, and any absolute URL built
-from the request carries a scheme that is wrong for the outside world (CLIM-974).
+Behind a TLS-terminating reverse proxy the request uvicorn sees is plain HTTP, so any absolute
+URL built from `request.base_url` carries the wrong scheme for the outside world (CLIM-974).
+An HTTPS page fetching those URLs is active mixed content: the browser blocks the requests and
+the map viewer renders an empty catalogue, while curl against every endpoint returns 200.
 
-`CLIMATE_SERVICE_BASE_URL` is the operator's statement of the public origin, so it wins.
-The request is the fallback for a direct deployment where nothing is configured, which is
-the local-development case.
+Two rules, one per kind of URL:
 
-The symptom is easy to misread. An HTTPS page fetching `http://` URLs is active mixed
-content, so the browser blocks the requests and the map viewer renders an empty catalogue,
-while curl against every endpoint returns 200 — the endpoints are not the problem. HSTS masks
-it entirely for clients that have already seen the header, so the deployment can look correct
-while non-browser STAC clients, which do not implement HSTS, still fail.
+- A URL that leaves the process (STAC links, openEO capabilities, the `/openeo` redirect) is
+  absolute and names the public service root: `absolute_base`, `absolute_url`, `self_url`.
+- A URL used inside a page the browser is already on (form actions, redirects, in-page fetches)
+  is a path with the mount prefix and no origin: `mount_prefix`. It inherits scheme and host
+  from the page, so an operator on a port-forward never submits a form to the public instance.
+
+Two settings feed them. `ROOT_PATH` is the deployment prefix and sets ASGI `root_path`.
+`CLIMATE_SERVICE_BASE_URL` is the public origin, needed when the proxy's forwarded headers are
+not trusted; a path in it is the service root as the outside world addresses it, and when it
+has none the ASGI prefix is appended, so the two settings compose.
 
 Use these helpers rather than `request.base_url` or `request.url` for anything that leaves the
-process, so the rule lives in one place instead of being repeated at each call site.
+process, and `route_path` rather than `request.url.path` for anything that matches a path
+against a route.
 """
 
 import functools
 import logging
 import os
 import urllib.parse
+from typing import NamedTuple
 
 from fastapi import Request
 
 logger = logging.getLogger(__name__)
 
 BASE_URL_ENV = "CLIMATE_SERVICE_BASE_URL"
+ROOT_PATH_ENV = "ROOT_PATH"
+
+
+class ConfiguredBase(NamedTuple):
+    """`CLIMATE_SERVICE_BASE_URL` split into its origin and its path, each `""` when absent."""
+
+    origin: str
+    path: str
 
 
 @functools.lru_cache(maxsize=8)
-def _parse_configured_base(raw: str) -> str:
-    """Normalise `CLIMATE_SERVICE_BASE_URL`, or return `""` when it is unusable.
+def _parse_configured_base(raw: str) -> ConfiguredBase:
+    """Parse `CLIMATE_SERVICE_BASE_URL`, refusing a value with no scheme or no host.
 
-    Parsed, not string-trimmed, because a path is appended to whatever comes back and every
-    consumer must read the value the same way. A surviving query string turns
-    `https://host/ocs?x=1` into `https://host/ocs?x=1/stac`.
-
-    A value with no scheme or no host is refused — `host.example` yields a schemeless
-    `host.example/stac`, which a browser resolves as a relative path, and `"/"` and `https://`
-    yield nothing to build on. Refusing falls back to the request origin: wrong in the way this
-    variable exists to fix, but well-formed and logged.
-
-    Cached on the raw string, so the warning appears once per distinct value rather than once
-    per request.
+    Parsed rather than trimmed so that every consumer reads the value the same way and a query
+    string or fragment cannot end up in the middle of a link. A schemeless value would give
+    links a browser resolves as relative paths, so it is refused and the request origin is
+    used instead, with a warning. Cached on the raw string so the warning appears once per
+    distinct value.
     """
     value = raw.strip()
     if not value:
-        return ""
+        return ConfiguredBase("", "")
     split = urllib.parse.urlsplit(value)
     if not split.scheme or not split.netloc:
         logger.warning(
@@ -58,88 +65,82 @@ def _parse_configured_base(raw: str) -> str:
             BASE_URL_ENV,
             value,
         )
-        return ""
+        return ConfiguredBase("", "")
     if split.query or split.fragment:
         logger.warning(
             "%s=%r carries a query string or fragment; ignoring them, since a path is appended to this value",
             BASE_URL_ENV,
             value,
         )
-    return urllib.parse.urlunsplit((split.scheme, split.netloc, split.path.rstrip("/"), "", ""))
+    return ConfiguredBase(f"{split.scheme}://{split.netloc}", split.path.rstrip("/"))
 
 
 def configured_base() -> str:
-    """The normalised configured public origin, or `""` when unset or unusable."""
-    return _parse_configured_base(os.getenv(BASE_URL_ENV, ""))
+    """The normalised configured public root, or `""` when unset or unusable."""
+    origin, path = _parse_configured_base(os.getenv(BASE_URL_ENV, ""))
+    return origin + path
 
 
-def absolute_base(request: Request) -> str:
-    """The public service root — origin and mount prefix — without a trailing slash.
+def configured_root_path() -> str:
+    """`ROOT_PATH` normalised to a leading slash and no trailing one, or `""` when unset.
 
-    The root of this service *as the outside world addresses it*, so appending a route path
-    always yields a working URL. One rule for every caller, so no document can mix a prefixed
-    link with an unprefixed one.
-
-    `request.base_url` is the fallback when nothing is configured, and it needs the prefix added:
-    Starlette builds it from `app_root_path`, which under an embedding `Mount("/ocs", app)` is
-    the outer root with no prefix at all.
+    Read by `create_app`, so it applies under every launcher rather than only the
+    `climate-service` entry point. Normalised because uvicorn joins `root_path + path`
+    verbatim: a trailing slash would put `/ocs//manage` on the scope, which routes but no
+    longer matches a closed prefix in read-only mode.
     """
-    configured = configured_base()
-    if configured:
-        return configured
-    base = str(request.base_url).rstrip("/")
-    prefix = asgi_prefix(request)
-    if prefix and not base.endswith(prefix):
-        base += prefix
-    return base
-
-
-def absolute_url(request: Request, path: str) -> str:
-    """`path` resolved against the public origin."""
-    return f"{absolute_base(request)}/{path.lstrip('/')}"
-
-
-def mount_prefix(request: Request) -> str:
-    """The path prefix this instance is served under, or `""` when it is at the root.
-
-    For links and form actions *within* a served page: a path carries no scheme and no host, so
-    it inherits both from the page — which is what fixes the mixed-content defect — while still
-    resolving under a deployment prefix. An origin would not, since an operator on a port-forward
-    would then submit forms to the configured public instance.
-
-    Two places can carry the prefix, and this reconciles them so callers have one answer. ASGI
-    `root_path` wins, which is what `ROOT_PATH` sets through `cli.py`. The fallback is the path
-    of `CLIMATE_SERVICE_BASE_URL`, for deployments that declare the prefix only there: without
-    it an instance behind `https://host/ocs/` renders `/map`, which 404s at the proxy. That
-    fallback cannot distinguish a proxied request from a direct one, so it prefixes links on a
-    port-forward too — a reason to prefer `ROOT_PATH`, not to drop the fallback.
-
-    Returned without a trailing slash, so `f"{mount_prefix(request)}/manage"` is right whether
-    or not there is a prefix.
-    """
-    root_path = str(request.scope.get("root_path", "")).rstrip("/")
-    if root_path:
-        return root_path
-    return urllib.parse.urlsplit(configured_base()).path.rstrip("/")
+    value = os.getenv(ROOT_PATH_ENV, "").strip().strip("/")
+    return f"/{value}" if value else ""
 
 
 def asgi_prefix(request: Request) -> str:
-    """The prefix the routing layer has put on `request.url.path`, or `""`.
+    """The ASGI `root_path` without a trailing slash, or `""` when served at the root.
 
-    Distinct from `mount_prefix`, and the two must not be swapped: this one describes the
-    *incoming* path, so it is what to remove before matching a path against a route. It never
-    consults `CLIMATE_SERVICE_BASE_URL`, because that variable states a public origin and its
-    path is not necessarily an ASGI mount — a base URL of `https://host/jobs` would otherwise
-    strip `/jobs` off a real route and turn read-only mode's `GET /jobs` into a 200.
+    Never consults `CLIMATE_SERVICE_BASE_URL`: that variable states a public origin, and its
+    path is not necessarily an ASGI mount.
     """
     return str(request.scope.get("root_path", "")).rstrip("/")
+
+
+def mount_prefix(request: Request) -> str:
+    """The prefix for links and form actions within a served page, or `""` at the root.
+
+    ASGI `root_path` wins. The fallback is the path of `CLIMATE_SERVICE_BASE_URL`, for
+    deployments that declare the prefix only there; it cannot tell a proxied request from a
+    direct one, so it prefixes links on a port-forward too, which is why `ROOT_PATH` is the
+    preferred setting.
+    """
+    return asgi_prefix(request) or _parse_configured_base(os.getenv(BASE_URL_ENV, "")).path
+
+
+def absolute_base(request: Request) -> str:
+    """The public service root, origin and mount prefix, without a trailing slash.
+
+    The configured origin wins over the request's. The prefix is the configured path when
+    there is one, else the ASGI prefix, so `ROOT_PATH` with an origin-only base URL still
+    yields links under the prefix. Built from the scope's scheme and host plus `root_path`
+    rather than from `request.base_url`, which Starlette derives from the outer app's root
+    under an embedding `Mount` and so may or may not already carry the prefix.
+    """
+    origin, path = _parse_configured_base(os.getenv(BASE_URL_ENV, ""))
+    prefix = path or asgi_prefix(request)
+    if origin:
+        return origin + prefix
+    return f"{request.url.scheme}://{request.url.netloc}{prefix}"
+
+
+def absolute_url(request: Request, path: str) -> str:
+    """`path` resolved against the public service root."""
+    return f"{absolute_base(request)}/{path.lstrip('/')}"
 
 
 def strip_mount(path: str, prefix: str) -> str:
     """`path` with `prefix` removed, only when it ends on a path-segment boundary.
 
-    `startswith` alone would turn `/stac` under a `/st` prefix into `/ac`. Unreachable through
-    uvicorn, but the guard costs one comparison and mirrors Starlette's own `get_route_path`.
+    The same rule Starlette routes by: `/stac` under a `/st` prefix stays `/stac`. Given the
+    raw `root_path`, a trailing slash in it consumes the slash that uvicorn's `root_path + path`
+    join doubles, so `/ocs//manage` under `/ocs/` is `/manage`. Returns `/` rather than `""`
+    for an exact match.
     """
     if not prefix or not path.startswith(prefix):
         return path
@@ -149,22 +150,23 @@ def strip_mount(path: str, prefix: str) -> str:
     return remainder or "/"
 
 
-def self_url(request: Request) -> str:
-    """The public URL of the document being requested.
+def route_path(request: Request) -> str:
+    """The request path as the app's routes see it: `request.url.path` less the ASGI prefix.
 
-    The path comes from the request — `/stac` and `/stac/catalog.json` are the same document
-    and each must name itself — while the origin comes from the configuration. The query
-    string is deliberately dropped: no OCS document varies by it, and reflecting arbitrary
-    client input back into a served document is not worth the trouble it invites.
-
-    The ASGI prefix comes off the path because `absolute_base` supplies it — one rule, whichever
-    origin is in play. It is **required in the ordinary deployment**, not defensive: uvicorn sets
-    `scope["path"] = root_path + path` (`uvicorn/protocols/http/h11_impl.py`), so behind a
-    stripping proxy with `--root-path /ocs` a request for `/stac` arrives with
-    `request.url.path == "/ocs/stac"`. Appending that unstripped gives `/ocs/ocs/stac` for `self`
-    while every other link stays correct, and a STAC client following `self` 404s.
-
-    `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, so a
-    test covering this has to build the scope by hand, or it passes either way.
+    Uvicorn sets `scope["path"] = root_path + path`, so under `--root-path /ocs` a request for
+    `/manage` arrives as `/ocs/manage`. Anything that matches the incoming path against a
+    declared route must use this rather than `request.url.path`, or it fails to match under a
+    prefix. The raw `root_path` is used, not `asgi_prefix`, so that a trailing slash in it
+    strips the same way Starlette strips it.
     """
-    return absolute_url(request, strip_mount(request.url.path, asgi_prefix(request)))
+    return strip_mount(request.url.path, str(request.scope.get("root_path", "")))
+
+
+def self_url(request: Request) -> str:
+    """The public URL of the document being requested, without its query string.
+
+    The path comes from the request, so `/stac` and `/stac/catalog.json` each name themselves,
+    and the origin and prefix come from `absolute_base`. No OCS document varies by query
+    string, so it is dropped rather than reflected into a served document.
+    """
+    return absolute_url(request, route_path(request))

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, TypeVar
@@ -29,6 +28,7 @@ from open_climate_service.shared.time import (
     period_type_to_iso_step,
     resolve_iso_period_step,
 )
+from open_climate_service.shared.urls import absolute_url, self_url
 from open_climate_service.stac.media_types import ZARR_V3_MEDIA_TYPE, zarr_media_type
 
 CATALOG_TITLE = "Open Climate Service"
@@ -90,8 +90,8 @@ def _get_catalog_id() -> str:
 
 def build_catalog(request: Request) -> dict[str, object]:
     """Build the STAC catalog document."""
-    self_href = str(request.url)
-    catalog_href = _abs_url(request, "/stac/catalog.json")
+    self_href = self_url(request)
+    catalog_href = absolute_url(request, "/stac/catalog.json")
     links = [
         {"rel": "self", "href": self_href, "type": "application/json"},
         {"rel": "root", "href": catalog_href, "type": "application/json"},
@@ -100,7 +100,7 @@ def build_catalog(request: Request) -> dict[str, object]:
         links.append(
             {
                 "rel": "child",
-                "href": _abs_url(request, f"/stac/collections/{dataset_id}"),
+                "href": absolute_url(request, f"/stac/collections/{dataset_id}"),
                 "title": artifact.dataset_name,
                 "type": "application/json",
             }
@@ -122,9 +122,9 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         raise HTTPException(status_code=404, detail=f"STAC collection '{dataset_id}' not found")
 
     source_dataset = registry_datasets.get_dataset(artifact.dataset_id) or {}
-    collection_href = _abs_url(request, f"/stac/collections/{dataset_id}")
-    catalog_href = _abs_url(request, "/stac/catalog.json")
-    dataset_href = _abs_url(request, f"/datasets/{dataset_id}")
+    collection_href = absolute_url(request, f"/stac/collections/{dataset_id}")
+    catalog_href = absolute_url(request, "/stac/catalog.json")
+    dataset_href = absolute_url(request, f"/datasets/{dataset_id}")
     zarr_href = _public_zarr_asset_href(request, dataset_id, artifact, source_dataset)
 
     template = _build_collection_template(
@@ -172,7 +172,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     }
     if artifact.format == ArtifactFormat.ICECHUNK:
         collection_payload["assets"]["icechunk"] = {
-            "href": _abs_url(request, f"/icechunk/{dataset_id}"),
+            "href": absolute_url(request, f"/icechunk/{dataset_id}"),
             "type": "application/octet-stream",
             "title": "Icechunk store (native SDK access)",
             "roles": ["data"],
@@ -563,14 +563,7 @@ def _public_zarr_asset_href(
     artifact: ArtifactRecord,
     source_dataset: dict[str, Any],
 ) -> str:
-    return _abs_url(request, f"/zarr/{dataset_id}")
-
-
-def _abs_url(request: Request, path: str) -> str:
-    base_url = os.getenv("CLIMATE_SERVICE_BASE_URL")
-    if base_url:
-        return f"{base_url.rstrip('/')}{path}"
-    return f"{str(request.base_url).rstrip('/')}{path}"
+    return absolute_url(request, f"/zarr/{dataset_id}")
 
 
 def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence: Cadence) -> None:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -125,7 +125,7 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     collection_href = absolute_url(request, f"/stac/collections/{dataset_id}")
     catalog_href = absolute_url(request, "/stac/catalog.json")
     dataset_href = absolute_url(request, f"/datasets/{dataset_id}")
-    zarr_href = _public_zarr_asset_href(request, dataset_id, artifact, source_dataset)
+    zarr_href = absolute_url(request, f"/zarr/{dataset_id}")
 
     template = _build_collection_template(
         dataset_id=dataset_id,
@@ -555,15 +555,6 @@ def _artifact_store_path(artifact: ArtifactRecord) -> str:
         status_code=500,
         detail=f"Published artifact '{artifact.artifact_id}' has no readable storage path metadata",
     )
-
-
-def _public_zarr_asset_href(
-    request: Request,
-    dataset_id: str,
-    artifact: ArtifactRecord,
-    source_dataset: dict[str, Any],
-) -> str:
-    return absolute_url(request, f"/zarr/{dataset_id}")
 
 
 def _override_time_step(collection: dict[str, Any], step: str | None, *, cadence: Cadence) -> None:

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import sys
 import urllib.parse
 from collections.abc import AsyncIterator
@@ -14,6 +13,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from starlette.responses import RedirectResponse, StreamingResponse
 
 from open_climate_service import config as api_config
+from open_climate_service.shared.urls import absolute_base
 
 from .schemas import AppInfo, HealthStatus, Status
 from .templates import (
@@ -39,10 +39,7 @@ async def _sse_events(queue: asyncio.Queue[dict[str, Any] | None]) -> AsyncItera
 @router.get("/", response_class=Response, responses=ROOT_RESPONSES)
 def read_index(request: Request) -> Response:
     """Return openEO capabilities (JSON) or the landing page (HTML)."""
-    import os
-
-    # Use CLIMATE_SERVICE_BASE_URL when set so links are correct behind a reverse proxy.
-    base = os.getenv("CLIMATE_SERVICE_BASE_URL", "").rstrip("/") or str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     if wants_json(request):
         from open_climate_service.openeo.capabilities import build_capabilities
 
@@ -54,14 +51,14 @@ def read_index(request: Request) -> Response:
 @router.get("/map", response_class=HTMLResponse, include_in_schema=False)
 def maps(request: Request) -> HTMLResponse:
     """Return the interactive map viewer."""
-    base = str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     return HTMLResponse(render_maps(base))
 
 
 @router.get("/openeo", response_class=HTMLResponse, include_in_schema=False)
 def openeo_editor(request: Request) -> RedirectResponse:
     """Redirect to the openEO Web Editor pre-connected to this backend."""
-    base = os.getenv("CLIMATE_SERVICE_BASE_URL", "").rstrip("/") or str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     params = urllib.parse.urlencode({"server": base, "server-title": api_config.get_name()})
     return RedirectResponse(f"https://editor.openeo.org/?{params}", status_code=302)
 
@@ -73,7 +70,7 @@ def manage(
     error: str | None = None,
 ) -> HTMLResponse:
     """Return the management interface for ingestion and sync operations."""
-    base = str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     return HTMLResponse(render_manage(app_version, base, message=message, error=error))
 
 
@@ -87,7 +84,7 @@ async def manage_ingest(request: Request) -> Response:
     from open_climate_service.extents.services import get_extent_or_404
     from open_climate_service.ingestions.services import create_artifact
 
-    base = str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
@@ -174,7 +171,7 @@ async def manage_sync(request: Request) -> Response:
 
     from open_climate_service.ingestions.services import sync_dataset
 
-    base = str(request.base_url).rstrip("/")
+    base = absolute_base(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -39,20 +39,21 @@ async def _sse_events(queue: asyncio.Queue[dict[str, Any] | None]) -> AsyncItera
 @router.get("/", response_class=Response, responses=ROOT_RESPONSES)
 def read_index(request: Request) -> Response:
     """Return openEO capabilities (JSON) or the landing page (HTML)."""
-    base = absolute_base(request)
     if wants_json(request):
         from open_climate_service.openeo.capabilities import build_capabilities
 
-        caps = build_capabilities(base)
+        # openEO capabilities are consumed by other processes, so their links must be absolute
+        # and must name the public origin. The HTML page is navigated in a browser that is
+        # already on the right origin, so it uses relative paths instead.
+        caps = build_capabilities(absolute_base(request))
         return JSONResponse(caps.model_dump())
-    return HTMLResponse(render_landing(app_version, base))
+    return HTMLResponse(render_landing(app_version))
 
 
 @router.get("/map", response_class=HTMLResponse, include_in_schema=False)
 def maps(request: Request) -> HTMLResponse:
     """Return the interactive map viewer."""
-    base = absolute_base(request)
-    return HTMLResponse(render_maps(base))
+    return HTMLResponse(render_maps())
 
 
 @router.get("/openeo", response_class=HTMLResponse, include_in_schema=False)
@@ -70,8 +71,7 @@ def manage(
     error: str | None = None,
 ) -> HTMLResponse:
     """Return the management interface for ingestion and sync operations."""
-    base = absolute_base(request)
-    return HTMLResponse(render_manage(app_version, base, message=message, error=error))
+    return HTMLResponse(render_manage(app_version, message=message, error=error))
 
 
 @router.post("/manage/ingest", include_in_schema=False)
@@ -84,7 +84,6 @@ async def manage_ingest(request: Request) -> Response:
     from open_climate_service.extents.services import get_extent_or_404
     from open_climate_service.ingestions.services import create_artifact
 
-    base = absolute_base(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
@@ -97,7 +96,7 @@ async def manage_ingest(request: Request) -> Response:
         template = get_dataset(dataset_id)
         if template is None:
             msg = urllib.parse.quote(f"Dataset template '{dataset_id}' not found")
-            return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+            return RedirectResponse(f"/manage?error={msg}", status_code=303)
 
         # Validate the blank start here rather than leaving it to create_artifact. The work
         # below runs inside an SSE stream, and a response that has already begun cannot
@@ -105,17 +104,17 @@ async def manage_ingest(request: Request) -> Response:
         # the error banner. Only a forecast may omit it (see temporal_direction).
         if start is None and not registry_datasets.is_future_facing(template):
             msg = urllib.parse.quote(f"Start period is required for '{dataset_id}': its periods are not in the future")
-            return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+            return RedirectResponse(f"/manage?error={msg}", status_code=303)
 
         extent = get_extent_or_404()
         resolved_bbox = list(extent["bbox"])
         country_code = extent.get("country_code")
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"/manage?error={msg}", status_code=303)
     except Exception as exc:
         msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"/manage?error={msg}", status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -143,19 +142,19 @@ async def manage_ingest(request: Request) -> Response:
             name = urllib.parse.quote(str(template.get("name", dataset_id)))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": f"{base}/manage?message=Ingested+{name}"},
+                {"redirect": f"/manage?message=Ingested+{name}"},
             )
         except HTTPException as exc:
             msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"{base}/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": f"/manage?error={msg}"},
             )
         except Exception as exc:
             msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"{base}/manage?error={msg}"},
+                {"error": str(exc), "redirect": f"/manage?error={msg}"},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)
@@ -171,7 +170,6 @@ async def manage_sync(request: Request) -> Response:
 
     from open_climate_service.ingestions.services import sync_dataset
 
-    base = absolute_base(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
@@ -182,10 +180,10 @@ async def manage_sync(request: Request) -> Response:
             raise HTTPException(status_code=400, detail="Dataset ID is required")
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"/manage?error={msg}", status_code=303)
     except Exception as exc:
         msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"{base}/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"/manage?error={msg}", status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -203,19 +201,19 @@ async def manage_sync(request: Request) -> Response:
             )
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": f"{base}/manage?message=Sync+completed"},
+                {"redirect": "/manage?message=Sync+completed"},
             )
         except HTTPException as exc:
             msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"{base}/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": f"/manage?error={msg}"},
             )
         except Exception as exc:
             msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"{base}/manage?error={msg}"},
+                {"error": str(exc), "redirect": f"/manage?error={msg}"},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -13,7 +13,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from starlette.responses import RedirectResponse, StreamingResponse
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.urls import absolute_base
+from open_climate_service.shared.urls import absolute_base, mount_prefix
 
 from .schemas import AppInfo, HealthStatus, Status
 from .templates import (
@@ -47,13 +47,13 @@ def read_index(request: Request) -> Response:
         # already on the right origin, so it uses relative paths instead.
         caps = build_capabilities(absolute_base(request))
         return JSONResponse(caps.model_dump())
-    return HTMLResponse(render_landing(app_version))
+    return HTMLResponse(render_landing(app_version, mount_prefix(request)))
 
 
 @router.get("/map", response_class=HTMLResponse, include_in_schema=False)
 def maps(request: Request) -> HTMLResponse:
     """Return the interactive map viewer."""
-    return HTMLResponse(render_maps())
+    return HTMLResponse(render_maps(mount_prefix(request)))
 
 
 @router.get("/openeo", response_class=HTMLResponse, include_in_schema=False)
@@ -71,7 +71,7 @@ def manage(
     error: str | None = None,
 ) -> HTMLResponse:
     """Return the management interface for ingestion and sync operations."""
-    return HTMLResponse(render_manage(app_version, message=message, error=error))
+    return HTMLResponse(render_manage(app_version, mount_prefix(request), message=message, error=error))
 
 
 @router.post("/manage/ingest", include_in_schema=False)
@@ -84,6 +84,7 @@ async def manage_ingest(request: Request) -> Response:
     from open_climate_service.extents.services import get_extent_or_404
     from open_climate_service.ingestions.services import create_artifact
 
+    mount = mount_prefix(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
@@ -96,7 +97,7 @@ async def manage_ingest(request: Request) -> Response:
         template = get_dataset(dataset_id)
         if template is None:
             msg = urllib.parse.quote(f"Dataset template '{dataset_id}' not found")
-            return RedirectResponse(f"/manage?error={msg}", status_code=303)
+            return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
 
         # Validate the blank start here rather than leaving it to create_artifact. The work
         # below runs inside an SSE stream, and a response that has already begun cannot
@@ -104,17 +105,17 @@ async def manage_ingest(request: Request) -> Response:
         # the error banner. Only a forecast may omit it (see temporal_direction).
         if start is None and not registry_datasets.is_future_facing(template):
             msg = urllib.parse.quote(f"Start period is required for '{dataset_id}': its periods are not in the future")
-            return RedirectResponse(f"/manage?error={msg}", status_code=303)
+            return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
 
         extent = get_extent_or_404()
         resolved_bbox = list(extent["bbox"])
         country_code = extent.get("country_code")
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
     except Exception as exc:
         msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -142,19 +143,19 @@ async def manage_ingest(request: Request) -> Response:
             name = urllib.parse.quote(str(template.get("name", dataset_id)))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": f"/manage?message=Ingested+{name}"},
+                {"redirect": f"{mount}/manage?message=Ingested+{name}"},
             )
         except HTTPException as exc:
             msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": f"{mount}/manage?error={msg}"},
             )
         except Exception as exc:
             msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"/manage?error={msg}"},
+                {"error": str(exc), "redirect": f"{mount}/manage?error={msg}"},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)
@@ -170,6 +171,7 @@ async def manage_sync(request: Request) -> Response:
 
     from open_climate_service.ingestions.services import sync_dataset
 
+    mount = mount_prefix(request)
     try:
         form = await request.form()
         dataset_id = str(form.get("dataset_id", "")).strip()
@@ -180,10 +182,10 @@ async def manage_sync(request: Request) -> Response:
             raise HTTPException(status_code=400, detail="Dataset ID is required")
     except HTTPException as exc:
         msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
     except Exception as exc:
         msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"/manage?error={msg}", status_code=303)
+        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -207,13 +209,13 @@ async def manage_sync(request: Request) -> Response:
             msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": f"{mount}/manage?error={msg}"},
             )
         except Exception as exc:
             msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"/manage?error={msg}"},
+                {"error": str(exc), "redirect": f"{mount}/manage?error={msg}"},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -203,7 +203,7 @@ async def manage_sync(request: Request) -> Response:
             )
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": "/manage?message=Sync+completed"},
+                {"redirect": f"{mount}/manage?message=Sync+completed"},
             )
         except HTTPException as exc:
             msg = urllib.parse.quote(str(exc.detail))

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -77,10 +77,9 @@ def manage(
 def _manage_url(mount: str, *, error: str | None = None, message: str | None = None) -> str:
     """A `/manage` URL carrying one banner, with the text percent-encoded.
 
-    Assembled in one place because it was assembled in twelve. Commit 32a74ad added the mount
-    prefix to eleven of them and missed the twelfth, which then needed its own follow-up commit
-    and a dedicated regression test — the redirect that fires on a *successful* sync, where the
-    error paths that surround it were all correct.
+    One place rather than at each redirect: a prefix added to most of them and missed on one is
+    a bug that only shows on the path nobody re-tests, and the miss landed on the *success*
+    redirect while every error path around it stayed correct.
     """
     banner = "error" if error is not None else "message"
     text = error if error is not None else message

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -74,6 +74,19 @@ def manage(
     return HTMLResponse(render_manage(app_version, mount_prefix(request), message=message, error=error))
 
 
+def _manage_url(mount: str, *, error: str | None = None, message: str | None = None) -> str:
+    """A `/manage` URL carrying one banner, with the text percent-encoded.
+
+    Assembled in one place because it was assembled in twelve. Commit 32a74ad added the mount
+    prefix to eleven of them and missed the twelfth, which then needed its own follow-up commit
+    and a dedicated regression test — the redirect that fires on a *successful* sync, where the
+    error paths that surround it were all correct.
+    """
+    banner = "error" if error is not None else "message"
+    text = error if error is not None else message
+    return f"{mount}/manage?{banner}={urllib.parse.quote(str(text))}"
+
+
 @router.post("/manage/ingest", include_in_schema=False)
 async def manage_ingest(request: Request) -> Response:
     """Handle ingest form submission and stream progress via SSE."""
@@ -96,26 +109,30 @@ async def manage_ingest(request: Request) -> Response:
 
         template = get_dataset(dataset_id)
         if template is None:
-            msg = urllib.parse.quote(f"Dataset template '{dataset_id}' not found")
-            return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+            return RedirectResponse(
+                _manage_url(mount, error=f"Dataset template '{dataset_id}' not found"), status_code=303
+            )
 
         # Validate the blank start here rather than leaving it to create_artifact. The work
         # below runs inside an SSE stream, and a response that has already begun cannot
         # redirect — the operator would get a progress bar that fails mid-flight instead of
         # the error banner. Only a forecast may omit it (see temporal_direction).
         if start is None and not registry_datasets.is_future_facing(template):
-            msg = urllib.parse.quote(f"Start period is required for '{dataset_id}': its periods are not in the future")
-            return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+            return RedirectResponse(
+                _manage_url(
+                    mount,
+                    error=f"Start period is required for '{dataset_id}': its periods are not in the future",
+                ),
+                status_code=303,
+            )
 
         extent = get_extent_or_404()
         resolved_bbox = list(extent["bbox"])
         country_code = extent.get("country_code")
     except HTTPException as exc:
-        msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+        return RedirectResponse(_manage_url(mount, error=str(exc.detail)), status_code=303)
     except Exception as exc:
-        msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+        return RedirectResponse(_manage_url(mount, error=str(exc)), status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -140,22 +157,20 @@ async def manage_ingest(request: Request) -> Response:
                     on_progress=on_progress,
                 )
             )
-            name = urllib.parse.quote(str(template.get("name", dataset_id)))
+            name = str(template.get("name", dataset_id))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": f"{mount}/manage?message=Ingested+{name}"},
+                {"redirect": _manage_url(mount, message=f"Ingested {name}")},
             )
         except HTTPException as exc:
-            msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"{mount}/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": _manage_url(mount, error=str(exc.detail))},
             )
         except Exception as exc:
-            msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"{mount}/manage?error={msg}"},
+                {"error": str(exc), "redirect": _manage_url(mount, error=str(exc))},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)
@@ -181,11 +196,9 @@ async def manage_sync(request: Request) -> Response:
         if not dataset_id:
             raise HTTPException(status_code=400, detail="Dataset ID is required")
     except HTTPException as exc:
-        msg = urllib.parse.quote(str(exc.detail))
-        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+        return RedirectResponse(_manage_url(mount, error=str(exc.detail)), status_code=303)
     except Exception as exc:
-        msg = urllib.parse.quote(str(exc))
-        return RedirectResponse(f"{mount}/manage?error={msg}", status_code=303)
+        return RedirectResponse(_manage_url(mount, error=str(exc)), status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -203,19 +216,17 @@ async def manage_sync(request: Request) -> Response:
             )
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": f"{mount}/manage?message=Sync+completed"},
+                {"redirect": _manage_url(mount, message="Sync completed")},
             )
         except HTTPException as exc:
-            msg = urllib.parse.quote(str(exc.detail))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": f"{mount}/manage?error={msg}"},
+                {"error": str(exc.detail), "redirect": _manage_url(mount, error=str(exc.detail))},
             )
         except Exception as exc:
-            msg = urllib.parse.quote(str(exc))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": f"{mount}/manage?error={msg}"},
+                {"error": str(exc), "redirect": _manage_url(mount, error=str(exc))},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)

--- a/open_climate_service/system/routes.py
+++ b/open_climate_service/system/routes.py
@@ -6,7 +6,7 @@ import sys
 import urllib.parse
 from collections.abc import AsyncIterator
 from importlib.metadata import version as _pkg_version
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -74,16 +74,12 @@ def manage(
     return HTMLResponse(render_manage(app_version, mount_prefix(request), message=message, error=error))
 
 
-def _manage_url(mount: str, *, error: str | None = None, message: str | None = None) -> str:
-    """A `/manage` URL carrying one banner, with the text percent-encoded.
+def _manage_url(mount: str, banner: Literal["error", "message"], text: str) -> str:
+    """A mount-relative `/manage` URL carrying one banner, with the text percent-encoded.
 
-    One place rather than at each redirect: a prefix added to most of them and missed on one is
-    a bug that only shows on the path nobody re-tests, and the miss landed on the *success*
-    redirect while every error path around it stayed correct.
+    Every redirect back to the console goes through here, so none can miss the prefix.
     """
-    banner = "error" if error is not None else "message"
-    text = error if error is not None else message
-    return f"{mount}/manage?{banner}={urllib.parse.quote(str(text))}"
+    return f"{mount}/manage?{banner}={urllib.parse.quote(text)}"
 
 
 @router.post("/manage/ingest", include_in_schema=False)
@@ -109,7 +105,7 @@ async def manage_ingest(request: Request) -> Response:
         template = get_dataset(dataset_id)
         if template is None:
             return RedirectResponse(
-                _manage_url(mount, error=f"Dataset template '{dataset_id}' not found"), status_code=303
+                _manage_url(mount, "error", f"Dataset template '{dataset_id}' not found"), status_code=303
             )
 
         # Validate the blank start here rather than leaving it to create_artifact. The work
@@ -120,7 +116,8 @@ async def manage_ingest(request: Request) -> Response:
             return RedirectResponse(
                 _manage_url(
                     mount,
-                    error=f"Start period is required for '{dataset_id}': its periods are not in the future",
+                    "error",
+                    f"Start period is required for '{dataset_id}': its periods are not in the future",
                 ),
                 status_code=303,
             )
@@ -129,9 +126,9 @@ async def manage_ingest(request: Request) -> Response:
         resolved_bbox = list(extent["bbox"])
         country_code = extent.get("country_code")
     except HTTPException as exc:
-        return RedirectResponse(_manage_url(mount, error=str(exc.detail)), status_code=303)
+        return RedirectResponse(_manage_url(mount, "error", str(exc.detail)), status_code=303)
     except Exception as exc:
-        return RedirectResponse(_manage_url(mount, error=str(exc)), status_code=303)
+        return RedirectResponse(_manage_url(mount, "error", str(exc)), status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -159,17 +156,17 @@ async def manage_ingest(request: Request) -> Response:
             name = str(template.get("name", dataset_id))
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": _manage_url(mount, message=f"Ingested {name}")},
+                {"redirect": _manage_url(mount, "message", f"Ingested {name}")},
             )
         except HTTPException as exc:
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": _manage_url(mount, error=str(exc.detail))},
+                {"error": str(exc.detail), "redirect": _manage_url(mount, "error", str(exc.detail))},
             )
         except Exception as exc:
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": _manage_url(mount, error=str(exc))},
+                {"error": str(exc), "redirect": _manage_url(mount, "error", str(exc))},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)
@@ -195,9 +192,9 @@ async def manage_sync(request: Request) -> Response:
         if not dataset_id:
             raise HTTPException(status_code=400, detail="Dataset ID is required")
     except HTTPException as exc:
-        return RedirectResponse(_manage_url(mount, error=str(exc.detail)), status_code=303)
+        return RedirectResponse(_manage_url(mount, "error", str(exc.detail)), status_code=303)
     except Exception as exc:
-        return RedirectResponse(_manage_url(mount, error=str(exc)), status_code=303)
+        return RedirectResponse(_manage_url(mount, "error", str(exc)), status_code=303)
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -215,17 +212,17 @@ async def manage_sync(request: Request) -> Response:
             )
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"redirect": _manage_url(mount, message="Sync completed")},
+                {"redirect": _manage_url(mount, "message", "Sync completed")},
             )
         except HTTPException as exc:
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc.detail), "redirect": _manage_url(mount, error=str(exc.detail))},
+                {"error": str(exc.detail), "redirect": _manage_url(mount, "error", str(exc.detail))},
             )
         except Exception as exc:
             loop.call_soon_threadsafe(
                 queue.put_nowait,
-                {"error": str(exc), "redirect": _manage_url(mount, error=str(exc))},
+                {"error": str(exc), "redirect": _manage_url(mount, "error", str(exc))},
             )
         finally:
             loop.call_soon_threadsafe(queue.put_nowait, None)

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -113,7 +113,7 @@ def wants_json(request: Request) -> bool:
     return json_q >= 0 and (html_q < 0 or json_q >= html_q)
 
 
-def render_maps() -> str:
+def render_maps(mount: str = "") -> str:
     """Render the map viewer page.
 
     Takes no base URL: every link and fetch target in the page is same-origin, so the template
@@ -122,7 +122,7 @@ def render_maps() -> str:
     port-forward would otherwise have the viewer fetch the configured public instance's
     catalogue instead of the one they are looking at.
     """
-    return get_template("map-viewer.html").render(name=api_config.get_name())
+    return get_template("map-viewer.html").render(mount=mount, name=api_config.get_name())
 
 
 def _load_extent() -> dict[str, Any] | None:
@@ -162,10 +162,11 @@ def _load_datasets() -> list[Any]:
         return []
 
 
-def render_landing(version: str) -> str:
+def render_landing(version: str, mount: str = "") -> str:
     """Render the root landing page with live instance status."""
     return get_template("landing_page.html").render(
         version=version,
+        mount=mount,
         name=api_config.get_name(),
         extent=_load_extent(),
         datasets=_load_datasets(),
@@ -175,12 +176,13 @@ def render_landing(version: str) -> str:
     )
 
 
-def render_manage(version: str, message: str | None = None, error: str | None = None) -> str:
+def render_manage(version: str, mount: str = "", message: str | None = None, error: str | None = None) -> str:
     """Render the management page."""
     today = date.today().isoformat()
     year_ago = date.today().replace(year=date.today().year - 1).isoformat()
     return get_template("manage.html").render(
         version=version,
+        mount=mount,
         name=api_config.get_name(),
         extent=_load_extent(),
         templates=_ingestable_templates(),

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -113,9 +113,16 @@ def wants_json(request: Request) -> bool:
     return json_q >= 0 and (html_q < 0 or json_q >= html_q)
 
 
-def render_maps(base: str) -> str:
-    """Render the map viewer page."""
-    return get_template("map-viewer.html").render(base=base, name=api_config.get_name())
+def render_maps() -> str:
+    """Render the map viewer page.
+
+    Takes no base URL: every link and fetch target in the page is same-origin, so the template
+    uses root-relative paths. Those inherit the page's scheme, which fixes the mixed-content
+    bug in CLIM-974 without the risk of substituting a *different* origin — an operator on a
+    port-forward would otherwise have the viewer fetch the configured public instance's
+    catalogue instead of the one they are looking at.
+    """
+    return get_template("map-viewer.html").render(name=api_config.get_name())
 
 
 def _load_extent() -> dict[str, Any] | None:
@@ -155,11 +162,10 @@ def _load_datasets() -> list[Any]:
         return []
 
 
-def render_landing(version: str, base: str) -> str:
+def render_landing(version: str) -> str:
     """Render the root landing page with live instance status."""
     return get_template("landing_page.html").render(
         version=version,
-        base=base,
         name=api_config.get_name(),
         extent=_load_extent(),
         datasets=_load_datasets(),
@@ -169,13 +175,12 @@ def render_landing(version: str, base: str) -> str:
     )
 
 
-def render_manage(version: str, base: str, message: str | None = None, error: str | None = None) -> str:
+def render_manage(version: str, message: str | None = None, error: str | None = None) -> str:
     """Render the management page."""
     today = date.today().isoformat()
     year_ago = date.today().replace(year=date.today().year - 1).isoformat()
     return get_template("manage.html").render(
         version=version,
-        base=base,
         name=api_config.get_name(),
         extent=_load_extent(),
         templates=_ingestable_templates(),

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -113,14 +113,18 @@ def wants_json(request: Request) -> bool:
     return json_q >= 0 and (html_q < 0 or json_q >= html_q)
 
 
-def render_maps(mount: str = "") -> str:
+def render_maps(mount: str) -> str:
     """Render the map viewer page.
 
-    Takes no base URL: every link and fetch target in the page is same-origin, so the template
-    uses root-relative paths. Those inherit the page's scheme, which fixes the mixed-content
-    bug in CLIM-974 without the risk of substituting a *different* origin — an operator on a
-    port-forward would otherwise have the viewer fetch the configured public instance's
-    catalogue instead of the one they are looking at.
+    Takes a mount prefix rather than a base URL: every link and fetch target in the page is
+    same-origin, so the template emits `{{ mount }}`-prefixed paths. A path carries no scheme
+    or host, so it inherits both from the page — which fixes the mixed-content bug in CLIM-974
+    without the risk of substituting a *different* origin, as an operator on a port-forward
+    would otherwise have the viewer fetch the configured public instance's catalogue. The
+    prefix is what keeps those paths resolving under `--root-path`.
+
+    Required rather than defaulted: an omitted mount yields links that work unmounted and 404
+    behind a prefix, which is the failure this parameter exists to prevent.
     """
     return get_template("map-viewer.html").render(mount=mount, name=api_config.get_name())
 
@@ -162,7 +166,7 @@ def _load_datasets() -> list[Any]:
         return []
 
 
-def render_landing(version: str, mount: str = "") -> str:
+def render_landing(version: str, mount: str) -> str:
     """Render the root landing page with live instance status."""
     return get_template("landing_page.html").render(
         version=version,
@@ -176,7 +180,7 @@ def render_landing(version: str, mount: str = "") -> str:
     )
 
 
-def render_manage(version: str, mount: str = "", message: str | None = None, error: str | None = None) -> str:
+def render_manage(version: str, mount: str, message: str | None = None, error: str | None = None) -> str:
     """Render the management page."""
     today = date.today().isoformat()
     year_ago = date.today().replace(year=date.today().year - 1).isoformat()

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -116,14 +116,13 @@ def wants_json(request: Request) -> bool:
 def render_maps(mount: str) -> str:
     """Render the map viewer page.
 
-    Takes a mount prefix rather than a base URL: every link and fetch target in the page is
-    same-origin, so the template emits `{{ mount }}`-prefixed paths. A path carries no scheme
-    or host, so it inherits both from the page — which fixes the mixed-content bug in CLIM-974
-    without the risk of substituting a *different* origin, as an operator on a port-forward
-    would otherwise have the viewer fetch the configured public instance's catalogue. The
-    prefix is what keeps those paths resolving under `--root-path`.
+    A mount prefix rather than a base URL, because every link and fetch target in the page is
+    same-origin. A path carries no scheme or host and inherits both from the page, which fixes
+    the mixed-content bug in CLIM-974 without the risk of naming a *different* origin — an
+    operator on a port-forward would otherwise have the viewer fetch the public instance's
+    catalogue. The prefix keeps those paths resolving under `--root-path`.
 
-    Required rather than defaulted: an omitted mount yields links that work unmounted and 404
+    Required rather than defaulted: an omitted mount gives links that work unmounted and 404
     behind a prefix, which is the failure this parameter exists to prevent.
     """
     return get_template("map-viewer.html").render(mount=mount, name=api_config.get_name())

--- a/open_climate_service/templates/landing_page.html
+++ b/open_climate_service/templates/landing_page.html
@@ -207,7 +207,7 @@
         {% else %}
         <p class="note">
           No extent configured. Set <code>extent:</code> in
-          <code>CLIMATE_SERVICE_CONFIG</code> — see <a href="/docs">API docs</a> for
+          <code>CLIMATE_SERVICE_CONFIG</code> — see <a href="{{ mount }}/docs">API docs</a> for
           details.
         </p>
         {% endif %}
@@ -220,7 +220,7 @@
           {% if not read_only %}
           <li>
             <span class="link-label"
-              ><a href="/manage">Manage</a></span
+              ><a href="{{ mount }}/manage">Manage</a></span
             >
             <span class="link-desc"
               >Ingest and sync datasets without using the API directly</span
@@ -229,7 +229,7 @@
           {% endif %}
           <li>
             <span class="link-label"
-              ><a href="/docs">API documentation</a></span
+              ><a href="{{ mount }}/docs">API documentation</a></span
             >
             <span class="link-desc"
               >Interactive Swagger UI for all endpoints</span
@@ -237,7 +237,7 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="/map">Map viewer</a></span
+              ><a href="{{ mount }}/map">Map viewer</a></span
             >
             <span class="link-desc"
               >Browse published datasets on an interactive map</span
@@ -245,7 +245,7 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="/openeo" target="_blank" rel="noopener">openEO Editor</a></span
+              ><a href="{{ mount }}/openeo" target="_blank" rel="noopener">openEO Editor</a></span
             >
             <span class="link-desc"
               >Build and run openEO process graphs in the browser</span
@@ -253,14 +253,14 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="/stac/catalog.json">STAC Catalog</a></span
+              ><a href="{{ mount }}/stac/catalog.json">STAC Catalog</a></span
             >
             <span class="link-desc"
               >SpatioTemporal Asset Catalog of published datasets</span
             >
           </li>
           <li>
-            <span class="link-label"><a href="/?f=json">Root (JSON)</a></span>
+            <span class="link-label"><a href="{{ mount }}/?f=json">Root (JSON)</a></span>
             <span class="link-desc">This page as a JSON navigation object</span>
           </li>
         </ul>
@@ -284,7 +284,7 @@
             {% for ds in datasets %}
             <tr>
               <td>
-                <a href="/datasets/{{ ds.dataset_id }}"
+                <a href="{{ mount }}/datasets/{{ ds.dataset_id }}"
                   >{{ ds.dataset_name }}</a
                 >
               </td>
@@ -307,11 +307,11 @@
         {% else %}
         <p class="note">
           No datasets ingested yet. Use
-          <a href="/docs#/Ingestions/create_ingestion_ingestions_post"
+          <a href="{{ mount }}/docs#/Ingestions/create_ingestion_ingestions_post"
             >POST /ingestions</a
           >
           to ingest data, or
-          <a href="/docs#/Sync/trigger_sync_sync_post">POST /sync</a>
+          <a href="{{ mount }}/docs#/Sync/trigger_sync_sync_post">POST /sync</a>
           to run an automated sync.
         </p>
         {% endif %}

--- a/open_climate_service/templates/landing_page.html
+++ b/open_climate_service/templates/landing_page.html
@@ -207,7 +207,7 @@
         {% else %}
         <p class="note">
           No extent configured. Set <code>extent:</code> in
-          <code>CLIMATE_SERVICE_CONFIG</code> — see <a href="{{ base }}/docs">API docs</a> for
+          <code>CLIMATE_SERVICE_CONFIG</code> — see <a href="/docs">API docs</a> for
           details.
         </p>
         {% endif %}
@@ -220,7 +220,7 @@
           {% if not read_only %}
           <li>
             <span class="link-label"
-              ><a href="{{ base }}/manage">Manage</a></span
+              ><a href="/manage">Manage</a></span
             >
             <span class="link-desc"
               >Ingest and sync datasets without using the API directly</span
@@ -229,7 +229,7 @@
           {% endif %}
           <li>
             <span class="link-label"
-              ><a href="{{ base }}/docs">API documentation</a></span
+              ><a href="/docs">API documentation</a></span
             >
             <span class="link-desc"
               >Interactive Swagger UI for all endpoints</span
@@ -237,7 +237,7 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="{{ base }}/map">Map viewer</a></span
+              ><a href="/map">Map viewer</a></span
             >
             <span class="link-desc"
               >Browse published datasets on an interactive map</span
@@ -245,7 +245,7 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="{{ base }}/openeo" target="_blank" rel="noopener">openEO Editor</a></span
+              ><a href="/openeo" target="_blank" rel="noopener">openEO Editor</a></span
             >
             <span class="link-desc"
               >Build and run openEO process graphs in the browser</span
@@ -253,14 +253,14 @@
           </li>
           <li>
             <span class="link-label"
-              ><a href="{{ base }}/stac/catalog.json">STAC Catalog</a></span
+              ><a href="/stac/catalog.json">STAC Catalog</a></span
             >
             <span class="link-desc"
               >SpatioTemporal Asset Catalog of published datasets</span
             >
           </li>
           <li>
-            <span class="link-label"><a href="{{ base }}/?f=json">Root (JSON)</a></span>
+            <span class="link-label"><a href="/?f=json">Root (JSON)</a></span>
             <span class="link-desc">This page as a JSON navigation object</span>
           </li>
         </ul>
@@ -284,7 +284,7 @@
             {% for ds in datasets %}
             <tr>
               <td>
-                <a href="{{ base }}/datasets/{{ ds.dataset_id }}"
+                <a href="/datasets/{{ ds.dataset_id }}"
                   >{{ ds.dataset_name }}</a
                 >
               </td>
@@ -307,11 +307,11 @@
         {% else %}
         <p class="note">
           No datasets ingested yet. Use
-          <a href="{{ base }}/docs#/Ingestions/create_ingestion_ingestions_post"
+          <a href="/docs#/Ingestions/create_ingestion_ingestions_post"
             >POST /ingestions</a
           >
           to ingest data, or
-          <a href="{{ base }}/docs#/Sync/trigger_sync_sync_post">POST /sync</a>
+          <a href="/docs#/Sync/trigger_sync_sync_post">POST /sync</a>
           to run an automated sync.
         </p>
         {% endif %}

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -365,7 +365,7 @@
   </head>
   <body>
     <header>
-      <h1><a href="{{ base }}/">{{ name }}</a></h1>
+      <h1><a href="/">{{ name }}</a></h1>
       <span class="subtitle">Manage</span>
     </header>
 
@@ -388,7 +388,7 @@
         {% elif not templates %}
         <p class="note">No dataset templates found.</p>
         {% else %}
-        <form id="ingest-form" method="post" action="{{ base }}/manage/ingest"
+        <form id="ingest-form" method="post" action="/manage/ingest"
               onsubmit="runJob(event, this, 'btn-ingest', 'ingest-progress')">
           <div class="form-grid">
             <div class="field span-2">
@@ -475,7 +475,7 @@
             {% set sync_dom_id = "sync-row-" ~ loop.index0 %}
             <tr>
               <td>
-                <a href="{{ base }}/datasets/{{ ds.dataset_id }}">{{ ds.dataset_name }}</a>
+                <a href="/datasets/{{ ds.dataset_id }}">{{ ds.dataset_name }}</a>
               </td>
               <td>{{ ds.period_type }}</td>
               <td>{{ ds.extent.temporal.start }} – {{ ds.extent.temporal.end }}</td>
@@ -489,7 +489,7 @@
               <td>
                 <form
                   method="post"
-                  action="{{ base }}/manage/sync"
+                  action="/manage/sync"
                   class="sync-form"
                   data-trigger-id="sync-trigger-{{ sync_dom_id }}"
                   data-progress-id="sync-progress-{{ sync_dom_id }}"

--- a/open_climate_service/templates/manage.html
+++ b/open_climate_service/templates/manage.html
@@ -365,7 +365,7 @@
   </head>
   <body>
     <header>
-      <h1><a href="/">{{ name }}</a></h1>
+      <h1><a href="{{ mount }}/">{{ name }}</a></h1>
       <span class="subtitle">Manage</span>
     </header>
 
@@ -388,7 +388,7 @@
         {% elif not templates %}
         <p class="note">No dataset templates found.</p>
         {% else %}
-        <form id="ingest-form" method="post" action="/manage/ingest"
+        <form id="ingest-form" method="post" action="{{ mount }}/manage/ingest"
               onsubmit="runJob(event, this, 'btn-ingest', 'ingest-progress')">
           <div class="form-grid">
             <div class="field span-2">
@@ -475,7 +475,7 @@
             {% set sync_dom_id = "sync-row-" ~ loop.index0 %}
             <tr>
               <td>
-                <a href="/datasets/{{ ds.dataset_id }}">{{ ds.dataset_name }}</a>
+                <a href="{{ mount }}/datasets/{{ ds.dataset_id }}">{{ ds.dataset_name }}</a>
               </td>
               <td>{{ ds.period_type }}</td>
               <td>{{ ds.extent.temporal.start }} – {{ ds.extent.temporal.end }}</td>
@@ -489,7 +489,7 @@
               <td>
                 <form
                   method="post"
-                  action="/manage/sync"
+                  action="{{ mount }}/manage/sync"
                   class="sync-form"
                   data-trigger-id="sync-trigger-{{ sync_dom_id }}"
                   data-progress-id="sync-progress-{{ sync_dom_id }}"

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -200,7 +200,7 @@
   <body>
     <div class="layout">
       <header>
-        <h1><a href="/">{{ name }}</a></h1>
+        <h1><a href="{{ mount }}/">{{ name }}</a></h1>
         <span class="subtitle">Map viewer</span>
       </header>
 
@@ -457,7 +457,7 @@
       async function fitToExtent() {
         if (!map || mapUnavailable) return;
         try {
-          const res = await fetch("/extent");
+          const res = await fetch("{{ mount }}/extent");
           if (!res.ok) return;
           const extent = await res.json();
           const [xmin, ymin, xmax, ymax] = extent.bbox;
@@ -467,7 +467,7 @@
 
       async function loadCatalog() {
         try {
-          const res = await fetch("/collections");
+          const res = await fetch("{{ mount }}/collections");
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const body = await res.json();
           const collections = body.collections ?? [];

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -200,7 +200,7 @@
   <body>
     <div class="layout">
       <header>
-        <h1><a href="{{ base }}/">{{ name }}</a></h1>
+        <h1><a href="/">{{ name }}</a></h1>
         <span class="subtitle">Map viewer</span>
       </header>
 
@@ -457,7 +457,7 @@
       async function fitToExtent() {
         if (!map || mapUnavailable) return;
         try {
-          const res = await fetch("{{ base }}/extent");
+          const res = await fetch("/extent");
           if (!res.ok) return;
           const extent = await res.json();
           const [xmin, ymin, xmax, ymax] = extent.bbox;
@@ -467,7 +467,7 @@
 
       async function loadCatalog() {
         try {
-          const res = await fetch("{{ base }}/collections");
+          const res = await fetch("/collections");
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           const body = await res.json();
           const collections = body.collections ?? [];
@@ -478,7 +478,7 @@
             return;
           }
           for (const col of collections) {
-            const href = `{{ base }}/collections/${col.id}`;
+            const href = `/collections/${col.id}`;
             const opt = document.createElement("option");
             opt.value = href;
             opt.textContent = col.title ?? col.id;

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -478,7 +478,7 @@
             return;
           }
           for (const col of collections) {
-            const href = `/collections/${col.id}`;
+            const href = `{{ mount }}/collections/${col.id}`;
             const opt = document.createElement("option");
             opt.value = href;
             opt.textContent = col.title ?? col.id;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,19 @@ def _reset_config_cache() -> Generator[None, None, None]:
     earthkit_processes._cache = None
 
 
+@pytest.fixture(autouse=True)
+def _unset_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serve tests from the request's own origin, whatever the developer's environment says.
+
+    `CLIMATE_SERVICE_BASE_URL` is documented in `.env.example` and loaded by compose via
+    `env_file`, so it is routinely exported on a machine that runs an instance. Every route
+    that builds an absolute URL reads it, so with it set the assertions that pin
+    `http://testserver/...` fail — a test run whose result depends on the shell it was started
+    from. Tests that need a configured origin set it themselves.
+    """
+    monkeypatch.delenv("CLIMATE_SERVICE_BASE_URL", raising=False)
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import os
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from open_climate_service import config as api_config
 from open_climate_service.main import app
@@ -52,8 +53,34 @@ def _unset_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     from. Tests that need a configured origin set it themselves.
     """
     monkeypatch.delenv("CLIMATE_SERVICE_BASE_URL", raising=False)
+    monkeypatch.delenv("ROOT_PATH", raising=False)
 
 
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)
+
+
+MountedClientFactory = Callable[..., TestClient]
+
+
+@pytest.fixture
+def mounted_client_factory() -> MountedClientFactory:
+    """Build a client that reaches the app the way uvicorn does under `--root-path`.
+
+    Uvicorn sets `scope["root_path"]` *and* prepends it to `scope["path"]`, so `/manage` under
+    `/ocs` arrives as `/ocs/manage`. `TestClient(root_path=...)` only sets the former, which
+    makes any prefix-stripping code a no-op under test and lets a test pass with the strip
+    removed. The prefix is passed verbatim, so a trailing slash reaches the app as it would in
+    production.
+    """
+
+    def make(root_path: str = "/ocs", target: ASGIApp = app) -> TestClient:
+        async def uvicorn_shaped(scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] == "http":
+                scope = {**scope, "root_path": root_path, "path": root_path + scope["path"]}
+            await target(scope, receive, send)
+
+        return TestClient(uvicorn_shaped)
+
+    return make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,15 @@ def _unset_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     that builds an absolute URL reads it, so with it set the assertions that pin
     `http://testserver/...` fail — a test run whose result depends on the shell it was started
     from. Tests that need a configured origin set it themselves.
+
+    `ROOT_PATH` is the same hazard one step earlier: `create_app()` reads it when `main` is
+    imported, so the shared `app` above already carries the developer's prefix by the time this
+    fixture runs, and unsetting the variable alone leaves every route rendering it. The
+    attribute is reset too, since FastAPI copies `app.root_path` into each request scope.
     """
     monkeypatch.delenv("CLIMATE_SERVICE_BASE_URL", raising=False)
     monkeypatch.delenv("ROOT_PATH", raising=False)
+    monkeypatch.setattr(app, "root_path", "")
 
 
 @pytest.fixture

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -76,10 +76,7 @@ def test_the_self_url_keeps_the_requested_path(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
     assert self_url(_fake_request("http://internal:9000/", "/stac")) == f"{_CONFIGURED}/stac"
-    assert (
-        self_url(_fake_request("http://internal:9000/", "/stac/catalog.json"))
-        == f"{_CONFIGURED}/stac/catalog.json"
-    )
+    assert self_url(_fake_request("http://internal:9000/", "/stac/catalog.json")) == f"{_CONFIGURED}/stac/catalog.json"
 
 
 def test_the_self_url_drops_the_query_string(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -241,3 +241,69 @@ def test_a_configured_origin_is_unaffected_by_a_mount_prefix(monkeypatch: pytest
         }
     )
     assert self_url(request) == "https://example.org/ocs/stac"
+
+
+# -- mount prefix ----------------------------------------------------------------------------
+#
+# Three positions on the same links, all of which have been in this file's history. Two are
+# wrong in opposite directions, so the tests below pin all three rather than the survivor:
+#
+#   absolute, configured origin -> submits to the *public* instance from a port-forward
+#   bare leading slash          -> drops a deployment prefix, proxy 404
+#   mount-relative path         -> inherits the page's origin, resolves under the prefix
+
+
+@pytest.fixture
+def mounted_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Served under `/ocs`, with a configured public origin that is *not* the request's."""
+    from open_climate_service.main import app
+
+    monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
+    return TestClient(app, root_path="/ocs")
+
+
+def test_the_manage_console_posts_under_the_mount_prefix(mounted_client: TestClient) -> None:
+    """A page served at `/ocs/manage` posting to `/manage/ingest` reached the proxy, not the
+    app, and returned 404."""
+    body = mounted_client.get("/manage").text
+
+    assert 'action="/ocs/manage/ingest"' in body
+    assert 'action="/manage/ingest"' not in body
+    # Still no origin: the prefix is a path, so the page's own scheme and host are inherited.
+    assert _CONFIGURED not in body
+
+
+def test_the_landing_page_links_under_the_mount_prefix(mounted_client: TestClient) -> None:
+    body = mounted_client.get("/", headers={"Accept": "text/html"}).text
+
+    assert 'href="/ocs/map"' in body
+    assert 'href="/map"' not in body
+    assert _CONFIGURED not in body
+
+
+def test_the_viewer_fetches_under_the_mount_prefix(mounted_client: TestClient) -> None:
+    """Without the prefix the viewer fetched `/extent` from the origin root and rendered
+    empty, which looks like missing data rather than a broken URL."""
+    body = mounted_client.get("/map").text
+
+    assert 'fetch("/ocs/extent")' in body
+    assert 'fetch("/ocs/collections")' in body
+    assert _CONFIGURED not in body
+
+
+def test_an_unmounted_instance_gains_no_prefix(https_client: TestClient) -> None:
+    """The prefix is empty at the root, so the same expression serves both deployments."""
+    body = https_client.get("/manage").text
+
+    assert 'action="/manage/ingest"' in body
+    assert "//manage" not in body, "empty prefix must not leave a doubled slash"
+
+
+def test_mount_prefix_strips_a_trailing_slash() -> None:
+    """`f"{mount_prefix(request)}/manage"` has to be right for every form the server reports."""
+    from open_climate_service.shared.urls import mount_prefix
+
+    for reported, expected in (("/ocs/", "/ocs"), ("/ocs", "/ocs"), ("/", ""), ("", "")):
+        request = _fake_request("http://host/", "/manage")
+        request.scope["root_path"] = reported
+        assert mount_prefix(request) == expected, reported

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -1,0 +1,151 @@
+"""Absolute URLs must carry the configured public scheme (CLIM-974).
+
+Behind a TLS-terminating proxy the request arrives over plain HTTP, so anything built from
+`request.base_url` or `request.url` emits `http://` on an HTTPS deployment. In a browser that
+is active mixed content: the fetches are blocked and the map viewer renders an empty
+catalogue, while curl against every endpoint still returns 200. HSTS hides it entirely, so
+the deployment where it was found looked fine.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_climate_service.shared.urls import BASE_URL_ENV
+
+_CONFIGURED = "https://ocs-demo-nepal.dhis2.org"
+
+
+@pytest.fixture
+def https_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """A client whose requests arrive over HTTP while the public origin is HTTPS.
+
+    This is exactly the proxied deployment: TestClient's own base URL is `http://testserver`,
+    standing in for what uvicorn sees behind the proxy.
+    """
+    from open_climate_service.main import app
+
+    monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
+    return TestClient(app)
+
+
+# -- the helper -----------------------------------------------------------------------------
+
+
+def test_the_configured_origin_wins_over_the_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.shared.urls import absolute_base
+
+    monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
+    request = _fake_request("http://internal:9000/", "/map")
+    assert absolute_base(request) == _CONFIGURED
+
+
+def test_the_request_is_the_fallback_when_nothing_is_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local development, served directly with no proxy and no configuration."""
+    from open_climate_service.shared.urls import absolute_base
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    request = _fake_request("http://localhost:9000/", "/map")
+    assert absolute_base(request) == "http://localhost:9000"
+
+
+@pytest.mark.parametrize("configured", [f"{_CONFIGURED}/", f"  {_CONFIGURED}  ", f"{_CONFIGURED}///"])
+def test_a_sloppy_base_url_is_normalised(monkeypatch: pytest.MonkeyPatch, configured: str) -> None:
+    """A trailing slash or stray whitespace in the deployment config must not double up in
+    every link on the page."""
+    from open_climate_service.shared.urls import absolute_base, absolute_url
+
+    monkeypatch.setenv(BASE_URL_ENV, configured)
+    request = _fake_request("http://internal:9000/", "/map")
+    assert absolute_base(request) == _CONFIGURED
+    assert absolute_url(request, "/collections") == f"{_CONFIGURED}/collections"
+
+
+def test_a_blank_base_url_is_not_a_configured_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty environment variable is how a compose file spells "unset"; treating it as an
+    origin would emit links with no host at all."""
+    from open_climate_service.shared.urls import absolute_base
+
+    monkeypatch.setenv(BASE_URL_ENV, "   ")
+    request = _fake_request("http://localhost:9000/", "/map")
+    assert absolute_base(request) == "http://localhost:9000"
+
+
+def test_the_self_url_keeps_the_requested_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`/stac` and `/stac/catalog.json` are one document, and each must name itself."""
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
+    assert self_url(_fake_request("http://internal:9000/", "/stac")) == f"{_CONFIGURED}/stac"
+    assert (
+        self_url(_fake_request("http://internal:9000/", "/stac/catalog.json"))
+        == f"{_CONFIGURED}/stac/catalog.json"
+    )
+
+
+def test_the_self_url_drops_the_query_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No OCS document varies by query string, so reflecting client input into a served
+    document buys nothing."""
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
+    request = _fake_request("http://internal:9000/", "/stac", query="a=1&b=2")
+    assert self_url(request) == f"{_CONFIGURED}/stac"
+
+
+def _fake_request(base: str, path: str, query: str = ""):
+    """A Request with just enough scope for the URL helpers."""
+    from fastapi import Request
+
+    host = base.split("://", 1)[1].rstrip("/")
+    hostname, _, port = host.partition(":")
+    return Request(
+        {
+            "type": "http",
+            "scheme": base.split("://", 1)[0],
+            "server": (hostname, int(port) if port else 80),
+            "path": path,
+            "query_string": query.encode(),
+            "headers": [(b"host", host.encode())],
+            "root_path": "",
+        }
+    )
+
+
+# -- the two reported endpoints -------------------------------------------------------------
+
+
+def test_the_map_viewer_never_emits_our_own_host_over_http(https_client: TestClient) -> None:
+    """The reported defect. Every fetch target and the header link came from the request, so
+    they carried `http` while the page itself was served over `https`."""
+    body = https_client.get("/map").text
+
+    assert "http://testserver" not in body
+    # The specific URLs named in the report.
+    for path in ("/extent", "/collections"):
+        assert f'"{_CONFIGURED}{path}"' in body
+    assert f'href="{_CONFIGURED}/"' in body
+
+
+def test_the_stac_self_link_uses_the_configured_scheme(https_client: TestClient) -> None:
+    """`self` was built from the raw request URL while its sibling links already used the
+    configured base — so one link in the document disagreed with the rest."""
+    links = {link["rel"]: link["href"] for link in https_client.get("/stac").json()["links"]}
+
+    assert links["self"] == f"{_CONFIGURED}/stac"
+    assert links["root"] == f"{_CONFIGURED}/stac/catalog.json"
+
+
+def test_the_catalog_json_self_link_names_its_own_path(https_client: TestClient) -> None:
+    links = {link["rel"]: link["href"] for link in https_client.get("/stac/catalog.json").json()["links"]}
+
+    assert links["self"] == f"{_CONFIGURED}/stac/catalog.json"
+
+
+def test_no_served_document_leaks_the_internal_origin(https_client: TestClient) -> None:
+    """A sweep rather than a list, so a new absolute URL built from the request is caught here
+    instead of on a deployment. Non-browser STAC clients do not implement HSTS, so an `http`
+    link is followed as written."""
+    for path in ("/", "/map", "/stac", "/stac/catalog.json", "/collections", "/processes"):
+        response = https_client.get(path, headers={"Accept": "application/json"} if path == "/" else {})
+        assert response.status_code == 200, path
+        assert "http://testserver" not in response.text, path

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -111,16 +111,46 @@ def _fake_request(base: str, path: str, query: str = ""):
 # -- the two reported endpoints -------------------------------------------------------------
 
 
-def test_the_map_viewer_never_emits_our_own_host_over_http(https_client: TestClient) -> None:
-    """The reported defect. Every fetch target and the header link came from the request, so
-    they carried `http` while the page itself was served over `https`."""
+def test_the_map_viewer_carries_no_origin_at_all(https_client: TestClient) -> None:
+    """The reported defect was `http://` fetch targets on an `https://` page. Root-relative
+    targets fix it without naming an origin, which also removes a hazard the first fix
+    introduced: with the configured origin baked in, opening the viewer through a port-forward
+    fetched the *public* instance's catalogue — permitted by the wildcard CORS — and the
+    operator would validate an ingest against another instance's data (CLIM-974 review).
+    """
     body = https_client.get("/map").text
 
     assert "http://testserver" not in body
-    # The specific URLs named in the report.
+    assert _CONFIGURED not in body, "the viewer should not name any origin"
     for path in ("/extent", "/collections"):
-        assert f'"{_CONFIGURED}{path}"' in body
-    assert f'href="{_CONFIGURED}/"' in body
+        assert f'fetch("{path}")' in body
+
+
+def test_the_manage_console_posts_to_the_origin_it_was_reached_on(https_client: TestClient) -> None:
+    """Form actions and redirects stay relative for the same reason: an operator on a
+    port-forward pressing Ingest must not POST to the configured public instance."""
+    body = https_client.get("/manage").text
+
+    assert _CONFIGURED not in body
+    assert 'action="/manage/ingest"' in body or "/manage/ingest" in body
+
+
+def test_the_landing_page_links_within_the_instance_it_is_served_from(https_client: TestClient) -> None:
+    """HTML explicitly: `/` content-negotiates, and the openEO capabilities on the JSON side
+    *must* carry the configured origin because other processes consume those links."""
+    body = https_client.get("/", headers={"Accept": "text/html"}).text
+
+    assert _CONFIGURED not in body
+    assert 'href="/map"' in body
+
+
+def test_the_capabilities_json_still_carries_the_configured_origin(https_client: TestClient) -> None:
+    """The other half of the split. Links in a document read by another process have to be
+    absolute and have to name the public origin."""
+    links = https_client.get("/", headers={"Accept": "application/json"}).json()["links"]
+
+    assert any(link["href"].startswith(_CONFIGURED) for link in links)
+    assert not any("testserver" in link["href"] for link in links)
 
 
 def test_the_stac_self_link_uses_the_configured_scheme(https_client: TestClient) -> None:
@@ -146,3 +176,68 @@ def test_no_served_document_leaks_the_internal_origin(https_client: TestClient) 
         response = https_client.get(path, headers={"Accept": "application/json"} if path == "/" else {})
         assert response.status_code == 200, path
         assert "http://testserver" not in response.text, path
+
+
+# -- degenerate configuration ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("configured", ["/", "///", "  /  "])
+def test_a_base_url_that_is_only_slashes_falls_back_to_the_request(
+    monkeypatch: pytest.MonkeyPatch, configured: str
+) -> None:
+    """Truthiness was tested before the trailing slashes were stripped, so `"/"` survived the
+    check, stripped to the empty string, and was returned — every href in every served
+    document lost its origin, and `/openeo` redirected to `editor.openeo.org/?server=`
+    (CLIM-974 review).
+    """
+    from open_climate_service.shared.urls import absolute_base
+
+    monkeypatch.setenv(BASE_URL_ENV, configured)
+    assert absolute_base(_fake_request("http://localhost:9000/", "/stac")) == "http://localhost:9000"
+
+
+def test_the_self_link_does_not_double_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Behind a non-stripping proxy in front of `--root-path /ocs`, the fallback origin ends
+    with the prefix and `request.url.path` carries it again, so `self` became
+    `/ocs/ocs/stac` while every other link stayed correct — a STAC client following `self`
+    would 404 (CLIM-974 review).
+    """
+    from fastapi import Request
+
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    request = Request(
+        {
+            "type": "http",
+            "scheme": "http",
+            "server": ("host", 80),
+            "path": "/ocs/stac",
+            "root_path": "/ocs",
+            "query_string": b"",
+            "headers": [(b"host", b"host")],
+        }
+    )
+    assert self_url(request) == "http://host/ocs/stac"
+
+
+def test_a_configured_origin_is_unaffected_by_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The prefix belongs to the deployment, so a configured public origin that already
+    includes it must not have it stripped or doubled."""
+    from fastapi import Request
+
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.setenv(BASE_URL_ENV, "https://example.org/ocs")
+    request = Request(
+        {
+            "type": "http",
+            "scheme": "http",
+            "server": ("host", 80),
+            "path": "/ocs/stac",
+            "root_path": "/ocs",
+            "query_string": b"",
+            "headers": [(b"host", b"host")],
+        }
+    )
+    assert self_url(request) == "https://example.org/ocs/stac"

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -132,7 +132,9 @@ def test_the_manage_console_posts_to_the_origin_it_was_reached_on(https_client: 
     body = https_client.get("/manage").text
 
     assert _CONFIGURED not in body
-    assert 'action="/manage/ingest"' in body or "/manage/ingest" in body
+    # Strict: the bare substring is also present in the pre-PR `action="http://testserver/..."`
+    # form this test exists to reject, so an `or` on it would pass against the very bug.
+    assert 'action="/manage/ingest"' in body
 
 
 def test_the_landing_page_links_within_the_instance_it_is_served_from(https_client: TestClient) -> None:
@@ -197,10 +199,17 @@ def test_a_base_url_that_is_only_slashes_falls_back_to_the_request(
 
 
 def test_the_self_link_does_not_double_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Behind a non-stripping proxy in front of `--root-path /ocs`, the fallback origin ends
-    with the prefix and `request.url.path` carries it again, so `self` became
-    `/ocs/ocs/stac` while every other link stayed correct — a STAC client following `self`
-    would 404 (CLIM-974 review).
+    """The ordinary mounted deployment, not an exotic one.
+
+    Uvicorn sets `scope["path"] = root_path + path`, so with `--root-path /ocs` behind a normal
+    stripping proxy the request arrives as `/stac` and `request.url.path` becomes `/ocs/stac`,
+    while the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path
+    unstripped gives `/ocs/ocs/stac` for `self` while every other link stays correct, and a STAC
+    client following `self` 404s.
+
+    The scope is built by hand rather than through `mounted_client` because
+    `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, and
+    because the configured origin must be unset for the fallback to be reached at all.
     """
     from fastapi import Request
 

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -116,18 +116,18 @@ def _fake_request(base: str, path: str, query: str = "", root_path: str = ""):
 
 
 def test_the_map_viewer_html_carries_no_origin(https_client: TestClient) -> None:
-    """The reported defect was `http://` fetch targets on an `https://` page. Mount-relative
-    targets fix it without naming an origin, which also removes a hazard the first fix
-    introduced: with the configured origin baked in, opening the viewer through a port-forward
-    fetched the *public* instance's catalogue — permitted by the wildcard CORS — and the
-    operator would validate an ingest against another instance's data (CLIM-974 review).
+    """The reported defect is `http://` fetch targets on an `https://` page (CLIM-974).
+
+    Mount-relative targets fix it without naming an origin, which matters: with the configured
+    origin baked in, opening the viewer through a port-forward fetches the *public* instance's
+    catalogue — permitted by the wildcard CORS — and the operator validates an ingest against
+    another instance's data.
 
     Scoped to the HTML the server renders, which is all this greps. Once a collection is
-    selected the page loads raster data from the `zarr.href` inside the collection JSON, and
-    `build_collection` builds that with `absolute_url`, so it names the configured origin. On a
-    port-forward the dropdown is therefore local while the chunks come from the configured
-    instance. That is arguably correct STAC behaviour and predates this change, but it is not
-    covered here — see the PR description.
+    selected the page loads raster data from the `zarr.href` inside the collection JSON, which
+    `build_collection` builds with `absolute_url` and so names the configured origin. On a
+    port-forward the dropdown is local while the chunks come from the configured instance —
+    arguably correct STAC behaviour, and not covered here; see the PR description.
     """
     body = https_client.get("/map").text
 
@@ -143,8 +143,8 @@ def test_the_manage_console_posts_to_the_origin_it_was_reached_on(https_client: 
     body = https_client.get("/manage").text
 
     assert _CONFIGURED not in body
-    # Strict: the bare substring is also present in the pre-PR `action="http://testserver/..."`
-    # form this test exists to reject, so an `or` on it would pass against the very bug.
+    # Strict: the bare substring also appears in the `action="http://testserver/..."` form this
+    # test exists to reject, so matching on it alone would pass against the very bug.
     assert 'action="/manage/ingest"' in body
 
 
@@ -198,10 +198,11 @@ def test_no_served_document_leaks_the_internal_origin(https_client: TestClient) 
 def test_a_base_url_that_is_only_slashes_falls_back_to_the_request(
     monkeypatch: pytest.MonkeyPatch, configured: str
 ) -> None:
-    """Truthiness was tested before the trailing slashes were stripped, so `"/"` survived the
-    check, stripped to the empty string, and was returned — every href in every served
-    document lost its origin, and `/openeo` redirected to `editor.openeo.org/?server=`
-    (CLIM-974 review).
+    """A value that is nothing but slashes has no origin in it to use.
+
+    Judged before the slashes come off, `"/"` passes as configured and then strips to the empty
+    string: every href in every served document loses its origin and `/openeo` redirects to
+    `editor.openeo.org/?server=`.
     """
     from open_climate_service.shared.urls import absolute_base
 
@@ -212,11 +213,11 @@ def test_a_base_url_that_is_only_slashes_falls_back_to_the_request(
 def test_the_self_link_does_not_double_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     """The ordinary mounted deployment, not an exotic one.
 
-    Uvicorn sets `scope["path"] = root_path + path`, so with `--root-path /ocs` behind a normal
-    stripping proxy the request arrives as `/stac` and `request.url.path` becomes `/ocs/stac`,
-    while the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path
-    unstripped gives `/ocs/ocs/stac` for `self` while every other link stays correct, and a STAC
-    client following `self` 404s.
+    Uvicorn sets `scope["path"] = root_path + path`, so with `--root-path /ocs` behind a
+    stripping proxy a request for `/stac` arrives with `request.url.path == "/ocs/stac"` while
+    the fallback origin `request.base_url` already ends in `/ocs/`. Appending that unstripped
+    gives `/ocs/ocs/stac` for `self` while every other link stays correct, and a STAC client
+    following `self` 404s.
 
     The scope is built by hand rather than through `mounted_client` because
     `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, and
@@ -241,8 +242,8 @@ def test_a_configured_origin_is_unaffected_by_a_mount_prefix(monkeypatch: pytest
 
 # -- mount prefix ----------------------------------------------------------------------------
 #
-# Three positions on the same links, all of which have been in this file's history. Two are
-# wrong in opposite directions, so the tests below pin all three rather than the survivor:
+# Three possible positions on the same links. Two are wrong in opposite directions, so the
+# tests below pin all three rather than only the right one:
 #
 #   absolute, configured origin -> submits to the *public* instance from a port-forward
 #   bare leading slash          -> drops a deployment prefix, proxy 404
@@ -259,8 +260,8 @@ def mounted_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
 
 def test_the_manage_console_posts_under_the_mount_prefix(mounted_client: TestClient) -> None:
-    """A page served at `/ocs/manage` posting to `/manage/ingest` reached the proxy, not the
-    app, and returned 404."""
+    """A page served at `/ocs/manage` that posts to `/manage/ingest` reaches the proxy, not the
+    app, and gets a 404."""
     body = mounted_client.get("/manage").text
 
     assert 'action="/ocs/manage/ingest"' in body
@@ -310,11 +311,12 @@ def test_mount_prefix_strips_a_trailing_slash() -> None:
 
 
 def test_the_mount_prefix_falls_back_to_the_base_url_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No shipped entry point sets ASGI `root_path`, so this is the usual mounted deployment.
+    """The deployment that declares its prefix only in `CLIMATE_SERVICE_BASE_URL`.
 
-    With the prefix declared only in `CLIMATE_SERVICE_BASE_URL`, in-page links previously came
-    out unprefixed — an instance behind `https://host/ocs/` rendered `/map`, which 404s at the
-    proxy. `root_path` still wins when a server does set it.
+    Without the fallback, in-page links come out unprefixed: an instance behind
+    `https://host/ocs/` renders `/map`, which 404s at the proxy. `ROOT_PATH` states this more
+    directly and `root_path` wins whenever set, but the fallback has to keep working for
+    deployments that cannot set it.
     """
     from open_climate_service.shared.urls import mount_prefix
 
@@ -326,11 +328,12 @@ def test_the_mount_prefix_falls_back_to_the_base_url_path(monkeypatch: pytest.Mo
 
 
 def test_the_self_link_keeps_the_prefix_of_an_embedding_mount(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`request.base_url` is built from `app_root_path`, so the strip must use the same key.
+    """Under an embedding mount the fallback origin needs the prefix added to it.
 
-    Under `outer.mount("/ocs", create_app())` Starlette sets `root_path` on the inner app while
-    `base_url` keeps the outer prefix; stripping `root_path` removed a prefix `base_url` had
-    never added, and `self` came back as `/stac` — a 404.
+    Starlette builds `base_url` from `app_root_path`, which under `Mount("/ocs", app)` is the
+    outer root with no prefix at all, while `request.url.path` carries `/ocs`. Stripping the
+    prefix off the path without adding it to the origin drops it altogether and `self` comes
+    back as `/stac` — a 404.
     """
     from starlette.applications import Starlette
     from starlette.routing import Mount
@@ -357,13 +360,12 @@ def test_stripping_a_prefix_respects_segment_boundaries() -> None:
 def test_the_self_link_does_not_double_a_configured_path_under_an_embedding_mount(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Two origins account for different amounts of the prefix, so the strip differs.
+    """The configured origin already is the service root, prefix included, so nothing adds it
+    twice.
 
-    A configured `CLIMATE_SERVICE_BASE_URL` *is* the service root, path included, so the whole
-    ASGI prefix comes off. `request.base_url` is built from `app_root_path` and already carries
-    exactly that much. `Mount("/ocs", app)` sets `root_path` while leaving `base_url` at the
-    outer root, so stripping the `base_url` amount there left the prefix on the path and the
-    configured path supplied it a second time: `https://public.example/ocs/ocs/stac`.
+    Varying how much of the prefix comes off the path by which origin it is appended to leaves
+    the prefix on the path under `Mount("/ocs", app)` while the configured path supplies it a
+    second time: `https://public.example/ocs/ocs/stac`.
     """
     from starlette.applications import Starlette
     from starlette.routing import Mount
@@ -375,6 +377,86 @@ def test_the_self_link_does_not_double_a_configured_path_under_an_embedding_moun
     payload = TestClient(outer).get("/ocs/stac").json()
     self_href = next(link["href"] for link in payload["links"] if link["rel"] == "self")
     assert self_href == "https://public.example/ocs/stac"
+
+
+def test_every_link_of_one_document_agrees_under_an_embedding_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`self` is not the only link in the document, and the others are built differently.
+
+    `root` and the child links come from `absolute_base` rather than the request path, so an
+    origin without the prefix puts both forms in one STAC document — `self` with `/ocs`, `root`
+    without — and a client following `root` gets a 404.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    from open_climate_service.main import app as inner
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    outer = Starlette(routes=[Mount("/ocs", app=inner)])
+    payload = TestClient(outer).get("/ocs/stac").json()
+
+    for link in payload["links"]:
+        assert link["href"].startswith("http://testserver/ocs/"), link
+
+
+# -- unusable configuration ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "configured",
+    ["ocs-demo-nepal.dhis2.org", "ocs-demo-nepal.dhis2.org/ocs", "https://", "//host/ocs"],
+)
+def test_a_base_url_without_a_scheme_and_host_falls_back_to_the_request(
+    monkeypatch: pytest.MonkeyPatch, configured: str
+) -> None:
+    """Trimming instead of parsing accepts anything non-empty as an origin.
+
+    A host with no scheme gives `ocs-demo-nepal.dhis2.org/stac`, which a browser resolves
+    against the current page as a *relative* path; `https://` gives `https:/stac`. Both leave
+    the API returning 200 and every served document carrying broken links. Falling back to the
+    request origin is wrong in the way this variable exists to fix, but it is well-formed and it
+    logs.
+    """
+    from open_climate_service.shared.urls import absolute_base
+
+    monkeypatch.setenv(BASE_URL_ENV, configured)
+    assert absolute_base(_fake_request("http://localhost:9000/", "/stac")) == "http://localhost:9000"
+
+
+def test_a_base_url_is_parsed_rather_than_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A query string or fragment otherwise lands in the middle of every absolute URL.
+
+    `https://host/ocs?x=1` gives `https://host/ocs?x=1/stac` while in-page links stay correct,
+    because two readings of one variable disagree. Both go through the same parse.
+    """
+    from open_climate_service.shared.urls import absolute_url, mount_prefix
+
+    for configured in ("https://host/ocs?x=1", "https://host/ocs#frag", "https://host/ocs/#"):
+        monkeypatch.setenv(BASE_URL_ENV, configured)
+        request = _fake_request("http://internal:9000/", "/stac")
+        assert absolute_url(request, "/stac") == "https://host/ocs/stac", configured
+        assert mount_prefix(request) == "/ocs", configured
+
+
+def test_an_unusable_base_url_is_logged_once(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Silence is how this survives: the links are broken but every response is a 200."""
+    import logging
+
+    from open_climate_service.shared.urls import _parse_configured_base, absolute_base
+
+    # `startup.py` gives the package logger its own handler and stops propagation, so `caplog`
+    # sees nothing until it is let through.
+    monkeypatch.setattr(logging.getLogger("open_climate_service"), "propagate", True)
+    _parse_configured_base.cache_clear()
+    monkeypatch.setenv(BASE_URL_ENV, "ocs-demo-nepal.dhis2.org")
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            absolute_base(_fake_request("http://localhost:9000/", "/stac"))
+
+    assert len(caplog.records) == 1, "cached on the raw value, so one warning per distinct value"
+    assert BASE_URL_ENV in caplog.text
 
 
 def test_the_asgi_prefix_ignores_the_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -7,10 +7,14 @@ catalogue, while curl against every endpoint still returns 200. HSTS hides it en
 the deployment where it was found looked fine.
 """
 
+import urllib.parse
+
 import pytest
 from fastapi.testclient import TestClient
 
 from open_climate_service.shared.urls import BASE_URL_ENV
+
+from .conftest import MountedClientFactory
 
 _CONFIGURED = "https://ocs-demo-nepal.dhis2.org"
 
@@ -89,27 +93,27 @@ def test_the_self_url_drops_the_query_string(monkeypatch: pytest.MonkeyPatch) ->
     assert self_url(request) == f"{_CONFIGURED}/stac"
 
 
-def _fake_request(base: str, path: str, query: str = "", root_path: str = ""):
+def _fake_request(base: str, path: str, query: str = "", root_path: str = "", app_root_path: str | None = None):
     """A Request with just enough scope for the URL helpers.
 
-    `root_path` is a parameter because the mounted cases need it and rebuilding the whole scope
-    inline to change one key is how three tests ended up with a copy of this dict.
+    `root_path` is what uvicorn or an embedding `Mount` sets; `app_root_path` is what Starlette
+    records for the outermost app, which under a `Mount` differs from `root_path`.
     """
     from fastapi import Request
 
-    host = base.split("://", 1)[1].rstrip("/")
-    hostname, _, port = host.partition(":")
-    return Request(
-        {
-            "type": "http",
-            "scheme": base.split("://", 1)[0],
-            "server": (hostname, int(port) if port else 80),
-            "path": path,
-            "query_string": query.encode(),
-            "headers": [(b"host", host.encode())],
-            "root_path": root_path,
-        }
-    )
+    split = urllib.parse.urlsplit(base)
+    scope = {
+        "type": "http",
+        "scheme": split.scheme,
+        "server": (split.hostname, split.port or 80),
+        "path": path,
+        "query_string": query.encode(),
+        "headers": [(b"host", split.netloc.encode())],
+        "root_path": root_path,
+    }
+    if app_root_path is not None:
+        scope["app_root_path"] = app_root_path
+    return Request(scope)
 
 
 # -- the two reported endpoints -------------------------------------------------------------
@@ -251,12 +255,26 @@ def test_a_configured_origin_is_unaffected_by_a_mount_prefix(monkeypatch: pytest
 
 
 @pytest.fixture
-def mounted_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    """Served under `/ocs`, with a configured public origin that is *not* the request's."""
-    from open_climate_service.main import app
-
+def mounted_client(monkeypatch: pytest.MonkeyPatch, mounted_client_factory: MountedClientFactory) -> TestClient:
+    """Served under `/ocs` the way uvicorn does it, with a configured public origin that is
+    *not* the request's and that carries no path of its own."""
     monkeypatch.setenv(BASE_URL_ENV, _CONFIGURED)
-    return TestClient(app, root_path="/ocs")
+    return mounted_client_factory("/ocs")
+
+
+def test_an_origin_only_base_url_composes_with_the_asgi_prefix(mounted_client: TestClient) -> None:
+    """`ROOT_PATH=/ocs` with `CLIMATE_SERVICE_BASE_URL=https://host` is the documented pairing.
+
+    Returning the configured value verbatim put the HTML links under `/ocs` while every STAC
+    and openEO href named the origin root: one document, two service roots, and the absolute
+    half 404s at the proxy.
+    """
+    payload = mounted_client.get("/stac").json()
+    for link in payload["links"]:
+        assert link["href"].startswith(f"{_CONFIGURED}/ocs/"), link
+
+    well_known = mounted_client.get("/.well-known/openeo").json()
+    assert all(v["url"].startswith(f"{_CONFIGURED}/ocs") for v in well_known["versions"]), well_known
 
 
 def test_the_manage_console_posts_under_the_mount_prefix(mounted_client: TestClient) -> None:
@@ -300,14 +318,50 @@ def test_an_unmounted_instance_gains_no_prefix(https_client: TestClient) -> None
     assert "//manage" not in body, "empty prefix must not leave a doubled slash"
 
 
-def test_mount_prefix_strips_a_trailing_slash() -> None:
+@pytest.mark.parametrize(("reported", "expected"), [("/ocs/", "/ocs"), ("/ocs", "/ocs"), ("/", ""), ("", "")])
+def test_mount_prefix_strips_a_trailing_slash(reported: str, expected: str) -> None:
     """`f"{mount_prefix(request)}/manage"` has to be right for every form the server reports."""
     from open_climate_service.shared.urls import mount_prefix
 
-    for reported, expected in (("/ocs/", "/ocs"), ("/ocs", "/ocs"), ("/", ""), ("", "")):
-        request = _fake_request("http://host/", "/manage")
-        request.scope["root_path"] = reported
-        assert mount_prefix(request) == expected, reported
+    assert mount_prefix(_fake_request("http://host/", "/manage", root_path=reported)) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("/ocs", "/ocs"), ("/ocs/", "/ocs"), ("ocs", "/ocs"), (" /ocs/ ", "/ocs"), ("/", ""), ("", ""), ("  ", "")],
+)
+def test_the_root_path_setting_is_normalised(monkeypatch: pytest.MonkeyPatch, raw: str, expected: str) -> None:
+    """Uvicorn joins `root_path + path` verbatim, so `ROOT_PATH=/ocs/` would put `/ocs//manage`
+    on the scope, and `ocs` would render relative links. Both are the operator's most likely
+    spellings after the canonical one."""
+    from open_climate_service.shared.urls import configured_root_path
+
+    monkeypatch.setenv("ROOT_PATH", raw)
+    assert configured_root_path() == expected
+
+
+def test_the_app_reads_the_root_path_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ROOT_PATH` set in `.env` must work under `make run` and bare uvicorn, which never go
+    through `cli.py`. The app owns the setting, so every launcher gets it."""
+    from open_climate_service.main import create_app
+
+    monkeypatch.setenv("ROOT_PATH", "/ocs/")
+    client = TestClient(create_app())
+
+    assert 'action="/ocs/manage/ingest"' in client.get("/manage").text
+    self_href = next(link["href"] for link in client.get("/stac").json()["links"] if link["rel"] == "self")
+    assert self_href == "http://testserver/ocs/stac"
+
+
+@pytest.mark.parametrize("root_path", ["/ocs", "/ocs/"])
+def test_the_route_path_strips_the_prefix_the_way_starlette_does(root_path: str) -> None:
+    """A trailing slash in `root_path` doubles the slash on the joined path. Starlette routes
+    `/ocs//manage` under `/ocs/` to `/manage`; the read-only policy must see the same path."""
+    from open_climate_service.shared.urls import route_path, self_url
+
+    request = _fake_request("http://host/", root_path + "/manage", root_path=root_path)
+    assert route_path(request) == "/manage"
+    assert self_url(request) == "http://host/ocs/manage"
 
 
 def test_the_mount_prefix_falls_back_to_the_base_url_path(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -355,6 +409,7 @@ def test_stripping_a_prefix_respects_segment_boundaries() -> None:
     assert strip_mount("/ocs/stac", "/ocs") == "/stac"
     assert strip_mount("/ocs", "/ocs") == "/"
     assert strip_mount("/stac", "") == "/stac"
+    assert strip_mount("/ocs//stac", "/ocs/") == "/stac", "a trailing-slash prefix consumes the doubled slash"
 
 
 def test_the_self_link_does_not_double_a_configured_path_under_an_embedding_mount(
@@ -401,6 +456,28 @@ def test_every_link_of_one_document_agrees_under_an_embedding_mount(
         assert link["href"].startswith("http://testserver/ocs/"), link
 
 
+def test_a_host_named_like_the_prefix_does_not_lose_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deciding whether `base_url` already carries the prefix by `endswith` compared a URL
+    against a path: `http://ocs` ends with `/ocs`, so a compose service named after its mount
+    served `self` as `http://ocs/stac`."""
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    request = _fake_request("http://ocs/", "/ocs/stac", root_path="/ocs", app_root_path="")
+    assert self_url(request) == "http://ocs/ocs/stac"
+
+
+def test_a_mount_inside_a_root_path_carries_both_prefixes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--root-path /api` with `Mount("/ocs", app)` inside it: Starlette composes the child
+    `root_path` as `/api/ocs` while `base_url` stops at the outer `/api`. Appending the whole
+    child prefix to that gave `/api/api/ocs`."""
+    from open_climate_service.shared.urls import self_url
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    request = _fake_request("http://host/", "/api/ocs/stac", root_path="/api/ocs", app_root_path="/api")
+    assert self_url(request) == "http://host/api/ocs/stac"
+
+
 # -- unusable configuration ------------------------------------------------------------------
 
 
@@ -425,7 +502,8 @@ def test_a_base_url_without_a_scheme_and_host_falls_back_to_the_request(
     assert absolute_base(_fake_request("http://localhost:9000/", "/stac")) == "http://localhost:9000"
 
 
-def test_a_base_url_is_parsed_rather_than_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("configured", ["https://host/ocs?x=1", "https://host/ocs#frag", "https://host/ocs/#"])
+def test_a_base_url_is_parsed_rather_than_trimmed(monkeypatch: pytest.MonkeyPatch, configured: str) -> None:
     """A query string or fragment otherwise lands in the middle of every absolute URL.
 
     `https://host/ocs?x=1` gives `https://host/ocs?x=1/stac` while in-page links stay correct,
@@ -433,11 +511,10 @@ def test_a_base_url_is_parsed_rather_than_trimmed(monkeypatch: pytest.MonkeyPatc
     """
     from open_climate_service.shared.urls import absolute_url, mount_prefix
 
-    for configured in ("https://host/ocs?x=1", "https://host/ocs#frag", "https://host/ocs/#"):
-        monkeypatch.setenv(BASE_URL_ENV, configured)
-        request = _fake_request("http://internal:9000/", "/stac")
-        assert absolute_url(request, "/stac") == "https://host/ocs/stac", configured
-        assert mount_prefix(request) == "/ocs", configured
+    monkeypatch.setenv(BASE_URL_ENV, configured)
+    request = _fake_request("http://internal:9000/", "/stac")
+    assert absolute_url(request, "/stac") == "https://host/ocs/stac"
+    assert mount_prefix(request) == "/ocs"
 
 
 def test_an_unusable_base_url_is_logged_once(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -111,12 +111,19 @@ def _fake_request(base: str, path: str, query: str = ""):
 # -- the two reported endpoints -------------------------------------------------------------
 
 
-def test_the_map_viewer_carries_no_origin_at_all(https_client: TestClient) -> None:
-    """The reported defect was `http://` fetch targets on an `https://` page. Root-relative
+def test_the_map_viewer_html_carries_no_origin(https_client: TestClient) -> None:
+    """The reported defect was `http://` fetch targets on an `https://` page. Mount-relative
     targets fix it without naming an origin, which also removes a hazard the first fix
     introduced: with the configured origin baked in, opening the viewer through a port-forward
     fetched the *public* instance's catalogue — permitted by the wildcard CORS — and the
     operator would validate an ingest against another instance's data (CLIM-974 review).
+
+    Scoped to the HTML the server renders, which is all this greps. Once a collection is
+    selected the page loads raster data from the `zarr.href` inside the collection JSON, and
+    `build_collection` builds that with `absolute_url`, so it names the configured origin. On a
+    port-forward the dropdown is therefore local while the chunks come from the configured
+    instance. That is arguably correct STAC behaviour and predates this change, but it is not
+    covered here — see the PR description.
     """
     body = https_client.get("/map").text
 

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -89,8 +89,12 @@ def test_the_self_url_drops_the_query_string(monkeypatch: pytest.MonkeyPatch) ->
     assert self_url(request) == f"{_CONFIGURED}/stac"
 
 
-def _fake_request(base: str, path: str, query: str = ""):
-    """A Request with just enough scope for the URL helpers."""
+def _fake_request(base: str, path: str, query: str = "", root_path: str = ""):
+    """A Request with just enough scope for the URL helpers.
+
+    `root_path` is a parameter because the mounted cases need it and rebuilding the whole scope
+    inline to change one key is how three tests ended up with a copy of this dict.
+    """
     from fastapi import Request
 
     host = base.split("://", 1)[1].rstrip("/")
@@ -103,7 +107,7 @@ def _fake_request(base: str, path: str, query: str = ""):
             "path": path,
             "query_string": query.encode(),
             "headers": [(b"host", host.encode())],
-            "root_path": "",
+            "root_path": root_path,
         }
     )
 
@@ -218,44 +222,20 @@ def test_the_self_link_does_not_double_a_mount_prefix(monkeypatch: pytest.Monkey
     `TestClient(root_path=...)` does not prepend the prefix to `path` the way uvicorn does, and
     because the configured origin must be unset for the fallback to be reached at all.
     """
-    from fastapi import Request
-
     from open_climate_service.shared.urls import self_url
 
     monkeypatch.delenv(BASE_URL_ENV, raising=False)
-    request = Request(
-        {
-            "type": "http",
-            "scheme": "http",
-            "server": ("host", 80),
-            "path": "/ocs/stac",
-            "root_path": "/ocs",
-            "query_string": b"",
-            "headers": [(b"host", b"host")],
-        }
-    )
+    request = _fake_request("http://host/", "/ocs/stac", root_path="/ocs")
     assert self_url(request) == "http://host/ocs/stac"
 
 
 def test_a_configured_origin_is_unaffected_by_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     """The prefix belongs to the deployment, so a configured public origin that already
     includes it must not have it stripped or doubled."""
-    from fastapi import Request
-
     from open_climate_service.shared.urls import self_url
 
     monkeypatch.setenv(BASE_URL_ENV, "https://example.org/ocs")
-    request = Request(
-        {
-            "type": "http",
-            "scheme": "http",
-            "server": ("host", 80),
-            "path": "/ocs/stac",
-            "root_path": "/ocs",
-            "query_string": b"",
-            "headers": [(b"host", b"host")],
-        }
-    )
+    request = _fake_request("http://host/", "/ocs/stac", root_path="/ocs")
     assert self_url(request) == "https://example.org/ocs/stac"
 
 
@@ -327,3 +307,48 @@ def test_mount_prefix_strips_a_trailing_slash() -> None:
         request = _fake_request("http://host/", "/manage")
         request.scope["root_path"] = reported
         assert mount_prefix(request) == expected, reported
+
+
+def test_the_mount_prefix_falls_back_to_the_base_url_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No shipped entry point sets ASGI `root_path`, so this is the usual mounted deployment.
+
+    With the prefix declared only in `CLIMATE_SERVICE_BASE_URL`, in-page links previously came
+    out unprefixed — an instance behind `https://host/ocs/` rendered `/map`, which 404s at the
+    proxy. `root_path` still wins when a server does set it.
+    """
+    from open_climate_service.shared.urls import mount_prefix
+
+    monkeypatch.setenv(BASE_URL_ENV, "https://host/ocs")
+    assert mount_prefix(_fake_request("https://host/", "/")) == "/ocs"
+
+    monkeypatch.setenv(BASE_URL_ENV, "https://host")
+    assert mount_prefix(_fake_request("https://host/", "/")) == ""
+
+
+def test_the_self_link_keeps_the_prefix_of_an_embedding_mount(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`request.base_url` is built from `app_root_path`, so the strip must use the same key.
+
+    Under `outer.mount("/ocs", create_app())` Starlette sets `root_path` on the inner app while
+    `base_url` keeps the outer prefix; stripping `root_path` removed a prefix `base_url` had
+    never added, and `self` came back as `/stac` — a 404.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    from open_climate_service.main import app as inner
+
+    monkeypatch.delenv(BASE_URL_ENV, raising=False)
+    outer = Starlette(routes=[Mount("/ocs", app=inner)])
+    payload = TestClient(outer).get("/ocs/stac").json()
+    self_href = next(link["href"] for link in payload["links"] if link["rel"] == "self")
+    assert self_href == "http://testserver/ocs/stac"
+
+
+def test_stripping_a_prefix_respects_segment_boundaries() -> None:
+    """`startswith` alone turned `/stac` under a `/st` prefix into `/ac`."""
+    from open_climate_service.shared.urls import strip_mount
+
+    assert strip_mount("/stac", "/st") == "/stac"
+    assert strip_mount("/ocs/stac", "/ocs") == "/stac"
+    assert strip_mount("/ocs", "/ocs") == "/"
+    assert strip_mount("/stac", "") == "/stac"

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -288,6 +288,10 @@ def test_the_viewer_fetches_under_the_mount_prefix(mounted_client: TestClient) -
 
     assert 'fetch("/ocs/extent")' in body
     assert 'fetch("/ocs/collections")' in body
+    # The per-collection href too, not just the two literal fetch targets: a viewer that lists
+    # datasets under the mount and then resolves each one outside it shows a catalogue where every
+    # entry 404s on selection.
+    assert "`/ocs/collections/${col.id}`" in body
     assert _CONFIGURED not in body
 
 

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -352,3 +352,40 @@ def test_stripping_a_prefix_respects_segment_boundaries() -> None:
     assert strip_mount("/ocs/stac", "/ocs") == "/stac"
     assert strip_mount("/ocs", "/ocs") == "/"
     assert strip_mount("/stac", "") == "/stac"
+
+
+def test_the_self_link_does_not_double_a_configured_path_under_an_embedding_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two origins account for different amounts of the prefix, so the strip differs.
+
+    A configured `CLIMATE_SERVICE_BASE_URL` *is* the service root, path included, so the whole
+    ASGI prefix comes off. `request.base_url` is built from `app_root_path` and already carries
+    exactly that much. `Mount("/ocs", app)` sets `root_path` while leaving `base_url` at the
+    outer root, so stripping the `base_url` amount there left the prefix on the path and the
+    configured path supplied it a second time: `https://public.example/ocs/ocs/stac`.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    from open_climate_service.main import app as inner
+
+    monkeypatch.setenv(BASE_URL_ENV, "https://public.example/ocs")
+    outer = Starlette(routes=[Mount("/ocs", app=inner)])
+    payload = TestClient(outer).get("/ocs/stac").json()
+    self_href = next(link["href"] for link in payload["links"] if link["rel"] == "self")
+    assert self_href == "https://public.example/ocs/stac"
+
+
+def test_the_asgi_prefix_ignores_the_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`asgi_prefix` describes the incoming path; `mount_prefix` describes outgoing links.
+
+    Swapping them is what let a base URL of `https://host/jobs` strip `/jobs` off a real route.
+    """
+    from open_climate_service.shared.urls import asgi_prefix, mount_prefix
+
+    monkeypatch.setenv(BASE_URL_ENV, "https://host/jobs")
+    request = _fake_request("https://host/", "/jobs")
+
+    assert asgi_prefix(request) == ""
+    assert mount_prefix(request) == "/jobs"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,8 @@
 """What the server entry point passes to uvicorn (CLIM-974).
 
-Three of the four settings only take effect if uvicorn is *told* about them, and none of them
-fails loudly when it is not: without `forwarded_allow_ips` a proxied deployment emits `http://`
-links, and without `root_path` a prefixed one has to declare its prefix in
-`CLIMATE_SERVICE_BASE_URL` and gets prefixed links on a direct port-forward too.
+`forwarded_allow_ips` only takes effect if uvicorn is *told* about it, and it does not fail
+loudly when it is not: a proxied deployment simply emits `http://` links. `ROOT_PATH` is
+read by the app itself (see `test_absolute_urls`), so the entry point does not forward it.
 """
 
 from typing import Any
@@ -14,8 +13,6 @@ import pytest
 @pytest.fixture
 def uvicorn_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """The keyword arguments `main()` hands to `uvicorn.run`, without starting a server."""
-    import dotenv
-
     import open_climate_service.cli as cli
 
     captured: dict[str, Any] = {}
@@ -25,39 +22,46 @@ def uvicorn_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured.update(kwargs)
 
     monkeypatch.setattr(cli.uvicorn, "run", fake_run)
-    # `.env` on a developer's machine would otherwise decide what these assertions see. `main`
-    # imports `load_dotenv` when it runs, so patching the attribute is enough.
-    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: False)
-    for name in ("HOST", "PORT", "ROOT_PATH", "FORWARDED_ALLOW_IPS"):
+    # `.env` was loaded when `cli` imported `startup`; clearing after that keeps a developer's
+    # machine from deciding what these assertions see.
+    for name in ("HOST", "PORT", "FORWARDED_ALLOW_IPS"):
         monkeypatch.delenv(name, raising=False)
     return captured
 
 
-def test_the_defaults_bind_locally_with_no_prefix(
-    monkeypatch: pytest.MonkeyPatch, uvicorn_kwargs: dict[str, Any]
-) -> None:
+def test_the_defaults_bind_locally(uvicorn_kwargs: dict[str, Any]) -> None:
     from open_climate_service.cli import DEFAULT_HOST, DEFAULT_PORT, main
 
     main()
 
+    assert uvicorn_kwargs["app"] == "open_climate_service.main:app"
     assert uvicorn_kwargs["host"] == DEFAULT_HOST
     assert uvicorn_kwargs["port"] == DEFAULT_PORT
-    assert uvicorn_kwargs["root_path"] == ""
     # None, not "": uvicorn's own default is 127.0.0.1 and an empty string would trust nothing.
     assert uvicorn_kwargs["forwarded_allow_ips"] is None
 
 
 def test_the_environment_reaches_uvicorn(monkeypatch: pytest.MonkeyPatch, uvicorn_kwargs: dict[str, Any]) -> None:
-    """`ROOT_PATH` is the whole point: nothing else in the process can set ASGI `root_path`."""
     from open_climate_service.cli import main
 
     monkeypatch.setenv("HOST", "127.0.0.1")
     monkeypatch.setenv("PORT", "8080")
-    monkeypatch.setenv("ROOT_PATH", "/ocs")
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "10.0.0.0/8")
     main()
 
     assert uvicorn_kwargs["host"] == "127.0.0.1"
     assert uvicorn_kwargs["port"] == 8080
-    assert uvicorn_kwargs["root_path"] == "/ocs"
     assert uvicorn_kwargs["forwarded_allow_ips"] == "10.0.0.0/8"
+
+
+def test_the_entry_point_does_not_own_the_root_path(
+    monkeypatch: pytest.MonkeyPatch, uvicorn_kwargs: dict[str, Any]
+) -> None:
+    """One owner: the app reads `ROOT_PATH`, so it applies under `make run` and bare uvicorn
+    too, and the entry point passing it as well would only be a second copy of the value."""
+    from open_climate_service.cli import main
+
+    monkeypatch.setenv("ROOT_PATH", "/ocs")
+    main()
+
+    assert "root_path" not in uvicorn_kwargs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+"""What the server entry point passes to uvicorn (CLIM-974).
+
+Three of the four settings only take effect if uvicorn is *told* about them, and none of them
+fails loudly when it is not: without `forwarded_allow_ips` a proxied deployment emits `http://`
+links, and without `root_path` a prefixed one has to declare its prefix in
+`CLIMATE_SERVICE_BASE_URL` and gets prefixed links on a direct port-forward too.
+"""
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def uvicorn_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """The keyword arguments `main()` hands to `uvicorn.run`, without starting a server."""
+    import dotenv
+
+    import open_climate_service.cli as cli
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(app: str, **kwargs: Any) -> None:
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    # `.env` on a developer's machine would otherwise decide what these assertions see. `main`
+    # imports `load_dotenv` when it runs, so patching the attribute is enough.
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: False)
+    for name in ("HOST", "PORT", "ROOT_PATH", "FORWARDED_ALLOW_IPS"):
+        monkeypatch.delenv(name, raising=False)
+    return captured
+
+
+def test_the_defaults_bind_locally_with_no_prefix(
+    monkeypatch: pytest.MonkeyPatch, uvicorn_kwargs: dict[str, Any]
+) -> None:
+    from open_climate_service.cli import DEFAULT_HOST, DEFAULT_PORT, main
+
+    main()
+
+    assert uvicorn_kwargs["host"] == DEFAULT_HOST
+    assert uvicorn_kwargs["port"] == DEFAULT_PORT
+    assert uvicorn_kwargs["root_path"] == ""
+    # None, not "": uvicorn's own default is 127.0.0.1 and an empty string would trust nothing.
+    assert uvicorn_kwargs["forwarded_allow_ips"] is None
+
+
+def test_the_environment_reaches_uvicorn(monkeypatch: pytest.MonkeyPatch, uvicorn_kwargs: dict[str, Any]) -> None:
+    """`ROOT_PATH` is the whole point: nothing else in the process can set ASGI `root_path`."""
+    from open_climate_service.cli import main
+
+    monkeypatch.setenv("HOST", "127.0.0.1")
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("ROOT_PATH", "/ocs")
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "10.0.0.0/8")
+    main()
+
+    assert uvicorn_kwargs["host"] == "127.0.0.1"
+    assert uvicorn_kwargs["port"] == 8080
+    assert uvicorn_kwargs["root_path"] == "/ocs"
+    assert uvicorn_kwargs["forwarded_allow_ips"] == "10.0.0.0/8"

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -301,3 +301,22 @@ def test_read_only_still_refuses_the_console_under_a_mount_prefix(monkeypatch: p
     assert mounted.get("/manage").status_code == 403
     assert mounted.get("/jobs").status_code == 403
     assert mounted.get("/stac").status_code == 200
+
+
+def test_a_configured_base_url_path_cannot_bypass_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The policy must read the ASGI path, not the configured public URL.
+
+    `mount_prefix` falls back to the path of `CLIMATE_SERVICE_BASE_URL` so that in-page links
+    carry the prefix when no server sets `root_path`. Applying that fallback to the *incoming*
+    path let a base URL of `https://public.example/jobs` strip `/jobs` off the real route:
+    `GET /jobs` matched no closed prefix and returned the shared job listing with a 200.
+    """
+    from open_climate_service import config as api_config
+    from open_climate_service.main import app
+
+    monkeypatch.setenv("CLIMATE_SERVICE_BASE_URL", "https://public.example/jobs")
+    monkeypatch.setattr(api_config, "is_read_only", lambda: True)
+    client = TestClient(app)
+
+    assert client.get("/jobs").status_code == 403
+    assert client.get("/manage").status_code == 403

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -12,6 +12,8 @@ from open_climate_service import config as api_config
 from open_climate_service.main import app
 from open_climate_service.read_only import is_blocked
 
+from .conftest import MountedClientFactory
+
 # The full mutating surface, written with the app's own path templates so
 # test_every_mutating_route_is_covered_by_the_policy can compare exactly rather than
 # approximately. Anything mutating that is intended to stay open goes in _OPEN_WRITES.
@@ -285,37 +287,30 @@ def test_policy_is_inert_when_the_flag_is_off(client: TestClient) -> None:
     assert client.post("/ingestions", json={}).status_code != 403  # ...but it is not applied
 
 
-def test_read_only_still_refuses_the_console_under_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("root_path", ["/ocs", "/ocs/"])
+def test_read_only_still_refuses_the_console_under_a_mount_prefix(
+    read_only: None, mounted_client_factory: MountedClientFactory, root_path: str
+) -> None:
     """The policy matches route paths as the app declares them, so the prefix must come off.
 
-    Unstripped, `/ocs/manage` matched no closed prefix and read-only mode failed *open*: the
-    admin console and the job listing were served. `POST /ocs/result` stayed refused only
-    because that rule falls through to the method check, which made the gap easy to miss.
+    Matched unstripped, `/ocs/manage` hits no closed prefix and read-only mode fails open. The
+    trailing-slash case is the same failure one step later: uvicorn joins `root_path + path`
+    verbatim, so `/ocs/` yields `/ocs//manage`, which Starlette still routes to `/manage`.
     """
-    from open_climate_service import config as api_config
-    from open_climate_service.main import app
-
-    monkeypatch.setattr(api_config, "is_read_only", lambda: True)
-    mounted = TestClient(app, root_path="/ocs")
+    mounted = mounted_client_factory(root_path)
 
     assert mounted.get("/manage").status_code == 403
     assert mounted.get("/jobs").status_code == 403
     assert mounted.get("/stac").status_code == 200
 
 
-def test_a_configured_base_url_path_cannot_bypass_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The policy must read the ASGI path, not the configured public URL.
+def test_a_configured_base_url_path_cannot_bypass_read_only(read_only: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The policy reads the ASGI path, never the path of `CLIMATE_SERVICE_BASE_URL`.
 
-    `mount_prefix` falls back to the path of `CLIMATE_SERVICE_BASE_URL` so that in-page links
-    carry the prefix when no server sets `root_path`. Applying that fallback to the *incoming*
-    path let a base URL of `https://public.example/jobs` strip `/jobs` off the real route:
-    `GET /jobs` matched no closed prefix and returned the shared job listing with a 200.
+    That path is a statement about the public origin, not about the incoming path. Stripping
+    it would let a base URL of `https://public.example/jobs` take `/jobs` off the real route.
     """
-    from open_climate_service import config as api_config
-    from open_climate_service.main import app
-
     monkeypatch.setenv("CLIMATE_SERVICE_BASE_URL", "https://public.example/jobs")
-    monkeypatch.setattr(api_config, "is_read_only", lambda: True)
     client = TestClient(app)
 
     assert client.get("/jobs").status_code == 403

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -283,3 +283,21 @@ def test_policy_is_inert_when_the_flag_is_off(client: TestClient) -> None:
     """is_blocked() describes the policy; the middleware only applies it when configured."""
     assert is_blocked("POST", "/ingestions")  # policy says yes...
     assert client.post("/ingestions", json={}).status_code != 403  # ...but it is not applied
+
+
+def test_read_only_still_refuses_the_console_under_a_mount_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The policy matches route paths as the app declares them, so the prefix must come off.
+
+    Unstripped, `/ocs/manage` matched no closed prefix and read-only mode failed *open*: the
+    admin console and the job listing were served. `POST /ocs/result` stayed refused only
+    because that rule falls through to the method check, which made the gap easy to miss.
+    """
+    from open_climate_service import config as api_config
+    from open_climate_service.main import app
+
+    monkeypatch.setattr(api_config, "is_read_only", lambda: True)
+    mounted = TestClient(app, root_path="/ocs")
+
+    assert mounted.get("/manage").status_code == 403
+    assert mounted.get("/jobs").status_code == 403
+    assert mounted.get("/stac").status_code == 200

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -4,6 +4,8 @@ from fastapi.testclient import TestClient
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.system.schemas import HealthStatus
 
+from .conftest import MountedClientFactory
+
 
 def test_root_returns_html_for_browser_request(client: TestClient) -> None:
     response = client.get("/", headers={"accept": "text/html,application/xhtml+xml,*/*;q=0.8"})
@@ -82,6 +84,26 @@ def test_zarr_route_echoes_origin_for_browser_access(client: TestClient, monkeyp
 
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "https://inspect.geozarr.org"
+
+
+def test_zarr_browser_headers_survive_a_mount_prefix(
+    mounted_client_factory: MountedClientFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Under `ROOT_PATH=/ocs` the request path is `/ocs/zarr/...`; matched against the literal
+    `/zarr`, the per-origin and private-network headers silently stop being added."""
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_dataset_zarr_store_file_or_404",
+        lambda _id, _path, range_header=None: {"zarr_format": 3, "node_type": "group", "attributes": {}},
+    )
+
+    response = mounted_client_factory("/ocs").get(
+        "/zarr/dataset-1/zarr.json", headers={"Origin": "https://inspect.geozarr.org"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://inspect.geozarr.org"
+    assert response.headers["access-control-allow-private-network"] == "true"
 
 
 def test_zarr_route_does_not_allow_unconfigured_origin(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -160,7 +160,9 @@ async def test_manage_sync_rejects_blank_dataset_id() -> None:
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == "http://testserver/manage?error=Dataset%20ID%20is%20required"
+    # Relative on purpose: a redirect back to the console must land on the origin the operator
+    # actually reached, not on the configured public one (CLIM-974 review).
+    assert response.headers["location"] == "/manage?error=Dataset%20ID%20is%20required"
 
 
 @pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -48,9 +48,17 @@ class _ManageHtmlParser(HTMLParser):
 
 
 class _FakeRequest:
-    def __init__(self, form_data: dict[str, str]) -> None:
+    """Enough of a Request for the /manage form handlers.
+
+    `scope` is part of that surface, not an extra: the handlers read `root_path` from it to
+    build mount-relative redirects, so a double without it passes tests the real object would
+    fail. Defaults to an unmounted instance; pass `root_path` for a prefixed deployment.
+    """
+
+    def __init__(self, form_data: dict[str, str], root_path: str = "") -> None:
         self._form_data = form_data
         self.base_url = URL("http://testserver/")
+        self.scope = {"root_path": root_path}
 
     async def form(self) -> dict[str, str]:
         return self._form_data
@@ -388,3 +396,17 @@ def test_map_viewer_initializes_at_latest_timestep(client: TestClient) -> None:
     assert "function renderDimControls()" in response.text
     # ...and a slider-type dimension (e.g. time) defaults to its last index (latest step).
     assert 'control === "slider" ? Math.max(0, count - 1) : 0' in response.text
+
+
+@pytest.mark.anyio  # pyright: ignore[reportUntypedFunctionDecorator]
+async def test_manage_redirects_keep_the_mount_prefix() -> None:
+    """A POST to `/ocs/manage/sync` that redirects to `/manage` drops the prefix and the proxy
+    returns 404. The Location has to be mount-relative — and still carry no origin, so it
+    lands on the host the operator actually reached."""
+    response = await system_routes.manage_sync(
+        cast("Request", _FakeRequest({"dataset_id": "  "}, root_path="/ocs")),
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/ocs/manage?error=")
+    assert "://" not in response.headers["location"]

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -446,7 +446,11 @@ async def test_a_successful_sync_redirects_under_the_mount(monkeypatch: pytest.M
         cast(Request, _FakeRequest({"dataset_id": "chirps3_precipitation_daily"}, root_path="/ocs"))
     )
     await scheduled[0]
-    payload = "".join([chunk.decode() if isinstance(chunk, bytes) else chunk async for chunk in response.body_iterator])
+    # Narrowed rather than accessed directly: the endpoint is typed `-> Response`, and only a
+    # StreamingResponse carries the SSE body this assertion reads.
+    assert isinstance(response, StreamingResponse)
+    chunks = [chunk async for chunk in response.body_iterator]
+    payload = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
 
     assert "/ocs/manage?message=Sync+completed" in payload
     assert '"/manage?message' not in payload, "the bare path would 404 behind the proxy"

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -452,5 +452,8 @@ async def test_a_successful_sync_redirects_under_the_mount(monkeypatch: pytest.M
     chunks = [chunk async for chunk in response.body_iterator]
     payload = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
 
-    assert "/ocs/manage?message=Sync+completed" in payload
+    # %20 rather than + : the banner text is now percent-encoded by `_manage_url` like every
+    # other manage banner, where these two success messages used to hard-code a literal +.
+    # Starlette decodes both to "Sync completed", so the page is unaffected.
+    assert "/ocs/manage?message=Sync%20completed" in payload
     assert '"/manage?message' not in payload, "the bare path would 404 behind the proxy"

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -5,7 +5,6 @@ from typing import cast
 import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
-from starlette.datastructures import URL
 from starlette.responses import StreamingResponse
 
 from open_climate_service.ingestions import services as ingestion_services
@@ -57,7 +56,6 @@ class _FakeRequest:
 
     def __init__(self, form_data: dict[str, str], root_path: str = "") -> None:
         self._form_data = form_data
-        self.base_url = URL("http://testserver/")
         self.scope = {"root_path": root_path}
 
     async def form(self) -> dict[str, str]:

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -452,8 +452,7 @@ async def test_a_successful_sync_redirects_under_the_mount(monkeypatch: pytest.M
     chunks = [chunk async for chunk in response.body_iterator]
     payload = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
 
-    # %20 rather than + : the banner text is now percent-encoded by `_manage_url` like every
-    # other manage banner, where these two success messages used to hard-code a literal +.
-    # Starlette decodes both to "Sync completed", so the page is unaffected.
+    # %20 rather than + : `_manage_url` percent-encodes the banner text for every manage
+    # redirect. Starlette decodes both spellings to "Sync completed", so the page is unaffected.
     assert "/ocs/manage?message=Sync%20completed" in payload
     assert '"/manage?message' not in payload, "the bare path would 404 behind the proxy"

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -410,3 +410,43 @@ async def test_manage_redirects_keep_the_mount_prefix() -> None:
     assert response.status_code == 303
     assert response.headers["location"].startswith("/ocs/manage?error=")
     assert "://" not in response.headers["location"]
+
+
+@pytest.mark.anyio
+async def test_a_successful_sync_redirects_under_the_mount(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The success redirect is the one a mounted deployment actually reaches on the happy path.
+
+    The error redirects were mount-relative while this one was not, so under `/ocs` a sync that
+    worked sent the browser to `/manage` and the proxy 404'd — a failure only visible when nothing
+    had gone wrong.
+    """
+    scheduled: list[Coroutine[object, object, None]] = []
+
+    def fake_sync_dataset(
+        *,
+        dataset_id: str,
+        end: str | None,
+        publish: bool,
+        on_progress: Callable[[int | None, int | None, str | None], None],
+    ) -> None:
+        on_progress(1, 1, "done")
+
+    async def fake_to_thread(func: Callable[[], None]) -> None:
+        func()
+
+    def fake_create_task(coro: Coroutine[object, object, None]) -> None:
+        scheduled.append(coro)
+        return None
+
+    monkeypatch.setattr(ingestion_services, "sync_dataset", fake_sync_dataset)
+    monkeypatch.setattr(system_routes.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system_routes.asyncio, "create_task", fake_create_task)
+
+    response = await system_routes.manage_sync(
+        cast(Request, _FakeRequest({"dataset_id": "chirps3_precipitation_daily"}, root_path="/ocs"))
+    )
+    await scheduled[0]
+    payload = "".join([chunk.decode() if isinstance(chunk, bytes) else chunk async for chunk in response.body_iterator])
+
+    assert "/ocs/manage?message=Sync+completed" in payload
+    assert '"/manage?message' not in payload, "the bare path would 404 behind the proxy"


### PR DESCRIPTION
[CLIM-974](https://dhis2.atlassian.net/browse/CLIM-974)

`/map` and the STAC catalogue `self` link built absolute URLs from the incoming request. Behind a TLS-terminating proxy that request arrives over plain HTTP, so an HTTPS deployment emitted `http://` fetch targets and an `http://` self link. In a browser those fetches are active mixed content: blocked, so the map renders an empty catalogue while curl against every endpoint returns 200.

The rule this settles on, since the reviews found two wrong answers before the right one:

- **A URL that leaves the process** is absolute and names the configured public origin: the STAC links, openEO capabilities, the `/openeo` redirect to the external editor.
- **A URL used inside a page the browser is already on** is a path with the mount prefix and no origin: form actions, redirects back to the console, in-page fetches.

Naming an origin in the second group was worse than the original bug — an operator reaching `/manage` through a port-forward, with `CLIMATE_SERVICE_BASE_URL` naming production, would have submitted forms to production, silently, because CORS is `allow_origins=["*"]`. A bare leading slash was wrong in the other direction: it drops a deployment prefix.

Also fixes two degenerate-configuration defects found in review: `CLIMATE_SERVICE_BASE_URL="/"` returned the empty string, so every href lost its origin; and `self_url` could double a mount prefix.

## Verified against running servers

Seven live configurations, probed through a reverse proxy sending `X-Forwarded-Proto: https` and the public `Host`:

| Setup | STAC `self` | HTML form action | Viewer fetch |
| --- | --- | --- | --- |
| Direct, no config | `http://127.0.0.1:8891/stac` | `/manage/ingest` | `/extent` |
| Direct, `BASE_URL` set | `https://ocs.example.org/stac` | `/manage/ingest` | `/extent` |
| `--root-path /ocs` | `…:8893/ocs/stac` | `/ocs/manage/ingest` | `/ocs/extent` |
| Loopback proxy, no config | `https://ocs.example.org/stac` | `/manage/ingest` | `/extent` |
| Loopback proxy + `BASE_URL` | `https://ocs.example.org/stac` | `/manage/ingest` | `/extent` |
| Forwarded headers distrusted | `http://…:8896/stac` | `/manage/ingest` | `/extent` |

Row 2 is the port-forward case: reached on localhost with the variable naming production, the form still posts locally. Row 3 is the mount case: every HTML path carries the prefix and the self link carries it exactly once. Real POSTs confirm the redirects — `Location=/manage?error=…` unmounted and `/ocs/manage?error=…` mounted, neither containing `://`.

No served HTML names an origin other than the one it was reached on, in any setup. The only third-party origins are upstream data-source links on the landing page.

## Two deployment notes from the measurements

**A proxy on loopback needs no configuration.** Uvicorn enables proxy headers by default with `forwarded_allow_ips="127.0.0.1"`, so the common same-host nginx or compose setup already derives the right scheme and host. `CLIMATE_SERVICE_BASE_URL` is required when the proxy's address is *not* trusted — a separate ingress or service mesh — which is the last row above, and is [CLIM-994](https://dhis2.atlassian.net/browse/CLIM-994).

**The `self_url` strip is required in the ordinary deployment.** Uvicorn sets `scope["path"] = root_path + path` (`h11_impl.py:202`), so behind a normal *stripping* proxy with `--root-path /ocs` the request arrives as `/stac`, `request.url.path` becomes `/ocs/stac`, and the fallback origin `request.base_url` already ends in `/ocs/`. Appending the path unstripped yields `/ocs/ocs/stac` for `self` while every other link stays correct, and a STAC client following `self` 404s. Verified against uvicorn booted with `root_path="/ocs"`. An earlier version of this description called it cheap defence rather than a live fix; that had the mechanism backwards.

**Not covered: the raster asset origin.** Once a collection is selected, the viewer loads chunks from `zarr.href` in the collection JSON, which `build_collection` builds with `absolute_url` — so it names the configured origin. On a port-forward with `CLIMATE_SERVICE_BASE_URL` pointing at production, the dropdown is local while the data comes from production, permitted by the wildcard CORS. Arguably correct STAC behaviour and pre-existing, but the HTML-level guarantee in this PR does not extend to it. CLIM-995 is the place for it.

**A mount prefix must still be stripped by the proxy.** `--root-path /ocs` makes the app serve at `/stac` and advertise `/ocs/stac`; a non-stripping proxy sends `/ocs/stac`, which 404s in the router before any URL is generated.


## Prefix handling at 7cda225

- `ROOT_PATH` is read by `create_app()`, so it works under `make run` and bare uvicorn, not only the `climate-service` entry point. It is normalised: `/ocs/` and `ocs` both mean `/ocs`.
- The two settings compose. `ROOT_PATH=/ocs` with `CLIMATE_SERVICE_BASE_URL=https://host` gives `https://host/ocs/...` for every absolute link. A path in the base URL is the service root as-is.
- Anything that matches the incoming path against a route goes through `route_path()`, which strips the raw ASGI `root_path` with Starlette's own boundary rule. Read-only mode and the Zarr browser-access headers both use it; before, `ROOT_PATH=/ocs/` produced `/ocs//manage`, which Starlette routed but the read-only policy did not recognise, so it failed open.
- `absolute_base` builds from the scope's scheme, host and `root_path`. The earlier `endswith` guard dropped the prefix for a host named like it and doubled it under a `Mount` inside a `--root-path`.
- The mount tests reach the app through a uvicorn-shaped client that prefixes the path, because `TestClient(root_path=...)` does not, and the earlier read-only mount test passed with the strip removed.

**Behaviour change to note in the release.** An operator with a path in `CLIMATE_SERVICE_BASE_URL` who reaches `/manage` on a direct port-forward now gets form actions under that path, which 404 locally. Set `ROOT_PATH` for the prefix and keep the base URL to the origin, or reach the console through the proxy.

[CLIM-974]: https://dhis2.atlassian.net/browse/CLIM-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-994]: https://dhis2.atlassian.net/browse/CLIM-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

