### PR TITLE
feat(licences): propagate licences to derived products (CLIM-989)

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -680,6 +680,8 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
     if template is None:
         raise ValueError(f"Auto-registered dataset template for '{dataset_id}' could not be reloaded")
 
+    template = _enforce_licence_on_loaded_template(dataset_id, template, source_template)
+
     # Prefer an explicit option, then the registered template's display name, and
     # only fall back to the raw id so published collections read as e.g.
     # "Mosquito hotspots (Rwanda 2018 Q1)" rather than "mosquito_hotspots".
@@ -773,14 +775,212 @@ def _recover_temporal_from_attrs(ds: Any) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _decide_derived_licence(source_template: dict[str, Any] | None, declared_raw: Any) -> tuple[Any, str | None]:
+    """The licence a derived product carries, and why it may not be published, if so.
+
+    THE ONLY PLACE THE DERIVED LICENCE IS DECIDED. Both publish paths ask it the same
+    question — the one that synthesises a template from save_result options, and the one that
+    reloads an already-registered template — so they cannot reach different answers.
+
+    That is the whole point of the function. An earlier version decided in both places: the
+    synthesise path copied an unparseable source licence forward (correct — carrying a licence
+    forward cannot launder it), and the reload path then refused the very template the
+    synthesise path had just written, because its check failed closed on a licence it could not
+    parse. No derived product from such a source could publish at all, and every unit test
+    passed, because they drove one path or the other and never both.
+
+    The rule, once:
+
+    * Nothing to inherit from — no source, or a source with no declared licence — and the
+      output's own claim stands unexamined. There is no derivation to constrain it.
+    * The output claims nothing, or claims *exactly* what the source says: verbatim
+      inheritance. Relicensing is impossible, so the obligation comparison has nothing to
+      say, and it must not run — it fails closed on an unparseable licence, which would refuse
+      the safest possible outcome. Only the derivation itself is checked, because a
+      no-derivatives source forbids the derivative work under any licence including its own.
+    * The output claims something different: compare in full, and fail closed if either side
+      is not understood. This is where laundering is possible and where refusing is right.
+
+    Returns `(licence, refusal)`. `refusal` is None when publication may proceed. The returned
+    licence is idempotent under this function: feeding it back as `declared_raw` yields the
+    same refusal, which is what makes the reload path an assertion rather than a second
+    opinion. `test_the_decision_is_stable_when_fed_back` pins that.
+
+    WARNING: ONE INPUT, NOT ALL OF THEM. save_result records a single `source_dataset_id`, so
+    that is the only input whose licence is visible here. `compute_anomaly` takes an observed
+    dataset *and* a normal, and propagates from whichever it was told about; the shipped
+    `aggregate_dekads_to_period` workflow names none, so nothing propagates for it at all.
+    Closing that needs save_result to carry every contributing dataset id, which is a change
+    to the process-graph contract rather than to this function.
+    """
+    from open_climate_service.shared.licences import (
+        parse_licence,
+        refuses_derivation,
+        refuses_publication,
+    )
+
+    if not isinstance(source_template, dict):
+        return declared_raw, None
+    source_raw = source_template.get("license")
+    if source_raw is None:
+        return declared_raw, None
+
+    source_licence = parse_licence(source_raw)
+
+    if declared_raw is None or declared_raw == source_raw:
+        return source_raw, refuses_derivation([source_licence])
+
+    return declared_raw, refuses_publication(parse_licence(declared_raw), [source_licence])
+
+
+def _apply_derived_licence(
+    template: dict[str, Any], options: dict[str, Any], source_template: dict[str, Any] | None
+) -> None:
+    """Set the synthesised template's licence and providers from the one decision.
+
+    Before CLIM-946 this path published every derived collection as `various`, which is
+    licence laundering by accident — and it is the *default* path, so nothing had to go wrong
+    for it to happen.
+    """
+    licence, refusal = _decide_derived_licence(source_template, options.get("license"))
+    if refusal:
+        raise ValueError(refusal)
+    if licence is not None:
+        template["license"] = licence
+        if options.get("license") is None and isinstance(source_template, dict):
+            logger.info(
+                "Derived dataset %s inherits licence from %s",
+                template.get("id"),
+                source_template.get("id"),
+            )
+
+    merged = _merge_providers(
+        source_template.get("providers") if isinstance(source_template, dict) else None,
+        options.get("providers"),
+    )
+    if merged:
+        template["providers"] = merged
+
+
+def _merge_providers(*groups: Any) -> list[Any]:
+    """Combine provider lists in order, dropping repeats of a name already seen.
+
+    Merged, not replaced. Attribution is a licence condition, so dropping the source's
+    licensor would breach it even while the obligation check still passes — and
+    `providers: []` or a list naming only the derived product's author would have done
+    exactly that. Source providers come first so the upstream licensor survives a derived
+    template that names only its own author.
+    """
+    merged: list[Any] = []
+    seen: set[str] = set()
+    for group in groups:
+        if not isinstance(group, list):
+            continue
+        for entry in group:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            key = name.strip().lower() if isinstance(name, str) else None
+            if key is None or key in seen:
+                continue
+            seen.add(key)
+            merged.append(entry)
+    return merged
+
+
+def _enforce_licence_on_loaded_template(
+    dataset_id: str, template: dict[str, Any], source_template: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Check an already-registered output template against the source it is derived from.
+
+    The licence rule used to run only while *synthesising* a template, and CLIM-946 recommends
+    pre-registering workflow outputs to control their display — so the recommended path
+    skipped the check entirely and a pre-registered CC0 template could publish CC-BY-NC data.
+
+    This asks `_decide_derived_licence` the same question the synthesise path asked, so it
+    cannot refuse what that path produced. What it can still catch is a template an operator
+    wrote by hand whose licence contradicts its source, and it fills in an inherited licence
+    on a template left undeclared by an older run.
+
+    Any change is written back to the registry. STAC builds the collection from the on-disk
+    template (`stac.services.build_collection` reads it by dataset id), so an in-memory fix
+    would leave the published collection exactly as wrong as before.
+    """
+    if not isinstance(source_template, dict):
+        return template
+
+    licence, refusal = _decide_derived_licence(source_template, template.get("license"))
+    if refusal:
+        raise ValueError(
+            f"Registered output template {dataset_id!r} cannot receive data derived from "
+            f"{source_template.get('id')!r}: {refusal}"
+        )
+
+    updates: dict[str, Any] = {}
+    if licence is not None and licence != template.get("license"):
+        logger.info(
+            "Output template %s declares no licence; inheriting from %s",
+            dataset_id,
+            source_template.get("id"),
+        )
+        updates["license"] = licence
+
+    # Merged even when the licence already passes: attribution is a condition of the licence,
+    # not of the identifier, so a template declaring CC-BY-NC-4.0 and naming only its own
+    # author satisfies the check and still publishes without crediting the licensor.
+    merged = _merge_providers(source_template.get("providers"), template.get("providers"))
+    if merged and merged != template.get("providers"):
+        updates["providers"] = merged
+
+    if not updates:
+        return template
+    return _persist_template_updates(dataset_id, template, updates)
+
+
+def _persist_template_updates(dataset_id: str, template: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Return `template` with `updates` applied, written back to the instance registry.
+
+    A failed write is logged, not raised: the licence and providers are already correct on the
+    returned template, so the publish should go ahead rather than abort over a read-only
+    templates directory. The next publish recomputes the same updates, so nothing is lost
+    permanently — what is lost is only the STAC collection's view of them until then.
+    """
+    updated = {**template, **updates}
+    from open_climate_service.data_registry.services import datasets as _reg
+
+    try:
+        _reg.write_dataset_template(updated, overwrite=True)
+    except Exception:
+        logger.warning(
+            "Could not persist licence metadata %s onto dataset template %s; the published "
+            "STAC collection will keep the registered values",
+            sorted(updates),
+            dataset_id,
+            exc_info=True,
+        )
+    return updated
+
+
 def _resolve_source_template(options: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the source dataset template referenced in save_result options, if any."""
+    """Return the source dataset template referenced in save_result options, if any.
+
+    Raises when a `source_dataset_id` is given but does not resolve. Returning None there
+    would silently mean "not derived from anything", which disables licence propagation
+    entirely — so a typo in the id would let a permissive output be published from a
+    restrictive source, with no error anywhere (CLIM-946).
+    """
     source_dataset_id = options.get("source_dataset_id")
     if not isinstance(source_dataset_id, str) or not source_dataset_id:
         return None
     from open_climate_service.data_registry.services import datasets as _reg
 
-    return _reg.get_dataset(source_dataset_id)
+    template = _reg.get_dataset(source_dataset_id)
+    if template is None:
+        raise ValueError(
+            f"save_result declares source_dataset_id {source_dataset_id!r}, which is not a "
+            f"registered dataset template. Fix the id, or omit it if this output is not "
+            f"derived from another dataset — it governs which licence and attribution the "
+            f"output inherits."
+        )
+    return template
 
 
 def _derive_period_type(
@@ -842,6 +1042,8 @@ def _derive_managed_dataset_template(
         inherited = source_template.get(field) if isinstance(source_template, dict) else None
         if isinstance(inherited, str) and inherited:
             template[field] = inherited
+
+    _apply_derived_licence(template, options, source_template)
 
     return template
 

--- a/open_climate_service/shared/licences.py
+++ b/open_climate_service/shared/licences.py
@@ -11,20 +11,29 @@ allowing them unlabelled is worse than either, because a derived product is a de
 A water mask computed from CC-BY-NC imagery inherits the restriction, and publishing it as
 `various` is licence laundering by accident — on the default path, with nothing to catch it.
 
-## Scope
-
-This module declares and publishes. Propagating a licence to a derived product — the
-laundering half — is a separate change, because two licences must be *comparable* for that
-and the comparison has to happen at exactly one point in the publish path. Splitting that
-decision across the synthesise and reload paths produced four rounds of fixes that
-contradicted each other, so the obligations recorded below are the input to that work rather
-than the whole of it.
-
 ## Why this is not just a string field
 
-A declaration is parsed into a `DatasetLicence` carrying one decisive fact: whether
-commercial use is allowed. Three states, not two — `None` means "we do not know", which is
-different from "yes" and must not be treated as it.
+Two licences must be *comparable*, or propagation cannot be checked. So a declaration is
+parsed into a `DatasetLicence` carrying what the licence requires, not merely what it is
+called. Commercial use is one obligation among several: comparing on it alone would let CC0
+be derived from CC-BY-4.0, since both permit commercial use, silently dropping the
+attribution requirement.
+
+Three states, not two — `known=False` means "we do not know what this requires", which is
+different from "it requires nothing" and must never be treated as it.
+
+## Comparison lives here; the decision does not
+
+This module answers "may a product under licence X be derived from one under licence Y". It
+does not decide what licence a derived product carries — `openeo.jobs._decide_derived_licence`
+does, at exactly one point in the publish path. That separation is deliberate: an earlier
+version decided in two places, one obliged to fail open and the other to fail closed, and
+they came to contradict each other.
+
+Note the asymmetry those two answers need, since it is the whole reason `refuses_derivation`
+exists alongside `refuses_publication`: carrying a licence forward verbatim cannot launder
+it, so an unparseable licence must be allowed through there, while a *different* declared
+licence that cannot be compared must be refused.
 
 ## SPDX where it exists, a name and URL where it does not
 
@@ -108,6 +117,22 @@ _SPDX_UNREVIEWED = frozenset(
 )
 _SPDX_BY_LOWER = {identifier.lower(): identifier for identifier in (*_SPDX_OBLIGATIONS, *_SPDX_UNREVIEWED)}
 
+# Share-alike is not satisfied by carrying "a share-alike obligation" — it requires the same
+# licence, or one the licence itself names as compatible. Without this, ODbL-1.0 and
+# CC-BY-SA-4.0 both reduce to {attribution, share-alike} and each would be accepted in place
+# of the other, and CC-BY-NC-SA-4.0 would be accepted over CC-BY-SA-4.0 because its obligation
+# set is a superset. Both are relicensing that share-alike forbids.
+#
+# Only same-family upgrades are listed. Cross-licence compatibility (CC-BY-SA to GPL, say) is
+# a legal judgement, not a lookup, so it is absent and therefore refused.
+_SHARE_ALIKE_COMPATIBLE: dict[str, frozenset[str]] = {
+    "CC-BY-SA-3.0": frozenset({"CC-BY-SA-3.0", "CC-BY-SA-4.0"}),
+    "CC-BY-SA-4.0": frozenset({"CC-BY-SA-4.0"}),
+    "CC-BY-NC-SA-3.0": frozenset({"CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0"}),
+    "CC-BY-NC-SA-4.0": frozenset({"CC-BY-NC-SA-4.0"}),
+    "ODbL-1.0": frozenset({"ODbL-1.0"}),
+}
+
 # Licences with no SPDX identifier, whose terms have been read. Without this a template author
 # has to restate the obligations by hand for every one, and an assertion repeated in five
 # templates is one that will eventually be wrong in a sixth.
@@ -165,6 +190,10 @@ class DatasetLicence:
         if not self.known:
             return None
         return NON_COMMERCIAL not in self.obligations
+
+    def drops_obligations_of(self, other: DatasetLicence) -> frozenset[str]:
+        """Obligations of `other` that this licence does not carry."""
+        return other.obligations - self.obligations
 
 
 UNDECLARED = DatasetLicence(identifier=None, name=None, url=None, obligations=frozenset(), known=False)
@@ -351,3 +380,82 @@ def parse_licence(declared: Any) -> DatasetLicence:
         return DatasetLicence(identifier=identifier, name=name, url=url, obligations=obligations, known=known)
 
     return UNDECLARED
+
+
+def _no_derivatives_refusal(candidate: DatasetLicence) -> str | None:
+    """Why `candidate` forbids any derived product, or None."""
+    if NO_DERIVATIVES not in candidate.obligations:
+        return None
+    return (
+        f"Input {candidate.label!r} prohibits derivative works, so no derived product "
+        f"may be published from it under any licence — including the same one. "
+        f"ND licences forbid distributing adapted material."
+    )
+
+
+def refuses_derivation(inputs: list[DatasetLicence]) -> str | None:
+    """Why no derived product may be published from `inputs` at all, or None.
+
+    Narrower than `refuses_publication`, which compares a *declared output* licence against
+    its inputs. This asks only whether the derivation itself is permitted, so it is the right
+    check when the output carries its input's licence verbatim: relicensing is impossible
+    there, but a no-derivatives input still forbids the derivative work.
+
+    Deliberately does NOT fail closed on an unknown input licence, unlike
+    `refuses_publication`. Copying a licence forward preserves whatever terms it carries, so
+    there is nothing to launder, and refusing would block every derived product whose source
+    licence OCS cannot parse — which template validation already warns about. The residual
+    gap is an unparseable licence that is ND in substance; that is unknowable here, and the
+    output at least carries the same terms as its input.
+    """
+    for candidate in inputs:
+        refusal = _no_derivatives_refusal(candidate)
+        if refusal:
+            return refusal
+    return None
+
+
+def refuses_publication(declared: DatasetLicence, inputs: list[DatasetLicence]) -> str | None:
+    """Why publishing `declared` for a product derived from `inputs` must be refused, or None.
+
+    A derived product is a derivative work: it may add obligations, never drop one. Refused
+    rather than warned about, because the failure is silent and a log line is not a defence.
+
+    Fails closed on anything not understood. If either side's obligations are unknown the pair
+    is incomparable, and the safe answer is to refuse rather than assume they are compatible —
+    which is how an unlabelled restrictive source would otherwise be laundered.
+    """
+    for candidate in inputs:
+        if not candidate.known:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, but its input "
+                f"{candidate.label!r} has no licence OCS understands, so the two cannot be "
+                f"compared. Declare the input's licence, or the derived product's terms are a "
+                f"guess."
+            )
+        if not declared.known:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, which OCS does not "
+                f"understand, so it cannot be checked against its input {candidate.label!r}. "
+                f"Use an SPDX identifier, or a licence name OCS knows, or list `obligations`."
+            )
+        no_derivatives = _no_derivatives_refusal(candidate)
+        if no_derivatives:
+            return no_derivatives
+        if SHARE_ALIKE in candidate.obligations:
+            compatible = _SHARE_ALIKE_COMPATIBLE.get(candidate.identifier or "", frozenset())
+            if declared.identifier not in compatible:
+                return (
+                    f"Input {candidate.label!r} is share-alike, so a derived product must carry "
+                    f"that licence or one it names as compatible ({sorted(compatible) or 'none'}), "
+                    f"not {declared.label!r}. Carrying some other share-alike licence is still "
+                    f"relicensing."
+                )
+        dropped = declared.drops_obligations_of(candidate)
+        if dropped:
+            return (
+                f"Derived dataset declares licence {declared.label!r}, which drops "
+                f"{sorted(dropped)} required by its input {candidate.label!r}. A derived "
+                f"product is a derivative work and inherits its inputs' obligations."
+            )
+    return None

--- a/tests/test_licence_propagation.py
+++ b/tests/test_licence_propagation.py
@@ -1,0 +1,363 @@
+"""Propagating a dataset licence to a derived product (CLIM-946 follow-up).
+
+A derived product is a derivative work: a water mask computed from CC-BY-NC imagery inherits
+the restriction, and publishing it as though it carried none is licence laundering by accident
+— on the default path, with nothing to catch it.
+
+The first attempt at this decided the licence in two places, one failing open and one failing
+closed, and took four review rounds during which two of its own fixes came to contradict each
+other. So the tests here are arranged around that failure:
+
+* They drive the real publish paths — `_derive_managed_dataset_template` and
+  `_enforce_licence_on_loaded_template` — not the comparison predicate. Every defect that got
+  through the first attempt was invisible to a test that called the predicate directly.
+* One test asserts the property that makes two paths safe: the decision is stable when fed
+  back into itself, so the reload path cannot refuse what the synthesise path wrote.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from open_climate_service.shared.licences import UNDECLARED, parse_licence
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+
+def _cube(variable: str) -> xr.Dataset:
+    """A real one-variable cube. The derived-template builder computes a display range from the
+    values, so stubbing far enough to satisfy it costs more than handing it a small array."""
+    import numpy as np
+    import xarray as xr
+
+    return xr.Dataset(
+        {variable: (("y", "x"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"))},
+        coords={"y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+
+
+def _derive(options: dict[str, Any], source_template: dict[str, Any] | None) -> dict[str, Any]:
+    """Run the real derived-template builder, not a reimplementation of its licence rule."""
+    from open_climate_service.openeo import jobs
+
+    return jobs._derive_managed_dataset_template(_cube(str(options["variable"])), options, source_template, None)
+
+
+_NC_SOURCE = {
+    "id": "vantor_flood_rgb_2026",
+    "name": "Flood true colour",
+    "variable": "true_colour",
+    "license": "CC-BY-NC-4.0",
+    "providers": [{"name": "Vantor", "roles": ["producer"]}],
+}
+_ND_SOURCE = {"id": "nd_imagery", "variable": "rgb", "license": "CC-BY-ND-4.0"}
+_VENDOR_SOURCE = {"id": "vendor_src", "variable": "v", "license": "Some Vendor Terms"}
+_SA_SOURCE = {"id": "sa_src", "variable": "v", "license": "CC-BY-SA-4.0"}
+
+
+# -- one decision, two paths ----------------------------------------------------------------
+
+
+_CASES = [
+    (None, None),
+    (_NC_SOURCE, None),
+    (_NC_SOURCE, "CC-BY-NC-4.0"),
+    (_NC_SOURCE, "CC0-1.0"),
+    (_NC_SOURCE, "CC-BY-NC-SA-4.0"),
+    (_ND_SOURCE, None),
+    (_ND_SOURCE, "CC-BY-ND-4.0"),
+    (_VENDOR_SOURCE, None),
+    (_VENDOR_SOURCE, "Some Vendor Terms"),
+    (_VENDOR_SOURCE, "CC0-1.0"),
+    (_SA_SOURCE, "CC-BY-4.0"),
+    (_SA_SOURCE, "CC-BY-SA-4.0"),
+    ({"id": "unreviewed", "variable": "v", "license": "BSD-3-Clause"}, None),
+    ({"id": "unlabelled", "variable": "v"}, "CC0-1.0"),
+]
+
+
+@pytest.mark.parametrize(("source", "declared"), _CASES, ids=lambda v: str(v)[:40])
+def test_the_decision_is_stable_when_fed_back(source: dict[str, Any] | None, declared: str | None) -> None:
+    """The invariant that lets two code paths share one rule.
+
+    Whatever licence the decision produces, asking again with that licence as the output's own
+    claim must give the same verdict. Without this the synthesise path can write a template the
+    reload path refuses — which is exactly what happened: an unparseable licence was inherited
+    by design and then rejected as incomparable, so nothing derived from such a source could
+    publish, and no unit test noticed because none drove both paths.
+    """
+    from open_climate_service.openeo import jobs
+
+    licence, refusal = jobs._decide_derived_licence(source, declared)
+    again_licence, again_refusal = jobs._decide_derived_licence(source, licence)
+
+    assert again_refusal == refusal
+    assert again_licence == licence
+
+
+def test_a_verbatim_inherited_licence_survives_the_reload(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regression that ended the first attempt, driven end to end rather than per-path.
+
+    `_apply_derived_licence` copies an unparseable source licence forward, because carrying a
+    licence forward cannot launder it. The reload check then saw a licence it could not parse
+    on both sides and refused it, so no derived product from such a source could publish.
+    """
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    monkeypatch.setattr(reg, "CONFIGS_DIR", tmp_path)
+    synthesised = _derive({"dataset_id": "derived", "variable": "v", "source_dataset_id": "vendor_src"}, _VENDOR_SOURCE)
+    assert synthesised["license"] == "Some Vendor Terms"
+
+    # Exactly what the publish path does next: persist, reload, check.
+    reg.write_dataset_template(synthesised, overwrite=True)
+    reloaded = reg.get_dataset("derived")
+    assert reloaded is not None
+    checked = jobs._enforce_licence_on_loaded_template("derived", reloaded, _VENDOR_SOURCE)
+    assert checked["license"] == "Some Vendor Terms"
+
+
+# -- the rule itself, through the real builder -----------------------------------------------
+
+
+def test_a_product_derived_from_a_non_commercial_source_inherits_the_restriction() -> None:
+    """The acceptance case: a water mask computed from CC-BY-NC imagery."""
+    template = _derive(
+        {"dataset_id": "flood_water_mask", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026"},
+        _NC_SOURCE,
+    )
+    assert parse_licence(template["license"]).commercial_use is False
+    # Attribution is a licence condition under CC-BY-NC, so it has to travel too.
+    assert [p["name"] for p in template["providers"]] == ["Vantor"]
+
+
+def test_publishing_a_derived_product_as_permissive_is_refused() -> None:
+    with pytest.raises(ValueError, match="drops"):
+        _derive(
+            {
+                "dataset_id": "flood_water_mask",
+                "variable": "water",
+                "source_dataset_id": "vantor_flood_rgb_2026",
+                "license": "CC0-1.0",
+            },
+            _NC_SOURCE,
+        )
+
+
+def test_a_derived_product_may_declare_a_stricter_licence() -> None:
+    template = _derive(
+        {
+            "dataset_id": "derived",
+            "variable": "value",
+            "source_dataset_id": "chirps3_precipitation_monthly",
+            "license": "CC-BY-NC-4.0",
+        },
+        {"id": "chirps3_precipitation_monthly", "variable": "precip", "license": "CC0-1.0"},
+    )
+    assert template["license"] == "CC-BY-NC-4.0"
+
+
+def test_deriving_from_an_unlabelled_source_leaves_the_output_unlabelled() -> None:
+    """Not permissive by omission: an unlabelled input yields an unlabelled output, which
+    publishes as `other` rather than as something reassuring."""
+    template = _derive(
+        {"dataset_id": "derived", "variable": "value", "source_dataset_id": "mystery"},
+        {"id": "mystery", "variable": "value"},
+    )
+    assert parse_licence(template.get("license")) is UNDECLARED
+
+
+def test_nothing_may_be_derived_from_a_no_derivatives_source() -> None:
+    """ND forbids distributing adapted material at all, so there is no licence under which the
+    derived product may be published — including the source's own."""
+    with pytest.raises(ValueError, match="prohibits derivative works"):
+        _derive({"dataset_id": "mask", "variable": "water", "source_dataset_id": "nd_imagery"}, _ND_SOURCE)
+
+
+def test_saying_nothing_does_not_publish_what_naming_the_licence_would_refuse() -> None:
+    """Declaring `CC-BY-ND-4.0` was refused while omitting `license` inherited the same licence
+    and published, so the check was reachable only by naming what it would reject."""
+    with pytest.raises(ValueError, match="prohibits derivative works"):
+        _derive(
+            {"dataset_id": "mask", "variable": "water", "source_dataset_id": "nd_imagery", "license": "CC-BY-ND-4.0"},
+            _ND_SOURCE,
+        )
+
+
+def test_another_share_alike_licence_is_not_an_acceptable_substitute() -> None:
+    """Share-alike is licence identity, not an obligation flag."""
+    with pytest.raises(ValueError, match="share-alike"):
+        _derive(
+            {"dataset_id": "d", "variable": "v", "source_dataset_id": "sa_src", "license": "ODbL-1.0"},
+            _SA_SOURCE,
+        )
+
+
+def test_deriving_from_an_unreviewed_spdx_licence_by_declaring_something_else_fails_closed() -> None:
+    with pytest.raises(ValueError, match="does not understand|cannot be compared"):
+        _derive(
+            {"dataset_id": "d", "variable": "v", "source_dataset_id": "unreviewed", "license": "CC0-1.0"},
+            {"id": "unreviewed", "variable": "v", "license": "BSD-3-Clause"},
+        )
+
+
+# -- providers ------------------------------------------------------------------------------
+
+
+def test_derived_providers_keep_the_source_licensor() -> None:
+    """An explicit list adds to the source's, never replaces it."""
+    template = _derive(
+        {
+            "dataset_id": "d",
+            "variable": "water",
+            "source_dataset_id": "vantor_flood_rgb_2026",
+            "providers": [{"name": "DHIS2"}],
+        },
+        _NC_SOURCE,
+    )
+    assert [p["name"] for p in template["providers"]] == ["Vantor", "DHIS2"]
+
+
+def test_an_empty_providers_option_cannot_erase_the_source_licensor() -> None:
+    template = _derive(
+        {"dataset_id": "d", "variable": "water", "source_dataset_id": "vantor_flood_rgb_2026", "providers": []},
+        _NC_SOURCE,
+    )
+    assert [p["name"] for p in template["providers"]] == ["Vantor"]
+
+
+def test_duplicate_providers_are_not_doubled() -> None:
+    template = _derive(
+        {
+            "dataset_id": "d",
+            "variable": "water",
+            "source_dataset_id": "vantor_flood_rgb_2026",
+            "providers": [{"name": "vantor"}],
+        },
+        _NC_SOURCE,
+    )
+    assert len(template["providers"]) == 1
+
+
+# -- an already-registered output template ---------------------------------------------------
+
+
+def test_a_preregistered_permissive_template_cannot_receive_restricted_data() -> None:
+    """The path CLIM-946 recommends. The rule ran only while synthesising a template, so
+    pre-registering one — which the ticket advises, to control the display — skipped it."""
+    from open_climate_service.openeo import jobs
+
+    with pytest.raises(ValueError, match="cannot receive data derived from"):
+        jobs._enforce_licence_on_loaded_template(
+            "flood_water_mask", {"id": "flood_water_mask", "license": "CC0-1.0"}, _NC_SOURCE
+        )
+
+
+def test_a_preregistered_undeclared_template_inherits_rather_than_staying_undeclared() -> None:
+    from open_climate_service.openeo import jobs
+
+    updated = jobs._enforce_licence_on_loaded_template("flood_water_mask", {"id": "flood_water_mask"}, _NC_SOURCE)
+    assert updated["license"] == "CC-BY-NC-4.0"
+    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
+
+
+def test_a_matching_preregistered_licence_still_has_to_credit_the_licensor() -> None:
+    """A compatible identifier is not the whole licence: attribution is a condition of it, and
+    this template names nobody."""
+    from open_climate_service.openeo import jobs
+
+    updated = jobs._enforce_licence_on_loaded_template(
+        "flood_water_mask", {"id": "flood_water_mask", "license": "CC-BY-NC-4.0"}, _NC_SOURCE
+    )
+    assert [p["name"] for p in updated["providers"]] == ["Vantor"]
+
+
+def test_a_template_needing_no_change_is_returned_untouched() -> None:
+    """No write and no copy when the registered metadata is already right."""
+    from open_climate_service.openeo import jobs
+
+    template = {
+        "id": "flood_water_mask",
+        "license": "CC-BY-NC-4.0",
+        "providers": [{"name": "Vantor", "roles": ["producer"]}],
+    }
+    assert jobs._enforce_licence_on_loaded_template("flood_water_mask", template, _NC_SOURCE) is template
+
+
+def test_no_source_means_a_preregistered_template_is_untouched() -> None:
+    from open_climate_service.openeo import jobs
+
+    template = {"id": "standalone", "license": "CC0-1.0"}
+    assert jobs._enforce_licence_on_loaded_template("standalone", template, None) is template
+
+
+def test_the_enforced_licence_reaches_the_registry_not_just_this_publish(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """STAC builds the collection from the on-disk template (`build_collection` reads the
+    registry by dataset id), so an in-memory fix publishes the same wrong licence."""
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    monkeypatch.setattr(reg, "CONFIGS_DIR", tmp_path)
+    jobs._enforce_licence_on_loaded_template(
+        "flood_water_mask",
+        {"id": "flood_water_mask", "variable": "water", "sync": {"kind": "static"}},
+        _NC_SOURCE,
+    )
+
+    written = yaml.safe_load((tmp_path / "flood_water_mask.yaml").read_text())[0]
+    assert written["license"] == "CC-BY-NC-4.0"
+    assert [p["name"] for p in written["providers"]] == ["Vantor"]
+
+
+# -- lineage that does not resolve ------------------------------------------------------------
+
+
+def test_an_unresolvable_source_dataset_id_is_an_error_not_absent_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returning None for a typo would silently mean "not derived from anything", which
+    disables propagation entirely — so a typo would publish a permissive output from a
+    restrictive source with no error anywhere."""
+    from open_climate_service.data_registry.services import datasets as reg
+    from open_climate_service.openeo import jobs
+
+    monkeypatch.setattr(reg, "get_dataset", lambda _: None)
+    with pytest.raises(ValueError, match="not a registered dataset template"):
+        jobs._resolve_source_template({"source_dataset_id": "chirps3_typooo"})
+
+
+# -- the shipped derived templates ------------------------------------------------------------
+
+
+def test_no_derived_builtin_declares_away_its_sources_obligations() -> None:
+    """The normals and anomalies are derivative works of CHIRPS3 and ERA5-Land. Checked through
+    the real predicate here, since propagation is what this module owns."""
+    import glob
+    import re
+
+    from open_climate_service.shared.licences import refuses_publication
+
+    licences = {}
+    for path in sorted(glob.glob("open_climate_service/plugins/datasets/*.yaml")):
+        for template in yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")):
+            if isinstance(template, dict) and template.get("id"):
+                licences[template["id"]] = parse_licence(template.get("license"))
+
+    pairs = [
+        (dataset_id, base)
+        for dataset_id in sorted(licences)
+        if (base := re.sub(r"_(relative_)?(normal|anomaly)_\d{4}_\d{4}$", "", dataset_id)) != dataset_id
+        and base in licences
+    ]
+    assert len(pairs) >= 12, "the suffix pattern stopped matching, so this checked nothing"
+    for derived_id, source_id in pairs:
+        assert refuses_publication(licences[derived_id], [licences[source_id]]) is None, derived_id


### PR DESCRIPTION
[CLIM-989](https://dhis2.atlassian.net/browse/CLIM-989)

Follow-up to #364, which declared and published licences. This propagates them to derived products — the half that was removed from #364 after four review rounds.

**Stacked on #364.** Base is `feat/clim-946-dataset-licences`; it will retarget to `main` when that merges.

## Why this is a separate PR

The first attempt enforced one rule — a derivative inherits its inputs' obligations — at four call sites, and one of them had to fail *open* while another had to fail *closed*. By round four, two of its own fixes contradicted each other: the synthesise path copied an unparseable source licence forward by design, and the reload path then refused the template it had just written, so nothing derived from such a source could publish at all. Every unit test passed, because each drove one path and none drove both.

## The change

`_decide_derived_licence` is the only place the derived licence is decided. Both publish paths ask it the same question, so they cannot disagree. The rule, once:

- Nothing to inherit from — the output's own claim stands.
- The output claims nothing, or claims **exactly** what the source says: verbatim inheritance, so only the derivation itself is checked. Relicensing is impossible here, and the obligation comparison must not run — it fails closed on an unparseable licence and would refuse the safest possible outcome.
- The output claims something different: compare in full, failing closed if either side is not understood. This is where laundering is possible.

The decision is **idempotent** — feeding its output back gives the same verdict. That is what makes the reload path an assertion rather than a second opinion, and it is pinned by a parametrised test over 14 (source, declared) pairs. Removing the verbatim branch fails it on exactly the unparseable and unreviewed-SPDX cases.

## Tests

They drive the real publish paths, not the predicate, including one that persists, reloads and re-checks the way the publish path does. That is deliberate: every defect that got through the first attempt was invisible to a test that called the predicate directly.

## Known limitation

`save_result` records a single `source_dataset_id`, so only one input's licence is visible. `compute_anomaly` takes an observed dataset *and* a normal; the shipped `aggregate_dekads_to_period` names none, so nothing propagates for it. Closing that needs the process-graph contract to carry every contributing dataset id — stated in the code, not just noted here.

Three failures in `test_openeo_execution.py` (CRS/rioxarray) are local-environment only; CI and `main` are green.



[CLIM-989]: https://dhis2.atlassian.net/browse/CLIM-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ