### PR TITLE
feat(automation): reference a declared feature set from a workflow trigger

### DIFF
--- a/climate-service.yaml.example
+++ b/climate-service.yaml.example
@@ -33,7 +33,8 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 #       publish: true
 #       max_attempts: 3
 
-# Named geometry sets live in plugins/features/*.yaml templates, not here -- see the instance guide.
+# Named geometry sets live in plugins/features/*.yaml templates, not here -- see the instance
+# guide. A trigger references one by id with {from_features: <id>} instead of inline GeoJSON.
 
 # Event-driven workflows are separate from cron schedules. Every trigger whose `on_update_of`
 # matches a successful dataset update creates an independent openEO workflow job.
@@ -45,7 +46,7 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 #       arguments:
 #         dataset_id: $event.dataset_id
 #         temporal_extent: [$event.previous_end, $event.current_end]
-#         geometries: {type: FeatureCollection, features: []}
+#         geometries: {from_features: districts}   # or an inline FeatureCollection for ad-hoc calls
 #         period_type: day
 #       replay_existing: false  # default: do not backfill events predating this trigger
 #
@@ -55,7 +56,7 @@ data_dir: ./data   # required — directory for downloaded NetCDF files and Zarr
 #       arguments:
 #         dataset_id: $event.dataset_id
 #         temporal_extent: [$event.previous_end, $event.current_end]
-#         geometries: {type: FeatureCollection, features: []}
+#         geometries: {from_features: districts}
 #         data_element_id: BXgDHhPdFVU
 #         period_type: day
 

--- a/docs/instance_guide.md
+++ b/docs/instance_guide.md
@@ -240,6 +240,28 @@ plugins/features/
 
 A template with no `provider` carries metadata only: nothing refreshes the file, and it exists so a collection an admin placed can still declare its licence.
 
+A trigger then references the id instead of carrying geometry:
+
+```yaml
+automation:
+  workflow_triggers:
+    - id: chirps-to-dhis2
+      on_update_of: chirps3_precipitation_daily
+      workflow_id: aggregate_to_dhis2_json
+      arguments:
+        geometries: { from_features: districts }
+```
+
+At submission this becomes a `load_features` **node** in the process graph, referenced by the workflow — not a copy of the geometry:
+
+```json
+{"features_districts": {"process_id": "load_features", "arguments": {"id": "districts"}},
+ "workflow": {"process_id": "aggregate_to_dhis2_json",
+              "arguments": {"geometries": {"from_node": "features_districts"}}, "result": true}}
+```
+
+The job's description records which version of each set it ran against (`against features districts@release-2026-09`), which is what explains why one run covered 47 districts and the next covered 48.
+
 There is **one** store, `<data_dir>/features/`. A provider-backed set updates its entry there rather than filling a separate cache — the same shape as a dataset plugin writing into `downloads/`. Each provider-maintained entry gets a JSON sidecar recording the runtime facts: provider, version and fetch time. A file an admin drops in has no sidecar, and a provider refuses to overwrite it.
 
 The `stored` provider reads that same store, so an instance with no external system configured can still declare feature sets and schedule aggregation against boundaries it ships itself.

--- a/open_climate_service/automation/service.py
+++ b/open_climate_service/automation/service.py
@@ -153,6 +153,97 @@ def _iter_strings(value: Any) -> Any:
             yield from _iter_strings(item)
 
 
+FROM_FEATURES = "from_features"
+"""Trigger-argument key naming a declared feature set instead of carrying its geometry."""
+
+
+def _feature_node_name(feature_id: str) -> str:
+    """The graph node that resolves one feature set. Stable, so two references share one node."""
+    return f"features_{feature_id}"
+
+
+def _resolve_feature_references(value: Any, nodes: dict[str, Any] | None = None) -> Any:
+    """Rewrite ``{"from_features": "districts"}`` into a reference to a `load_features` node.
+
+    Geometry must not be resolved here. The rewritten arguments are copied verbatim into the
+    submitted process graph, which is persisted in the job record — so producing a FeatureCollection
+    at this point would write a country's whole hierarchy into ``jobs.json`` on every scheduled run,
+    which is the problem the reference exists to remove.
+
+    The reference is emitted as ``{"from_node": ...}`` with the `load_features` call added to
+    ``nodes`` as a sibling, **not** as an inline ``{"process_id": ...}`` dict in the argument.
+    An inline process dict is not evaluated: the graph parser passes it through untouched, so
+    `aggregate_spatial` would receive the dict itself and try to read it as GeoJSON. Only a
+    ``from_node`` reference becomes a `ResultReference` the executor resolves.
+    """
+    if isinstance(value, list):
+        return [_resolve_feature_references(item, nodes) for item in value]
+    if not isinstance(value, dict):
+        return value
+    if set(value) == {FROM_FEATURES} and isinstance(value[FROM_FEATURES], str):
+        feature_id = value[FROM_FEATURES]
+        name = _feature_node_name(feature_id)
+        if nodes is not None:
+            nodes[name] = {"process_id": "load_features", "arguments": {"id": feature_id}}
+        return {"from_node": name}
+    return {key: _resolve_feature_references(item, nodes) for key, item in value.items()}
+
+
+def _feature_provenance(arguments: Any) -> str:
+    """Describe the feature versions this job runs against, for the job's own record.
+
+    Refreshing here rather than only at execution is what makes the description meaningful: it names
+    the version the store actually holds when the job is submitted, which is what explains why one
+    run covered 47 districts and the next covered 48.
+
+    Best-effort. A provider that is briefly unreachable should delay the fetch to execution, not
+    fail the submission — and a job with no provenance line is a smaller problem than a schedule
+    that stops dispatching.
+    """
+    from open_climate_service.features import resolver
+
+    parts = []
+    for feature_id in sorted(set(_iter_feature_references(arguments))):
+        try:
+            parts.append(f"{feature_id}@{resolver.ensure_current(feature_id)}")
+        except Exception:
+            logger.warning("Could not refresh feature set '%s' at submission", feature_id, exc_info=True)
+            parts.append(f"{feature_id}@unresolved")
+    return f" against features {', '.join(parts)}" if parts else ""
+
+
+def _validate_feature_references(config: AutomationConfig) -> None:
+    """Refuse a `from_features` reference to an id the instance does not declare.
+
+    Checked at startup rather than at fire time: a typo in a schedule should be a boot error, not a
+    job that fails at 3am on the first trigger.
+    """
+    from open_climate_service.features.config import get_feature_templates
+
+    declared = {template.id for template in get_feature_templates().templates}
+    for trigger in config.workflow_triggers:
+        for feature_id in _iter_feature_references(trigger.arguments):
+            if feature_id not in declared:
+                available = ", ".join(sorted(declared)) or "none"
+                raise ValueError(
+                    f"Workflow trigger {trigger.id!r} references feature {feature_id!r}, "
+                    f"which is not declared under `features:`. Declared: {available}"
+                )
+
+
+def _iter_feature_references(value: Any) -> Any:
+    """Yield every feature id referenced by a `from_features` key in a nested structure."""
+    if isinstance(value, list):
+        for item in value:
+            yield from _iter_feature_references(item)
+    elif isinstance(value, dict):
+        if set(value) == {FROM_FEATURES} and isinstance(value[FROM_FEATURES], str):
+            yield value[FROM_FEATURES]
+            return
+        for item in value.values():
+            yield from _iter_feature_references(item)
+
+
 def _validate_event_references(config: AutomationConfig) -> None:
     """Refuse arguments that look like event references but are not the known tokens.
 
@@ -195,6 +286,7 @@ class WorkflowAutomationService:
                 raise ValueError(f"Workflow trigger {trigger.id!r} references unknown workflow {trigger.workflow_id!r}")
         _validate_output_ownership(self._config)
         _validate_event_references(self._config)
+        _validate_feature_references(self._config)
         if api_config.is_read_only():
             return
         activations = _load_activations()
@@ -254,17 +346,21 @@ class WorkflowAutomationService:
     def _submit(self, trigger: WorkflowTrigger, event: JobEvent, service: OpenEOJobService) -> None:
         """Create and start the deterministic job for one trigger/event pair."""
         dataset_id = event.data.get("dataset_id")
-        arguments = _resolve_event_values(trigger.arguments, event)
+        resolved = _resolve_event_values(trigger.arguments, event)
+        provenance = _feature_provenance(resolved)
+        feature_nodes: dict[str, Any] = {}
+        arguments = _resolve_feature_references(resolved, feature_nodes)
         body = OpenEOJobCreate(
             title=f"{trigger.workflow_id} after {dataset_id} update",
-            description=f"Triggered by {event.event_id} using automation rule {trigger.id}",
+            description=f"Triggered by {event.event_id} using automation rule {trigger.id}{provenance}",
             process={
                 "process_graph": {
+                    **feature_nodes,
                     "workflow": {
                         "process_id": trigger.workflow_id,
                         "arguments": arguments,
                         "result": True,
-                    }
+                    },
                 }
             },
         )

--- a/tests/test_feature_triggers.py
+++ b/tests/test_feature_triggers.py
@@ -151,3 +151,80 @@ def test_a_trigger_referencing_an_undeclared_feature_fails_at_startup(
     )
     with pytest.raises(ValueError, match="references feature 'distrcits'.*Declared: districts"):
         automation_service._validate_feature_references(config)
+
+
+# --- the trigger actually firing -----------------------------------------------------------------
+
+
+def _event() -> Any:
+    from datetime import UTC, datetime
+
+    from open_climate_service.jobs.models import DATASET_UPDATED_EVENT_TYPE, JobEvent
+
+    return JobEvent(
+        event_id="native-job:0",
+        time=datetime(2026, 8, 19, tzinfo=UTC),
+        type=DATASET_UPDATED_EVENT_TYPE,
+        source="/datasets/chirps",
+        data={
+            "dataset_id": "chirps",
+            "artifact_id": "artifact-2",
+            "action": "append",
+            "previous_end": "2026-08-17",
+            "current_end": "2026-08-18",
+        },
+    )
+
+
+def test_a_dataset_update_submits_a_job_carrying_the_feature_node(
+    instance: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: an event fires a trigger, and the submitted job names the set rather than carrying it.
+
+    The unit tests cover the rewrite and that its output parses; this covers the dispatch that uses
+    it, which is the whole point of the trigger integration.
+    """
+    from unittest.mock import MagicMock
+
+    from open_climate_service.automation.config import AutomationConfig, WorkflowTrigger
+    from open_climate_service.automation.service import WorkflowAutomationService
+
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    _register(monkeypatch, "counting", lambda **_: (_collection(["MW.N", "MW.S"]), "release-9"))
+
+    config = AutomationConfig(
+        workflow_triggers=[
+            WorkflowTrigger(
+                id="chirps-to-dhis2",
+                on_update_of="chirps",
+                workflow_id="aggregate_to_dhis2_json",
+                arguments={
+                    "dataset_id": "$event.dataset_id",
+                    "temporal_extent": ["$event.previous_end", "$event.current_end"],
+                    "geometries": {"from_features": "districts"},
+                },
+            )
+        ]
+    )
+    openeo = MagicMock()
+    record = MagicMock()
+    record.id = "triggered-job"
+    openeo.create_triggered_job.return_value = (record, True)
+
+    service = WorkflowAutomationService(config_loader=lambda: config, openeo_service=openeo)
+    service.consume([_event()])
+
+    body = openeo.create_triggered_job.call_args.args[0]
+    graph = body.process["process_graph"]
+
+    # The feature set is a sibling node the executor can resolve, referenced by the workflow.
+    assert graph["features_districts"] == {"process_id": "load_features", "arguments": {"id": "districts"}}
+    assert graph["workflow"]["arguments"]["geometries"] == {"from_node": "features_districts"}
+    assert graph["workflow"]["arguments"]["dataset_id"] == "chirps", "event references still resolve"
+
+    # No geometry anywhere in what gets persisted.
+    assert "coordinates" not in str(body.process)
+
+    # And the job says which boundaries it ran against.
+    assert "districts@release-9" in body.description
+    openeo.start_triggered_job.assert_called_once_with("triggered-job")

--- a/tests/test_feature_triggers.py
+++ b/tests/test_feature_triggers.py
@@ -1,0 +1,153 @@
+"""Referencing a declared feature set from a workflow trigger (CLIM-926).
+
+The trigger layer's job is to turn `{"from_features": "districts"}` into something the process graph
+can resolve, *without* putting geometry into the persisted job record. These cover both halves of
+that: the rewrite produces a node the executor evaluates, and the job still records which version of
+each set it ran against.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from shapely.geometry import Polygon
+
+from open_climate_service.automation import service as automation_service
+from open_climate_service.automation.config import AutomationConfig
+from open_climate_service.features.config import FeatureTemplates
+from open_climate_service.features.provider import feature_provider
+
+_NORTH = Polygon([(0, 2), (4, 2), (4, 4), (0, 4)])
+_SOUTH = Polygon([(0, 0), (4, 0), (4, 2), (0, 2)])
+
+
+def _collection(ids: list[Any]) -> dict[str, Any]:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "id": ids[0], "properties": {}, "geometry": _NORTH.__geo_interface__},
+            {"type": "Feature", "id": ids[1], "properties": {}, "geometry": _SOUTH.__geo_interface__},
+        ],
+    }
+
+
+@pytest.fixture
+def instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr("open_climate_service.data_manager.services.downloader.DOWNLOAD_DIR", tmp_path / "downloads")
+    monkeypatch.setattr("open_climate_service.config.get_data_root", lambda: tmp_path)
+    (tmp_path / "features").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _declare(monkeypatch: pytest.MonkeyPatch, *templates: dict[str, Any]) -> None:
+    loaded = FeatureTemplates.model_validate({"templates": list(templates)})
+    monkeypatch.setattr("open_climate_service.features.config.get_feature_templates", lambda: loaded)
+    monkeypatch.setattr("open_climate_service.features.resolver.get_feature_templates", lambda: loaded)
+
+
+def _register(monkeypatch: pytest.MonkeyPatch, name: str, func: Any) -> None:
+    decorated = feature_provider(name)(func)
+    monkeypatch.setattr("open_climate_service.features.provider.registry", lambda: {name: decorated})
+
+
+def test_a_trigger_reference_becomes_a_node_not_geometry(instance: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: the persisted process graph names the set, it does not carry polygons."""
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    _register(monkeypatch, "counting", lambda **_: _collection(["MW.N", "MW.S"]))
+
+    nodes: dict[str, Any] = {}
+    resolved = automation_service._resolve_feature_references(
+        {"dataset_id": "chirps", "geometries": {"from_features": "districts"}}, nodes
+    )
+
+    assert resolved["dataset_id"] == "chirps"
+    assert resolved["geometries"] == {"from_node": "features_districts"}
+    assert nodes == {"features_districts": {"process_id": "load_features", "arguments": {"id": "districts"}}}
+    assert "coordinates" not in str(resolved) + str(nodes), "geometry must not reach the job record"
+
+
+def test_the_reference_is_a_node_the_executor_actually_resolves(
+    instance: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An inline `{"process_id": ...}` in an argument is *not* evaluated — it is passed through.
+
+    The graph parser leaves such a dict untouched, so `aggregate_spatial` would receive it and try
+    to read it as GeoJSON. Only a sibling node plus `from_node` becomes a `ResultReference` the
+    executor resolves, so this asserts the wiring is that shape rather than the inline one.
+    """
+    from openeo_pg_parser_networkx import OpenEOProcessGraph
+    from openeo_pg_parser_networkx.pg_schema import ResultReference
+
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    _register(monkeypatch, "counting", lambda **_: _collection(["MW.N", "MW.S"]))
+
+    nodes: dict[str, Any] = {}
+    arguments = automation_service._resolve_feature_references({"geometries": {"from_features": "districts"}}, nodes)
+    graph = {"process_graph": {**nodes, "workflow": {"process_id": "add", "arguments": arguments, "result": True}}}
+
+    parsed = OpenEOProcessGraph(pg_data=graph)
+    workflow = next(attrs for _, attrs in parsed.nodes if attrs["process_id"] == "add")
+
+    assert isinstance(workflow["resolved_kwargs"]["geometries"], ResultReference)
+
+
+def test_the_job_records_which_feature_version_it_ran_against(instance: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explaining why one run covered 47 districts and the next covered 48 needs the version."""
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    _register(monkeypatch, "counting", lambda **_: (_collection(["MW.N", "MW.S"]), "release-2026-09"))
+
+    provenance = automation_service._feature_provenance({"geometries": {"from_features": "districts"}})
+
+    assert provenance == " against features districts@release-2026-09"
+
+
+def test_an_unreachable_provider_does_not_fail_the_submission(instance: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A schedule that stops dispatching is worse than a job with no provenance line."""
+
+    def unreachable(**_: Any) -> dict[str, Any]:
+        raise ConnectionError("DHIS2 unreachable")
+
+    _declare(monkeypatch, {"id": "districts", "provider": "flaky"})
+    _register(monkeypatch, "flaky", unreachable)
+
+    assert automation_service._feature_provenance({"geometries": {"from_features": "districts"}}) == (
+        " against features districts@unresolved"
+    )
+
+
+def test_the_rewritten_node_stays_small(instance: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A level-3 hierarchy is megabytes; the record that replaces it must not grow with it."""
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    _register(monkeypatch, "counting", lambda **_: _collection(["MW.N", "MW.S"]))
+
+    resolved = automation_service._resolve_feature_references({"geometries": {"from_features": "districts"}})
+
+    assert len(str(resolved)) < 200
+
+
+def test_a_literal_argument_is_left_alone(instance: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _declare(monkeypatch, {"id": "districts", "provider": "counting"})
+    inline = {"type": "FeatureCollection", "features": []}
+    assert automation_service._resolve_feature_references({"geometries": inline}) == {"geometries": inline}
+    assert automation_service._resolve_feature_references({"from_features": 3}) == {"from_features": 3}
+
+
+def test_a_trigger_referencing_an_undeclared_feature_fails_at_startup(
+    instance: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo in a schedule should be a boot error, not a job that fails at 3am."""
+    _declare(monkeypatch, {"id": "districts", "provider": "stored"})
+    config = AutomationConfig.model_validate(
+        {
+            "workflow_triggers": [
+                {
+                    "id": "t",
+                    "on_update_of": "chirps",
+                    "workflow_id": "w",
+                    "arguments": {"geometries": {"from_features": "distrcits"}},
+                }
+            ]
+        }
+    )
+    with pytest.raises(ValueError, match="references feature 'distrcits'.*Declared: districts"):
+        automation_service._validate_feature_references(config)


### PR DESCRIPTION
The scheduling half of [CLIM-926](https://dhis2.atlassian.net/browse/CLIM-926). **Stacked on #371**, which defines what a feature set is — the diff below is this change alone.

A trigger can only take geometry inline. A country's hierarchy is megabytes, it would have to live in `climate-service.yaml`, and trigger arguments are copied verbatim into the submitted process graph — so every scheduled run would write another copy into `jobs.json`.

## What this does

```yaml
automation:
  workflow_triggers:
    - id: chirps-to-dhis2
      on_update_of: chirps3_precipitation_daily
      workflow_id: aggregate_to_dhis2_json
      arguments:
        geometries: { from_features: districts }
```

At submission that becomes a node the workflow references:

```json
{"features_districts": {"process_id": "load_features", "arguments": {"id": "districts"}},
 "workflow": {"process_id": "aggregate_to_dhis2_json",
              "arguments": {"geometries": {"from_node": "features_districts"}}, "result": true}}
```

## Worth a reviewer's attention

- **Geometry must not resolve here.** `_submit` copies resolved arguments into the process graph, which is persisted — producing a `FeatureCollection` at this point puts the hierarchy in the job record on every run.
- **A sibling node, not an inline process dict.** An inline `{"process_id": ...}` written as an argument value is never evaluated: the parser passes it through, and `aggregate_spatial` receives the dict. Only `{"from_node": ...}` becomes a `ResultReference` the executor resolves.
- **Provenance without geometry.** The job description records the version each set held at submission — `against features districts@release-2026-09` — which is what explains why one run covered 47 districts and the next 48.
- **Failures are deliberately asymmetric.** An unreachable provider leaves `@unresolved` and the submission proceeds, because a schedule that stops dispatching is worse than a job with no provenance line. A trigger naming an undeclared feature id fails at *startup* — that is a typo in a schedule, and it should not wait until 3am.

## Tests

`tests/test_feature_triggers.py`, 8 tests, including an event firing a trigger end to end. `make lint` clean. Full suite passes, apart from 3 pre-existing failures in `test_openeo_execution.py` from a local PROJ install, identical on `main`.


[CLIM-926]: https://dhis2.atlassian.net/browse/CLIM-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ