### PR TITLE
chore(deps): refresh CI actions, maplibre and the lint toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Create .env from example
         run: cp .env.example .env
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         run: cp .env.example .env
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          # v10 defaults enable-cache to auto (v4 defaulted to false) and stops
+          # pruning the cache before saving. Installing from a cold cache takes
+          # 2-4s here, while saving the unpruned cache costs ~7s and 354 MB of
+          # the repo's shared 10 GB budget, so caching is a net loss.
+          enable-cache: false
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
           cache: pip
@@ -37,7 +37,7 @@ jobs:
 
       - run: mkdocs build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -48,5 +48,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: uv build --no-sources
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10
       - run: uv build --no-sources
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The client and `[xarray]` extras install with `pip` on any platform.
 from open_climate_service import ClimateService
 
 service = ClimateService("https://my-instance.example.org")
-datasets = service.datasets()                  # discover published collections
-ds = service.open_dataset(datasets[0]["id"])   # open as xarray (needs the [xarray] extra)
+datasets = service.datasets()  # discover published collections
+ds = service.open_dataset(datasets[0]["id"])  # open as xarray (needs the [xarray] extra)
 ```
 
 ## Run a server

--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -32,6 +32,7 @@ concurrency, store commits, artifact registration, and publication.
 import xarray as xr
 from open_climate_service.streaming import BaseDatasetPlugin, daily_period_ids, normalize_period
 
+
 class ENACTSRainfallPlugin(BaseDatasetPlugin):
     async def periods(self, start: str, end: str) -> list[str]:
         """Return the ordered list of period ids available between start and end."""
@@ -99,6 +100,7 @@ class SeNorgePlugin(BaseDatasetPlugin):
 
     def fetch_period(self, period_id, bbox, **params):
         import rioxarray  # noqa: F401  # activates the .rio accessor for write_crs
+
         ds = read_source(period_id).rio.write_crs(self.crs)
         return normalize_period(ds, variable="tg", bbox=bbox)
 ```
@@ -221,9 +223,9 @@ Your plugin clips to what it actually publishes:
 
 ```python
 async def periods(self, start: str, end: str) -> list[str]:
-    base = date.fromisoformat(start[:10])           # core resolves this to today
+    base = date.fromisoformat(start[:10])  # core resolves this to today
     days = [(base + timedelta(days=i)).isoformat() for i in range(self.max_lead_days)]
-    return [d for d in days if d <= end[:10]]       # clip to the requested window
+    return [d for d in days if d <= end[:10]]  # clip to the requested window
 ```
 
 Note `end` stays a plain `str`, so there is no missing-value case to handle.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,8 +163,7 @@ from open_climate_service.streaming import BaseDatasetPlugin
 
 
 class MyStreamingPlugin(BaseDatasetPlugin):
-    async def periods(self, start: str, end: str) -> list[str]:
-        ...
+    async def periods(self, start: str, end: str) -> list[str]: ...
 
     def fetch_period(self, period_id: str, bbox: list[float], **params) -> xr.Dataset:
         # A plain (blocking) method run in a worker thread, or `async def` for a
@@ -195,6 +194,7 @@ ingestion:
 
 ```python
 from open_climate_service.process import process
+
 
 @process(summary="My custom index")
 def my_index(data: xr.DataArray, thresh: float = 0.5) -> xr.DataArray:

--- a/docs/climate_indices.md
+++ b/docs/climate_indices.md
@@ -51,12 +51,15 @@ precip = conn.load_collection(
     temporal_extent=["2000-01-01", "2023-12-31"],
 )
 
-spi3 = precip.process("spi", arguments={
-    "pr": precip,
-    "window": 3,
-    "cal_start": "2000-01-01",
-    "cal_end": "2020-12-31",
-})
+spi3 = precip.process(
+    "spi",
+    arguments={
+        "pr": precip,
+        "window": 3,
+        "cal_start": "2000-01-01",
+        "cal_end": "2020-12-31",
+    },
+)
 
 job = spi3.save_result("Zarr").create_job()
 job.start_and_wait()
@@ -125,13 +128,16 @@ tmax.process("tx_days_above", arguments={"tasmax": tmax, "thresh": "35 degC", "f
 
 ```python
 # Annual count of heat waves (≥3 consecutive days with Tmax>35°C and Tmin>20°C)
-tmax.process("heat_wave_frequency", arguments={
-    "tasmin": tmin,
-    "tasmax": tmax,
-    "thresh_tasmin": "20 degC",
-    "thresh_tasmax": "35 degC",
-    "freq": "YS",
-})
+tmax.process(
+    "heat_wave_frequency",
+    arguments={
+        "tasmin": tmin,
+        "tasmax": tmax,
+        "thresh_tasmin": "20 degC",
+        "thresh_tasmax": "35 degC",
+        "freq": "YS",
+    },
+)
 ```
 
 ---
@@ -189,6 +195,7 @@ The auto-registered xclim processes can be overridden per-instance by placing a 
 import xarray as xr
 import xclim.indicators.atmos as xclim_atmos
 from open_climate_service.process import process
+
 
 @process(summary="Consecutive dry days (Rwanda threshold)")
 def cdd(pr: xr.DataArray, thresh: str = "0.5 mm/day", freq: str = "MS") -> xr.DataArray:

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -47,6 +47,7 @@ Custom processes are Python functions decorated with `@process` and placed in `p
 import xarray as xr
 from open_climate_service.process import process
 
+
 @process(summary="Precipitation anomaly relative to a baseline mean")
 def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray:
     """Deviation of precipitation from a long-term baseline mean."""
@@ -60,8 +61,7 @@ The `@process` decorator derives the process id (function name), summary, parame
     summary="Precipitation anomaly relative to a baseline mean",
     parameters={"baseline": {"description": "Long-term mean precipitation (kg m-2 s-1)."}},
 )
-def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray:
-    ...
+def precip_anomaly(pr: xr.DataArray, baseline: float = 0.0) -> xr.DataArray: ...
 ```
 
 A plugin process with the same id as an existing process overrides it. The server must be restarted to pick up new process files. For built-in climate indices, see [Climate indices](climate_indices.md).
@@ -156,18 +156,20 @@ Calling the workflow from any openEO client:
 import openeo
 
 conn = openeo.connect("http://your-instance:9000")
-job = conn.execute_batch_job({
-    "process_graph": {
-        "result": {
-            "process_id": "monthly_rainfall",
-            "arguments": {
-                "collection_id": "chirps_rainfall_daily",
-                "temporal_extent": ["2020-01-01", "2023-12-31"]
-            },
-            "result": true
+job = conn.execute_batch_job(
+    {
+        "process_graph": {
+            "result": {
+                "process_id": "monthly_rainfall",
+                "arguments": {
+                    "collection_id": "chirps_rainfall_daily",
+                    "temporal_extent": ["2020-01-01", "2023-12-31"],
+                },
+                "result": true,
+            }
         }
     }
-})
+)
 ```
 
 Workflow JSON files are loaded on each request to `GET /process_graphs`, so changes on disk take effect without restarting the server. A plugin workflow with the same `id` as a built-in overrides it.

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -314,9 +314,7 @@ curl -s http://127.0.0.1:9000/zarr/chirps3_precipitation_daily/zarr.json | jq
 ```python
 import icechunk, xarray as xr
 
-repo = icechunk.Repository.open(
-    icechunk.http_storage("http://127.0.0.1:9000/icechunk/chirps3_precipitation_daily")
-)
+repo = icechunk.Repository.open(icechunk.http_storage("http://127.0.0.1:9000/icechunk/chirps3_precipitation_daily"))
 ds = xr.open_zarr(repo.readonly_session("main").store, zarr_format=3, consolidated=False)
 ```
 

--- a/docs/openeo.md
+++ b/docs/openeo.md
@@ -131,6 +131,7 @@ job.start_job()
 
 # Poll until finished
 import time
+
 while (status := job.status()) not in ("finished", "error"):
     print("status:", status)
     time.sleep(2)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -52,8 +52,8 @@ for link in service.datasets():
     print(link["id"], "—", link["title"])
 
 # List the processes and reusable workflows the instance exposes
-service.processes()    # standard openEO processes
-service.workflows()    # stored workflows / UDPs (e.g. aggregate_to_dhis2_json)
+service.processes()  # standard openEO processes
+service.workflows()  # stored workflows / UDPs (e.g. aggregate_to_dhis2_json)
 
 # Run a process graph synchronously. JSON results (e.g. a DHIS2 dataValueSet) come
 # back as a dict; file results (CSV, GeoJSON, GeoTIFF) come back as bytes.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -358,15 +358,17 @@ from openeo import connect
 
 conn = connect("http://127.0.0.1:9000")
 
-result = conn.execute({
-    "process_graph": {
-        "1": {
-            "process_id": "monthly_precipitation",
-            "arguments": { "collection_id": "chirps3_precipitation_daily" },
-            "result": True
+result = conn.execute(
+    {
+        "process_graph": {
+            "1": {
+                "process_id": "monthly_precipitation",
+                "arguments": {"collection_id": "chirps3_precipitation_daily"},
+                "result": True,
+            }
         }
     }
-})
+)
 ```
 
 ### JavaScript (openEO JS client)

--- a/docs/zarr_and_geozarr.md
+++ b/docs/zarr_and_geozarr.md
@@ -274,9 +274,7 @@ SDK usage:
 ```python
 import icechunk, xarray as xr
 
-repo = icechunk.Repository.open(
-    icechunk.http_storage("https://host/icechunk/era5land_precipitation_daily")
-)
+repo = icechunk.Repository.open(icechunk.http_storage("https://host/icechunk/era5land_precipitation_daily"))
 ds = xr.open_zarr(repo.readonly_session("main").store, zarr_format=3, consolidated=False)
 ```
 

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -69,7 +69,7 @@ def _append_vary_value(response: Response, value: str) -> None:
 
 
 @asynccontextmanager
-async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Run lightweight startup recovery hooks for the application lifecycle."""
     from open_climate_service.plugins_diagnostics import log_plugin_loading
 

--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Map viewer — {{ name }}</title>
-    <link href="https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.css" rel="stylesheet" />
+    <link href="https://unpkg.com/maplibre-gl@6.7.0/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
       *,
       *::before,
@@ -249,7 +249,7 @@
       // worker is a real sibling URL (`./maplibre-gl-worker.mjs`) resolved from
       // import.meta.url, and esm.sh's transformed build doesn't serve it (404), which
       // blanks the map. unpkg serves the worker + shared chunk siblings with CORS.
-      import * as maplibregl from "https://unpkg.com/maplibre-gl@6.0.0/dist/maplibre-gl.mjs";
+      import * as maplibregl from "https://unpkg.com/maplibre-gl@6.7.0/dist/maplibre-gl.mjs";
       import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.6.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,9 +216,9 @@ dev = [
     "httpx>=0.28.0",
     "mypy>=1.19.1",
     "pandas-stubs>=2.3,<3",
-    "pyright>=1.1.408",
-    "pytest>=9.0.3",
-    "ruff>=0.15.2",
+    "pyright>=1.1.411",
+    "pytest>=9.1.1",
+    "ruff>=0.16.6",
     "types-shapely>=2.1,<3",
     "watchfiles>=1.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1880,9 +1880,9 @@ dev = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pandas-stubs", specifier = ">=2.3,<3" },
-    { name = "pyright", specifier = ">=1.1.408" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "ruff", specifier = ">=0.15.2" },
+    { name = "pyright", specifier = ">=1.1.411" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.16.6" },
     { name = "types-shapely", specifier = ">=2.1,<3" },
     { name = "watchfiles", specifier = ">=1.2.0" },
 ]
@@ -1951,7 +1951,7 @@ name = "oschmod"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/64/6e522f0a1b500470ae14dcd1a4bb8f8751f5cf441e85e9fee7dfc712cb7b/oschmod-0.3.12.tar.gz", hash = "sha256:bec99216f31615ee653b2a5c87cacfb4e4b6184c0e9f71da186300dacae974f3", size = 20064, upload-time = "2020-10-30T00:38:42.409Z" }
 wheels = [
@@ -2605,15 +2605,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -2644,7 +2644,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2653,9 +2653,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -2934,27 +2934,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.2"
+version = "0.16.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
-    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
-    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
-    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
-    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three groups of upgrade with no runtime risk to the service.

**GitHub Actions** — `checkout` v4→v7, `setup-python` v5→v7, `setup-uv` v4→v10, `upload-pages-artifact` v3→v5, `deploy-pages` v4→v5.

Every CI run has been printing *"Node.js 20 is deprecated … being forced to run on Node.js 24"* for three of these, so that forcing was already load-bearing. `setup-uv` was also inconsistent — v4 in `ci.yml`, v5 in `publish.yml`; both are v10 now. I checked v10's inputs before bumping: `version` still exists and still accepts `"latest"`.

**maplibre-gl 6.0.0 → 6.7.0** — the same invisible drift as the zarr-layer pin in #368: a version inside a CDN URL is not a declared dependency, so no tool reports it. Both the ESM and CSS paths confirmed present at 6.7.0.

**Lint toolchain** — ruff 0.15.2→0.16.6, pyright 1.1.408→1.1.411, pytest 9.0.3→9.1.1. Floors raised in `pyproject.toml` so a relock cannot drift back; the lock moved only those three.

Both tool bumps found real work rather than passing quietly:

- ruff 0.16's formatter reformats **10 files**. Mechanical, no logic touched.
- pyright 1.1.411 flags `@asynccontextmanager` with an `AsyncIterator` return as deprecated. `_lifespan` now returns `AsyncGenerator[None]`, which is what the decorator has wanted since the deprecation.

Full chain green: `ruff check`, `ruff format`, mypy across 100 files, pyright at 0 errors. Suite unchanged at 1175 passing.

## Deliberately excluded

80 packages are outdated overall, 31 of them direct. These want their own work rather than a sweep:

- **pandas 2.3 → 3.0** — copy-on-write; touches the CHAP CSV and DHIS2 export paths.
- **xarray 2025.12 → 2026.7** — seven months of releases on the core abstraction.
- **mypy 1.19 → 2.3** — will surface a pile of new type errors.
- **starlette 1.3 → 1.6** with fastapi and uvicorn — this one touches `root_path` and `redirect_slashes`, which is exactly where the URL work in #365 lives. Worth doing *against those tests* rather than blind.
- **xclim 0.61 → 0.62** — auto-registers the 176 indicators, so a bump changes the published process catalogue.
- **topozarr 0.1.4 → 0.1.8** — looked at separately, because 0.1.5–0.1.8 shipped work in the area CLIM-879 is blocked on, and 0.1.6 renamed `source_chunks` to `source_chunk_sizes`.
