### PR TITLE
fix(openeo): support n-way named predictor merges

### DIFF
--- a/docs/openeo.md
+++ b/docs/openeo.md
@@ -201,6 +201,14 @@ The `format` argument of `save_result` controls what the server writes. `GET /fi
 
 For aggregating a dataset to DHIS2 org units and producing `DHIS2JSON` or `CHAPCSV` directly, see the built-in [org-unit aggregation workflows](workflows.md#built-in-workflows).
 
+To combine three or more named predictors for CHAP, chain `merge_cubes`: merge two
+predictors, then merge the result with another predictor or another merged group.
+Distinct variable names are retained as predictor labels, including single-variable
+datasets returned by spatial aggregation. Additional predictors must have matching
+dimensions and coordinate indexes; align their periods and locations before merging.
+Overlapping predictor labels continue to use the upstream merge and overlap-resolver
+behavior.
+
 ```bash
 # Monthly precipitation totals as NetCDF
 curl -X POST http://127.0.0.1:9000/result \

--- a/docs/openeo.md
+++ b/docs/openeo.md
@@ -205,9 +205,10 @@ To combine three or more named predictors for CHAP, chain `merge_cubes`: merge t
 predictors, then merge the result with another predictor or another merged group.
 Distinct variable names are retained as predictor labels, including single-variable
 datasets returned by spatial aggregation. Additional predictors must have matching
-dimensions and coordinate indexes; align their periods and locations before merging.
-Overlapping predictor labels continue to use the upstream merge and overlap-resolver
-behavior.
+dimensions and coordinate labels. Label ordering is aligned automatically, and
+floating coordinates use the upstream tolerance of `1e-6`; genuinely different
+periods or locations must be aligned before merging. A supplied overlap resolver
+and its context, or overlapping predictor labels, use the upstream merge behavior.
 
 ```bash
 # Monthly precipitation totals as NetCDF

--- a/docs/openeo.md
+++ b/docs/openeo.md
@@ -207,8 +207,9 @@ Distinct variable names are retained as predictor labels, including single-varia
 datasets returned by spatial aggregation. Additional predictors must have matching
 dimensions and coordinate labels. Label ordering is aligned automatically, and
 floating coordinates use the upstream tolerance of `1e-6`; genuinely different
-periods or locations must be aligned before merging. A supplied overlap resolver
-and its context, or overlapping predictor labels, use the upstream merge behavior.
+periods or locations must be aligned before merging. An overlap resolver and its
+context are supported on the initial two-cube merge. They are not supported when
+extending an already stacked named-predictor group.
 
 ```bash
 # Monthly precipitation totals as NetCDF

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -100,8 +100,9 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
     A later ``merge_cubes`` in the same graph receives that already-stacked
     DataArray plus another predictor. Upstream treats their shared dimensions as
     an unresolved overlap and raises ``OverlapResolverMissing``. Append predictors
-    with disjoint ``__cubes__`` labels directly, requiring all remaining indexes
-    to match exactly so temporal or location misalignment is never hidden.
+    with disjoint ``__cubes__`` labels directly when no resolver is supplied.
+    Match upstream's coordinate tolerance and align label order before requiring
+    equal indexes, so temporal or location misalignment is never hidden.
 
     ``aggregate_spatial`` returns an ``xr.Dataset`` even for one input variable.
     Normalise that common single-variable result back to its named DataArray so
@@ -144,23 +145,36 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
         if set(left.indexes) != set(right.indexes):
             raise ValueError("Named predictors must have the same coordinate indexes before merging")
 
-        # ``join=exact`` is deliberate: combining predictors must not silently
-        # introduce missing location-period rows through an outer alignment.
-        return xr.concat(
+        from openeo_processes_dask.process_implementations.cubes.merge import _align_coordinates
+
+        # Compare in label order so upstream's float tolerance also works for
+        # independently reordered grids. Restore the left cube's order only after
+        # verifying equality, without filling any missing location-period rows.
+        dimensions = [dim for dim in left.dims if dim != cube_axis and dim in left.indexes]
+        ordered_left, ordered_right = left, right
+        for dim in dimensions:
+            ordered_left = ordered_left.sortby(dim)
+            ordered_right = ordered_right.sortby(dim)
+        ordered_left, ordered_right = _align_coordinates(ordered_left, ordered_right)
+        xr.align(ordered_left, ordered_right, join="exact", exclude={cube_axis})
+        right = ordered_right.reindex({dim: left[dim] for dim in dimensions})
+        appended: xr.DataArray = xr.concat(
             [left, right],
             dim=cube_axis,
             join="exact",
             coords="minimal",
             compat="equals",
-        )
+        ).chunk({cube_axis: -1})
+        return appended
 
     def _named_merge_cubes(cube1: Any, cube2: Any, **kwargs: Any) -> Any:
         array1 = _as_named_array(cube1)
         array2 = _as_named_array(cube2)
         if array1 is not None and array2 is not None:
-            appended = _append_disjoint_predictors(array1, array2)
-            if appended is not None:
-                return appended
+            if kwargs.get("overlap_resolver") is None:
+                appended = _append_disjoint_predictors(array1, array2)
+                if appended is not None:
+                    return appended
             cube1, cube2 = array1, array2
 
         merged = original_fn(cube1=cube1, cube2=cube2, **kwargs)

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -14,6 +14,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
 import xarray as xr
 from fastapi import HTTPException, Request
 
@@ -127,10 +128,7 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
             return None
         return cube.expand_dims({cube_axis: [str(cube.name)]})
 
-    def _append_disjoint_predictors(cube1: xr.DataArray, cube2: xr.DataArray) -> xr.DataArray | None:
-        if cube_axis not in cube1.dims and cube_axis not in cube2.dims:
-            return None
-
+    def _append_disjoint_predictors(cube1: xr.DataArray, cube2: xr.DataArray) -> xr.DataArray:
         left = _with_cube_axis(cube1)
         right = _with_cube_axis(cube2)
         if left is None or right is None:
@@ -154,10 +152,10 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
         for dim in dimensions:
             left_index = left.indexes[dim]
             right_index = right.indexes[dim]
+            if len(left_index) != len(right_index):
+                raise ValueError(f"Named predictors have different labels on index '{dim}'")
             if left_index.equals(right_index):
                 continue
-            if not right_index.is_unique:
-                raise ValueError(f"Named predictor index '{dim}' cannot be reordered because it has duplicate labels")
             positions = right_index.get_indexer(left_index)
             if (positions < 0).any():
                 left_values = left_index.to_numpy()
@@ -167,9 +165,23 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
                     and left_values.dtype.kind == "f"
                     and right_values.dtype.kind == "f"
                 ):
-                    positions = abs(left_values[:, None] - right_values[None, :]).argmin(axis=1)
-                    if (abs(left_values - right_values[positions]) >= FLOAT_TOLERANCE).any():
-                        raise ValueError(f"Named predictors have different labels on index '{dim}'")
+                    if (abs(left_values - right_values) < FLOAT_TOLERANCE).all():
+                        positions = np.arange(len(left_index))
+                    else:
+                        if not right_index.is_unique:
+                            raise ValueError(
+                                f"Named predictor index '{dim}' cannot be reordered because it has duplicate labels"
+                            )
+                        order = np.argsort(right_values)
+                        sorted_right = right_index.take(order)
+                        nearest = sorted_right.get_indexer(
+                            left_index,
+                            method="nearest",
+                            tolerance=FLOAT_TOLERANCE,
+                        )
+                        if (nearest < 0).any():
+                            raise ValueError(f"Named predictors have different labels on index '{dim}'")
+                        positions = order[nearest]
                 else:
                     raise ValueError(f"Named predictors have different labels on index '{dim}'")
             if len(set(positions.tolist())) != len(left_index):
@@ -179,24 +191,21 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
             # floating-point noise should use the left cube's canonical labels.
             right = right.assign_coords({dim: left[dim]})
 
-        # Scalar/non-index coordinates are metadata, not row alignment keys.
-        # Keep the left value on conflict and omit right-only scalar metadata,
-        # matching upstream's compat="override" behavior.
-        left_non_indexes = [name for name in left.coords if name not in left.indexes and name != cube_axis]
-        right_non_indexes = [name for name in right.coords if name not in right.indexes and name != cube_axis]
-        left_metadata = {name: left.coords[name] for name in left_non_indexes}
-        left = left.drop_vars(left_non_indexes)
-        right = right.drop_vars(right_non_indexes)
+        # Right-only auxiliary coordinates cannot describe the merged group and
+        # make concat reject otherwise aligned predictors. Shared auxiliaries,
+        # including dimensioned coordinates, keep the left value on conflict.
+        right_only_auxiliary = [
+            name for name in right.coords if name not in right.indexes and name != cube_axis and name not in left.coords
+        ]
+        right = right.drop_vars(right_only_auxiliary)
         appended: xr.DataArray = xr.concat(
             [left, right],
             dim=cube_axis,
             join="exact",
             coords="minimal",
             compat="override",
-        ).chunk({cube_axis: -1})
-        if left_metadata:
-            appended = appended.assign_coords(left_metadata)
-        return appended
+        )
+        return appended.chunk({dim: -1 if dim == cube_axis else "auto" for dim in appended.dims})
 
     def _named_merge_cubes(
         cube1: Any,
@@ -210,9 +219,7 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
         if array1 is not None and array2 is not None and (cube_axis in array1.dims or cube_axis in array2.dims):
             if overlap_resolver is not None:
                 raise ValueError("An overlap resolver is only supported on the initial named predictor merge")
-            appended = _append_disjoint_predictors(array1, array2)
-            if appended is not None:
-                return appended
+            return _append_disjoint_predictors(array1, array2)
 
         # Distinct single-variable Datasets are the aggregate_spatial predictor
         # case. Do not promote same-variable Datasets or any ordinary merge.
@@ -238,8 +245,6 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
             and array1.name
             and array2.name
             and array1.name != array2.name
-            and cube_axis not in array1.dims
-            and cube_axis not in array2.dims
             and isinstance(merged, xr.DataArray)
             and cube_axis in merged.dims
         ):

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -156,6 +156,8 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
                 raise ValueError(f"Named predictors have different labels on index '{dim}'")
             if left_index.equals(right_index):
                 continue
+            if not right_index.is_unique:
+                raise ValueError(f"Named predictor index '{dim}' cannot be reordered because it has duplicate labels")
             positions = right_index.get_indexer(left_index)
             if (positions < 0).any():
                 left_values = left_index.to_numpy()
@@ -168,10 +170,6 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
                     if (abs(left_values - right_values) < FLOAT_TOLERANCE).all():
                         positions = np.arange(len(left_index))
                     else:
-                        if not right_index.is_unique:
-                            raise ValueError(
-                                f"Named predictor index '{dim}' cannot be reordered because it has duplicate labels"
-                            )
                         order = np.argsort(right_values)
                         sorted_right = right_index.take(order)
                         nearest = sorted_right.get_indexer(

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -89,28 +89,94 @@ def _make_sorted_atp(original_fn: Any) -> Any:
 
 
 def _make_named_merge_cubes(original_fn: Any) -> Any:
-    """Wrap merge_cubes to preserve DataArray names on the ``__cubes__`` axis.
+    """Wrap merge_cubes to preserve and extend named predictor cubes.
 
     The upstream implementation returns a DataArray stacked on a synthetic
     ``__cubes__`` dimension with labels like ``cube1`` / ``cube2``. That loses
     semantic source names like ``tp`` and ``t2m``. Keep the upstream return type
-    unchanged, but relabel ``__cubes__`` to the original DataArray names when
-    both inputs are named and distinct.
+    unchanged for the initial merge, but relabel ``__cubes__`` to the original
+    DataArray names when both inputs are named and distinct.
+
+    A later ``merge_cubes`` in the same graph receives that already-stacked
+    DataArray plus another predictor. Upstream treats their shared dimensions as
+    an unresolved overlap and raises ``OverlapResolverMissing``. Append predictors
+    with disjoint ``__cubes__`` labels directly, requiring all remaining indexes
+    to match exactly so temporal or location misalignment is never hidden.
+
+    ``aggregate_spatial`` returns an ``xr.Dataset`` even for one input variable.
+    Normalise that common single-variable result back to its named DataArray so
+    predictors can be merged before or after zonal aggregation in the same way.
     """
+    cube_axis = "__cubes__"
+
+    def _as_named_array(cube: Any) -> xr.DataArray | None:
+        if isinstance(cube, xr.DataArray):
+            return cube
+        if isinstance(cube, xr.Dataset) and len(cube.data_vars) == 1:
+            variable = str(next(iter(cube.data_vars)))
+            array = cube[variable]
+            return array if array.name else array.rename(variable)
+        return None
+
+    def _with_cube_axis(cube: xr.DataArray) -> xr.DataArray | None:
+        if cube_axis in cube.dims:
+            return cube if cube_axis in cube.coords else None
+        if not cube.name:
+            return None
+        return cube.expand_dims({cube_axis: [str(cube.name)]})
+
+    def _append_disjoint_predictors(cube1: xr.DataArray, cube2: xr.DataArray) -> xr.DataArray | None:
+        if cube_axis not in cube1.dims and cube_axis not in cube2.dims:
+            return None
+
+        left = _with_cube_axis(cube1)
+        right = _with_cube_axis(cube2)
+        if left is None or right is None:
+            return None
+
+        left_labels = {str(value) for value in left[cube_axis].values.tolist()}
+        right_labels = {str(value) for value in right[cube_axis].values.tolist()}
+        if left_labels & right_labels:
+            return None
+
+        if set(left.dims) != set(right.dims):
+            raise ValueError("Named predictors must have the same dimensions before merging")
+        if set(left.indexes) != set(right.indexes):
+            raise ValueError("Named predictors must have the same coordinate indexes before merging")
+
+        # ``join=exact`` is deliberate: combining predictors must not silently
+        # introduce missing location-period rows through an outer alignment.
+        return xr.concat(
+            [left, right],
+            dim=cube_axis,
+            join="exact",
+            coords="minimal",
+            compat="equals",
+        )
 
     def _named_merge_cubes(cube1: Any, cube2: Any, **kwargs: Any) -> Any:
+        array1 = _as_named_array(cube1)
+        array2 = _as_named_array(cube2)
+        if array1 is not None and array2 is not None:
+            appended = _append_disjoint_predictors(array1, array2)
+            if appended is not None:
+                return appended
+            cube1, cube2 = array1, array2
+
         merged = original_fn(cube1=cube1, cube2=cube2, **kwargs)
         if (
-            isinstance(cube1, xr.DataArray)
-            and isinstance(cube2, xr.DataArray)
-            and cube1.name
-            and cube2.name
-            and cube1.name != cube2.name
+            array1 is not None
+            and array2 is not None
+            and array1.name
+            and array2.name
+            and array1.name != array2.name
+            and cube_axis not in array1.dims
+            and cube_axis not in array2.dims
             and isinstance(merged, xr.DataArray)
-            and "__cubes__" in merged.dims
+            and cube_axis in merged.dims
         ):
             try:
-                return merged.assign_coords(__cubes__=[str(cube1.name), str(cube2.name)])
+                return merged.assign_coords({cube_axis: [str(array1.name), str(array2.name)]})
             except Exception as exc:
                 logger.debug("Falling back to default __cubes__ labels after merge_cubes", exc_info=exc)
         return merged

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -105,18 +105,19 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
     equal indexes, so temporal or location misalignment is never hidden.
 
     ``aggregate_spatial`` returns an ``xr.Dataset`` even for one input variable.
-    Normalise that common single-variable result back to its named DataArray so
-    predictors can be merged before or after zonal aggregation in the same way.
+    Distinct single-variable datasets are normalised only when starting a named
+    predictor stack; ordinary Dataset merges retain upstream types and attrs.
     """
-    cube_axis = "__cubes__"
+    from openeo_processes_dask.process_implementations.cubes.merge import NEW_DIM_NAME
+
+    cube_axis = NEW_DIM_NAME
 
     def _as_named_array(cube: Any) -> xr.DataArray | None:
         if isinstance(cube, xr.DataArray):
             return cube
         if isinstance(cube, xr.Dataset) and len(cube.data_vars) == 1:
             variable = str(next(iter(cube.data_vars)))
-            array = cube[variable]
-            return array if array.name else array.rename(variable)
+            return cube[variable]
         return None
 
     def _with_cube_axis(cube: xr.DataArray) -> xr.DataArray | None:
@@ -133,51 +134,104 @@ def _make_named_merge_cubes(original_fn: Any) -> Any:
         left = _with_cube_axis(cube1)
         right = _with_cube_axis(cube2)
         if left is None or right is None:
-            return None
+            raise ValueError("Every predictor in a merged group must have a distinct name")
 
         left_labels = {str(value) for value in left[cube_axis].values.tolist()}
         right_labels = {str(value) for value in right[cube_axis].values.tolist()}
         if left_labels & right_labels:
-            return None
+            raise ValueError("Named predictor labels must be distinct when extending a merged group")
 
         if set(left.dims) != set(right.dims):
             raise ValueError("Named predictors must have the same dimensions before merging")
         if set(left.indexes) != set(right.indexes):
             raise ValueError("Named predictors must have the same coordinate indexes before merging")
 
-        from openeo_processes_dask.process_implementations.cubes.merge import _align_coordinates
+        from openeo_processes_dask.process_implementations.cubes.merge import FLOAT_TOLERANCE
 
-        # Compare in label order so upstream's float tolerance also works for
-        # independently reordered grids. Restore the left cube's order only after
-        # verifying equality, without filling any missing location-period rows.
+        # Align index objects rather than sorting cube data. The common case of
+        # identical indexes, including unsorted duplicates, stays untouched.
         dimensions = [dim for dim in left.dims if dim != cube_axis and dim in left.indexes]
-        ordered_left, ordered_right = left, right
         for dim in dimensions:
-            ordered_left = ordered_left.sortby(dim)
-            ordered_right = ordered_right.sortby(dim)
-        ordered_left, ordered_right = _align_coordinates(ordered_left, ordered_right)
-        xr.align(ordered_left, ordered_right, join="exact", exclude={cube_axis})
-        right = ordered_right.reindex({dim: left[dim] for dim in dimensions})
+            left_index = left.indexes[dim]
+            right_index = right.indexes[dim]
+            if left_index.equals(right_index):
+                continue
+            if not right_index.is_unique:
+                raise ValueError(f"Named predictor index '{dim}' cannot be reordered because it has duplicate labels")
+            positions = right_index.get_indexer(left_index)
+            if (positions < 0).any():
+                left_values = left_index.to_numpy()
+                right_values = right_index.to_numpy()
+                if (
+                    left_values.shape == right_values.shape
+                    and left_values.dtype.kind == "f"
+                    and right_values.dtype.kind == "f"
+                ):
+                    positions = abs(left_values[:, None] - right_values[None, :]).argmin(axis=1)
+                    if (abs(left_values - right_values[positions]) >= FLOAT_TOLERANCE).any():
+                        raise ValueError(f"Named predictors have different labels on index '{dim}'")
+                else:
+                    raise ValueError(f"Named predictors have different labels on index '{dim}'")
+            if len(set(positions.tolist())) != len(left_index):
+                raise ValueError(f"Named predictors have different labels on index '{dim}'")
+            right = right.isel({dim: positions})
+            # Equal timestamps with different datetime64 units and tolerated
+            # floating-point noise should use the left cube's canonical labels.
+            right = right.assign_coords({dim: left[dim]})
+
+        # Scalar/non-index coordinates are metadata, not row alignment keys.
+        # Keep the left value on conflict and omit right-only scalar metadata,
+        # matching upstream's compat="override" behavior.
+        left_non_indexes = [name for name in left.coords if name not in left.indexes and name != cube_axis]
+        right_non_indexes = [name for name in right.coords if name not in right.indexes and name != cube_axis]
+        left_metadata = {name: left.coords[name] for name in left_non_indexes}
+        left = left.drop_vars(left_non_indexes)
+        right = right.drop_vars(right_non_indexes)
         appended: xr.DataArray = xr.concat(
             [left, right],
             dim=cube_axis,
             join="exact",
             coords="minimal",
-            compat="equals",
+            compat="override",
         ).chunk({cube_axis: -1})
+        if left_metadata:
+            appended = appended.assign_coords(left_metadata)
         return appended
 
-    def _named_merge_cubes(cube1: Any, cube2: Any, **kwargs: Any) -> Any:
+    def _named_merge_cubes(
+        cube1: Any,
+        cube2: Any,
+        overlap_resolver: Any = None,
+        context: Any = None,
+        **kwargs: Any,
+    ) -> Any:
         array1 = _as_named_array(cube1)
         array2 = _as_named_array(cube2)
-        if array1 is not None and array2 is not None:
-            if kwargs.get("overlap_resolver") is None:
-                appended = _append_disjoint_predictors(array1, array2)
-                if appended is not None:
-                    return appended
-            cube1, cube2 = array1, array2
+        if array1 is not None and array2 is not None and (cube_axis in array1.dims or cube_axis in array2.dims):
+            if overlap_resolver is not None:
+                raise ValueError("An overlap resolver is only supported on the initial named predictor merge")
+            appended = _append_disjoint_predictors(array1, array2)
+            if appended is not None:
+                return appended
 
-        merged = original_fn(cube1=cube1, cube2=cube2, **kwargs)
+        # Distinct single-variable Datasets are the aggregate_spatial predictor
+        # case. Do not promote same-variable Datasets or any ordinary merge.
+        promote_datasets = (
+            isinstance(cube1, xr.Dataset)
+            and isinstance(cube2, xr.Dataset)
+            and array1 is not None
+            and array2 is not None
+            and array1.name != array2.name
+        )
+        original_cube1 = array1 if promote_datasets else cube1
+        original_cube2 = array2 if promote_datasets else cube2
+        merged = original_fn(
+            cube1=original_cube1,
+            cube2=original_cube2,
+            overlap_resolver=overlap_resolver,
+            context=context,
+            **kwargs,
+        )
         if (
             array1 is not None
             and array2 is not None

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1219,7 +1219,7 @@ def test_merge_cubes_wrapper_rejects_misaligned_predictor_indexes() -> None:
     )
 
     climate = merge(cube1=precipitation, cube2=temperature)
-    with pytest.raises(ValueError, match="cannot align objects with join='exact'"):
+    with pytest.raises(ValueError, match="different labels on index 't'"):
         merge(cube1=climate, cube2=population)
 
 
@@ -1290,7 +1290,7 @@ def test_merge_cubes_wrapper_uses_upstream_coordinate_tolerance(offset: float) -
     stacked = merge(cube1=cube, cube2=cube.rename("t2m").copy(deep=True))
     third = cube.rename("population").assign_coords(x=cube.x + offset)
     if offset > 1e-6:
-        with pytest.raises(ValueError, match="cannot align objects with join='exact'"):
+        with pytest.raises(ValueError, match="different labels on index 'x'"):
             merge(cube1=stacked, cube2=third)
     else:
         result = merge(cube1=stacked, cube2=third)
@@ -1298,28 +1298,22 @@ def test_merge_cubes_wrapper_uses_upstream_coordinate_tolerance(offset: float) -
 
 
 @pytest.mark.parametrize("grouped", [False, True])
-def test_merge_cubes_wrapper_delegates_disjoint_resolver_and_context(grouped: bool) -> None:
+def test_merge_cubes_wrapper_rejects_resolver_when_extending_group(grouped: bool) -> None:
     from open_climate_service.openeo.execution import _make_named_merge_cubes
 
     cube = xr.DataArray([[1.0], [2.0]], dims=("__cubes__", "t"), coords={"__cubes__": ["precip", "t2m"], "t": [0]})
     other = xr.DataArray([3.0], dims="t", coords={"t": [0]}, name="population")
     if grouped:
         other = other.expand_dims(__cubes__=["population"])
-    captured: dict[str, Any] = {}
-    reduced = other.sum()
-
-    def original(**kwargs: Any) -> xr.DataArray:
-        captured.update(kwargs)
-        return reduced
-
     resolver = object()
     context = {"scale": 2}
-    result = _make_named_merge_cubes(original)(cube1=cube, cube2=other, overlap_resolver=resolver, context=context)
-    assert captured == {"cube1": cube, "cube2": other, "overlap_resolver": resolver, "context": context}
-    assert result is reduced
+    with pytest.raises(ValueError, match="only supported on the initial"):
+        _make_named_merge_cubes(lambda **kwargs: other)(
+            cube1=cube, cube2=other, overlap_resolver=resolver, context=context
+        )
 
 
-def test_merge_cubes_wrapper_delegates_overlapping_labels_and_resolver() -> None:
+def test_merge_cubes_wrapper_rejects_resolver_for_overlapping_stacked_labels() -> None:
     from open_climate_service.openeo.execution import _make_named_merge_cubes
 
     cube = xr.DataArray(
@@ -1329,19 +1323,120 @@ def test_merge_cubes_wrapper_delegates_overlapping_labels_and_resolver() -> None
         name="precip",
     )
     other = cube.rename("other")
-    captured: dict[str, Any] = {}
-
-    def original(**kwargs: Any) -> xr.DataArray:
-        captured.update(kwargs)
-        return cube
-
     resolver = object()
-    result = _make_named_merge_cubes(original)(cube1=cube, cube2=other, overlap_resolver=resolver)
-    assert captured["cube1"] is cube
-    assert captured["cube2"] is other
-    assert captured["overlap_resolver"] is resolver
-    assert result is cube
-    assert list(result["__cubes__"].values) == ["precip", "t2m"]
+    with pytest.raises(ValueError, match="only supported on the initial"):
+        _make_named_merge_cubes(lambda **kwargs: cube)(cube1=cube, cube2=other, overlap_resolver=resolver)
+
+
+def test_merge_cubes_registry_passes_context_and_overlap_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    import openeo_processes_dask.process_implementations as implementations
+
+    import open_climate_service.openeo.execution as execution
+
+    captured: dict[str, Any] = {}
+    expected = xr.DataArray([3.0], dims="t", coords={"t": [0]})
+
+    def original(
+        cube1: Any,
+        cube2: Any,
+        overlap_resolver: Any = None,
+        context: Any = None,
+    ) -> xr.DataArray:
+        captured.update(overlap_resolver=overlap_resolver, context=context)
+        return expected
+
+    monkeypatch.setattr(implementations, "merge_cubes", original)
+    monkeypatch.setattr(execution, "_registry", None)
+    merge = execution._build_process_registry()["merge_cubes"].implementation
+    resolver = object()
+    context = {"scale": 2}
+
+    result = merge(
+        cube1=xr.DataArray([1.0], dims="t", coords={"t": [0]}),
+        cube2=xr.DataArray([2.0], dims="t", coords={"t": [0]}),
+        overlap_resolver=resolver,
+        context=context,
+    )
+
+    assert result is expected
+    assert captured == {"overlap_resolver": resolver, "context": context}
+
+
+def test_merge_cubes_wrapper_accepts_equivalent_datetime_units() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    daily = xr.DataArray(
+        [1.0, 2.0],
+        dims="t",
+        coords={"t": np.array(["2025-01-01", "2025-01-02"], dtype="datetime64[ns]")},
+        name="precip",
+    )
+    stacked = merge(cube1=daily, cube2=daily.rename("t2m"))
+    population = xr.DataArray(
+        [3.0, 4.0],
+        dims="t",
+        coords={"t": np.array(["2025-01-01", "2025-01-02"], dtype="datetime64[s]")},
+        name="population",
+    )
+
+    result = merge(cube1=stacked, cube2=population)
+
+    assert list(result["__cubes__"].values) == ["precip", "t2m", "population"]
+
+
+@pytest.mark.parametrize("right_scalar", [None, "EPSG:3857"])
+def test_merge_cubes_wrapper_ignores_non_index_scalar_coordinate_differences(right_scalar: str | None) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([1.0], dims="t", coords={"t": [0], "spatial_ref": "EPSG:4326"}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m"))
+    third = xr.DataArray([2.0], dims="t", coords={"t": [0]}, name="population")
+    if right_scalar is not None:
+        third = third.assign_coords(spatial_ref=right_scalar)
+
+    result = merge(cube1=stacked, cube2=third)
+
+    assert result.coords["spatial_ref"].item() == "EPSG:4326"
+
+
+def test_merge_cubes_wrapper_accepts_matching_unsorted_duplicate_index() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([1.0, 2.0, 3.0], dims="t", coords={"t": [1, 0, 1]}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m"))
+
+    result = merge(cube1=stacked, cube2=cube.rename("population"))
+
+    xr.testing.assert_equal(result.sel(__cubes__="population", drop=True), cube.rename("population"))
+
+
+def test_merge_cubes_wrapper_preserves_same_variable_dataset_type_and_attrs() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    first = xr.Dataset({"temperature": ("t", [1.0])}, coords={"t": [0]}, attrs={"source": "first"})
+    second = xr.Dataset({"temperature": ("t", [2.0])}, coords={"t": [0]}, attrs={"source": "second"})
+
+    result = merge(cube1=first, cube2=second)
+
+    assert isinstance(result, xr.Dataset)
+    assert result.attrs == first.attrs
+
+
+@pytest.mark.parametrize("kind", ["unnamed", "duplicate"])
+def test_merge_cubes_wrapper_reports_invalid_third_predictor_name(kind: str) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([1.0], dims="t", coords={"t": [0]}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m"))
+    third = cube.rename(None if kind == "unnamed" else "precip")
+
+    with pytest.raises(ValueError, match="distinct name|labels must be distinct"):
+        merge(cube1=stacked, cube2=third)
 
 
 def test_dhis2_period_string_accepts_existing_monthly_string() -> None:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1118,6 +1118,176 @@ def test_merge_cubes_wrapper_preserves_named_dataarrays_on_cube_axis() -> None:
     assert list(merged["__cubes__"].values) == ["tp", "t2m"]
 
 
+def test_merge_cubes_wrapper_appends_third_named_predictor() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    reg = _build_process_registry()
+    merge = reg["merge_cubes"].implementation
+    coords = {
+        "t": np.array(["2025-01-01", "2025-02-01"], dtype="datetime64[D]"),
+        "geometry": ["DISTRICT_A", "DISTRICT_B"],
+    }
+    precipitation = xr.DataArray(
+        np.array([[100.0, 80.0], [120.0, 90.0]], dtype=np.float32),
+        dims=("t", "geometry"),
+        coords=coords,
+        name="precip",
+    )
+    temperature = xr.DataArray(
+        np.array([[25.0, 24.0], [26.0, 25.0]], dtype=np.float32),
+        dims=("t", "geometry"),
+        coords=coords,
+        name="t2m",
+    )
+    population = xr.DataArray(
+        np.array([[10_000.0, 20_000.0], [10_000.0, 20_000.0]], dtype=np.float32),
+        dims=("t", "geometry"),
+        coords=coords,
+        name="pop_total",
+    )
+
+    climate = merge(cube1=precipitation, cube2=temperature)
+    merged = merge(cube1=climate, cube2=population)
+
+    assert isinstance(merged, xr.DataArray)
+    assert list(merged["__cubes__"].values) == ["precip", "t2m", "pop_total"]
+    xr.testing.assert_equal(merged.sel(__cubes__="pop_total", drop=True), population)
+
+
+def test_merge_cubes_wrapper_combines_three_zonal_datasets_as_chap_csv() -> None:
+    """Single-variable Datasets mirror aggregate_spatial's return type."""
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    reg = _build_process_registry()
+    merge = reg["merge_cubes"].implementation
+    coords = {
+        "t": np.array(["2025-01-01", "2025-02-01"], dtype="datetime64[D]"),
+        "geometry": ["DISTRICT_A"],
+    }
+    precipitation = xr.Dataset(
+        {"precip": (("t", "geometry"), np.array([[100.0], [120.0]], dtype=np.float32))},
+        coords=coords,
+    )
+    temperature = xr.Dataset(
+        {"t2m": (("t", "geometry"), np.array([[25.0], [26.0]], dtype=np.float32))},
+        coords=coords,
+    )
+    population = xr.Dataset(
+        {"pop_total": (("t", "geometry"), np.array([[10_000.0], [10_000.0]], dtype=np.float32))},
+        coords=coords,
+    )
+
+    climate = merge(cube1=precipitation, cube2=temperature)
+    merged = merge(cube1=climate, cube2=population)
+    frame = _build_chap_csv_frame(merged.to_dataframe().reset_index(), {"period_type": "monthly"})
+
+    assert frame.to_dict(orient="records") == [
+        {
+            "time_period": "202501",
+            "location": "DISTRICT_A",
+            "precip": "100",
+            "t2m": "25",
+            "pop_total": "10000",
+        },
+        {
+            "time_period": "202502",
+            "location": "DISTRICT_A",
+            "precip": "120",
+            "t2m": "26",
+            "pop_total": "10000",
+        },
+    ]
+
+
+def test_merge_cubes_wrapper_rejects_misaligned_predictor_indexes() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    reg = _build_process_registry()
+    merge = reg["merge_cubes"].implementation
+    precipitation = xr.DataArray(
+        np.ones((2, 1), dtype=np.float32),
+        dims=("t", "geometry"),
+        coords={"t": [0, 1], "geometry": ["DISTRICT_A"]},
+        name="precip",
+    )
+    temperature = precipitation.rename("t2m")
+    population = xr.DataArray(
+        np.ones((2, 1), dtype=np.float32),
+        dims=("t", "geometry"),
+        coords={"t": [0, 2], "geometry": ["DISTRICT_A"]},
+        name="pop_total",
+    )
+
+    climate = merge(cube1=precipitation, cube2=temperature)
+    with pytest.raises(ValueError, match="cannot align objects with join='exact'"):
+        merge(cube1=climate, cube2=population)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_merge_cubes_wrapper_combines_two_named_predictor_groups(reverse: bool) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    predictors = [
+        xr.DataArray([float(index)], dims="t", coords={"t": [0]}, name=name)
+        for index, name in enumerate(["precip", "t2m", "pop_total", "elevation"])
+    ]
+    left = merge(cube1=predictors[0], cube2=predictors[1])
+    right = merge(cube1=predictors[2], cube2=predictors[3])
+    merged = merge(cube1=right, cube2=left) if reverse else merge(cube1=left, cube2=right)
+
+    expected = predictors[2:] + predictors[:2] if reverse else predictors
+    assert list(merged["__cubes__"].values) == [cube.name for cube in expected]
+    for cube in predictors:
+        xr.testing.assert_equal(merged.sel(__cubes__=cube.name, drop=True), cube)
+
+
+@pytest.mark.parametrize("missing", ["dimension", "index"])
+def test_merge_cubes_wrapper_does_not_broadcast_missing_predictor_axes(missing: str) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray(
+        np.ones((2, 1)),
+        dims=("t", "geometry"),
+        coords={"t": [0, 1], "geometry": ["DISTRICT_A"]},
+        name="precip",
+    )
+    climate = merge(cube1=cube, cube2=cube.rename("t2m"))
+    population = cube.rename("pop_total")
+    if missing == "dimension":
+        population = population.isel(t=0, drop=True)
+    else:
+        population = population.drop_indexes("t")
+    with pytest.raises(ValueError, match="Named predictors must have the same"):
+        merge(cube1=climate, cube2=population)
+
+
+def test_merge_cubes_wrapper_delegates_overlapping_labels_and_resolver() -> None:
+    from open_climate_service.openeo.execution import _make_named_merge_cubes
+
+    cube = xr.DataArray(
+        [[1.0], [2.0]],
+        dims=("__cubes__", "t"),
+        coords={"__cubes__": ["precip", "t2m"], "t": [0]},
+        name="precip",
+    )
+    other = cube.rename("other")
+    captured: dict[str, Any] = {}
+
+    def original(**kwargs: Any) -> xr.DataArray:
+        captured.update(kwargs)
+        return cube
+
+    resolver = object()
+    result = _make_named_merge_cubes(original)(cube1=cube, cube2=other, overlap_resolver=resolver)
+    assert captured["cube1"] is cube
+    assert captured["cube2"] is other
+    assert captured["overlap_resolver"] is resolver
+    assert result is cube
+    assert list(result["__cubes__"].values) == ["precip", "t2m"]
+
+
 def test_dhis2_period_string_accepts_existing_monthly_string() -> None:
     assert _to_dhis2_period_string("202401") == "202401"
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1263,8 +1263,10 @@ def test_merge_cubes_wrapper_does_not_broadcast_missing_predictor_axes(missing: 
         merge(cube1=climate, cube2=population)
 
 
-@pytest.mark.parametrize("dimension, labels", [("geometry", ["B", "A"]), ("y", [2.0, 1.0])])
-@pytest.mark.parametrize("noise", [0.0, 1e-9])
+@pytest.mark.parametrize(
+    "dimension, labels, noise",
+    [("geometry", ["B", "A"], 0.0), ("y", [2.0, 1.0], 0.0), ("y", [2.0, 1.0], 1e-9)],
+)
 def test_merge_cubes_wrapper_aligns_reordered_predictors(dimension: str, labels: list[Any], noise: float) -> None:
     from open_climate_service.openeo.execution import _build_process_registry
 
@@ -1297,6 +1299,29 @@ def test_merge_cubes_wrapper_uses_upstream_coordinate_tolerance(offset: float) -
         xr.testing.assert_equal(result.sel(__cubes__="population", drop=True), cube.rename("population"))
 
 
+@pytest.mark.parametrize("extra_side", ["stacked", "third"])
+def test_merge_cubes_wrapper_rejects_extra_index_labels(extra_side: str) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([1.0, 2.0], dims="geometry", coords={"geometry": ["A", "B"]}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m"))
+    third = cube.rename("population")
+    extra = xr.DataArray(
+        [1.0, 2.0, 3.0],
+        dims="geometry",
+        coords={"geometry": ["A", "B", "C"]},
+        name="population",
+    )
+    if extra_side == "stacked":
+        stacked = merge(cube1=extra.rename("precip"), cube2=extra.rename("t2m"))
+    else:
+        third = extra
+
+    with pytest.raises(ValueError, match="different labels on index 'geometry'"):
+        merge(cube1=stacked, cube2=third)
+
+
 @pytest.mark.parametrize("grouped", [False, True])
 def test_merge_cubes_wrapper_rejects_resolver_when_extending_group(grouped: bool) -> None:
     from open_climate_service.openeo.execution import _make_named_merge_cubes
@@ -1311,21 +1336,6 @@ def test_merge_cubes_wrapper_rejects_resolver_when_extending_group(grouped: bool
         _make_named_merge_cubes(lambda **kwargs: other)(
             cube1=cube, cube2=other, overlap_resolver=resolver, context=context
         )
-
-
-def test_merge_cubes_wrapper_rejects_resolver_for_overlapping_stacked_labels() -> None:
-    from open_climate_service.openeo.execution import _make_named_merge_cubes
-
-    cube = xr.DataArray(
-        [[1.0], [2.0]],
-        dims=("__cubes__", "t"),
-        coords={"__cubes__": ["precip", "t2m"], "t": [0]},
-        name="precip",
-    )
-    other = cube.rename("other")
-    resolver = object()
-    with pytest.raises(ValueError, match="only supported on the initial"):
-        _make_named_merge_cubes(lambda **kwargs: cube)(cube1=cube, cube2=other, overlap_resolver=resolver)
 
 
 def test_merge_cubes_registry_passes_context_and_overlap_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1399,6 +1409,28 @@ def test_merge_cubes_wrapper_ignores_non_index_scalar_coordinate_differences(rig
     result = merge(cube1=stacked, cube2=third)
 
     assert result.coords["spatial_ref"].item() == "EPSG:4326"
+
+
+def test_merge_cubes_wrapper_preserves_shared_auxiliary_and_drops_right_only_auxiliary() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray(
+        [1.0, 2.0],
+        dims="geometry",
+        coords={"geometry": ["A", "B"], "name": ("geometry", ["Alpha", "Beta"])},
+        name="precip",
+    )
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m"))
+    third = cube.rename("population").assign_coords(
+        name=("geometry", ["Other A", "Other B"]),
+        source_name=("geometry", ["one", "two"]),
+    )
+
+    result = merge(cube1=stacked, cube2=third)
+
+    assert result.coords["name"].values.tolist() == ["Alpha", "Beta"]
+    assert "source_name" not in result.coords
 
 
 def test_merge_cubes_wrapper_accepts_matching_unsorted_duplicate_index() -> None:

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1263,6 +1263,62 @@ def test_merge_cubes_wrapper_does_not_broadcast_missing_predictor_axes(missing: 
         merge(cube1=climate, cube2=population)
 
 
+@pytest.mark.parametrize("dimension, labels", [("geometry", ["B", "A"]), ("y", [2.0, 1.0])])
+@pytest.mark.parametrize("noise", [0.0, 1e-9])
+def test_merge_cubes_wrapper_aligns_reordered_predictors(dimension: str, labels: list[Any], noise: float) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([10.0, 20.0], dims=dimension, coords={dimension: labels}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m").copy(deep=True))
+    third = cube.rename("population").isel({dimension: [1, 0]})
+    if dimension == "y":
+        third = third.assign_coords({dimension: third[dimension] + noise})
+    before = third.copy(deep=True)
+    result = merge(cube1=stacked, cube2=third)
+    xr.testing.assert_equal(result.sel(__cubes__="population", drop=True), cube.rename("population"))
+    xr.testing.assert_identical(third, before)
+    assert result.chunksizes["__cubes__"] == (3,)
+
+
+@pytest.mark.parametrize("offset", [1e-9, 1e-4])
+def test_merge_cubes_wrapper_uses_upstream_coordinate_tolerance(offset: float) -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    cube = xr.DataArray([1.0, 2.0], dims="x", coords={"x": [10.0, 11.0]}, name="precip")
+    stacked = merge(cube1=cube, cube2=cube.rename("t2m").copy(deep=True))
+    third = cube.rename("population").assign_coords(x=cube.x + offset)
+    if offset > 1e-6:
+        with pytest.raises(ValueError, match="cannot align objects with join='exact'"):
+            merge(cube1=stacked, cube2=third)
+    else:
+        result = merge(cube1=stacked, cube2=third)
+        xr.testing.assert_equal(result.sel(__cubes__="population", drop=True), cube.rename("population"))
+
+
+@pytest.mark.parametrize("grouped", [False, True])
+def test_merge_cubes_wrapper_delegates_disjoint_resolver_and_context(grouped: bool) -> None:
+    from open_climate_service.openeo.execution import _make_named_merge_cubes
+
+    cube = xr.DataArray([[1.0], [2.0]], dims=("__cubes__", "t"), coords={"__cubes__": ["precip", "t2m"], "t": [0]})
+    other = xr.DataArray([3.0], dims="t", coords={"t": [0]}, name="population")
+    if grouped:
+        other = other.expand_dims(__cubes__=["population"])
+    captured: dict[str, Any] = {}
+    reduced = other.sum()
+
+    def original(**kwargs: Any) -> xr.DataArray:
+        captured.update(kwargs)
+        return reduced
+
+    resolver = object()
+    context = {"scale": 2}
+    result = _make_named_merge_cubes(original)(cube1=cube, cube2=other, overlap_resolver=resolver, context=context)
+    assert captured == {"cube1": cube, "cube2": other, "overlap_resolver": resolver, "context": context}
+    assert result is reduced
+
+
 def test_merge_cubes_wrapper_delegates_overlapping_labels_and_resolver() -> None:
     from open_climate_service.openeo.execution import _make_named_merge_cubes
 

--- a/tests/test_openeo_execution.py
+++ b/tests/test_openeo_execution.py
@@ -1445,6 +1445,18 @@ def test_merge_cubes_wrapper_accepts_matching_unsorted_duplicate_index() -> None
     xr.testing.assert_equal(result.sel(__cubes__="population", drop=True), cube.rename("population"))
 
 
+def test_merge_cubes_wrapper_rejects_different_duplicate_index() -> None:
+    from open_climate_service.openeo.execution import _build_process_registry
+
+    merge = _build_process_registry()["merge_cubes"].implementation
+    first = xr.DataArray([1.0, 2.0, 3.0], dims="t", coords={"t": [0, 1, 2]}, name="precip")
+    stacked = merge(cube1=first, cube2=first.rename("t2m"))
+    third = xr.DataArray([4.0, 5.0, 6.0], dims="t", coords={"t": [0, 1, 1]}, name="population")
+
+    with pytest.raises(ValueError, match="cannot be reordered because it has duplicate labels"):
+        merge(cube1=stacked, cube2=third)
+
+
 def test_merge_cubes_wrapper_preserves_same_variable_dataset_type_and_attrs() -> None:
     from open_climate_service.openeo.execution import _build_process_registry
 


### PR DESCRIPTION
Chaining `merge_cubes` for a third named predictor currently raises `OverlapResolverMissing` after the initial merge creates a `__cubes__` axis. This change combines predictors with distinct labels, including single-variable datasets returned by spatial aggregation, so precipitation, temperature, and population can be exported as separate CHAP CSV columns.

The wrapper also combines previously merged groups. Additional predictors must have matching dimensions and coordinate indexes; label ordering and tolerated floating-point coordinate noise are aligned without broadcasting or dropping extra rows. Shared auxiliary coordinates retain the left group metadata, while right-only auxiliaries are omitted. Overlap resolvers remain supported for the initial two-cube merge but are rejected when extending an already stacked predictor group.

Closes [CLIM-1012](https://dhis2.atlassian.net/browse/CLIM-1012).

[CLIM-1012]: https://dhis2.atlassian.net/browse/CLIM-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ