### PR TITLE
feat(viewer): upgrade zarr-layer to 0.9.0, and the CRS/metadata fixes it unlocks

### DIFF
--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -12,7 +12,7 @@ from topozarr import CoarseningMethod
 from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
-from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
+from open_climate_service.shared.geozarr import check_grid_description, grid_geometry, write_gdal_geotransform
 from open_climate_service.shared.raster_contract import prepare_for_publication
 
 logger = logging.getLogger(__name__)
@@ -383,6 +383,17 @@ def write_to_icechunk_store(
         # projected store off the map. topozarr writes the same affine for pyramid level 0,
         # and this matches it exactly (pixel registration, so the origin is the cell edge).
         geozarr_attrs["spatial:transform"] = geometry["transform"]
+
+    # Refuse to write a grid description that contradicts the grid. Getting the positional
+    # order wrong is silent otherwise — see check_grid_description.
+    check_grid_description(
+        geozarr_attrs,
+        y_dim=y_dim,
+        x_dim=x_dim,
+        y_size=int(ds.sizes[y_dim]),
+        x_size=int(ds.sizes[x_dim]),
+        store=store_path.name,
+    )
 
     ds = ds.proj.assign_crs(spatial_ref=crs)
     ds = ds.rio.write_crs(crs)

--- a/open_climate_service/data_manager/services/downloader.py
+++ b/open_climate_service/data_manager/services/downloader.py
@@ -12,6 +12,7 @@ from topozarr import CoarseningMethod
 from topozarr.coarsen import create_pyramid
 
 from open_climate_service import config as api_config
+from open_climate_service.shared.crs import store_crs_attrs
 from open_climate_service.shared.geozarr import check_grid_description, grid_geometry, write_gdal_geotransform
 from open_climate_service.shared.raster_contract import prepare_for_publication
 
@@ -354,6 +355,14 @@ def write_to_icechunk_store(
     # at the write boundary — rather than relying on every plugin to get it right (CLIM-821).
     prepared = prepare_for_publication(ds, fallback_crs=crs, x_dim=x_dim, y_dim=y_dim)
     ds, crs = prepared.dataset, prepared.crs
+    # Onto the cube itself, not only the root attrs written below, because a client reads the
+    # `proj:` convention from the innermost source that declares any of it: the data array,
+    # then the level-0 group, and only then the root. `prepare_for_publication` puts a bare
+    # `proj:code` on the cube, and the pyramid path writes each level group from it — so a
+    # definition written at the root alone would sit behind a level-0 `proj:code` that
+    # shadows it, and an unresolvable code would stay unresolvable. Both levels agree now.
+    crs_attrs = store_crs_attrs(crs)
+    ds = ds.assign_attrs(crs_attrs)
     if t_dim is not None and t_dim != "t":
         # The caller named the temporal dim as it arrived; normalisation has renamed it, so the
         # rest of this function (root time coordinate, chunking) must follow the new name.
@@ -377,6 +386,9 @@ def write_to_icechunk_store(
         bbox = geometry["bbox"]
         shape = tuple(geometry["shape"])
     geozarr_attrs = create_geozarr_attrs(dimensions=dims, crs=crs, bbox=bbox, shape=shape)
+    # `create_geozarr_attrs` reduces an EPSG input to `proj:code`, which describes the store
+    # only to a reader that can look the code up. Overwrite with the full `proj:` set.
+    geozarr_attrs.update(crs_attrs)
     if geometry is not None:
         # The affine is what a client places the raster with; without it, viewers infer a grid
         # from the coordinate arrays and assume EPSG:4326 while doing so, which puts every

--- a/open_climate_service/shared/crs.py
+++ b/open_climate_service/shared/crs.py
@@ -46,34 +46,6 @@ def is_builtin_crs(code: str | int) -> bool:
     return canonical_crs_code(code).upper() in _BUILTIN_CRS_CODES
 
 
-def crs_to_proj4(crs_input: object) -> str | None:
-    """Derive a proj4 string from a CRS code, WKT, or proj4 input.
-
-    Returns ``None`` for built-in CRSes (EPSG:4326 / EPSG:3857 — clients resolve those
-    from the code) and for anything pyproj cannot parse. proj4 is lossy (PROJ warns), so
-    it is only a client render hint; ``proj:code`` / WKT stay the canonical CRS.
-    """
-    import warnings
-
-    # A CRS84 alias passed as a code/int is built-in even though pyproj's to_epsg()
-    # may return None for it, so short-circuit on is_builtin_crs before parsing.
-    if isinstance(crs_input, (str, int)) and is_builtin_crs(crs_input):
-        return None
-
-    try:
-        from pyproj import CRS
-
-        crs = CRS.from_user_input(crs_input)
-        if crs.to_epsg() in (4326, 3857):
-            return None
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")  # proj4 is lossy; accepted for a render hint
-            proj4 = crs.to_proj4()
-        return proj4.strip() if proj4 else None
-    except Exception:
-        return None
-
-
 def dataset_crs(ds: "xr.Dataset", default: str = "EPSG:4326") -> str:
     """Return *ds*'s own CRS as an ``EPSG:xxxx`` string.
 

--- a/open_climate_service/shared/crs.py
+++ b/open_climate_service/shared/crs.py
@@ -1,18 +1,24 @@
-"""Read a dataset's own CRS.
+"""Read a dataset's own CRS, and describe it to a reader.
 
 Data is stored in its **native** CRS — the CRS the source provides it in — never
 the instance-wide config CRS. These helpers recover that native CRS from a
 dataset so that ingestion writes it, and serving (STAC, coverage) reports it,
 without ever consulting ``api_config.get_crs()``.
+
+:func:`store_crs_attrs` is the other direction: what a *store* has to say about its CRS
+for a client to resolve it without a lookup table of its own.
 """
 
 from __future__ import annotations
 
+import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import xarray as xr
+
+logger = logging.getLogger(__name__)
 
 
 # CRSes that map clients (proj4js, GDAL) resolve from the authority code alone; any
@@ -68,3 +74,49 @@ def dataset_crs(ds: "xr.Dataset", default: str = "EPSG:4326") -> str:
     except Exception:
         pass
     return default
+
+
+def store_crs_attrs(code: str | int) -> dict[str, Any]:
+    """The ``proj:`` attributes a store must carry to describe *code* by itself.
+
+    ``proj:code`` identifies a CRS only to a reader that can look the code up, and map
+    clients cannot. proj4 — which zarr-layer, and so the viewer, resolves through — ships
+    definitions for WGS84, Web Mercator and every UTM zone, and knows nothing else; given a
+    code outside that set it deliberately leaves the CRS unresolved rather than inferring a
+    different one. A store on a national grid (EPSG:27700, EPSG:2154) would then ingest
+    cleanly and render in the wrong place, with only a console warning to say so.
+
+    ``proj:wkt2`` and ``proj:projjson`` carry the definition in full, and proj4 parses
+    either without a lookup. Writing them beside the code is what makes the store
+    self-describing to *any* client, and what makes dropping the epsg.io fallback safe for
+    an arbitrary CRS rather than only the ones proj4 happens to ship (CLIM-833).
+
+    The same two fields are published on the STAC collection by ``stac/services.py``, for
+    clients that read the catalogue; these are for the ones that only ever open the Zarr.
+
+    A built-in code gets the code alone. Nothing has to resolve those — they *are* what a
+    client reprojects to — and they cover the large majority of our stores, so spending a
+    kilobyte of root metadata each on the redundant case is not worth it. A CRS pyproj cannot interpret gets the
+    code alone too, with a warning: an unusable definition helps no one, and the code at
+    least records what the store claimed.
+    """
+    attrs: dict[str, Any] = {"proj:code": canonical_crs_code(code)}
+    if is_builtin_crs(code):
+        return attrs
+    try:
+        from pyproj import CRS
+
+        crs = CRS.from_user_input(attrs["proj:code"])
+        # WKT2 forced explicitly: pyproj's to_wkt() default varies by version and can emit
+        # WKT1 (PROJCS), while both the STAC Projection extension and the GeoZarr ``proj:``
+        # convention define this field as WKT2.
+        attrs["proj:wkt2"] = crs.to_wkt(version="WKT2_2019")
+        attrs["proj:projjson"] = crs.to_json_dict()
+    except Exception:
+        logger.warning(
+            "Could not derive a full CRS definition for %r; writing proj:code alone. A "
+            "client that cannot resolve the code will not render this store correctly.",
+            attrs["proj:code"],
+            exc_info=True,
+        )
+    return attrs

--- a/open_climate_service/shared/geozarr.py
+++ b/open_climate_service/shared/geozarr.py
@@ -84,6 +84,47 @@ def grid_geometry(
     }
 
 
+def check_grid_description(
+    attrs: dict[str, Any],
+    *,
+    y_dim: str,
+    x_dim: str,
+    y_size: int,
+    x_size: int,
+    store: str = "",
+) -> None:
+    """Raise when the attributes about to be written contradict the grid they describe.
+
+    ``spatial:dimensions`` and ``spatial:shape`` are read positionally, so getting their
+    order wrong does not fail loudly: the store publishes successfully and every client that
+    trusts the convention silently renders a transposed grid. That is what happened before
+    CLIM-852 — 39 of 68 stores on one machine declared ``["x", "y"]`` with a reversed shape,
+    and it went unnoticed until a viewer started reading the attributes (CLIM-1008).
+
+    Both are derived from the same dataset moments earlier, so a mismatch here is a bug in
+    our own writer rather than bad input. Refusing the write is therefore the right response:
+    a store that never claims the wrong geometry cannot mislead a reader later, and no amount
+    of downstream care recovers a wrong claim once it is published.
+
+    Square grids are the case worth having a checker for at all — ``[n, n]`` matches either
+    way round, so the shape check passes and only the dimension names give the transposition
+    away.
+    """
+    where = f" for {store}" if store else ""
+
+    declared_dims = attrs.get("spatial:dimensions")
+    if list(declared_dims or []) != [y_dim, x_dim]:
+        raise ValueError(
+            f"spatial:dimensions{where} must be array order (y, x) — expected "
+            f"{[y_dim, x_dim]}, got {declared_dims!r}. Written x-first, every client that "
+            "reads the convention positionally transposes the grid."
+        )
+
+    declared_shape = attrs.get("spatial:shape")
+    if declared_shape is not None and list(declared_shape) != [y_size, x_size]:
+        raise ValueError(f"spatial:shape{where} must be (y, x) == {[y_size, x_size]}, got {list(declared_shape)!r}.")
+
+
 def gdal_geotransform(transform: Sequence[float]) -> str:
     """A GeoZarr ``spatial:transform`` as GDAL's ``GeoTransform`` string.
 

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -642,10 +642,16 @@ def _add_temporal_values(collection: dict[str, Any], ds: xr.Dataset, time_dimens
 def reference_system_for(store_crs: str | int | None) -> int | str:
     """The datacube ``reference_system`` describing a store's spatial axes.
 
-    The datacube extension accepts an EPSG code as a number, or a WKT2/PROJJSON string, and
-    defaults to 4326 when absent. An EPSG code is published as the number because that is
-    the unambiguous form, and because it is what a client comparing against a numeric code
-    expects; anything not shaped like ``EPSG:<digits>`` is passed through as its string.
+    The datacube extension accepts an EPSG code as a number, or a WKT2 (ISO 19162) or
+    PROJJSON string, and defaults to 4326 when absent. An EPSG code is published as the
+    number because that is the unambiguous form, and because it is what a client comparing
+    against a numeric code expects.
+
+    Anything else is converted to WKT2 rather than passed through: a proj4 string is neither
+    WKT2 nor PROJJSON, so publishing one verbatim puts an invalid value in a standard field.
+    A CRS we cannot interpret at all leaves nothing honest to publish — the field has no
+    "unknown", and omitting it means the same 4326 default — so it falls back to 4326 and
+    says so in the log, loudly enough to be found.
 
     Both cube-building paths must resolve this the same way. They previously did not: the
     temporal path hardcoded ``4326`` for every dataset, so a projected store published its
@@ -659,7 +665,24 @@ def reference_system_for(store_crs: str | int | None) -> int | str:
     prefix, _, tail = code.partition(":")
     if prefix.upper() == "EPSG" and tail.isdigit():
         return int(tail)
-    return code
+
+    from pyproj import CRS
+    from pyproj.exceptions import CRSError
+
+    try:
+        parsed = CRS.from_user_input(code)
+    except (CRSError, TypeError, ValueError):
+        logger.warning(
+            "Could not interpret CRS %r as a coordinate reference system; publishing "
+            "cube:dimensions reference_system as 4326, which is wrong if the store is "
+            "projected. Fix the store's proj:code.",
+            code,
+        )
+        return 4326
+    epsg = parsed.to_epsg()
+    if epsg is not None:
+        return int(epsg)
+    return parsed.to_wkt()
 
 
 def _build_static_cube_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str) -> dict[str, Any]:

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -286,29 +286,20 @@ def _build_collection_template(
 def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_crs: str) -> None:
     """Surface CRS render hints on the collection for projected (non-built-in) stores.
 
-    Map clients reproject Zarr on the fly with proj4js, which resolves only the
-    built-in ``EPSG:4326`` / ``EPSG:3857`` from their code — any other CRS (e.g.
-    seNorge's UTM33, ``EPSG:32633``) needs a full definition, or the client has to
-    fetch one at render time (an external epsg.io lookup). Publishing the definition
-    in STAC removes that runtime dependency.
+    A client reprojecting Zarr on the fly needs to resolve the store's CRS. We used to hand
+    it a proj4 string under ``open_climate_service:proj4`` because zarr-layer 0.6.1 accepted
+    only its two built-in codes or an explicit proj4 definition. From 0.8.0 it resolves a
+    code through proj4's own registry, so that non-standard field and the viewer's epsg.io
+    fallback are both retired (CLIM-833) and only standard fields remain.
 
-    Four fields are emitted:
+    Three fields are emitted:
 
     * ``proj:wkt2`` — the STAC Projection-extension standard, lossless CRS
       representation. It is the same information GeoZarr already carries in the CF
       ``spatial_ref`` grid-mapping's ``crs_wkt`` attribute.
     * ``proj:projjson`` — the same CRS as PROJJSON. Also a STAC Projection-extension
       standard (and the GeoZarr ``proj:`` convention), but a JSON object a JS/STAC
-      client can consume directly instead of parsing WKT2 — the convention-aligned
-      sibling of the namespaced proj4 hint below.
-    * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
-      proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
-      strings as lossy), so it lives under our namespace rather than ``proj:``.
-      No longer required by the viewer, which now runs zarr-layer 0.9.0: carbonplan/zarr-layer#61
-      (auto-resolving any EPSG code through proj4's own registry) landed in 0.8.0. Dropping
-      this hint and the viewer's epsg.io fallback with it is CLIM-833, kept separate because
-      it wants the map checked by eye rather than riding along with a version bump. Other
-      STAC clients may still consume it, so it stays published either way.
+      client can consume directly instead of parsing WKT2.
     * ``proj:bbox`` — the data extent in the store's native CRS, as an optional hint for
       STAC clients. It is *not* how our own viewer places a layer, and not the primary
       record of a store's geometry: both write paths already write the GeoZarr
@@ -330,8 +321,6 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     if is_builtin_crs(store_crs):
         return
     try:
-        import warnings
-
         from pyproj import CRS
 
         # Prefer the CRS the data was actually written with (the CF grid-mapping WKT)
@@ -348,12 +337,6 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
         # PROJJSON alongside it — the same CRS as a JSON object, cheaper for JS/STAC
         # clients than parsing WKT2. Cheap to emit next to the WKT2 above.
         template.extra_fields["proj:projjson"] = crs.to_json_dict()
-        with warnings.catch_warnings():
-            # to_proj4() warns that proj4 is lossy; that's acceptable for a render hint.
-            warnings.simplefilter("ignore")
-            proj4 = crs.to_proj4()
-        if proj4:
-            template.extra_fields["open_climate_service:proj4"] = proj4.strip()
     except Exception:
         logger.warning("Could not derive CRS render hints for '%s'", store_crs, exc_info=True)
 

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -309,15 +309,23 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
       this hint and the viewer's epsg.io fallback with it is CLIM-833, kept separate because
       it wants the map checked by eye rather than riding along with a version bump. Other
       STAC clients may still consume it, so it stays published either way.
-    * ``proj:bbox`` — the data extent in the store's native CRS. Without it, a client
-      reprojecting the Zarr must fetch the x/y coordinate arrays at render time to
-      derive bounds (zarr-layer's "proj4 provided without explicit bounds" warning);
-      publishing it lets the client pass explicit bounds and skip that round-trip, which
-      the viewer now does. zarr-layer 0.8.0 can instead read ``spatial:transform``/
-      ``spatial:bbox`` from the store, but we do not write those attributes, so for that
-      client this hint stays the only route. Writing the ``spatial:`` conventions into the
-      store, so placement travels with the data rather than only with our catalogue, would
-      be the better fix and is not done here.
+    * ``proj:bbox`` — the data extent in the store's native CRS, as an optional hint for
+      STAC clients. It is *not* how our own viewer places a layer, and not the primary
+      record of a store's geometry: both write paths already write the GeoZarr
+      ``spatial:bbox`` — and ``spatial:transform`` whenever the cell size is derivable from
+      the coordinates, so all but a degenerate single-cell axis — into the store itself
+      (``shared/geozarr.py``, via ``data_manager/services/downloader.py`` and
+      ``streaming/store.py``), and from 0.8.0 zarr-layer reads those directly. The viewer
+      therefore passes no ``bounds`` and lets the library read the store.
+
+      Publishing the extent here still helps a STAC client that has the catalogue but has
+      not opened the store, and spares a reprojecting client the coordinate-array read it
+      would otherwise need. Note the two describe the extent differently: ``spatial:bbox``
+      is edge-based under ``pixel`` registration, whereas this falls back to the coordinate
+      min/max — cell centres — when the store declares no ``spatial:bbox``.
+
+      Stores written before CLIM-852 declare their ``spatial:*`` axes transposed, which now
+      misplaces them for any client that trusts the convention; see CLIM-1008.
     """
     if is_builtin_crs(store_crs):
         return

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -304,11 +304,11 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
       proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
       strings as lossy), so it lives under our namespace rather than ``proj:``.
-      Still required by the viewer: zarr-layer only accepts a built-in ``crs`` code or a
-      ``proj4`` string at the version we pin. carbonplan/zarr-layer#61 (auto-resolving any
-      EPSG code) landed in 0.8.0, so dropping this hint and the viewer's epsg.io fallback
-      with it — CLIM-833 — becomes possible only once we can move off 0.6.1. See the pin
-      comment in ``templates/map-viewer.html`` for what blocks that.
+      No longer required by the viewer, which now runs zarr-layer 0.9.0: carbonplan/zarr-layer#61
+      (auto-resolving any EPSG code through proj4's own registry) landed in 0.8.0. Dropping
+      this hint and the viewer's epsg.io fallback with it is CLIM-833, kept separate because
+      it wants the map checked by eye rather than riding along with a version bump. Other
+      STAC clients may still consume it, so it stays published either way.
     * ``proj:bbox`` — the data extent in the store's native CRS. Without it, a client
       reprojecting the Zarr must fetch the x/y coordinate arrays at render time to
       derive bounds (zarr-layer's "proj4 provided without explicit bounds" warning);

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -428,7 +428,9 @@ def _build_collection_with_xstac(
                 temporal_dimension=time_dimension,
                 x_dimension=x_dimension,
                 y_dimension=y_dimension,
-                reference_system=4326,
+                # The store's own CRS, not a constant: these axes are in whatever the store
+                # uses, and seNorge's are UTM33 metres. See reference_system_for.
+                reference_system=reference_system_for(store_crs),
                 # Schema validation can trigger outbound fetches for STAC extension schemas.
                 validate=False,
             )
@@ -629,9 +631,32 @@ def _add_temporal_values(collection: dict[str, Any], ds: xr.Dataset, time_dimens
     dim["values"] = [f"{s.isoformat()}Z" for s in stamps.tz_localize(None)]
 
 
+def reference_system_for(store_crs: str | int | None) -> int | str:
+    """The datacube ``reference_system`` describing a store's spatial axes.
+
+    The datacube extension accepts an EPSG code as a number, or a WKT2/PROJJSON string, and
+    defaults to 4326 when absent. An EPSG code is published as the number because that is
+    the unambiguous form, and because it is what a client comparing against a numeric code
+    expects; anything not shaped like ``EPSG:<digits>`` is passed through as its string.
+
+    Both cube-building paths must resolve this the same way. They previously did not: the
+    temporal path hardcoded ``4326`` for every dataset, so a projected store published its
+    UTM metres as degrees, while the static path read the store's own ``proj:code`` and
+    published a string. A client reading the field got a different answer, of a different
+    type, depending on whether the dataset happened to have a time axis (CLIM-1004).
+    """
+    if not store_crs:
+        return 4326
+    code = canonical_crs_code(store_crs)
+    prefix, _, tail = code.partition(":")
+    if prefix.upper() == "EPSG" and tail.isdigit():
+        return int(tail)
+    return code
+
+
 def _build_static_cube_dimensions(ds: xr.Dataset, x_dim: str, y_dim: str) -> dict[str, Any]:
     """Build minimal cube:dimensions for a dataset with no time axis."""
-    crs = ds.attrs.get("proj:code", "EPSG:4326")
+    crs = reference_system_for(ds.attrs.get("proj:code"))
     x_vals = ds[x_dim].values
     y_vals = ds[y_dim].values
     x_step = float(x_vals[1] - x_vals[0]) if len(x_vals) > 1 else None

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -304,13 +304,16 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
       proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
       strings as lossy), so it lives under our namespace rather than ``proj:``.
-      zarr-layer only accepts a built-in ``crs`` code or a ``proj4`` string today; once
-      carbonplan/zarr-layer#61 lands (auto-resolving any EPSG code) this proj4 hint
-      becomes unnecessary and only ``proj:wkt2`` need remain, for other STAC clients.
+      Kept for now, but no longer required by the viewer: zarr-layer 0.8.0 resolves a
+      ``crs`` code through proj4's own registry, which is what carbonplan/zarr-layer#61
+      asked for. Dropping this hint, and the viewer's epsg.io fallback with it, is
+      CLIM-833 — a change that needs the map checked by eye, not a version bump.
     * ``proj:bbox`` — the data extent in the store's native CRS. Without it, a client
       reprojecting the Zarr must fetch the x/y coordinate arrays at render time to
       derive bounds (zarr-layer's "proj4 provided without explicit bounds" warning);
       publishing it lets the client pass explicit bounds and skip that round-trip.
+      zarr-layer 0.8.0 reads ``spatial:transform``/``spatial:bbox`` from the store
+      instead, so for that client this is now a fallback rather than the only route.
     """
     if is_builtin_crs(store_crs):
         return

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -304,16 +304,20 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     * ``open_climate_service:proj4`` — a proj4 string for direct consumption by
       proj4js. proj4 is intentionally *not* a STAC-standard field (PROJ treats proj4
       strings as lossy), so it lives under our namespace rather than ``proj:``.
-      Kept for now, but no longer required by the viewer: zarr-layer 0.8.0 resolves a
-      ``crs`` code through proj4's own registry, which is what carbonplan/zarr-layer#61
-      asked for. Dropping this hint, and the viewer's epsg.io fallback with it, is
-      CLIM-833 — a change that needs the map checked by eye, not a version bump.
+      Still required by the viewer: zarr-layer only accepts a built-in ``crs`` code or a
+      ``proj4`` string at the version we pin. carbonplan/zarr-layer#61 (auto-resolving any
+      EPSG code) landed in 0.8.0, so dropping this hint and the viewer's epsg.io fallback
+      with it — CLIM-833 — becomes possible only once we can move off 0.6.1. See the pin
+      comment in ``templates/map-viewer.html`` for what blocks that.
     * ``proj:bbox`` — the data extent in the store's native CRS. Without it, a client
       reprojecting the Zarr must fetch the x/y coordinate arrays at render time to
       derive bounds (zarr-layer's "proj4 provided without explicit bounds" warning);
-      publishing it lets the client pass explicit bounds and skip that round-trip.
-      zarr-layer 0.8.0 reads ``spatial:transform``/``spatial:bbox`` from the store
-      instead, so for that client this is now a fallback rather than the only route.
+      publishing it lets the client pass explicit bounds and skip that round-trip, which
+      the viewer now does. zarr-layer 0.8.0 can instead read ``spatial:transform``/
+      ``spatial:bbox`` from the store, but we do not write those attributes, so for that
+      client this hint stays the only route. Writing the ``spatial:`` conventions into the
+      store, so placement travels with the data rather than only with our catalogue, would
+      be the better fix and is not done here.
     """
     if is_builtin_crs(store_crs):
         return

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -289,14 +289,18 @@ def _add_crs_render_hints(*, template: pystac.Collection, ds: xr.Dataset, store_
     A client reprojecting Zarr on the fly needs to resolve the store's CRS. We used to hand
     it a proj4 string under ``open_climate_service:proj4`` because zarr-layer 0.6.1 accepted
     only its two built-in codes or an explicit proj4 definition. From 0.8.0 it resolves a
-    code through proj4's own registry, so that non-standard field and the viewer's epsg.io
-    fallback are both retired (CLIM-833) and only standard fields remain.
+    code through proj4's own registry, and a code proj4 does not ship through the full
+    definition the store publishes for itself (``shared/crs.py``, ``store_crs_attrs``) — so
+    that non-standard field and the viewer's epsg.io fallback are both retired (CLIM-833)
+    and only standard fields remain.
 
     Three fields are emitted:
 
     * ``proj:wkt2`` — the STAC Projection-extension standard, lossless CRS
-      representation. It is the same information GeoZarr already carries in the CF
-      ``spatial_ref`` grid-mapping's ``crs_wkt`` attribute.
+      representation. It is the same information the store already carries, in the CF
+      ``spatial_ref`` grid-mapping's ``crs_wkt`` attribute and in its own ``proj:wkt2``
+      root attribute (``shared/crs.py``, ``store_crs_attrs``); this is the copy a client
+      that reads the catalogue and never opens the Zarr can see.
     * ``proj:projjson`` — the same CRS as PROJJSON. Also a STAC Projection-extension
       standard (and the GeoZarr ``proj:`` convention), but a JSON object a JS/STAC
       client can consume directly instead of parsing WKT2.

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -243,7 +243,7 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
     # (GDAL/QGIS, zarr-layer) read the CRS from the CF grid-mapping (`crs_wkt`) / `proj:`
     # convention that create_geozarr_attrs already writes, and the extent from here or the
     # coordinate arrays — no non-standard `proj4`/`bounds` attrs required. The STAC hints
-    # (open_climate_service:proj4, proj:bbox) in stac/services.py serve the map viewer.
+    # (proj:wkt2, proj:projjson, proj:bbox) in stac/services.py serve other STAC clients.
     attrs["spatial:bbox"] = bbox
     if geometry is not None:
         # The affine is what a client actually places the raster with. Without it, viewers

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from geozarr_toolkit import create_geozarr_attrs
 
-from open_climate_service.shared.geozarr import grid_geometry, write_gdal_geotransform
+from open_climate_service.shared.geozarr import check_grid_description, grid_geometry, write_gdal_geotransform
 from open_climate_service.stac.media_types import is_multiscales_convention
 from open_climate_service.streaming.protocol import GridSpec
 
@@ -253,6 +253,16 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
         attrs["spatial:shape"] = geometry["shape"]
         attrs["spatial:bbox"] = geometry["bbox"]
     attrs.update(spec.attrs)
+
+    # Checked after `spec.attrs` is merged, not before: a plugin's own attrs land last and
+    # could otherwise reintroduce a bad description past the guard. `spec.shape` is (y, x).
+    check_grid_description(
+        attrs,
+        y_dim=spec.y_dim,
+        x_dim=spec.x_dim,
+        y_size=int(spec.shape[0]),
+        x_size=int(spec.shape[1]),
+    )
 
     # An append to a pyramided store must not un-declare its pyramid. `create_geozarr_attrs`
     # builds `zarr_conventions` for a *flat* store, and the `update` below replaces the list

--- a/open_climate_service/streaming/store.py
+++ b/open_climate_service/streaming/store.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from geozarr_toolkit import create_geozarr_attrs
 
+from open_climate_service.shared.crs import store_crs_attrs
 from open_climate_service.shared.geozarr import check_grid_description, grid_geometry, write_gdal_geotransform
 from open_climate_service.stac.media_types import is_multiscales_convention
 from open_climate_service.streaming.protocol import GridSpec
@@ -237,13 +238,15 @@ def write_geozarr_attrs(store: Any, *, spec: GridSpec, bbox: list[float]) -> Non
         bbox=bbox,
         shape=spec.shape,
     )
-    crs_code = f"EPSG:{spec.crs}"
-    attrs["proj:code"] = crs_code
+    # `create_geozarr_attrs` records an EPSG input as `proj:code` and nothing else, which
+    # only describes the store to a reader that can look the code up. Overwrite with the full
+    # `proj:` set so the store carries its own definition — see store_crs_attrs.
+    attrs.update(store_crs_attrs(f"EPSG:{spec.crs}"))
     # Native-CRS extent, in the GeoZarr `spatial:bbox` convention. Direct-Zarr clients
-    # (GDAL/QGIS, zarr-layer) read the CRS from the CF grid-mapping (`crs_wkt`) / `proj:`
-    # convention that create_geozarr_attrs already writes, and the extent from here or the
-    # coordinate arrays — no non-standard `proj4`/`bounds` attrs required. The STAC hints
-    # (proj:wkt2, proj:projjson, proj:bbox) in stac/services.py serve other STAC clients.
+    # (GDAL/QGIS, zarr-layer) read the CRS from the CF grid-mapping (`crs_wkt`) / the `proj:`
+    # convention above, and the extent from here or the coordinate arrays — no non-standard
+    # `proj4`/`bounds` attrs required. stac/services.py publishes the same CRS fields plus
+    # `proj:bbox` on the collection, for clients that read the catalogue and not the store.
     attrs["spatial:bbox"] = bbox
     if geometry is not None:
         # The affine is what a client actually places the raster with. Without it, viewers

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -250,32 +250,28 @@
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
       import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
-      // Held below 0.8.0 deliberately. From 0.8.0 on, our projected stores misrender:
-      // seNorge's UTM33 grid comes out as diagonal streaks in offset blocks instead of a
-      // map. Bisected by changing only this URL against a live instance —
+      // Held at 0.6.1 because of our own stores, not because of the library.
       //
-      //   0.6.1 correct | 0.7.0 correct | 0.8.0 STREAKS | 0.9.0 streaks
+      // 0.8.0 began reading the GeoZarr `spatial:*` attributes (`spatial:dimensions`,
+      // `spatial:shape`, `spatial:transform`) instead of inferring geometry from the
+      // coordinate arrays. Stores we wrote before the CLIM-852 fix (2026-08-05) declare
+      // those transposed — `["x","y"]` with a shape of `[x, y]` on a `(t, y, x)` array,
+      // and no affine — so from 0.8.0 on they render as diagonal streaks in offset blocks.
+      // The library is doing what it is told; the metadata is wrong.
       //
-      // so 0.8.0 is the first bad version and 0.7.0 the last good one. That is the release
-      // which added the `spatial:transform`/`spatial:shape`/`spatial:registration`
-      // handling (absent from the 0.7.0 bundle, ~30 references in 0.8.0). Our stores write
-      // none of those attributes, so 0.8.0 takes its coordinate-array fallback and places
-      // the chunks wrongly. Passing explicit `bounds` does not help, so this is not the
-      // missing georeferencing hint it first looks like.
+      // Proven by two stores on the same grid, same CRS, same 388x299 chunking over
+      // 1550x1195, differing only in when they were written:
       //
-      // The stores that break are the ones whose chunks do not divide their shape evenly —
-      // seNorge is 1550x1195 in 388x299 chunks, a 4x4 grid with partial edges, matching
-      // the blocks on screen — but our projected and unevenly-chunked stores are the same
-      // set, so that is a suspicion rather than a proven trigger. Single-chunk stores
-      // (CHIRPS3, ERA5-Land) render fine on 0.9.0.
+      //   senorge_temperature_daily  (2026-06-26, dimensions ["x","y"])  -> streaks on 0.9.0
+      //   senorge_precipitation_daily (2026-08-06, dimensions ["y","x"]) -> correct on 0.9.0
       //
-      // Upstream: carbonplan/zarr-layer#88. CLIM-833 (dropping the proj4 hint) needs
-      // 0.8.0+, so it waits on this being fixed rather than on a version bump.
+      // So this is not a chunking problem and not a zarr-layer bug (retracted upstream:
+      // carbonplan/zarr-layer#88). The blocker is that instances still hold stores written
+      // by the old writer, which 0.6.1 tolerates because it ignores `spatial:*` entirely.
       //
-      // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
-      // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading
-      // was the proposed fix for it, which is what this pin rules out. 0.7.0 is also clear
-      // of the 0.8.0 bug, but moving there buys nothing on its own.
+      // Lift this pin once those stores are reingested — CLIM-1008 — which also unblocks
+      // CLIM-833. Note CLIM-1006 (CHIRPS3 streaks on the Rwanda instance) was reported
+      // against 0.6.1, which never reads these attributes, so it is a separate fault.
       //
       // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
       // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading
@@ -629,49 +625,17 @@
         // Only projected stores publish `proj:bbox` — the STAC CRS render hints are
         // skipped for built-in CRSes — so a built-in-CRS store keeps deriving bounds from
         // its coordinate arrays exactly as before.
-        const nativeBbox = collection["proj:bbox"] ?? null;
-        let centreBbox = null;
-        if (Array.isArray(nativeBbox) && nativeBbox.every((n) => Number.isFinite(n))) {
-          // proj:bbox is [xmin, ymin, xmax, ymax] when 2D and
-          // [xmin, ymin, zmin, xmax, ymax, zmax] when 3D; ZarrLayer wants the 2D form.
-          if (nativeBbox.length === 4) centreBbox = nativeBbox;
-          else if (nativeBbox.length === 6)
-            centreBbox = [nativeBbox[0], nativeBbox[1], nativeBbox[3], nativeBbox[4]];
-        }
-
-        // `proj:bbox` is the min/max of the coordinate arrays, so it spans cell *centres*,
-        // while ZarrLayer documents `bounds` as "edge bounds (not center-to-center)".
-        // Passing it raw is half a cell out on every side — invisible at country zoom,
-        // wrong nonetheless, and increasingly visible as you zoom in. So grow it by half a
-        // cell, taking the pitch from the published `cube:dimensions` step.
+        // Deliberately not passing `bounds`. It looked like the fix for the misplaced
+        // projected stores and is not: the cause is transposed `spatial:*` metadata in
+        // stores written before CLIM-852 (see the note at the import), and `bounds`
+        // overrides the extent, not the axis order, so it changes nothing either way.
         //
-        // Without a usable step there is no way to convert, and half-wrong bounds are worse
-        // than none: the library's own derivation at least applies whatever registration it
-        // assumes consistently. So in that case pass nothing and let it derive.
-        const dimsForStep = collection["cube:dimensions"] ?? {};
-        const stepFor = (axis) => {
-          const dim = Object.values(dimsForStep).find((d) => d?.axis === axis);
-          const step = Math.abs(Number(dim?.step));
-          return Number.isFinite(step) && step > 0 ? step : null;
-        };
-        const xStep = stepFor("x");
-        const yStep = stepFor("y");
-
-        let bounds = null;
-        if (centreBbox !== null && xStep !== null && yStep !== null) {
-          bounds = [
-            centreBbox[0] - xStep / 2,
-            centreBbox[1] - yStep / 2,
-            centreBbox[2] + xStep / 2,
-            centreBbox[3] + yStep / 2,
-          ];
-        }
-        if (bounds === null && !isBuiltinCrs) {
-          console.warn(
-            `[map] No usable proj:bbox and cube:dimensions step for projected store ` +
-              `"${collection.id}" — bounds will be derived from coordinate arrays`
-          );
-        }
+        // It is also not a safe thing to pass blind. ZarrLayer documents `bounds` as edge
+        // bounds, while `proj:bbox` is edge-based only when the store declares
+        // `spatial:bbox` for the STAC builder to prefer; where that is absent it falls back
+        // to the coordinate min/max, which spans cell centres. Passing one as the other is
+        // half a cell out — invisible at country zoom, wrong up close. The store knows
+        // which it has and we do not, so let the library read the store.
 
         let cm;
         try {
@@ -689,7 +653,6 @@
             ...(fillValue !== null && { fillValue }),
             crs: nativeCrs,
             ...(proj4String !== null && { proj4: proj4String }),
-            ...(bounds !== null && { bounds }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -250,17 +250,32 @@
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
       import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
-      // Held at 0.6.1 deliberately. 0.9.0 (the current latest) misrenders our projected
-      // stores: seNorge's UTM33 grid comes out as diagonal streaks in offset blocks
-      // instead of a map, while 0.6.1 renders the same store correctly from the same
-      // server. Passing explicit `bounds` does not fix it, so this is not the missing
-      // georeferencing hint it first looks like. The stores that break are the ones whose
-      // chunks do not divide their shape evenly — seNorge is 1550x1195 in 388x299 chunks,
-      // a 4x4 grid with partial edges, and 16 blocks is what appears on screen — but our
-      // projected and unevenly-chunked stores are the same set, so that is a strong
-      // suspicion rather than a proven trigger. Single-chunk stores (CHIRPS3, ERA5-Land)
-      // render fine on 0.9.0. Re-check on the next release before bumping; CLIM-833
-      // (dropping the proj4 hint) also waits on this, since it needs 0.8.0+.
+      // Held below 0.8.0 deliberately. From 0.8.0 on, our projected stores misrender:
+      // seNorge's UTM33 grid comes out as diagonal streaks in offset blocks instead of a
+      // map. Bisected by changing only this URL against a live instance —
+      //
+      //   0.6.1 correct | 0.7.0 correct | 0.8.0 STREAKS | 0.9.0 streaks
+      //
+      // so 0.8.0 is the first bad version and 0.7.0 the last good one. That is the release
+      // which added the `spatial:transform`/`spatial:shape`/`spatial:registration`
+      // handling (absent from the 0.7.0 bundle, ~30 references in 0.8.0). Our stores write
+      // none of those attributes, so 0.8.0 takes its coordinate-array fallback and places
+      // the chunks wrongly. Passing explicit `bounds` does not help, so this is not the
+      // missing georeferencing hint it first looks like.
+      //
+      // The stores that break are the ones whose chunks do not divide their shape evenly —
+      // seNorge is 1550x1195 in 388x299 chunks, a 4x4 grid with partial edges, matching
+      // the blocks on screen — but our projected and unevenly-chunked stores are the same
+      // set, so that is a suspicion rather than a proven trigger. Single-chunk stores
+      // (CHIRPS3, ERA5-Land) render fine on 0.9.0.
+      //
+      // Upstream: carbonplan/zarr-layer#88. CLIM-833 (dropping the proj4 hint) needs
+      // 0.8.0+, so it waits on this being fixed rather than on a version bump.
+      //
+      // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
+      // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading
+      // was the proposed fix for it, which is what this pin rules out. 0.7.0 is also clear
+      // of the 0.8.0 bug, but moving there buys nothing on its own.
       //
       // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
       // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -259,7 +259,8 @@
       // `["x","y"]` with a shape of `[x, y]` on a `(t, y, x)` array — renders as diagonal
       // streaks in offset blocks, because that is what it asked for. Stores written before
       // the CLIM-852 fix (2026-08-05) do exactly that, and 0.6.1 concealed it by ignoring
-      // these attributes altogether. Those stores need reingesting or migrating: CLIM-1008.
+      // these attributes altogether. Those stores get reingested rather than patched in
+      // place — CLIM-1008 records that decision, and which stores were affected.
       //
       // Two stores on the same grid and CRS, same 388x299 chunking over 1550x1195,
       // differing only in when they were written, are what establish this is metadata

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -368,6 +368,20 @@
         return { lazy: true, start, inc, count };
       }
 
+      // Select a step by *index*, explicitly. ZarrLayer resolves a bare value against the
+      // dimension's coordinate array first, and a CF time axis holds raw offsets (hours since
+      // epoch) that never match a slider position — so it logged a resolution failure on every
+      // layer load, then fell through to treating a numeric value as the index. That fallback
+      // happened to be what we meant, so this worked by accident (CLIM-1003).
+      //
+      // Saying it outright drops the wasted coordinate read and the logged failure, and stops
+      // depending on a fallback the library is actively changing: carbonplan/zarr-layer#87
+      // tightens the same resolver, rejecting unresolvable *string* selectors while keeping
+      // numeric ones. Every write to `selector` goes through here so they cannot drift apart.
+      function indexSelection(index) {
+        return { selected: index, type: "index" };
+      }
+
       function stepCount(steps) {
         return Array.isArray(steps) ? steps.length : steps.count;
       }
@@ -574,7 +588,7 @@
           return { key, dim, steps, control, count, label: dimLabel(key, dim), index };
         });
         selector = {};
-        for (const d of dimStates) selector[d.key] = d.index;
+        for (const d of dimStates) selector[d.key] = indexSelection(d.index);
 
         // The CRS code alone is enough now. From 0.8.0 ZarrLayer resolves a code through
         // proj4's own registry, which carries every UTM zone among others, so a projected
@@ -725,7 +739,7 @@
             slider.addEventListener("input", (e) => {
               const i = parseInt(e.target.value, 10);
               d.index = i;
-              selector[d.key] = i;
+              selector[d.key] = indexSelection(i);
               valueEl.textContent = stepDisplay(d.key, d.steps, i) ?? "—";
               count.textContent = `${i + 1} / ${d.count}`;
               applySelector();
@@ -743,7 +757,7 @@
             select.addEventListener("change", (e) => {
               const i = parseInt(e.target.value, 10);
               d.index = i;
-              selector[d.key] = i;
+              selector[d.key] = indexSelection(i);
               applySelector();
             });
             block.append(select);

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -576,39 +576,25 @@
         selector = {};
         for (const d of dimStates) selector[d.key] = d.index;
 
-        // ZarrLayer resolves only its built-in CRSes (EPSG:4326 / EPSG:3857) from the
-        // code alone; every other CRS — e.g. seNorge's UTM33 (EPSG:32633) — needs an
-        // explicit proj4 definition, or it is treated as WGS84 degrees and lands in the
-        // wrong place. See ZarrLayerOptions `crs` docs: "built-in projections (EPSG:4326
-        // or EPSG:3857). For any other CRS, provide a matching proj4 definition."
+        // The CRS code alone is enough now. From 0.8.0 ZarrLayer resolves a code through
+        // proj4's own registry, which carries every UTM zone among others, so a projected
+        // store no longer needs a proj4 definition handed to it. That retires both the
+        // `open_climate_service:proj4` hint we used to publish and the epsg.io fetch that
+        // backed it up (CLIM-833) — one fewer non-standard field, and no third-party
+        // request on the render path.
         //
-        // Prefer the proj4 string published in the STAC collection
-        // (open_climate_service:proj4) so we don't depend on an external epsg.io lookup at
-        // render time; fall back to epsg.io only for older stores that predate the field.
+        // What this does *not* rely on is carbonplan/zarr-layer#61, which would bundle a
+        // full EPSG database and is still open. So the guarantee is "any code proj4 ships a
+        // definition for", not "any EPSG code". That covers all four CRSes in use across our
+        // instances — EPSG:4326, EPSG:3857, EPSG:32633, EPSG:32645 — but a store in, say, a
+        // national grid outside proj4's defs would fall back to an inferred CRS and land in
+        // the wrong place. ZarrLayer warns when that happens; #61 is what would remove the
+        // caveat entirely.
         let nativeCrs = collection["proj:code"] ?? "EPSG:4326";
-        // CRS84 aliases (CRS84, OGC:CRS84, CRS:84, or a CRS84 URI) are geographic WGS84;
-        // ZarrLayer only recognizes EPSG:4326 / EPSG:3857 by code, so normalize to EPSG:4326
-        // before both the built-in check and passing `crs` into new ZarrLayer. Separators
-        // are stripped first so the short OGC form CRS:84 is matched too.
+        // CRS84 aliases (CRS84, OGC:CRS84, CRS:84, or a CRS84 URI) are geographic WGS84,
+        // normalised so `crs` is a code ZarrLayer recognises directly. Separators are
+        // stripped first so the short OGC form CRS:84 is matched too.
         if (nativeCrs.toUpperCase().replace(/[^A-Z0-9]/g, "").endsWith("CRS84")) nativeCrs = "EPSG:4326";
-        const BUILTIN_CRS = new Set(["EPSG:4326", "EPSG:3857"]);
-        const isBuiltinCrs = BUILTIN_CRS.has(nativeCrs.toUpperCase());
-        let proj4String = collection["open_climate_service:proj4"] ?? null;
-        if (!isBuiltinCrs && !proj4String) {
-          try {
-            const match = nativeCrs.match(/(\d+)$/);
-            const epsgId = match?.[1];
-            if (epsgId) {
-              const p4res = await fetch(`https://epsg.io/${epsgId}.proj4`);
-              if (p4res.ok) proj4String = (await p4res.text()).trim();
-              else console.warn(`[map] Could not fetch proj4 for ${nativeCrs} (HTTP ${p4res.status})`);
-            } else {
-              console.warn(`[map] Cannot extract EPSG id from CRS "${nativeCrs}" — rendering may be incorrect`);
-            }
-          } catch (err) {
-            console.warn(`[map] Failed to fetch proj4 string for "${nativeCrs}":`, err);
-          }
-        }
 
         // No `bounds` is passed, deliberately: the store carries its own placement in the
         // GeoZarr `spatial:*` attributes, and from 0.8.0 ZarrLayer reads them. Handing it a
@@ -636,7 +622,6 @@
             ...(zarrVersion !== null && { zarrVersion }),
             ...(fillValue !== null && { fillValue }),
             crs: nativeCrs,
-            ...(proj4String !== null && { proj4: proj4String }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -250,7 +250,7 @@
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
       import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
-      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
+      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.9.0";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 
       // Suffix _r means the scale is reversed (matplotlib convention).

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -261,6 +261,10 @@
       // suspicion rather than a proven trigger. Single-chunk stores (CHIRPS3, ERA5-Land)
       // render fine on 0.9.0. Re-check on the next release before bumping; CLIM-833
       // (dropping the proj4 hint) also waits on this, since it needs 0.8.0+.
+      //
+      // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
+      // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading
+      // was the proposed fix for it, which is what this pin rules out.
       import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -630,18 +630,46 @@
         // skipped for built-in CRSes — so a built-in-CRS store keeps deriving bounds from
         // its coordinate arrays exactly as before.
         const nativeBbox = collection["proj:bbox"] ?? null;
-        let bounds = null;
+        let centreBbox = null;
         if (Array.isArray(nativeBbox) && nativeBbox.every((n) => Number.isFinite(n))) {
           // proj:bbox is [xmin, ymin, xmax, ymax] when 2D and
           // [xmin, ymin, zmin, xmax, ymax, zmax] when 3D; ZarrLayer wants the 2D form.
-          if (nativeBbox.length === 4) bounds = nativeBbox;
+          if (nativeBbox.length === 4) centreBbox = nativeBbox;
           else if (nativeBbox.length === 6)
-            bounds = [nativeBbox[0], nativeBbox[1], nativeBbox[3], nativeBbox[4]];
+            centreBbox = [nativeBbox[0], nativeBbox[1], nativeBbox[3], nativeBbox[4]];
+        }
+
+        // `proj:bbox` is the min/max of the coordinate arrays, so it spans cell *centres*,
+        // while ZarrLayer documents `bounds` as "edge bounds (not center-to-center)".
+        // Passing it raw is half a cell out on every side — invisible at country zoom,
+        // wrong nonetheless, and increasingly visible as you zoom in. So grow it by half a
+        // cell, taking the pitch from the published `cube:dimensions` step.
+        //
+        // Without a usable step there is no way to convert, and half-wrong bounds are worse
+        // than none: the library's own derivation at least applies whatever registration it
+        // assumes consistently. So in that case pass nothing and let it derive.
+        const dimsForStep = collection["cube:dimensions"] ?? {};
+        const stepFor = (axis) => {
+          const dim = Object.values(dimsForStep).find((d) => d?.axis === axis);
+          const step = Math.abs(Number(dim?.step));
+          return Number.isFinite(step) && step > 0 ? step : null;
+        };
+        const xStep = stepFor("x");
+        const yStep = stepFor("y");
+
+        let bounds = null;
+        if (centreBbox !== null && xStep !== null && yStep !== null) {
+          bounds = [
+            centreBbox[0] - xStep / 2,
+            centreBbox[1] - yStep / 2,
+            centreBbox[2] + xStep / 2,
+            centreBbox[3] + yStep / 2,
+          ];
         }
         if (bounds === null && !isBuiltinCrs) {
           console.warn(
-            `[map] No usable proj:bbox for projected store "${collection.id}" — bounds will be ` +
-              `inferred from coordinate arrays and the layer may be misplaced`
+            `[map] No usable proj:bbox and cube:dimensions step for projected store ` +
+              `"${collection.id}" — bounds will be derived from coordinate arrays`
           );
         }
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -609,29 +609,16 @@
           }
         }
 
-        // Without explicit bounds ZarrLayer fetches the x/y coordinate arrays to derive
-        // them, and says so ("proj4 provided without explicit bounds"). `proj:bbox` is the
-        // extent in the store's native CRS, which is the unit `bounds` expects when
-        // `proj4` is given ("source CRS units (e.g. meters) when proj4 is provided"), so
-        // passing it skips that round-trip on every layer load.
+        // No `bounds` is passed, deliberately: the store carries its own placement in the
+        // GeoZarr `spatial:*` attributes, and from 0.8.0 ZarrLayer reads them. Handing it a
+        // catalogue-derived extent as well would only add a second source of truth.
         //
-        // This is the round-trip, not the streaks: 0.6.1 places the store correctly either
-        // way, and 0.9.0 streaks either way. See the pin comment at the import.
-        //
-        // Only projected stores publish `proj:bbox` — the STAC CRS render hints are
-        // skipped for built-in CRSes — so a built-in-CRS store keeps deriving bounds from
-        // its coordinate arrays exactly as before.
-        // Deliberately not passing `bounds`. It looked like the fix for the misplaced
-        // projected stores and is not: the cause is transposed `spatial:*` metadata in
-        // stores written before CLIM-852 (see the note at the import), and `bounds`
-        // overrides the extent, not the axis order, so it changes nothing either way.
-        //
-        // It is also not a safe thing to pass blind. ZarrLayer documents `bounds` as edge
-        // bounds, while `proj:bbox` is edge-based only when the store declares
-        // `spatial:bbox` for the STAC builder to prefer; where that is absent it falls back
-        // to the coordinate min/max, which spans cell centres. Passing one as the other is
-        // half a cell out — invisible at country zoom, wrong up close. The store knows
-        // which it has and we do not, so let the library read the store.
+        // It is also not safe to pass blind. ZarrLayer documents `bounds` as *edge* bounds,
+        // while `proj:bbox` is edge-based only when the store declares `spatial:bbox` for
+        // the STAC builder to prefer; without that it falls back to the coordinate min/max,
+        // which spans cell *centres*. Passing one as the other is half a cell out —
+        // invisible at country zoom, wrong as you zoom in. The store knows which it holds
+        // and the viewer does not, so let the library read the store.
 
         let cm;
         try {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -250,33 +250,29 @@
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
       import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
-      // Held at 0.6.1 because of our own stores, not because of the library.
+      // 0.8.0 onwards reads the GeoZarr `spatial:*` attributes (`spatial:dimensions`,
+      // `spatial:shape`, `spatial:transform`) rather than inferring geometry from the
+      // coordinate arrays. That is the behaviour we want: placement comes from the store,
+      // not from a guess, and not from our own catalogue passed in by hand.
       //
-      // 0.8.0 began reading the GeoZarr `spatial:*` attributes (`spatial:dimensions`,
-      // `spatial:shape`, `spatial:transform`) instead of inferring geometry from the
-      // coordinate arrays. Stores we wrote before the CLIM-852 fix (2026-08-05) declare
-      // those transposed — `["x","y"]` with a shape of `[x, y]` on a `(t, y, x)` array,
-      // and no affine — so from 0.8.0 on they render as diagonal streaks in offset blocks.
-      // The library is doing what it is told; the metadata is wrong.
+      // It also means the store has to be right. One that declares its axes transposed —
+      // `["x","y"]` with a shape of `[x, y]` on a `(t, y, x)` array — renders as diagonal
+      // streaks in offset blocks, because that is what it asked for. Stores written before
+      // the CLIM-852 fix (2026-08-05) do exactly that, and 0.6.1 concealed it by ignoring
+      // these attributes altogether. Those stores need reingesting or migrating: CLIM-1008.
       //
-      // Proven by two stores on the same grid, same CRS, same 388x299 chunking over
-      // 1550x1195, differing only in when they were written:
+      // Two stores on the same grid and CRS, same 388x299 chunking over 1550x1195,
+      // differing only in when they were written, are what establish this is metadata
+      // rather than the library:
       //
-      //   senorge_temperature_daily  (2026-06-26, dimensions ["x","y"])  -> streaks on 0.9.0
-      //   senorge_precipitation_daily (2026-08-06, dimensions ["y","x"]) -> correct on 0.9.0
+      //   senorge_temperature_daily   (2026-06-26, ["x","y"]) -> streaks
+      //   senorge_precipitation_daily (2026-08-06, ["y","x"]) -> correct
       //
-      // So this is not a chunking problem and not a zarr-layer bug (retracted upstream:
-      // carbonplan/zarr-layer#88). The blocker is that instances still hold stores written
-      // by the old writer, which 0.6.1 tolerates because it ignores `spatial:*` entirely.
-      //
-      // Lift this pin once those stores are reingested — CLIM-1008 — which also unblocks
-      // CLIM-833. Note CLIM-1006 (CHIRPS3 streaks on the Rwanda instance) was reported
-      // against 0.6.1, which never reads these attributes, so it is a separate fault.
-      //
-      // 0.6.1 is not known-good, only better here. CLIM-1006 (CHIRPS3 drawing as streaks
-      // on the Rwanda instance) was reported against 0.6.1 and is still open; upgrading
-      // was the proposed fix for it, which is what this pin rules out.
-      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
+      // No upstream bug is involved; an earlier report of one was withdrawn
+      // (carbonplan/zarr-layer#88). CLIM-1006 (CHIRPS3 streaks on the Rwanda instance) was
+      // reported against 0.6.1, which never read these attributes, so it is a separate
+      // fault and still open.
+      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.9.0";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 
       // Suffix _r means the scale is reversed (matplotlib convention).

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -250,7 +250,18 @@
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
       import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
-      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.9.0";
+      // Held at 0.6.1 deliberately. 0.9.0 (the current latest) misrenders our projected
+      // stores: seNorge's UTM33 grid comes out as diagonal streaks in offset blocks
+      // instead of a map, while 0.6.1 renders the same store correctly from the same
+      // server. Passing explicit `bounds` does not fix it, so this is not the missing
+      // georeferencing hint it first looks like. The stores that break are the ones whose
+      // chunks do not divide their shape evenly — seNorge is 1550x1195 in 388x299 chunks,
+      // a 4x4 grid with partial edges, and 16 blocks is what appears on screen — but our
+      // projected and unevenly-chunked stores are the same set, so that is a strong
+      // suspicion rather than a proven trigger. Single-chunk stores (CHIRPS3, ERA5-Land)
+      // render fine on 0.9.0. Re-check on the next release before bumping; CLIM-833
+      // (dropping the proj4 hint) also waits on this, since it needs 0.8.0+.
+      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 
       // Suffix _r means the scale is reversed (matplotlib convention).
@@ -587,6 +598,34 @@
           }
         }
 
+        // Without explicit bounds ZarrLayer fetches the x/y coordinate arrays to derive
+        // them, and says so ("proj4 provided without explicit bounds"). `proj:bbox` is the
+        // extent in the store's native CRS, which is the unit `bounds` expects when
+        // `proj4` is given ("source CRS units (e.g. meters) when proj4 is provided"), so
+        // passing it skips that round-trip on every layer load.
+        //
+        // This is the round-trip, not the streaks: 0.6.1 places the store correctly either
+        // way, and 0.9.0 streaks either way. See the pin comment at the import.
+        //
+        // Only projected stores publish `proj:bbox` — the STAC CRS render hints are
+        // skipped for built-in CRSes — so a built-in-CRS store keeps deriving bounds from
+        // its coordinate arrays exactly as before.
+        const nativeBbox = collection["proj:bbox"] ?? null;
+        let bounds = null;
+        if (Array.isArray(nativeBbox) && nativeBbox.every((n) => Number.isFinite(n))) {
+          // proj:bbox is [xmin, ymin, xmax, ymax] when 2D and
+          // [xmin, ymin, zmin, xmax, ymax, zmax] when 3D; ZarrLayer wants the 2D form.
+          if (nativeBbox.length === 4) bounds = nativeBbox;
+          else if (nativeBbox.length === 6)
+            bounds = [nativeBbox[0], nativeBbox[1], nativeBbox[3], nativeBbox[4]];
+        }
+        if (bounds === null && !isBuiltinCrs) {
+          console.warn(
+            `[map] No usable proj:bbox for projected store "${collection.id}" — bounds will be ` +
+              `inferred from coordinate arrays and the layer may be misplaced`
+          );
+        }
+
         let cm;
         try {
           cm = buildColormap(colormapName);
@@ -603,6 +642,7 @@
             ...(fillValue !== null && { fillValue }),
             crs: nativeCrs,
             ...(proj4String !== null && { proj4: proj4String }),
+            ...(bounds !== null && { bounds }),
           });
           map.addLayer(activeLayer);
           for (const layer of map.getStyle().layers) {

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -590,20 +590,20 @@
         selector = {};
         for (const d of dimStates) selector[d.key] = indexSelection(d.index);
 
-        // The CRS code alone is enough now. From 0.8.0 ZarrLayer resolves a code through
+        // The CRS code alone is enough here. From 0.8.0 ZarrLayer resolves a code through
         // proj4's own registry, which carries every UTM zone among others, so a projected
         // store no longer needs a proj4 definition handed to it. That retires both the
         // `open_climate_service:proj4` hint we used to publish and the epsg.io fetch that
         // backed it up (CLIM-833) — one fewer non-standard field, and no third-party
         // request on the render path.
         //
-        // What this does *not* rely on is carbonplan/zarr-layer#61, which would bundle a
-        // full EPSG database and is still open. So the guarantee is "any code proj4 ships a
-        // definition for", not "any EPSG code". That covers all four CRSes in use across our
-        // instances — EPSG:4326, EPSG:3857, EPSG:32633, EPSG:32645 — but a store in, say, a
-        // national grid outside proj4's defs would fall back to an inferred CRS and land in
-        // the wrong place. ZarrLayer warns when that happens; #61 is what would remove the
-        // caveat entirely.
+        // proj4's registry does not cover *every* EPSG code — carbonplan/zarr-layer#61,
+        // which would bundle a full database, is still open — so a code alone would leave a
+        // national grid (EPSG:27700, EPSG:2154) unresolved. Passing one here is harmless
+        // rather than fatal: ZarrLayer keeps no override for a code it cannot resolve, and
+        // falls back to reading the store's own `proj:wkt2` / `proj:projjson`, which both
+        // write paths publish beside `proj:code` (shared/crs.py, store_crs_attrs). The
+        // store, not the reader's lookup table, is what has to know the CRS.
         let nativeCrs = collection["proj:code"] ?? "EPSG:4326";
         // CRS84 aliases (CRS84, OGC:CRS84, CRS:84, or a CRS84 URI) are geographic WGS84,
         // normalised so `crs` is a code ZarrLayer recognises directly. Separators are

--- a/tests/test_downloader_pyramid.py
+++ b/tests/test_downloader_pyramid.py
@@ -245,3 +245,48 @@ def test_pyramid_build_never_materialises_the_source(tmp_path: Path, monkeypatch
     root = zarr.open_group(repo.readonly_session("main").store, mode="r")
     assert "multiscales" in dict(root.attrs)
     assert {"0", "1"} <= {k for k, _ in root.groups()}
+
+
+def _projected_pyramid_sized_cube():
+    """A pyramid-sized cube on the British National Grid, in its native metres.
+
+    The coordinates have to be real eastings/northings, not degrees: the write path replaces
+    a projected CRS declared over coordinates that can only be degrees (see
+    ``resolve_store_crs``), so a lon/lat grid labelled EPSG:27700 would be stored as
+    EPSG:4326 and the test would assert nothing.
+    """
+    ny = nx = 2100
+    return xr.Dataset(
+        {"v": (("t", "y", "x"), np.ones((1, ny, nx), dtype="float32"))},
+        coords={
+            "t": np.array(["2020-01-01"], dtype="datetime64[ns]"),
+            "y": np.linspace(700000.0, 100000.0, ny),
+            "x": np.linspace(100000.0, 600000.0, nx),
+        },
+    )
+
+
+def test_pyramid_levels_carry_the_crs_definition_and_not_just_the_code(tmp_path: Path) -> None:
+    """Every group that declares `proj:` must declare the whole CRS, root and levels alike.
+
+    A client reads the `proj:` convention from the innermost source that declares any of it
+    — the data array, then the level-0 group, then the root — and stops there. Level groups
+    are written from the cube's own attrs, which carry a bare `proj:code`, so a definition
+    written only at the root sits behind a level-0 code that shadows it. For a code proj4
+    cannot resolve (EPSG:27700 here, unlike the UTM zones it ships) that leaves the CRS
+    unresolved and the store rendered in the wrong place, exactly as if the root said
+    nothing — see CLIM-833.
+    """
+    import icechunk
+    from pyproj import CRS
+
+    store_path = tmp_path / "national_grid.icechunk"
+    write_to_icechunk_store(_projected_pyramid_sized_cube(), store_path, crs="EPSG:27700")
+
+    repo = icechunk.Repository.open(icechunk.local_filesystem_storage(str(store_path)))
+    root = zarr.open_group(repo.readonly_session("main").store, mode="r")
+
+    for name, attrs in [("root", dict(root.attrs)), ("level 0", dict(root["0"].attrs))]:
+        assert attrs["proj:code"] == "EPSG:27700", name
+        assert CRS.from_wkt(attrs["proj:wkt2"]) == CRS.from_epsg(27700), name
+        assert CRS.from_json_dict(attrs["proj:projjson"]) == CRS.from_epsg(27700), name

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 import zarr
 
-from open_climate_service.shared.crs import crs_to_proj4, is_builtin_crs
+from open_climate_service.shared.crs import is_builtin_crs
 from open_climate_service.streaming.protocol import GridSpec
 from open_climate_service.streaming.store import write_geozarr_attrs
 
@@ -70,12 +70,3 @@ def test_write_geozarr_attrs_wgs84_extent(tmp_path: Path) -> None:
 )
 def test_is_builtin_crs(code: str | int, is_builtin: bool) -> None:
     assert is_builtin_crs(code) is is_builtin
-
-
-def test_crs_to_proj4() -> None:
-    assert crs_to_proj4("EPSG:4326") is None  # built-in → no proj4 hint
-    assert crs_to_proj4(4326) is None  # int form too
-    assert crs_to_proj4("OGC:CRS84") is None  # CRS84 alias is built-in despite to_epsg()==None
-    proj4 = crs_to_proj4("EPSG:32633")
-    assert proj4 is not None and "proj=utm" in proj4 and "zone=33" in proj4
-    assert crs_to_proj4("not-a-crs") is None

--- a/tests/test_geozarr_attrs.py
+++ b/tests/test_geozarr_attrs.py
@@ -1,10 +1,15 @@
 """Store-level CRS/extent attributes written by ``write_geozarr_attrs``.
 
-The store conveys its CRS through the CF grid-mapping (``crs_wkt``) / GeoZarr ``proj:``
-convention that ``create_geozarr_attrs`` writes, and its native-CRS extent through the
-GeoZarr ``spatial:bbox`` root attribute. No non-standard ``proj4`` / ``bounds`` attrs are
-written — those duplicated the above and nothing consumed them (map clients read the STAC
-hints in ``stac/services.py``; GDAL/QGIS read ``crs_wkt``).
+The store conveys its CRS through the CF grid-mapping (``crs_wkt``) and the GeoZarr
+``proj:`` convention, and its native-CRS extent through the GeoZarr ``spatial:bbox`` root
+attribute. No non-standard ``proj4`` / ``bounds`` attrs are written — those duplicated the
+above and nothing consumed them (GDAL/QGIS read ``crs_wkt``).
+
+The ``proj:`` set has to be enough on its own. ``create_geozarr_attrs`` reduces an EPSG
+input to ``proj:code``, and a code is only as good as the reader's lookup table: proj4,
+which the map viewer resolves through, ships WGS84, Web Mercator and the UTM zones and
+nothing else. So ``store_crs_attrs`` adds the full definition for anything outside that
+set, and the tests below pin which codes get one.
 """
 
 from __future__ import annotations
@@ -70,3 +75,50 @@ def test_write_geozarr_attrs_wgs84_extent(tmp_path: Path) -> None:
 )
 def test_is_builtin_crs(code: str | int, is_builtin: bool) -> None:
     assert is_builtin_crs(code) is is_builtin
+
+
+def test_write_geozarr_attrs_carries_a_definition_for_a_code_proj4_does_not_ship(
+    tmp_path: Path,
+) -> None:
+    """A store on a national grid must describe its CRS in full, not just name it.
+
+    proj4 resolves WGS84, Web Mercator and the UTM zones from a code and nothing else, and
+    a client handed a code it cannot resolve deliberately leaves the CRS unresolved rather
+    than inferring another one. EPSG:27700 is the boundary case: with ``proj:code`` alone
+    such a store ingests cleanly and then renders in the wrong place, so the definition has
+    to travel with it (CLIM-833).
+
+    Both fields are asserted by parsing them back, not by matching text: what matters is
+    that a reader recovers *this* CRS from them, and pyproj's exact WKT rendering is free
+    to change between versions.
+    """
+    from pyproj import CRS
+
+    store = _init_group(tmp_path)
+    spec = GridSpec(shape=(3, 3), crs=27700, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
+
+    write_geozarr_attrs(store, spec=spec, bbox=[100000.0, 100000.0, 600000.0, 700000.0])
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    wkt2, projjson = attrs["proj:wkt2"], attrs["proj:projjson"]
+    assert isinstance(wkt2, str) and isinstance(projjson, dict)
+    assert attrs["proj:code"] == "EPSG:27700"
+    assert CRS.from_wkt(wkt2) == CRS.from_epsg(27700)
+    assert CRS.from_json_dict(projjson) == CRS.from_epsg(27700)
+
+
+def test_write_geozarr_attrs_leaves_a_builtin_crs_as_the_code_alone(tmp_path: Path) -> None:
+    """EPSG:4326 needs no definition: it is what clients reproject *to*.
+
+    Nearly every store we hold is WGS84, so writing a kilobyte of redundant WKT2 and
+    PROJJSON into each one's root metadata buys nothing.
+    """
+    store = _init_group(tmp_path)
+    spec = GridSpec(shape=(3, 3), crs=4326, dtype=np.dtype("float32"), x_dim="x", y_dim="y")
+
+    write_geozarr_attrs(store, spec=spec, bbox=[-13.5, 6.9, -10.1, 10.0])
+
+    attrs = dict(zarr.open_group(store, mode="r").attrs)
+    assert attrs["proj:code"] == "EPSG:4326"
+    assert "proj:wkt2" not in attrs
+    assert "proj:projjson" not in attrs

--- a/tests/test_geozarr_grid_metadata.py
+++ b/tests/test_geozarr_grid_metadata.py
@@ -31,6 +31,7 @@ pytest.importorskip("rioxarray")
 zarr = pytest.importorskip("zarr")
 
 from open_climate_service.shared.geozarr import (  # noqa: E402
+    check_grid_description,
     gdal_geotransform,
     grid_geometry,
 )
@@ -276,3 +277,74 @@ def test_pyramid_levels_get_their_own_geotransform(tmp_path: Path) -> None:
         checked += 1
 
     assert checked == len(layout) >= 2  # every level covered, and there is more than one
+
+
+# --- the write-time guard ---------------------------------------------------------------
+#
+# Getting the positional order wrong is silent: the store writes fine and every client that
+# trusts the convention transposes the grid. 39 of 68 stores on one machine had it wrong for
+# months before a viewer started reading the attributes. The guard refuses the write instead,
+# because a wrong claim cannot be un-published.
+
+
+def test_check_grid_description_accepts_a_correct_description() -> None:
+    check_grid_description(
+        {"spatial:dimensions": ["y", "x"], "spatial:shape": [60, 581]},
+        y_dim="y",
+        x_dim="x",
+        y_size=60,
+        x_size=581,
+    )
+
+
+def test_check_grid_description_rejects_x_first_dimensions() -> None:
+    with pytest.raises(ValueError, match="array order"):
+        check_grid_description(
+            {"spatial:dimensions": ["x", "y"], "spatial:shape": [60, 581]},
+            y_dim="y",
+            x_dim="x",
+            y_size=60,
+            x_size=581,
+        )
+
+
+def test_check_grid_description_rejects_a_reversed_shape() -> None:
+    with pytest.raises(ValueError, match=r"spatial:shape"):
+        check_grid_description(
+            {"spatial:dimensions": ["y", "x"], "spatial:shape": [581, 60]},
+            y_dim="y",
+            x_dim="x",
+            y_size=60,
+            x_size=581,
+        )
+
+
+def test_check_grid_description_catches_a_transposed_square_grid() -> None:
+    """The case a shape check alone misses: [n, n] matches either way round."""
+    with pytest.raises(ValueError, match="array order"):
+        check_grid_description(
+            {"spatial:dimensions": ["x", "y"], "spatial:shape": [1509, 1509]},
+            y_dim="y",
+            x_dim="x",
+            y_size=1509,
+            x_size=1509,
+        )
+
+
+def test_streaming_store_refuses_attrs_that_contradict_the_grid(tmp_path: Path) -> None:
+    """Through the write path: a plugin's own attrs land last and must not slip past.
+
+    `spec.attrs` is merged after the derived description, so the guard has to run after that
+    merge — otherwise a plugin could reintroduce exactly the bug this exists to stop.
+    """
+    x, y = _chirps_coords()
+    store = _init_store(tmp_path, _cube(x, y, "EPSG:4326"))
+    spec = GridSpec(
+        shape=(CHIRPS_NY, CHIRPS_NX),
+        crs=4326,
+        dtype=np.dtype("float32"),
+        attrs={"spatial:dimensions": ["x", "y"]},
+    )
+
+    with pytest.raises(ValueError, match="array order"):
+        write_geozarr_attrs(store, spec=spec, bbox=CHIRPS_REQUESTED_BBOX)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1035,3 +1035,82 @@ def test_cf_extension_is_not_declared_when_no_cf_attrs_are_present(
 
     assert not any(key.startswith("cf:") for key in payload["cube:variables"]["precip"])
     assert stac_services.CF_EXTENSION not in payload["stac_extensions"]
+
+
+# --- reference_system (CLIM-1004) -------------------------------------------------------
+#
+# The defect was a hardcoded `reference_system=4326` at the xstac call site, so a projected
+# store published its UTM metres as degrees. Testing `reference_system_for` alone would not
+# catch that returning: the constant has to be gone from the *caller*, so the call-site test
+# below asserts on what xstac actually receives.
+
+
+@pytest.mark.parametrize(
+    ("store_crs", "expected"),
+    [
+        (None, 4326),
+        ("", 4326),
+        ("EPSG:4326", 4326),
+        ("EPSG:32633", 32633),
+        ("EPSG:3857", 3857),
+        ("OGC:CRS84", 4326),  # a CRS84 alias is geographic WGS84
+        ("CRS:84", 4326),
+        (4326, 4326),  # a bare number, as canonical_crs_code accepts
+        ("+proj=utm +zone=33 +datum=WGS84", "+proj=utm +zone=33 +datum=WGS84"),
+    ],
+)
+def test_reference_system_for_resolves_the_stores_own_crs(store_crs: str | int | None, expected: int | str) -> None:
+    assert stac_services.reference_system_for(store_crs) == expected
+
+
+def test_xstac_is_given_the_stores_crs_not_a_constant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A projected store's axes must be published in that CRS, not as degrees."""
+    ds = xr.Dataset(
+        {"tg": (("time", "y", "x"), np.zeros((2, 3, 4), dtype="float32"))},
+        coords={
+            "time": pd.date_range("2026-01-01", periods=2, freq="D"),
+            "y": [7000000.0, 6999000.0, 6998000.0],
+            "x": [-74500.0, -73500.0, -72500.0, -71500.0],
+        },
+        attrs={"proj:code": "EPSG:32633"},
+    )
+
+    seen: dict[str, object] = {}
+
+    def _capture(dataset: xr.Dataset, template: pystac.Collection, **kwargs: object) -> pystac.Collection:
+        seen.update(kwargs)
+        return template
+
+    monkeypatch.setattr(stac_services, "_open_published_store", lambda _: ds)
+    monkeypatch.setattr(stac_services, "xarray_to_stac", _capture)
+    monkeypatch.setattr(stac_services, "_add_crs_render_hints", lambda **_: None)
+
+    template = pystac.Collection(
+        id="senorge_temperature_daily",
+        description="test",
+        extent=pystac.Extent(
+            pystac.SpatialExtent([[0, 0, 0, 0]]),
+            pystac.TemporalExtent([[None, None]]),
+        ),
+    )
+    stac_services._build_collection_with_xstac(
+        artifact=_artifact(artifact_id="a1", dataset_id="senorge_temperature_daily"),
+        template=template,
+    )
+
+    assert seen["reference_system"] == 32633, (
+        "the xstac call must pass the store's CRS; 4326 here means the constant is back"
+    )
+
+
+def test_both_cube_paths_agree_on_reference_system() -> None:
+    """The static (no time axis) path must resolve the CRS the same way as the temporal one."""
+    ds = xr.Dataset(
+        {"tg": (("y", "x"), np.zeros((3, 4), dtype="float32"))},
+        coords={"y": [7000000.0, 6999000.0, 6998000.0], "x": [-74500.0, -73500.0, -72500.0, -71500.0]},
+        attrs={"proj:code": "EPSG:32633"},
+    )
+    dims = stac_services._build_static_cube_dimensions(ds, "x", "y")
+    expected = stac_services.reference_system_for("EPSG:32633")
+    assert dims["x"]["reference_system"] == expected
+    assert dims["y"]["reference_system"] == expected

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -1056,11 +1057,44 @@ def test_cf_extension_is_not_declared_when_no_cf_attrs_are_present(
         ("OGC:CRS84", 4326),  # a CRS84 alias is geographic WGS84
         ("CRS:84", 4326),
         (4326, 4326),  # a bare number, as canonical_crs_code accepts
-        ("+proj=utm +zone=33 +datum=WGS84", "+proj=utm +zone=33 +datum=WGS84"),
+        # A proj4 string that names a known CRS resolves to its EPSG code rather than being
+        # published verbatim: proj4 is neither WKT2 nor PROJJSON, so the string form of the
+        # field cannot carry it.
+        ("+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs +type=crs", 32633),
     ],
 )
 def test_reference_system_for_resolves_the_stores_own_crs(store_crs: str | int | None, expected: int | str) -> None:
     assert stac_services.reference_system_for(store_crs) == expected
+
+
+def test_reference_system_for_emits_wkt2_when_there_is_no_epsg_code() -> None:
+    """A CRS with no EPSG equivalent must be published as WKT2, never as proj4."""
+    # A rotated pole grid has no EPSG code, so this exercises the WKT2 branch.
+    proj4 = "+proj=ob_tran +o_proj=longlat +o_lat_p=90 +o_lon_p=0 +lon_0=0 +datum=WGS84 +no_defs +type=crs"
+    result = stac_services.reference_system_for(proj4)
+
+    assert isinstance(result, str)
+    assert not result.startswith("+proj="), "a proj4 string is not a valid reference_system"
+    # WKT2 opens with a CRS keyword; good enough to tell WKT from proj4 without parsing it.
+    assert result.split("[")[0].endswith("CRS") or result.startswith("GEOGCRS"), result[:60]
+
+
+def test_reference_system_for_falls_back_to_4326_and_warns_on_an_uninterpretable_crs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Nothing honest can be published for a CRS we cannot parse, so say so in the log."""
+    # `startup.py` sets `propagate = False` on the `open_climate_service` logger, so caplog's
+    # root handler never sees these records and `caplog.text` stays empty. Attaching its
+    # handler to the emitting logger works whatever the propagation policy is.
+    emitting = logging.getLogger(stac_services.__name__)
+    emitting.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("WARNING", logger=emitting.name):
+            assert stac_services.reference_system_for("not a coordinate reference system") == 4326
+    finally:
+        emitting.removeHandler(caplog.handler)
+
+    assert "Could not interpret CRS" in caplog.text
 
 
 def test_xstac_is_given_the_stores_crs_not_a_constant(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -686,7 +686,7 @@ def test_build_collection_with_xstac_reads_normalised_zarr_coordinates(tmp_path:
 
 
 def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: Path) -> None:
-    """Projected (non-built-in) stores get proj:wkt2 + open_climate_service:proj4 so map
+    """Projected (non-built-in) stores get proj:wkt2 + proj:projjson so map
     clients can reproject without a runtime epsg.io lookup."""
     zarr_path = tmp_path / "senorge_temperature_daily.zarr"
     ds = xr.Dataset(
@@ -713,8 +713,9 @@ def test_build_collection_emits_crs_render_hints_for_projected_store(tmp_path: P
     payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
 
     assert payload["proj:code"] == "EPSG:32633"
-    proj4 = payload["open_climate_service:proj4"]
-    assert "proj=utm" in proj4 and "zone=33" in proj4
+    # The non-standard proj4 hint is retired (CLIM-833): zarr-layer resolves the code
+    # through proj4's own registry, so only standard fields are published now.
+    assert "open_climate_service:proj4" not in payload
     assert payload["proj:wkt2"].startswith("PROJCRS")  # WKT2, not WKT1 (PROJCS)
     # proj:projjson — same CRS as a PROJJSON object (EPSG:32633 = UTM zone 33N)
     assert payload["proj:projjson"]["type"] == "ProjectedCRS"
@@ -910,8 +911,7 @@ def test_build_collection_crs_render_hints_use_store_wkt(tmp_path: Path) -> None
 
     payload = stac_services._build_collection_with_xstac(artifact=artifact, template=template)
 
-    proj4 = payload["open_climate_service:proj4"]
-    assert "proj=utm" in proj4 and "zone=33" in proj4
+    assert "open_climate_service:proj4" not in payload
     assert payload["proj:wkt2"].startswith("PROJCRS")
 
 


### PR DESCRIPTION
[CLIM-833](https://dhis2.atlassian.net/browse/CLIM-833) · [CLIM-1003](https://dhis2.atlassian.net/browse/CLIM-1003) · [CLIM-1004](https://dhis2.atlassian.net/browse/CLIM-1004)

Upgrades the map viewer's zarr-layer from 0.6.1 to 0.9.0, and takes the three fixes the upgrade unlocks or exposes, plus a guard against the metadata class behind the last of them.

**0.8.0 onwards reads the GeoZarr `spatial:*` attributes** rather than inferring geometry from the coordinate arrays. Placement then comes from the store instead of a guess, which is what makes the rest of this possible.

## Operators: pre-CLIM-852 stores must be reingested first

A store that declares its axes transposed renders as diagonal streaks in offset blocks, because that is what it asked for. Stores written before [CLIM-852](https://dhis2.atlassian.net/browse/CLIM-852) (2026-08-05) do exactly that, and 0.6.1 concealed it by ignoring these attributes entirely. Reingest before this reaches an instance with old data, or those datasets will look wrong. [CLIM-1008](https://dhis2.atlassian.net/browse/CLIM-1008) has the survey and records the decision to reingest rather than migrate.

This makes existing breakage visible rather than introducing it: any direct-Zarr consumer reading the conventions already gets a transposed grid from those stores. The viewer was the last client not looking.

Two Norway stores are the evidence that this is metadata and not the renderer — same CRS, same 1550×1195 grid, same 388×299 chunking, differing only in when they were written:

| store | written | `spatial:dimensions` | on 0.9.0 |
|---|---|---|---|
| `senorge_temperature_daily` | 2026-06-26 | `["x","y"]` | diagonal streaks |
| `senorge_precipitation_daily` | 2026-08-06 | `["y","x"]` | correct |

## CLIM-833 — drop the proj4 hint and the epsg.io fallback

0.8.0 resolves a CRS code through proj4's own registry, so a projected store no longer needs a proj4 definition handed to it. Removes the non-standard `open_climate_service:proj4` field, the viewer's read of it, the epsg.io fetch behind it, and the now-dead `crs_to_proj4`. Only standard `proj:wkt2` / `proj:projjson` / `proj:bbox` are published, and the only fetches left on the render path go to our own endpoints.

This does **not** depend on [carbonplan/zarr-layer#61](https://github.com/carbonplan/zarr-layer/issues/61), which is still open — the capability was checked directly. proj4 resolves a code only for what it ships: EPSG:4326, EPSG:3857 and every UTM zone, which covers all four CRSes in use (EPSG:4326 ×60, EPSG:32633 ×4, EPSG:32645 ×3, EPSG:3857 ×1) but not a national grid such as EPSG:27700 or EPSG:2154.

So the store now describes its CRS rather than naming it: both write paths publish `proj:wkt2` and `proj:projjson` beside `proj:code` for any non-built-in CRS, and proj4 parses either without a lookup. That makes dropping the external fetch safe for an arbitrary CRS, not only the ones proj4 happens to know, and it is what a direct-Zarr client needs anyway. Built-in codes keep the code alone.

The definition goes onto the cube's attrs as well as the store root. A client reads the `proj:` convention from the innermost source that declares any of it — data array, then level-0 group, then root — and level groups are written from the cube's attrs, so a root-only definition would sit behind a level-0 `proj:code` that shadows it.

## CLIM-1004 — publish each store's own reference_system

The xstac call hardcoded `reference_system=4326`, so every dataset declared its axes as degrees whatever the store used; seNorge's are UTM33 metres. The static (no time axis) path already read the store's `proj:code`, so the two paths disagreed on value *and* type — `4326` as a number versus `"EPSG:4326"` as a string. Both now go through `reference_system_for`, which returns the EPSG code as a number, else WKT2, and falls back to 4326 with a warning only when the CRS cannot be interpreted at all.

Tested at the call site rather than only on the helper, since the defect was a constant in the caller: reintroducing it makes the test fail.

## CLIM-1003 — select a time step by index explicitly

The viewer wrote a bare integer into `selector`, so zarr-layer tried to resolve it against the dimension's coordinate array first. A CF time axis holds raw offsets that never match a slider position, so every layer load did a wasted coordinate read and logged a resolution failure before falling through to treating a numeric value as the index — which was what we meant. It worked by accident, on a fallback [carbonplan/zarr-layer#87](https://github.com/carbonplan/zarr-layer/pull/87) is currently tightening.

All three writes to `selector` now go through one `indexSelection` helper so they cannot drift apart.

Verified by driving the real slider: the failure is gone, and step 0 vs the last step render differently and plausibly — 1990-01-01 cold blue with a warm coastal fringe, 2026-06-24 warm red. A disappearing warning alone would not have shown that the index selects the step it names.

## A write-time guard

`check_grid_description` refuses a write whose `spatial:dimensions` is not array order `(y, x)`, or whose `spatial:shape` disagrees with the array. Called from both write paths, and in the streaming one *after* `spec.attrs` is merged — a plugin's attrs land last and could otherwise reintroduce the bug past the guard.

It checks the dimension *names* and not just the shape, because `[n, n]` matches either way round: that is how Sri Lanka's four square stores would pass a shape-only check.

## Verified

- By eye against a live instance: seNorge (UTM33, no proj4, no epsg.io), CHIRPS3, ERA5-Land and `senorge_precipitation_daily` all render correctly with working time controls.
- `make lint` clean (ruff, mypy, pyright); 1192 tests pass.
- The three `test_openeo_execution` failures seen locally are a dependency artefact of a non-frozen sync (a newer pyproj returning `None` from `to_epsg()` on an authority-less WKT), not from this branch — CI is green.

## Not in this PR

- Reingesting the 39 pre-CLIM-852 stores — [CLIM-1008](https://dhis2.atlassian.net/browse/CLIM-1008).
- [CLIM-1006](https://dhis2.atlassian.net/browse/CLIM-1006) — CHIRPS3 streaks on the Rwanda instance, reported against 0.6.1, which never read these attributes. Separate and still open.


[CLIM-833]: https://dhis2.atlassian.net/browse/CLIM-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-1003]: https://dhis2.atlassian.net/browse/CLIM-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-1004]: https://dhis2.atlassian.net/browse/CLIM-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-852]: https://dhis2.atlassian.net/browse/CLIM-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-1008]: https://dhis2.atlassian.net/browse/CLIM-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
