### PR TITLE
chore: ignore .venv, .claude and data as symlinks; anchor data to the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 .DS_Store
-.claude/
 __pycache__/
-.venv/
 .env
 climate-service.yaml
 eo_api.egg-info/
-data/
 docs/internal/
 site/
+
+# Without a trailing slash these match a symlink of that name too, which "/" lets through.
+.venv
+.claude
+
+# Anchored to the repo root, so a nested tests/data/ stays visible to git.
+/data


### PR DESCRIPTION
Two changes to `.gitignore`, both about patterns matching less than they appear to.

## A trailing slash lets a symlink through

A pattern ending in `/` matches a **directory** only, so a symlink of that name is not ignored and can be committed. Verified in a scratch repo with `.claude/`, `__pycache__/`, `.venv`, `data/`, `site/` in the ignore file:

```
git status --short --untracked-files=all
?? .claude
?? data
?? site
```

Only `.venv`, the one without a slash, is ignored.

`.venv`, `.claude` and `data` all get pointed elsewhere in practice — a shared virtualenv or agent config across git worktrees, a data directory onto external storage — and each misbehaves when committed. A `.venv` symlink makes CI fail at dependency install with `failed to create directory .venv: File exists (os error 17)`, an error that says nothing about a committed symlink being the cause; that happened on #374. The other two publish a path that exists on one machine only.

Build output keeps its trailing slashes: nobody symlinks `__pycache__`, `eo_api.egg-info` or the mkdocs `site` directory, and widening them would also start ignoring a same-named *file* for no benefit.

## `data` was shadowing `tests/data/`

Unanchored, `data` matches a `data` directory at **any depth** — including `tests/data/`, which holds five tracked fixtures:

```
data/   ->  tests/data/newfixture.csv    IGNORED
data    ->  tests/data/newfixture.csv    IGNORED
/data   ->  tests/data/newfixture.csv    not ignored
```

The committed fixtures were unaffected, since gitignore never applies to tracked files, but any *new* fixture added there was invisible to `git status` and needed `git add -f`. Anchoring as `/data` fixes that and still catches a root-level symlink, the two concerns being orthogonal.

Safe because the runtime data root falls back to XDG when unconfigured, so the pattern only ever mattered for a locally configured `./data`. `.venv` and `.claude` stay unanchored — neither shadows anything, and anchoring `.venv` would stop ignoring a venv created in a subdirectory.

## Verified

Symlink and directory ignored at the repo root for all three names, and `tests/data/newfixture.csv` visible again.
