### PR TITLE
fix(process): resolve string annotations so parameters publish a schema

### DIFF
--- a/open_climate_service/plugins/processes/climatological_normal.py
+++ b/open_climate_service/plugins/processes/climatological_normal.py
@@ -25,6 +25,7 @@ _FREQUENCIES = ("dayofyear", "month")
 @process(
     summary="Climatological normal (day-of-year or month-of-year)",
     parameters={
+        "data": {"description": "A raster data cube with a temporal dimension."},
         "frequency": {"description": "Climatology resolution: 'dayofyear' (1..366, default) or 'month' (1..12)."},
         "smoothing_window": {
             "description": (

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -76,12 +76,33 @@ def _resolved_annotations(fn: Any) -> dict[str, Any]:
     untyped field with nothing to validate against.
 
     Resolution needs the module's namespace and can fail on a type imported only under
-    `TYPE_CHECKING`. That falls back to the raw annotations rather than dropping the process.
+    `TYPE_CHECKING`.
+
+    `get_type_hints` resolves the whole mapping atomically, so a single unresolvable name would
+    cost *every* parameter its schema — a plugin annotating one exotic type would publish an
+    untyped contract for its ordinary `str` and `int` parameters too. So a failure degrades to
+    resolving each annotation on its own, and only the ones that genuinely cannot be resolved
+    are left out. Omitting a name is what the caller wants: it falls back to the raw string
+    annotation, which maps to an empty schema for that parameter alone.
     """
     try:
         return typing.get_type_hints(fn)
-    except Exception:  # noqa: BLE001 — an unresolvable hint is not worth losing the process over
-        return {}
+    except Exception:  # noqa: BLE001 — fall through to per-annotation resolution below
+        pass
+
+    # Same operation `get_type_hints` performs internally, against the function's own module
+    # globals — the strings come from the plugin's source, so this is no wider a trust boundary.
+    globalns = getattr(fn, "__globals__", {})
+    resolved: dict[str, Any] = {}
+    for name, annotation in getattr(fn, "__annotations__", {}).items():
+        if not isinstance(annotation, str):
+            resolved[name] = annotation
+            continue
+        try:
+            resolved[name] = eval(annotation, globalns)  # noqa: S307 — see above
+        except Exception:  # noqa: BLE001, S112 — one unresolvable name costs only its own schema
+            continue
+    return resolved
 
 
 @overload

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -39,20 +39,6 @@ def _annotation_to_schema(ann: Any) -> dict[str, Any]:
     return {}
 
 
-@overload
-def process(func: F) -> F: ...
-
-
-@overload
-def process(
-    func: None = None,
-    *,
-    summary: str | None = None,
-    description: str | None = None,
-    parameters: dict[str, dict[str, Any]] | None = None,
-) -> Callable[[F], F]: ...
-
-
 def _resolved_annotations(fn: Any) -> dict[str, Any]:
     """A function's annotations as objects rather than strings.
 
@@ -68,6 +54,20 @@ def _resolved_annotations(fn: Any) -> dict[str, Any]:
         return typing.get_type_hints(fn)
     except Exception:  # noqa: BLE001 — an unresolvable hint is not worth losing the process over
         return {}
+
+
+@overload
+def process(func: F) -> F: ...
+
+
+@overload
+def process(
+    func: None = None,
+    *,
+    summary: str | None = None,
+    description: str | None = None,
+    parameters: dict[str, dict[str, Any]] | None = None,
+) -> Callable[[F], F]: ...
 
 
 def process(

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -25,6 +25,12 @@ def _annotation_to_schema(ann: Any) -> dict[str, Any]:
 
     Handles plain types (str, int, …) and nullable unions (str | None).
     Returns {} for types with no known mapping (e.g. xr.DataArray).
+
+    A nullable annotation keeps its null: `str | None` is `{"type": ["string", "null"]}`,
+    matching how the openEO process specs express an optional parameter whose default is
+    null (`aggregate_spatial`'s `target_dimension` is exactly this). Unwrapping to a bare
+    `"string"` would publish a schema that rejects the documented default, which is worse
+    than publishing none — a client validating the graph would refuse a valid call.
     """
     direct = _PYTHON_TYPE_MAP.get(ann)
     if direct:
@@ -35,8 +41,30 @@ def _annotation_to_schema(ann: Any) -> dict[str, Any]:
     if isinstance(ann, types.UnionType) or origin is typing.Union:
         non_none = [a for a in args if a is not type(None)]
         if len(non_none) == 1:
-            return _annotation_to_schema(non_none[0])
+            inner = _annotation_to_schema(non_none[0])
+            if not inner:
+                return {}
+            if len(non_none) < len(args):
+                return {**inner, "type": [inner["type"], "null"]}
+            return inner
     return {}
+
+
+def _schema_types(schema: Any) -> tuple[str, ...]:
+    """The JSON Schema `type` of a parameter schema, always as a tuple.
+
+    `type` is either a string or a list of them, and an absent or declared-empty schema has
+    none. Callers only ask whether a particular type is admitted, so normalise the shape here
+    rather than at each site.
+    """
+    if not isinstance(schema, dict):
+        return ()
+    declared = schema.get("type")
+    if isinstance(declared, str):
+        return (declared,)
+    if isinstance(declared, list):
+        return tuple(str(item) for item in declared)
+    return ()
 
 
 def _resolved_annotations(fn: Any) -> dict[str, Any]:
@@ -116,10 +144,11 @@ def process(
                     p["schema"] = schema
             if param.default is not inspect.Parameter.empty:
                 p["optional"] = True
-                # Only emit the default value when it is not None, or when the
-                # schema explicitly allows null.  Emitting default=None for a
-                # purely-string schema creates a type mismatch in the catalog.
-                if param.default is not None or not p.get("schema"):
+                # A nullable annotation now carries "null" in its schema, so a None default
+                # no longer contradicts it and can be published as-is. The check remains for
+                # a parameter annotated non-nullable but defaulting to None, where emitting
+                # default=None would still mismatch the declared type.
+                if param.default is not None or not p.get("schema") or "null" in _schema_types(p.get("schema")):
                     p["default"] = param.default
             if parameters and name in parameters:
                 p.update(parameters[name])

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -53,6 +53,23 @@ def process(
 ) -> Callable[[F], F]: ...
 
 
+def _resolved_annotations(fn: Any) -> dict[str, Any]:
+    """A function's annotations as objects rather than strings.
+
+    `from __future__ import annotations` stores every annotation as a string, so a raw
+    `param.annotation` is `"str"` rather than `str` and the type map below never matches — the
+    parameter is then published with an empty schema, and a client building a graph gets an
+    untyped field with nothing to validate against.
+
+    Resolution needs the module's namespace and can fail on a type imported only under
+    `TYPE_CHECKING`. That falls back to the raw annotations rather than dropping the process.
+    """
+    try:
+        return typing.get_type_hints(fn)
+    except Exception:  # noqa: BLE001 — an unresolvable hint is not worth losing the process over
+        return {}
+
+
 def process(
     func: F | None = None,
     *,
@@ -85,13 +102,14 @@ def process(
     def decorator(fn: F) -> F:
         doc = inspect.getdoc(fn) or ""
         sig = inspect.signature(fn)
+        hints = _resolved_annotations(fn)
 
         params: list[dict[str, Any]] = []
         for name, param in sig.parameters.items():
             if name in ("self", "cls"):
                 continue
             p: dict[str, Any] = {"name": name, "schema": {}}
-            ann = param.annotation
+            ann = hints.get(name, param.annotation)
             if ann is not inspect.Parameter.empty:
                 schema = _annotation_to_schema(ann)
                 if schema:

--- a/open_climate_service/process.py
+++ b/open_climate_service/process.py
@@ -163,16 +163,21 @@ def process(
                 schema = _annotation_to_schema(ann)
                 if schema:
                     p["schema"] = schema
+            override = parameters.get(name, {}) if parameters else {}
+            if override:
+                p.update(override)
+            # The default is decided after the override, against the schema that actually
+            # ships. An explicit schema can narrow a nullable annotation or widen a
+            # non-nullable one, and deciding beforehand would contradict either.
             if param.default is not inspect.Parameter.empty:
-                p["optional"] = True
-                # A nullable annotation now carries "null" in its schema, so a None default
-                # no longer contradicts it and can be published as-is. The check remains for
-                # a parameter annotated non-nullable but defaulting to None, where emitting
-                # default=None would still mismatch the declared type.
-                if param.default is not None or not p.get("schema") or "null" in _schema_types(p.get("schema")):
+                p.setdefault("optional", True)
+                # A schema carrying "null" admits a None default, so it is published as-is.
+                # A non-nullable one would be contradicted by it, so the default is withheld.
+                # An explicit default in the override always wins.
+                if "default" not in override and (
+                    param.default is not None or not p.get("schema") or "null" in _schema_types(p.get("schema"))
+                ):
                     p["default"] = param.default
-            if parameters and name in parameters:
-                p.update(parameters[name])
             params.append(p)
 
         meta: dict[str, Any] = {

--- a/tests/test_plugin_processes.py
+++ b/tests/test_plugin_processes.py
@@ -113,3 +113,44 @@ def cdd(pr: xr.DataArray, thresh: str = "1mm/day") -> xr.DataArray:
     procs = {p["id"]: p for p in response.json()["processes"]}
     assert "cdd" in procs
     assert procs["cdd"]["summary"] == "Consecutive dry days"
+
+
+def test_string_annotations_are_resolved_to_schemas() -> None:
+    """`from __future__ import annotations` stores annotations as strings.
+
+    A raw `param.annotation` is then `"str"` rather than `str`, the type map never matches, and the
+    parameter is published with an empty schema — a client building a graph gets an untyped field
+    with nothing to validate against. Written here as explicit string annotations, which is exactly
+    what that import produces.
+    """
+
+    @process
+    def scaled(threshold: "str", count: "int" = 3, ratio: "float | None" = None) -> "str":
+        """Do something with a threshold."""
+        return threshold
+
+    meta = get_process_metadata(scaled)
+    assert meta is not None
+    schemas = {p["name"]: p.get("schema") for p in meta["parameters"]}
+    assert schemas == {
+        "threshold": {"type": "string"},
+        "count": {"type": "integer"},
+        "ratio": {"type": "number"},
+    }
+
+
+def test_an_unresolvable_annotation_does_not_lose_the_process() -> None:
+    """A plugin may annotate a type it imports only under TYPE_CHECKING.
+
+    Resolution needs the module namespace and fails for those, which must cost the schema for that
+    process rather than the process itself.
+    """
+
+    @process
+    def exotic(data: "SomeTypeThatIsNotImported", factor: "int" = 2) -> None:  # noqa: F821
+        """Takes something unresolvable."""
+
+    meta = get_process_metadata(exotic)
+    assert meta is not None
+    assert [p["name"] for p in meta["parameters"]] == ["data", "factor"]
+    assert meta["parameters"][0]["schema"] == {}

--- a/tests/test_plugin_processes.py
+++ b/tests/test_plugin_processes.py
@@ -179,5 +179,11 @@ def test_an_unresolvable_annotation_does_not_lose_the_process() -> None:
 
     meta = get_process_metadata(exotic)
     assert meta is not None
+    data, factor = meta["parameters"]
     assert [p["name"] for p in meta["parameters"]] == ["data", "factor"]
-    assert meta["parameters"][0]["schema"] == {}
+
+    # Only the offending parameter loses its schema. `get_type_hints` resolves the whole
+    # mapping atomically, so without per-annotation fallback `factor` would be empty too —
+    # one exotic type would publish an untyped contract for the whole process.
+    assert data["schema"] == {}
+    assert factor["schema"] == {"type": "integer"}

--- a/tests/test_plugin_processes.py
+++ b/tests/test_plugin_processes.py
@@ -187,3 +187,49 @@ def test_an_unresolvable_annotation_does_not_lose_the_process() -> None:
     # one exotic type would publish an untyped contract for the whole process.
     assert data["schema"] == {}
     assert factor["schema"] == {"type": "integer"}
+
+
+def test_an_explicit_schema_decides_whether_the_default_is_published() -> None:
+    """The null/default check must run against the schema that ships, not the inferred one.
+
+    A `parameters=` override replaces the schema after it is inferred, so deciding beforehand
+    contradicts whichever side the override changed. Both directions are wrong in the same way:
+    a narrowed schema would publish a null default it rejects, and a widened one would withhold
+    a null default it admits, leaving an optional parameter with nothing to fall back on.
+    """
+
+    @process(parameters={"target": {"schema": {"type": "string"}}})
+    def narrowed(target: str | None = None) -> None:
+        """An override narrows a nullable annotation."""
+
+    meta = get_process_metadata(narrowed)
+    assert meta is not None
+    (target,) = meta["parameters"]
+    assert target["schema"] == {"type": "string"}
+    assert target["optional"] is True
+    assert "default" not in target
+
+    @process(parameters={"target": {"schema": {"type": ["string", "null"]}}})
+    def widened(target: str = None) -> None:  # type: ignore[assignment]  # pyright: ignore[reportArgumentType]
+        """An override widens a non-nullable annotation."""
+
+    meta = get_process_metadata(widened)
+    assert meta is not None
+    (target,) = meta["parameters"]
+    assert target["schema"] == {"type": ["string", "null"]}
+    assert target["optional"] is True
+    assert target["default"] is None
+
+
+def test_an_override_may_set_the_default_itself() -> None:
+    """An explicit default in the override is the author's, and survives the inferred one."""
+
+    @process(parameters={"target": {"default": "explicit"}})
+    def overridden(target: str = None) -> None:  # type: ignore[assignment]  # pyright: ignore[reportArgumentType]
+        """An override supplies its own default."""
+
+    meta = get_process_metadata(overridden)
+    assert meta is not None
+    (target,) = meta["parameters"]
+    assert target["default"] == "explicit"
+    assert target["optional"] is True

--- a/tests/test_plugin_processes.py
+++ b/tests/test_plugin_processes.py
@@ -135,8 +135,35 @@ def test_string_annotations_are_resolved_to_schemas() -> None:
     assert schemas == {
         "threshold": {"type": "string"},
         "count": {"type": "integer"},
-        "ratio": {"type": "number"},
+        # `float | None` keeps its null, as the openEO specs do for a nullable parameter.
+        "ratio": {"type": ["number", "null"]},
     }
+
+
+def test_a_nullable_annotation_keeps_its_null_and_its_default() -> None:
+    """`str | None` must publish `["string", "null"]`, not a bare `"string"`.
+
+    This is how the openEO specs express an optional parameter defaulting to null —
+    `aggregate_spatial`'s `target_dimension` is exactly this shape. Unwrapping to `"string"`
+    publishes a schema that rejects the documented default, so a client validating the graph
+    would refuse a valid call. That is worse than publishing no schema at all.
+    """
+
+    @process
+    def nullable(target: str | None = None, count: int = 1) -> None:
+        """Has a nullable parameter."""
+
+    meta = get_process_metadata(nullable)
+    assert meta is not None
+    target, count = meta["parameters"]
+
+    assert target["schema"] == {"type": ["string", "null"]}
+    assert target["optional"] is True
+    assert target["default"] is None
+
+    # A non-nullable parameter is unaffected.
+    assert count["schema"] == {"type": "integer"}
+    assert count["default"] == 1
 
 
 def test_an_unresolvable_annotation_does_not_lose_the_process() -> None:

--- a/tests/test_plugin_processes.py
+++ b/tests/test_plugin_processes.py
@@ -147,7 +147,7 @@ def test_an_unresolvable_annotation_does_not_lose_the_process() -> None:
     """
 
     @process
-    def exotic(data: "SomeTypeThatIsNotImported", factor: "int" = 2) -> None:  # noqa: F821
+    def exotic(data: "SomeTypeThatIsNotImported", factor: "int" = 2) -> None:  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
         """Takes something unresolvable."""
 
     meta = get_process_metadata(exotic)


### PR DESCRIPTION
Parameters reach `GET /processes` with an empty schema, so a client building a graph — the openEO Editor among them — renders an untyped field with nothing to validate against.

`from __future__ import annotations` stores every annotation as a string, so `param.annotation` is `"str"` rather than `str` and the type map never matches:

```
type  str    -> {'type': 'string'}
string "str" ->  {}
```

## Affected

Four OCS processes use that import and lose their schemas to it: `aggregate_dekads`, `aggregate_spatial`, `climatological_normal` and `compute_anomaly`. Most of the catalogue is unaffected, because it comes from `openeo-processes-dask`, which does not use the import.

## What this does

Annotations are resolved with `typing.get_type_hints`, which needs the defining module's namespace and raises for a type imported only under `TYPE_CHECKING`. That case falls back to the raw annotations, so an unresolvable hint costs one schema rather than the whole process.

A nullable annotation also keeps its null: `str | None` publishes `{"type": ["string", "null"]}` rather than a bare `"string"`. This matters because a bare string *rejects* the None default the parameter actually has — worse than publishing no schema, since a client validating the graph would refuse a valid call. It matches how the openEO specs express the same thing (`aggregate_spatial.target_dimension` is exactly this shape), and it retires the workaround that suppressed `default: null` to avoid contradicting the narrower type.

## What this does not do

`aggregate_spatial` still publishes an empty schema for `data`, `geometries` and `reducer`. Those are annotated `Any` and `Callable`, and no inference over Python types can produce what openEO wants for them:

| parameter | published here | openEO spec |
| --- | --- | --- |
| `data` | `{}` | `{"type": "object", "subtype": "datacube", …}` |
| `geometries` | `{}` | vector datacube or GeoJSON, both with `subtype` |
| `reducer` | `{}` | `{"type": "object", "subtype": "process-graph", …}` |

`subtype` is the openEO convention that tells a client to offer a cube picker, a geometry input or a nested-process builder, and it has to be **declared** rather than derived. The `@process` decorator already supports that — a `schema` in its `parameters=` override passes straight through — so this is a follow-up across the process definitions, deliberately kept out of this PR: it is a per-parameter reading of the spec rather than a change to the machinery here.

That follow-up is **not** implemented by this PR — it is tracked in [CLIM-1049](https://dhis2.atlassian.net/browse/CLIM-1049), which also covers the empty `returns` schemas and 17 earthkit processes publishing a parameter with no description.

## Tests

`tests/test_plugin_processes.py`, covering resolution of string annotations, the nullable shape and its default, and an unresolvable annotation degrading to an empty schema rather than dropping the process. `make lint` clean, full suite passes.



[CLIM-1049]: https://dhis2.atlassian.net/browse/CLIM-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ