### PR TITLE
feat(exports): add export plugins and DHIS2 delivery (CLIM-840)

### DIFF
--- a/docs/export_plugins.md
+++ b/docs/export_plugins.md
@@ -1,0 +1,138 @@
+# Export plugins and named mappings
+
+Named exports render a computed aggregate using a mapping in instance configuration.
+They work with synchronous `POST /result` and batch jobs. Rendering does not contact
+DHIS2, resolve a credential, fetch organisation units, or run another aggregation.
+
+## Render one series for DHIS2
+
+Add an export to the file referenced by `CLIMATE_SERVICE_CONFIG`:
+
+```yaml
+exports:
+  - id: rainfall-monthly
+    plugin: dhis2
+    period_type: monthly
+    org_unit_field: geometry
+    period_field: t
+    series:
+      - select: {}
+        data_element: BXgDHhPdFVU
+```
+
+Replace the data-element UID with the destination defined in your DHIS2 instance.
+Pass the prepared aggregate to `save_result`:
+
+```json
+{
+  "process_id": "save_result",
+  "arguments": {
+    "data": {"from_node": "aggregate"},
+    "format": "DHIS2JSON",
+    "options": {"export": "rainfall-monthly"}
+  },
+  "result": true
+}
+```
+
+This is a graph node; `aggregate` must be a preceding node in the full graph.
+Named exports accept only the `export` option. Change the configured mapping to
+change its destination or fields; per-request overrides are rejected. Existing
+`DHIS2JSON` calls using `data_element_id`, `org_unit_field`, and `period_type`
+continue to work without a named export.
+
+Each named DHIS2 export currently selects one value series. `select: {}` requires
+an unambiguous value column. To select a variable from a result with several
+variables, use `select: {variable: precip}`. Additional dimensions such as
+quantile or ensemble member must be selected or reduced upstream. Several datasets
+can be published through separate single-series exports; no merged cube is required.
+
+The series may also specify `category_option_combo` and `attribute_option_combo`.
+All destination and organisation-unit IDs must have DHIS2 UID syntax. Positional
+labels such as `0`, missing IDs, duplicate organisation-unit/period keys, and invalid
+calendar periods are rejected. Zero values are preserved; missing observations are
+omitted and counted. Non-finite and non-numeric values are rejected.
+
+Supported output periods are daily, weekly (ISO), monthly, quarterly, and yearly.
+`period_type` formats already prepared observations; it does not aggregate them.
+Multiple dekads in the same month cannot be exported simply by labelling them
+monthly, since they would produce duplicate destination keys. Explicit incompatible
+`period_type` attributes are also rejected. Without execution provenance, the
+renderer cannot prove that an arbitrary input value was aggregated correctly.
+
+The optional `dataset`, `org_units`, and `connection` references, and the optional
+`aggregation` declaration, describe intended input/delivery configuration. This
+phase does not resolve those references or verify the computation against them.
+They do not trigger any work. A connection is not required to render a payload.
+Use [named connections](importing_to_dhis2.md#named-connections-for-server-side-plugins)
+when writing a separate operator integration that needs a client.
+
+## Write a render-only plugin
+
+Export plugins implement the public `BaseExportPlugin` contract and expose an
+instance named `plugin` in each discoverable module:
+
+```python
+import json
+
+from open_climate_service.exports import BaseExportPlugin, RenderedExport
+
+
+class SummaryExport(BaseExportPlugin):
+    id = "summary"
+    format = "SUMMARYJSON"
+    extension = ".json"
+    media_type = "application/json"
+
+    def validate_mapping(self, mapping):
+        if mapping:
+            raise ValueError("Summary export does not accept mapping fields")
+        return {}
+
+    def render(self, data, mapping):
+        payload = {"variables": list(data.data_vars)}
+        return RenderedExport(json.dumps(payload).encode(), record_count=len(data.data_vars))
+
+
+plugin = SummaryExport()
+```
+
+Declare `exports: [{id: summary, plugin: summary}]` and use
+`save_result(format="SUMMARYJSON", options={"export": "summary"})`.
+The format is advertised in `GET /file_formats` with its `export` parameter.
+
+`render` receives the computed result and the validated mapping. It returns bytes
+and non-negative `record_count` / `skipped_count` values. The framework owns file
+paths, persistence, and HTTP response metadata. Both methods must be pure: no
+network calls, credential resolution, file writes, or delivery. Keep invocation
+state local because plugin instances may be shared by concurrent jobs.
+
+For an installed package, put the module in `<package>/exports/` and include
+`__init__.py`. Use the same `open_climate_service.plugins` entry point as other
+[installable plugins](installable_plugins.md). No separate export entry point is
+needed. For an instance, put it in `plugins_dir/exports/`; relative helper imports
+are supported. Prefix helper filenames with `_` so discovery skips them.
+
+Precedence is built-in, then installed packages, then local instance plugins,
+matched by plugin ID. Installed packages and module filenames are sorted for
+deterministic loading. Broken modules fail explicitly rather than falling back to
+a different renderer. Python modules are cached by Python's import machinery;
+restart the service after changing plugin code.
+
+Format identifiers use uppercase letters, digits, and underscores. File extensions
+are a dot followed by lowercase letters or digits; Zarr directories are excluded.
+Media types use `type/subtype` without parameters. Plugin code is operator-installed
+Python code and must be trusted by the deployment.
+
+## Saved results and subsequent phases
+
+Batch jobs write `export.<extension>` and a small `.export.json` file containing
+the format, media type, and counts. Assets retain their media type even if plugin
+configuration later changes. Synchronous rendering returns the payload directly
+and remains available in read-only mode.
+
+The file metadata is not a delivery manifest. Source snapshots, feature versions,
+frozen mapping/target bindings, payload digests, retention, and delivery eligibility
+belong to the next phase. Server-side sending, dry runs against DHIS2, import reports,
+retry/recovery, and multi-series mappings are not implemented by this rendering
+phase. Downloaded DHIS2 JSON can still be imported by the existing client workflow.

--- a/docs/export_plugins.md
+++ b/docs/export_plugins.md
@@ -61,11 +61,13 @@ monthly, since they would produce duplicate destination keys. Explicit incompati
 renderer cannot prove that an arbitrary input value was aggregated correctly.
 
 The optional `dataset`, `org_units`, and `connection` references, and the optional
-`aggregation` declaration, describe intended input/delivery configuration. This
-phase does not resolve those references or verify the computation against them.
-They do not trigger any work. A connection is not required to render a payload.
-Use [named connections](importing_to_dhis2.md#named-connections-for-server-side-plugins)
-when writing a separate operator integration that needs a client.
+`aggregation` declaration, describe intended input/delivery configuration. They
+do not trigger any work. Batch exports bind these declarations to a manifest and
+check an observed dataset reference when execution provenance contains one. A
+connection is not required to render or download a payload, but a bound connection
+is required for later server-side delivery. Use
+[named connections](importing_to_dhis2.md#named-connections-for-server-side-plugins)
+for that binding.
 
 ## Write a render-only plugin
 
@@ -124,15 +126,27 @@ are a dot followed by lowercase letters or digits; Zarr directories are excluded
 Media types use `type/subtype` without parameters. Plugin code is operator-installed
 Python code and must be trusted by the deployment.
 
-## Saved results and subsequent phases
+## Saved results and delivery eligibility
 
-Batch jobs write `export.<extension>` and a small `.export.json` file containing
-the format, media type, and counts. Assets retain their media type even if plugin
-configuration later changes. Synchronous rendering returns the payload directly
-and remains available in read-only mode.
+Each batch render writes a fresh payload generation and a versioned JSON manifest,
+then atomically replaces `.export.json` as the pointer to that generation. The
+manifest records payload and mapping digests, renderer identity and version, record
+counts and periods, the source job, public configuration references, a credential-free
+target fingerprint, and execution provenance available from OCS processes. The
+payload and manifest are both exposed as job result assets. Synchronous rendering
+still returns the payload directly and remains available in read-only mode.
 
-The file metadata is not a delivery manifest. Source snapshots, feature versions,
-frozen mapping/target bindings, payload digests, retention, and delivery eligibility
-belong to the next phase. Server-side sending, dry runs against DHIS2, import reports,
-retry/recovery, and multi-series mappings are not implemented by this rendering
-phase. Downloaded DHIS2 JSON can still be imported by the existing client workflow.
+Execution provenance records observed managed artifacts, Icechunk snapshot IDs,
+and hashes of inline spatial features where those inputs pass through native OCS
+processes. The manifest explicitly lists evidence that is unavailable; declarations
+alone do not prove aggregation semantics or per-output lineage.
+
+The delivery-input validator accepts only completed jobs with intact payloads and
+manifests whose mapping, plugin version, target, references, and process graph still
+match. It holds a cross-process lease that prevents job update, rerun, or deletion
+while a future delivery worker consumes the bytes. Older named-export assets remain
+downloadable but are not eligible for automatic delivery.
+
+Server-side sending, remote dry runs, import reports, retry/recovery, and multi-series
+mappings remain subsequent work. Downloaded DHIS2 JSON can still be imported by the
+existing client workflow.

--- a/docs/export_plugins.md
+++ b/docs/export_plugins.md
@@ -41,13 +41,18 @@ change its destination or fields; per-request overrides are rejected. Existing
 `DHIS2JSON` calls using `data_element_id`, `org_unit_field`, and `period_type`
 continue to work without a named export.
 
-Each named DHIS2 export currently selects one value series. `select: {}` requires
+Each series mapping selects one value series. `select: {}` requires
 an unambiguous value column. To select a variable from a result with several
 variables, use `select: {variable: precip}`. Additional dimensions such as
-quantile or ensemble member must be selected or reduced upstream. Several datasets
+quantile can be selected with `select: {variable: precip, quantile: 0.1}`;
+other dimensions, such as ensemble member, must be reduced upstream. Several datasets
 can be published through separate single-series exports; no merged cube is required.
 
 The series may also specify `category_option_combo` and `attribute_option_combo`.
+When several series target the same data element, specify each combo consistently
+on every series or omit it on every series. Mixing implicit and explicit defaults
+is rejected because the renderer cannot resolve target metadata without a network
+request. Explicit duplicate destination keys are always rejected.
 All destination and organisation-unit IDs must have DHIS2 UID syntax. Positional
 labels such as `0`, missing IDs, duplicate organisation-unit/period keys, and invalid
 calendar periods are rejected. Zero values are preserved; missing observations are
@@ -144,9 +149,63 @@ alone do not prove aggregation semantics or per-output lineage.
 The delivery-input validator accepts only completed jobs with intact payloads and
 manifests whose mapping, plugin version, target, references, and process graph still
 match. It holds a cross-process lease that prevents job update, rerun, or deletion
-while a future delivery worker consumes the bytes. Older named-export assets remain
+while a delivery worker consumes the bytes. Older named-export assets remain
 downloadable but are not eligible for automatic delivery.
 
-Server-side sending, remote dry runs, import reports, retry/recovery, and multi-series
-mappings remain subsequent work. Downloaded DHIS2 JSON can still be imported by the
-existing client workflow.
+## Deliver a saved export
+
+Configure `connection` on the export, then submit a completed source job:
+
+```http
+POST /exports/rainfall-monthly
+Idempotency-Key: rainfall-job-123-validation
+Content-Type: application/json
+
+{"job_id": "job-123", "dry_run": true}
+```
+
+The response is `202 Accepted` with a delivery job ID and status/report URL. The
+source job also links to that delivery. Inspect `report.outcome`, which distinguishes
+success, dry-run validation, partial imports, rejection, cancellation and unknown
+remote outcomes. A dry run can be rejected; its counts describe validation rather
+than saved writes. Use a new idempotency key to request the actual import with
+`dry_run: false`. Reports are scoped to `/exports/{export_id}/jobs/{delivery_job_id}`.
+
+Reservations are persisted before jobs are enqueued. Repeating a key returns the
+original job; changing its source, manifest or mode is a conflict. After a crash
+between reservation and job creation, repeat the request to create the reserved job.
+The worker checks the exact manifest captured at submission, so rerendering the
+source while delivery is queued requires a new submission. Old queued delivery
+jobs without that binding fail before sending and must be submitted again.
+
+DHIS2 payloads are split into deterministic chunks of at most 1,000 values. Chunk
+intent is saved before POST; completed chunks are reused on recovery. An uncertain
+POST without a task ID is reported as unknown and is never automatically resent.
+Known async tasks are polled through the DHIS2 `DATAVALUE_IMPORT` task summaries
+endpoint. Corrupt or incompatible checkpoints stop recovery. Imports for the same
+export are serialized; different exports may still overlap in their destination
+keys, so operators must coordinate those mappings. `submitted` counts attempted
+values, including uncertain writes, rather than the full planned payload.
+
+Delivery and reports require a writable instance and are closed in read-only mode.
+Writable deployments must put these endpoints behind an operator access boundary;
+OCS does not yet provide per-user authorization. Downloaded JSON remains usable
+through the existing client workflow.
+
+## Map multiple series
+
+Use one entry per output series; a merged raster cube is not required:
+
+```yaml
+series:
+  - select: {variable: temperature}
+    data_element: TEMP0000001
+  - select: {variable: precipitation}
+    data_element: PREC0000001
+```
+
+Replace these example UIDs with target metadata. Wide DataFrames, multi-variable
+xarray aggregates and merged aggregate cubes are supported. Zero is retained and
+missing values are counted separately per series. Direct named DHIS2 graphs check
+original GeoJSON feature IDs before spatial aggregation; the renderer also rejects
+invalid organisation-unit UIDs and duplicate destination keys.

--- a/docs/importing_to_dhis2.md
+++ b/docs/importing_to_dhis2.md
@@ -81,6 +81,10 @@ operator command or future HTTP route remains responsible for those controls.
 
 ## 1. Fetch organisation units from DHIS2
 
+For reusable destination mappings and pure rendering through `save_result`, see
+[Export plugins and named mappings](export_plugins.md). The client-driven workflow
+below remains supported.
+
 Pull the org unit boundaries as GeoJSON. Each feature's `id` is the org unit UID, which the workflow uses as the `orgUnit`.
 
 ```python

--- a/docs/importing_to_dhis2.md
+++ b/docs/importing_to_dhis2.md
@@ -18,6 +18,67 @@ The full runnable script is [`examples/aggregate_and_import_to_dhis2.py`](https:
 
   `open-climate-service` ships the `ClimateService` client; [dhis2-python-client](https://github.com/dhis2/dhis2-python-client) handles the DHIS2 Web API calls.
 
+## Named connections for server-side plugins
+
+Exporters and feature providers running inside an OCS instance can share a named
+DHIS2 connection. Configure it in the file referenced by `CLIMATE_SERVICE_CONFIG`:
+
+```yaml
+dhis2_connections:
+  - id: national-hmis
+    url: https://hmis.example.org/dhis
+    token_env: DHIS2_IMPORT_TOKEN
+    timeout: 30
+    connect_timeout: 10
+    retries: 3
+```
+
+Use the instance URL, including its deployment path if any, without appending
+`/api`. The timeout fields are positive seconds; `retries` is an integer from 0 to
+10. The shown values are defaults. TLS verification is enabled. Connection IDs
+must be unique and contain letters, digits, underscores, or hyphens.
+
+Supply the raw personal access token in the server process's `DHIS2_IMPORT_TOKEN`
+environment variable. Connection fields are literal: use `token_env: DHIS2_IMPORT_TOKEN`,
+not `token_env: ${DHIS2_IMPORT_TOKEN}`. Embedded credentials, token/password fields,
+and URLs with query strings or fragments are rejected. Configuration using this
+section must be valid YAML before environment substitution; quote placeholders in
+other sections when necessary. Existing interpolation outside this section remains
+available.
+
+The client is optional and is supplied by the deployment or integration plugin.
+It is not yet available on PyPI. The connection accessor was tested against
+`dhis2-python-client` revision `41d696ad59f5ac09fce282ead80df32e451e7ff1` (0.3.1).
+For an instance managed with uv, add it to that instance's project:
+
+```bash
+uv add "dhis2-client @ git+https://github.com/dhis2/dhis2-python-client.git@41d696ad59f5ac09fce282ead80df32e451e7ff1"
+```
+
+An independently installed provider can use the public accessor without reading
+OCS configuration or handling credentials itself:
+
+```python
+from contextlib import closing
+
+from open_climate_service.exports.dhis2 import get_connection
+
+with closing(get_connection("national-hmis")) as dhis2:
+    org_units = dhis2.get_org_units_geojson(level=2)
+```
+
+Each call creates a client and resolves the current token. The caller must close
+the client; `contextlib.closing` also closes it if the operation fails. Creating a
+client sends no network requests. A new call picks up token rotation, while an
+already open client retains its original token. `get_connection_config(id)` returns
+only non-secret settings and works without the optional client or a configured token.
+
+The tested client retries GET responses with server errors; it does not
+automatically replay POST requests or retry transport exceptions. Delivery jobs
+will own import recovery and reports. This connection helper does not introduce
+an export endpoint, bypass read-only guards, or authorize operations: the calling
+operator command or future HTTP route remains responsible for those controls.
+
 ## 1. Fetch organisation units from DHIS2
 
 Pull the org unit boundaries as GeoJSON. Each feature's `id` is the org unit UID, which the workflow uses as the `orgUnit`.

--- a/docs/installable_plugins.md
+++ b/docs/installable_plugins.md
@@ -1,6 +1,6 @@
 # Installable plugins
 
-There are two ways to add datasets, processes, and workflows to an instance, and they
+There are two ways to add datasets, processes, workflows, and export renderers to an instance, and they
 complement each other:
 
 - **`plugins_dir`** — drop files into the instance's local plugins folder. Ideal for
@@ -15,9 +15,9 @@ keeps working exactly as before, and still takes precedence (see [Precedence](#p
 
 ## Package layout
 
-An importable package can ship any combination of the three extension points — **datasets,
-processes, and workflows are all auto-discovered** when the package is installed. `datasets/`
-and `processes/` hold importable Python, so each needs an `__init__.py` (`workflows/` is plain
+An importable package can ship any combination of these extension points — **datasets,
+processes, workflows, and exports are auto-discovered** when the package is installed. `datasets/`,
+`processes/`, and `exports/` hold importable Python, so each needs an `__init__.py` (`workflows/` is plain
 JSON and does not):
 
 ```
@@ -32,6 +32,9 @@ osc_example_plugin/
     my_process.py
   workflows/             # optional: openEO UDP JSON graphs
     my_workflow.json
+  exports/               # optional: pure export renderers
+    __init__.py
+    my_export.py         # exposes plugin = BaseExportPlugin subclass instance
 ```
 
 The layout mirrors `plugins_dir`, so migrating a `plugins_dir`-based plugin to a distributable
@@ -71,8 +74,9 @@ uv add osc-example-plugin
 ```
 
 OCS auto-discovers every installed package in the `open_climate_service.plugins` group and loads
-its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), and its
-`workflows/*.json` (openEO UDPs). The ingestion plugin class is importable by dotted path because
+its `datasets/*.yaml` templates, its `processes/` (`@process`-decorated callables), its
+`workflows/*.json` (openEO UDPs), and its `exports/` renderers (see [Export plugins](export_plugins.md)).
+The ingestion plugin class is importable by dotted path because
 the package is installed. The datasets then appear in `/datasets` and can be ingested like any
 built-in.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Adding custom datasets: adding_custom_datasets.md
       - Extensibility: extensibility.md
       - Installable plugins: installable_plugins.md
+      - Export plugins: export_plugins.md
       - API reference: managed_data_api_guide.md
   - Roadmap: roadmap.md
   - Team: team.md

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -89,14 +89,18 @@ def _block_uses_interpolation(text: str, key: str) -> bool:
         if not re.match(rf"^{re.escape(key)}\s*:", lines[index]):
             index += 1
             continue
-        # The value may be written on the key line itself, for example
-        # ``exports: ${EXPORTS}`` or as an inline YAML collection.
-        if "${" in lines[index]:
+        # The value may be written on the key line itself. Aliases and anchors
+        # make the protected value depend on YAML outside this block, where the
+        # literal interpolation check cannot safely follow it.
+        value = lines[index].split(":", 1)[1].strip()
+        if "${" in value or value.startswith(("*", "&")):
             return True
         index += 1
         while index < len(lines):
             candidate = lines[index]
-            if candidate and candidate[0] not in (" ", "\t"):
+            # Column-zero comments remain part of the surrounding YAML block.
+            # Stop only at the next ordinary top-level mapping key.
+            if re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", candidate):
                 break
             if "${" in candidate:
                 return True

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -51,10 +51,28 @@ def _load_config() -> dict[str, Any]:
         return {}
     if not path.exists():
         raise FileNotFoundError(f"CLIMATE_SERVICE_CONFIG not found: {path}")
-    text = _substitute_env_vars(path.read_text(encoding="utf-8"))
-    loaded = yaml.safe_load(text)
+    text = path.read_text(encoding="utf-8")
+    try:
+        literal = yaml.safe_load(text)
+    except yaml.YAMLError:
+        # Existing configurations may interpolate YAML syntax (for example bbox
+        # members). Preserve that behavior when named connections are not used.
+        literal = None
+    if isinstance(literal, dict) and "dhis2_connections" in literal:
+        from open_climate_service.exports.dhis2_config import parse_connections
+
+        # Do this before substitution, including when a secret contains YAML syntax.
+        parse_connections(literal["dhis2_connections"])
+    loaded = yaml.safe_load(_substitute_env_vars(text))
     if loaded is not None and not isinstance(loaded, dict):
         raise ValueError(f"CLIMATE_SERVICE_CONFIG must be a YAML mapping at the top level: {path}")
+    if loaded is not None and "dhis2_connections" in loaded:
+        # Validate the literal definitions before caching anything. In particular,
+        # token_env: ${TOKEN} must not expand a credential into cached configuration.
+        if not isinstance(literal, dict) or "dhis2_connections" not in literal:
+            raise ValueError("dhis2_connections requires literal definitions in YAML valid before interpolation")
+        if literal["dhis2_connections"] != loaded["dhis2_connections"]:
+            raise ValueError("dhis2_connections does not support environment interpolation; use token_env references")
     _cache = dict(loaded or {})
     return _cache
 

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -63,6 +63,10 @@ def _load_config() -> dict[str, Any]:
 
         # Do this before substitution, including when a secret contains YAML syntax.
         parse_connections(literal["dhis2_connections"])
+    if isinstance(literal, dict) and "exports" in literal:
+        from open_climate_service.exports.manifest import validate_public_mapping
+
+        validate_public_mapping(literal["exports"])
     loaded = yaml.safe_load(_substitute_env_vars(text))
     if loaded is not None and not isinstance(loaded, dict):
         raise ValueError(f"CLIMATE_SERVICE_CONFIG must be a YAML mapping at the top level: {path}")
@@ -73,6 +77,9 @@ def _load_config() -> dict[str, Any]:
             raise ValueError("dhis2_connections requires literal definitions in YAML valid before interpolation")
         if literal["dhis2_connections"] != loaded["dhis2_connections"]:
             raise ValueError("dhis2_connections does not support environment interpolation; use token_env references")
+    if loaded is not None and "exports" in loaded:
+        if not isinstance(literal, dict) or literal.get("exports") != loaded["exports"]:
+            raise ValueError("exports requires literal definitions in YAML valid before interpolation")
     _cache = dict(loaded or {})
     return _cache
 

--- a/open_climate_service/config.py
+++ b/open_climate_service/config.py
@@ -52,36 +52,57 @@ def _load_config() -> dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"CLIMATE_SERVICE_CONFIG not found: {path}")
     text = path.read_text(encoding="utf-8")
-    try:
-        literal = yaml.safe_load(text)
-    except yaml.YAMLError:
-        # Existing configurations may interpolate YAML syntax (for example bbox
-        # members). Preserve that behavior when named connections are not used.
-        literal = None
-    if isinstance(literal, dict) and "dhis2_connections" in literal:
-        from open_climate_service.exports.dhis2_config import parse_connections
-
-        # Do this before substitution, including when a secret contains YAML syntax.
-        parse_connections(literal["dhis2_connections"])
-    if isinstance(literal, dict) and "exports" in literal:
-        from open_climate_service.exports.manifest import validate_public_mapping
-
-        validate_public_mapping(literal["exports"])
+    # Named connections and export mappings are validated as literal definitions.
+    # Reject environment interpolation inside only these two blocks before
+    # substitution, so a secret that happens to contain YAML syntax can never
+    # break parsing or be cached, while existing interpolation elsewhere (for
+    # example bbox: [${MINX}, ${MINY}]) keeps working.
+    for block in ("dhis2_connections", "exports"):
+        if _block_uses_interpolation(text, block):
+            raise ValueError(f"{block} does not support environment interpolation; use literal values")
     loaded = yaml.safe_load(_substitute_env_vars(text))
     if loaded is not None and not isinstance(loaded, dict):
         raise ValueError(f"CLIMATE_SERVICE_CONFIG must be a YAML mapping at the top level: {path}")
     if loaded is not None and "dhis2_connections" in loaded:
-        # Validate the literal definitions before caching anything. In particular,
-        # token_env: ${TOKEN} must not expand a credential into cached configuration.
-        if not isinstance(literal, dict) or "dhis2_connections" not in literal:
-            raise ValueError("dhis2_connections requires literal definitions in YAML valid before interpolation")
-        if literal["dhis2_connections"] != loaded["dhis2_connections"]:
-            raise ValueError("dhis2_connections does not support environment interpolation; use token_env references")
+        from open_climate_service.exports.dhis2_config import parse_connections
+
+        parse_connections(loaded["dhis2_connections"])
     if loaded is not None and "exports" in loaded:
-        if not isinstance(literal, dict) or literal.get("exports") != loaded["exports"]:
-            raise ValueError("exports requires literal definitions in YAML valid before interpolation")
+        from open_climate_service.exports.manifest import validate_public_mapping
+
+        validate_public_mapping(loaded["exports"])
     _cache = dict(loaded or {})
     return _cache
+
+
+def _block_uses_interpolation(text: str, key: str) -> bool:
+    """Return True when the top-level ``key`` block contains ``${...}`` tokens.
+
+    Interpolation is disallowed inside ``dhis2_connections`` and ``exports``
+    because those definitions are validated as literals and a substituted secret
+    must never be cached. The scan stops at the next top-level key, so
+    interpolation in other blocks remains supported.
+    """
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        if not re.match(rf"^{re.escape(key)}\s*:", lines[index]):
+            index += 1
+            continue
+        # The value may be written on the key line itself, for example
+        # ``exports: ${EXPORTS}`` or as an inline YAML collection.
+        if "${" in lines[index]:
+            return True
+        index += 1
+        while index < len(lines):
+            candidate = lines[index]
+            if candidate and candidate[0] not in (" ", "\t"):
+                break
+            if "${" in candidate:
+                return True
+            index += 1
+        break
+    return False
 
 
 DEFAULT_CRS = "EPSG:4326"

--- a/open_climate_service/data_accessor/services/accessor.py
+++ b/open_climate_service/data_accessor/services/accessor.py
@@ -154,6 +154,9 @@ def open_icechunk_dataset(store_path: str | Path) -> xr.Dataset:
         ds = ds.sortby(t_dim)
     except ValueError:
         pass
+    from open_climate_service.shared.provenance import record_snapshot
+
+    record_snapshot(str(path), session.snapshot_id)
     return ds
 
 

--- a/open_climate_service/exports/__init__.py
+++ b/open_climate_service/exports/__init__.py
@@ -1,5 +1,6 @@
 """Public integration helpers for exporting computed results."""
 
 from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
+from open_climate_service.exports.report import ExportOutcome, ExportReport
 
-__all__ = ["BaseExportPlugin", "RenderedExport"]
+__all__ = ["BaseExportPlugin", "RenderedExport", "ExportOutcome", "ExportReport"]

--- a/open_climate_service/exports/__init__.py
+++ b/open_climate_service/exports/__init__.py
@@ -1,1 +1,5 @@
 """Public integration helpers for exporting computed results."""
+
+from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
+
+__all__ = ["BaseExportPlugin", "RenderedExport"]

--- a/open_climate_service/exports/__init__.py
+++ b/open_climate_service/exports/__init__.py
@@ -1,0 +1,1 @@
+"""Public integration helpers for exporting computed results."""

--- a/open_climate_service/exports/__init__.py
+++ b/open_climate_service/exports/__init__.py
@@ -1,6 +1,13 @@
 """Public integration helpers for exporting computed results."""
 
-from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
-from open_climate_service.exports.report import ExportOutcome, ExportReport
+from open_climate_service.exports.base import BaseExportPlugin, DeliveryContext, RenderedExport
+from open_climate_service.exports.report import ExportOutcome, ExportReport, merge_chunk_reports
 
-__all__ = ["BaseExportPlugin", "RenderedExport", "ExportOutcome", "ExportReport"]
+__all__ = [
+    "BaseExportPlugin",
+    "DeliveryContext",
+    "RenderedExport",
+    "ExportOutcome",
+    "ExportReport",
+    "merge_chunk_reports",
+]

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from open_climate_service.exports.report import ExportReport
 
@@ -22,6 +22,32 @@ class RenderedExport:
         for count in (self.record_count, self.skipped_count):
             if type(count) is not int or count < 0:
                 raise ValueError("Export counts must be non-negative integers")
+
+
+class DeliveryContext(Protocol):
+    """Execution hooks the framework hands a delivery plugin during ``send``.
+
+    The protocol mirrors the native job's ``JobExecutionContext`` without coupling
+    external plugins to job internals: progress reporting, cooperative
+    cancellation, and durable per-chunk checkpoints. Plugins must remain usable
+    with a no-op implementation so their delivery code works standalone.
+    """
+
+    def report_progress(self, done: int | None = None, total: int | None = None, message: str | None = None) -> None:
+        """Persist coarse progress (e.g. chunks sent) for one delivery job."""
+        ...
+
+    def is_cancel_requested(self) -> bool:
+        """Return True when the delivery job has been asked to stop."""
+        ...
+
+    def save_checkpoint(self, key: str, state: dict[str, Any]) -> None:
+        """Persist one resumable chunk checkpoint under a plugin-chosen key."""
+        ...
+
+    def load_checkpoint(self, key: str) -> dict[str, Any] | None:
+        """Return a previously saved chunk checkpoint, or None."""
+        ...
 
 
 class BaseExportPlugin(ABC):
@@ -50,10 +76,19 @@ class BaseExportPlugin(ABC):
     def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
         """Serialize a computed result using a validated mapping."""
 
-    def send(self, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
+    def send(
+        self,
+        payload: bytes,
+        target: Any,
+        *,
+        dry_run: bool = False,
+        context: DeliveryContext | None = None,
+    ) -> ExportReport:
         """Deliver a rendered payload and report what the far end accepted.
 
         Delivery plugins override this and set ``supports_delivery = True``. The
+        ``context`` carries progress, cancellation, and checkpoint hooks; a plugin
+        must tolerate ``context=None`` so it remains callable standalone. The
         default raises so a render-only plugin fails loudly instead of being
         silently treated as a no-op delivery.
         """

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -1,0 +1,43 @@
+"""Public contract for pure export renderers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RenderedExport:
+    """Serialized payload and counts; the framework owns file creation."""
+
+    content: bytes
+    record_count: int
+    skipped_count: int = 0
+
+    def __post_init__(self) -> None:
+        if type(self.content) is not bytes:
+            raise TypeError("Export content must be bytes")
+        for count in (self.record_count, self.skipped_count):
+            if type(count) is not int or count < 0:
+                raise ValueError("Export counts must be non-negative integers")
+
+
+class BaseExportPlugin(ABC):
+    """Render a computed result without network calls or delivery side effects.
+
+    Plugin modules expose an instance as ``plugin``. Configuration validation must
+    also be pure. Instances may be shared between threads; keep invocation state
+    in local variables. Delivery will be introduced as a separate capability.
+    """
+
+    id: str
+    format: str
+    extension: str
+    media_type: str
+
+    @abstractmethod
+    def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
+        """Return a validated mapping or raise ValueError."""
+
+    @abstractmethod
+    def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
+        """Serialize a computed result using a validated mapping."""

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -49,6 +49,10 @@ class DeliveryContext(Protocol):
         """Return a previously saved chunk checkpoint, or None."""
         ...
 
+    def delete_checkpoint(self, key: str) -> None:
+        """Remove a previously saved chunk checkpoint so it can be retried."""
+        ...
+
 
 class BaseExportPlugin(ABC):
     """Render a computed result without network calls or delivery side effects.

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -49,10 +49,6 @@ class DeliveryContext(Protocol):
         """Return a previously saved chunk checkpoint, or None."""
         ...
 
-    def delete_checkpoint(self, key: str) -> None:
-        """Remove a previously saved chunk checkpoint so it can be retried."""
-        ...
-
 
 class BaseExportPlugin(ABC):
     """Render a computed result without network calls or delivery side effects.

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -12,6 +12,7 @@ class RenderedExport:
     content: bytes
     record_count: int
     skipped_count: int = 0
+    periods: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if type(self.content) is not bytes:
@@ -33,6 +34,9 @@ class BaseExportPlugin(ABC):
     format: str
     extension: str
     media_type: str
+    # Renderer authors bump this when changing payload semantics. An unversioned
+    # renderer may produce files but cannot supply a verified delivery input.
+    version: str | None = None
 
     @abstractmethod
     def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:

--- a/open_climate_service/exports/base.py
+++ b/open_climate_service/exports/base.py
@@ -1,8 +1,10 @@
-"""Public contract for pure export renderers."""
+"""Public contract for export renderers and optional delivery."""
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
+
+from open_climate_service.exports.report import ExportReport
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,8 @@ class BaseExportPlugin(ABC):
     # Renderer authors bump this when changing payload semantics. An unversioned
     # renderer may produce files but cannot supply a verified delivery input.
     version: str | None = None
+    # Render-only plugins leave this False; the delivery endpoint refuses them.
+    supports_delivery: bool = False
 
     @abstractmethod
     def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
@@ -45,3 +49,12 @@ class BaseExportPlugin(ABC):
     @abstractmethod
     def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
         """Serialize a computed result using a validated mapping."""
+
+    def send(self, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
+        """Deliver a rendered payload and report what the far end accepted.
+
+        Delivery plugins override this and set ``supports_delivery = True``. The
+        default raises so a render-only plugin fails loudly instead of being
+        silently treated as a no-op delivery.
+        """
+        raise NotImplementedError(f"Export plugin '{self.id}' does not support delivery")

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -70,20 +70,6 @@ class JobDeliveryContext:
             raise ValueError("Invalid delivery checkpoints; refusing to resend")
         return checkpoints.get(key)
 
-    def delete_checkpoint(self, key: str) -> None:
-        """Remove one chunk checkpoint so the chunk can be retried."""
-        if self._load_cursor is None or self._save_cursor is None:
-            return
-        cursor = self._load_cursor()
-        if not isinstance(cursor, dict):
-            return
-        checkpoints = cursor.get("delivery_checkpoints")
-        if not isinstance(checkpoints, dict) or key not in checkpoints:
-            return
-        checkpoints = dict(checkpoints)
-        checkpoints.pop(key, None)
-        self._save_cursor({**cursor, "delivery_checkpoints": checkpoints})
-
 
 def deliver_named_export(
     export_id: str,

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -1,0 +1,143 @@
+"""Background delivery of a saved export payload and its submission."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+
+from open_climate_service.exports.delivery_input import VerifiedExport, lease_export_input
+from open_climate_service.exports.report import ExportReport
+from open_climate_service.shared.provenance import json_digest
+
+logger = logging.getLogger(__name__)
+
+
+def deliver_named_export(
+    export_id: str,
+    job_id: str,
+    dry_run: bool = False,
+    on_progress: Any = None,
+    is_cancel_requested: Any = None,
+) -> dict[str, Any]:
+    """Send a completed source job's saved payload through its export plugin.
+
+    Module-level so the native job store can re-import it on restart. Runs on the
+    native job thread; the source result lease is held for the entire send.
+    """
+    if on_progress is not None:
+        on_progress(0, 1, "Delivering export")
+    with lease_export_input(export_id, job_id) as verified:
+        report = _deliver(verified, export_id, dry_run)
+    if on_progress is not None:
+        on_progress(1, 1, "Delivery complete")
+    return report.model_dump(mode="json")
+
+
+def _deliver(verified: VerifiedExport, export_id: str, dry_run: bool) -> ExportReport:
+    from open_climate_service.exports.service import resolve_named_export
+
+    resolved = resolve_named_export(verified.manifest.plugin.format, {"export": export_id})
+    if not resolved.plugin.supports_delivery:
+        raise ValueError(f"Export plugin '{resolved.plugin.id}' does not support delivery")
+    target = verified.manifest.target.connection_id if verified.manifest.target else None
+    if target is None:
+        raise ValueError("Export was rendered without a delivery target")
+    report = resolved.plugin.send(verified.content, target, dry_run=dry_run)
+    # External Python plugins are not necessarily type-checked.
+    if not isinstance(report, ExportReport):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise TypeError("Export plugin send() must return ExportReport")
+    return report
+
+
+def submit_delivery(
+    export_id: str,
+    source_job_id: str,
+    dry_run: bool,
+    idempotency_key: str,
+) -> tuple[str, bool]:
+    """Verify, dedupe by idempotency key, enqueue, and reserve one delivery.
+
+    Returns ``(delivery_job_id, reused)``. Raises 409 when an idempotency key is
+    reused with different content, and 404/409 for invalid source jobs or
+    mappings via :func:`lease_export_input`.
+    """
+    from open_climate_service.exports.reservations import find_delivery, reserve_delivery
+    from open_climate_service.jobs.service import get_job_service
+
+    # Verify once under a brief lease to capture the content fingerprint before
+    # enqueuing; the worker re-acquires the lease for the actual send.
+    with lease_export_input(export_id, source_job_id) as verified:
+        connection_id = verified.manifest.target.connection_id if verified.manifest.target else None
+        fingerprint = _fingerprint(export_id, source_job_id, dry_run, verified.manifest.payload_sha256, connection_id)
+
+    existing = find_delivery(idempotency_key)
+    if existing is not None:
+        if existing.get("fingerprint") == fingerprint:
+            return str(existing["delivery_job_id"]), True
+        raise HTTPException(status_code=409, detail="Idempotency key reused with different delivery content")
+
+    record = get_job_service().submit_callable_job(
+        func=deliver_named_export,
+        label=f"export:{export_id}",
+        request={"export_id": export_id, "job_id": source_job_id, "dry_run": dry_run},
+        job_href_base=f"/exports/{export_id}/jobs",
+    )
+    reserve_delivery(
+        idempotency_key,
+        delivery_job_id=record.job_id,
+        export_id=export_id,
+        source_job_id=source_job_id,
+        dry_run=dry_run,
+        fingerprint=fingerprint,
+    )
+    link_source_job(source_job_id, export_id, record.job_id)
+    return record.job_id, False
+
+
+def link_source_job(source_job_id: str, export_id: str, delivery_job_id: str) -> None:
+    """Advertise a delivery job from its source openEO job's result metadata."""
+    from open_climate_service.openeo.jobs import store_update_job
+    from open_climate_service.shared.time import utc_now
+
+    entry = {
+        "delivery_job_id": delivery_job_id,
+        "export_id": export_id,
+        "status_url": f"/exports/{export_id}/jobs/{delivery_job_id}",
+        "created_at": utc_now().isoformat(),
+    }
+
+    def _mutation(record: Any) -> Any:
+        usage = dict(record.usage or {})
+        deliveries = usage.get("deliveries")
+        deliveries = list(deliveries) if isinstance(deliveries, list) else []
+        if not any(isinstance(item, dict) and item.get("delivery_job_id") == delivery_job_id for item in deliveries):
+            deliveries.append(entry)
+        usage["deliveries"] = deliveries
+        return record.model_copy(update={"usage": usage})
+
+    try:
+        store_update_job(source_job_id, _mutation)
+    except KeyError:
+        # The source job vanished between verification and linking; the delivery
+        # job is already enqueued, so do not fail the accepted submission.
+        logger.warning("Could not link delivery '%s' to missing source job '%s'", delivery_job_id, source_job_id)
+
+
+def _fingerprint(
+    export_id: str,
+    source_job_id: str,
+    dry_run: bool,
+    payload_sha256: str,
+    connection_id: str | None,
+) -> str:
+    return json_digest(
+        {
+            "export_id": export_id,
+            "source_job_id": source_job_id,
+            "dry_run": dry_run,
+            "payload_sha256": payload_sha256,
+            "connection_id": connection_id,
+        }
+    )

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import uuid4
 
 from fastapi import HTTPException
 
+from open_climate_service import config
 from open_climate_service.exports.base import DeliveryContext
 from open_climate_service.exports.delivery_input import VerifiedExport, lease_export_input
 from open_climate_service.exports.report import ExportReport
+from open_climate_service.shared.persistence import index_lock
 from open_climate_service.shared.provenance import json_digest
 
 logger = logging.getLogger(__name__)
@@ -56,11 +59,15 @@ class JobDeliveryContext:
         if self._load_cursor is None:
             return None
         cursor = self._load_cursor()
+        if cursor is None:
+            return None
         if not isinstance(cursor, dict):
-            return None
+            raise ValueError("Invalid delivery checkpoint cursor; refusing to resend")
         checkpoints = cursor.get("delivery_checkpoints")
-        if not isinstance(checkpoints, dict):
+        if checkpoints is None:
             return None
+        if not isinstance(checkpoints, dict):
+            raise ValueError("Invalid delivery checkpoints; refusing to resend")
         return checkpoints.get(key)
 
 
@@ -72,6 +79,7 @@ def deliver_named_export(
     is_cancel_requested: Any = None,
     save_cursor: Any = None,
     load_cursor: Any = None,
+    expected_manifest_sha256: str | None = None,
 ) -> dict[str, Any]:
     """Send a completed source job's saved payload through its export plugin.
 
@@ -86,7 +94,13 @@ def deliver_named_export(
         save_cursor=save_cursor,
         load_cursor=load_cursor,
     )
-    with lease_export_input(export_id, job_id) as verified:
+    # Serialize imports for this export even when they use different source jobs.
+    with (
+        index_lock(config.get_data_root() / "exports" / "active" / json_digest(export_id)),
+        lease_export_input(export_id, job_id) as verified,
+    ):
+        if expected_manifest_sha256 is None or _manifest_digest(verified) != expected_manifest_sha256:
+            raise ValueError("Source export changed or submission lacks a frozen manifest; submit a new delivery")
         report = _deliver(verified, export_id, dry_run, context)
     if on_progress is not None:
         on_progress(1, 1, "Delivery complete")
@@ -121,37 +135,65 @@ def submit_delivery(
     reused with different content, and 404/409 for invalid source jobs or
     mappings via :func:`lease_export_input`.
     """
-    from open_climate_service.exports.reservations import find_delivery, reserve_delivery
+    from open_climate_service.exports.reservations import find_delivery, reserve_delivery, submission_lock
+    from open_climate_service.jobs import store
     from open_climate_service.jobs.service import get_job_service
 
-    # Verify once under a brief lease to capture the content fingerprint before
-    # enqueuing; the worker re-acquires the lease for the actual send.
-    with lease_export_input(export_id, source_job_id) as verified:
-        connection_id = verified.manifest.target.connection_id if verified.manifest.target else None
-        fingerprint = _fingerprint(export_id, source_job_id, dry_run, verified.manifest.payload_sha256, connection_id)
+    with submission_lock():
+        existing = find_delivery(idempotency_key)
+        if existing is not None:
+            if (existing.get("export_id"), existing.get("source_job_id"), existing.get("dry_run")) != (
+                export_id,
+                source_job_id,
+                dry_run,
+            ):
+                raise HTTPException(status_code=409, detail="Idempotency key reused with different delivery content")
+            # A request retry must work while the worker holds its source lease
+            # or after the source has been deleted. The reserved job is immutable.
+            existing_job = store.get_job_record(str(existing["delivery_job_id"]))
+            if existing_job is not None:
+                from open_climate_service.exports.delivery_input import _verify
+                from open_climate_service.openeo.jobs import store_get_job
 
-    existing = find_delivery(idempotency_key)
-    if existing is not None:
-        if existing.get("fingerprint") == fingerprint:
-            return str(existing["delivery_job_id"]), True
-        raise HTTPException(status_code=409, detail="Idempotency key reused with different delivery content")
+                if store_get_job(source_job_id) is not None:
+                    # Read-only verification needs no exclusive consumer lease:
+                    # this branch returns a job, never sends the bytes it reads.
+                    current_digest = _manifest_digest(_verify(export_id, source_job_id))
+                    if current_digest != existing_job.request.get("expected_manifest_sha256"):
+                        raise HTTPException(
+                            status_code=409, detail="Idempotency key reused with different delivery content"
+                        )
+                return existing_job.job_id, True
 
-    record = get_job_service().submit_callable_job(
-        func=deliver_named_export,
-        label=f"export:{export_id}",
-        request={"export_id": export_id, "job_id": source_job_id, "dry_run": dry_run},
-        job_href_base=f"/exports/{export_id}/jobs",
-    )
-    reserve_delivery(
-        idempotency_key,
-        delivery_job_id=record.job_id,
-        export_id=export_id,
-        source_job_id=source_job_id,
-        dry_run=dry_run,
-        fingerprint=fingerprint,
-    )
-    link_source_job(source_job_id, export_id, record.job_id)
-    return record.job_id, False
+        with lease_export_input(export_id, source_job_id) as verified:
+            digest = _manifest_digest(verified)
+            fingerprint = json_digest({"manifest": digest, "dry_run": dry_run})
+        if existing is not None and existing.get("fingerprint") != fingerprint:
+            raise HTTPException(status_code=409, detail="Idempotency key reused with different delivery content")
+        delivery_id = str(existing["delivery_job_id"]) if existing is not None else str(uuid4())
+        if existing is None:
+            reserve_delivery(
+                idempotency_key,
+                delivery_job_id=delivery_id,
+                export_id=export_id,
+                source_job_id=source_job_id,
+                dry_run=dry_run,
+                fingerprint=fingerprint,
+            )
+        record = get_job_service().submit_callable_job(
+            func=deliver_named_export,
+            label=f"export:{export_id}",
+            request={
+                "export_id": export_id,
+                "job_id": source_job_id,
+                "dry_run": dry_run,
+                "expected_manifest_sha256": digest,
+            },
+            job_href_base=f"/exports/{export_id}/jobs",
+            job_id=delivery_id,
+        )
+        link_source_job(source_job_id, export_id, record.job_id)
+        return record.job_id, existing is not None
 
 
 def link_source_job(source_job_id: str, export_id: str, delivery_job_id: str) -> None:
@@ -183,19 +225,5 @@ def link_source_job(source_job_id: str, export_id: str, delivery_job_id: str) ->
         logger.warning("Could not link delivery '%s' to missing source job '%s'", delivery_job_id, source_job_id)
 
 
-def _fingerprint(
-    export_id: str,
-    source_job_id: str,
-    dry_run: bool,
-    payload_sha256: str,
-    connection_id: str | None,
-) -> str:
-    return json_digest(
-        {
-            "export_id": export_id,
-            "source_job_id": source_job_id,
-            "dry_run": dry_run,
-            "payload_sha256": payload_sha256,
-            "connection_id": connection_id,
-        }
-    )
+def _manifest_digest(verified: VerifiedExport) -> str:
+    return json_digest(verified.manifest.model_dump(mode="json"))

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -11,8 +11,8 @@ from fastapi import HTTPException
 from open_climate_service import config
 from open_climate_service.exports.base import DeliveryContext
 from open_climate_service.exports.delivery_input import VerifiedExport, lease_export_input
-from open_climate_service.exports.report import ExportReport
-from open_climate_service.shared.persistence import index_lock
+from open_climate_service.exports.report import ExportOutcome, ExportReport
+from open_climate_service.shared.persistence import AlreadyLocked, try_index_lock
 from open_climate_service.shared.provenance import json_digest
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,20 @@ class JobDeliveryContext:
             raise ValueError("Invalid delivery checkpoints; refusing to resend")
         return checkpoints.get(key)
 
+    def delete_checkpoint(self, key: str) -> None:
+        """Remove one chunk checkpoint so the chunk can be retried."""
+        if self._load_cursor is None or self._save_cursor is None:
+            return
+        cursor = self._load_cursor()
+        if not isinstance(cursor, dict):
+            return
+        checkpoints = cursor.get("delivery_checkpoints")
+        if not isinstance(checkpoints, dict) or key not in checkpoints:
+            return
+        checkpoints = dict(checkpoints)
+        checkpoints.pop(key, None)
+        self._save_cursor({**cursor, "delivery_checkpoints": checkpoints})
+
 
 def deliver_named_export(
     export_id: str,
@@ -95,15 +109,25 @@ def deliver_named_export(
         load_cursor=load_cursor,
     )
     # Serialize imports for this export even when they use different source jobs.
-    with (
-        index_lock(config.get_data_root() / "exports" / "active" / json_digest(export_id)),
-        lease_export_input(export_id, job_id) as verified,
-    ):
-        if expected_manifest_sha256 is None or _manifest_digest(verified) != expected_manifest_sha256:
-            raise ValueError("Source export changed or submission lacks a frozen manifest; submit a new delivery")
-        report = _deliver(verified, export_id, dry_run, context)
+    # Acquisition is non-blocking: a second delivery for the same export must fail
+    # fast rather than pin a worker thread for the full send.
+    active_lock = config.get_data_root() / "exports" / "active" / json_digest(export_id)
+    try:
+        with (
+            try_index_lock(active_lock),
+            lease_export_input(export_id, job_id) as verified,
+        ):
+            if expected_manifest_sha256 is None or _manifest_digest(verified) != expected_manifest_sha256:
+                raise ValueError("Source export changed or submission lacks a frozen manifest; submit a new delivery")
+            report = _deliver(verified, export_id, dry_run, context)
+    except AlreadyLocked:
+        raise HTTPException(status_code=409, detail="A delivery for this export is already in progress") from None
     if on_progress is not None:
         on_progress(1, 1, "Delivery complete")
+    if report.outcome == ExportOutcome.CANCELLED:
+        from open_climate_service.jobs.models import JobCancelledError
+
+        raise JobCancelledError("Export delivery was cancelled")
     return report.model_dump(mode="json")
 
 

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -7,11 +7,61 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from open_climate_service.exports.base import DeliveryContext
 from open_climate_service.exports.delivery_input import VerifiedExport, lease_export_input
 from open_climate_service.exports.report import ExportReport
 from open_climate_service.shared.provenance import json_digest
 
 logger = logging.getLogger(__name__)
+
+
+class JobDeliveryContext:
+    """Adapt the native job's execution hooks to the plugin delivery protocol.
+
+    Checkpoints are namespaced under ``delivery_checkpoints`` inside the job
+    cursor so a plugin's chunk state never collides with other cursor users.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_progress: Any = None,
+        is_cancel_requested: Any = None,
+        save_cursor: Any = None,
+        load_cursor: Any = None,
+    ) -> None:
+        self._on_progress = on_progress
+        self._is_cancel_requested = is_cancel_requested
+        self._save_cursor = save_cursor
+        self._load_cursor = load_cursor
+
+    def report_progress(self, done: int | None = None, total: int | None = None, message: str | None = None) -> None:
+        if self._on_progress is not None:
+            self._on_progress(done, total, message)
+
+    def is_cancel_requested(self) -> bool:
+        return bool(self._is_cancel_requested is not None and self._is_cancel_requested())
+
+    def save_checkpoint(self, key: str, state: dict[str, Any]) -> None:
+        if self._save_cursor is None:
+            return
+        cursor = self._load_cursor() if self._load_cursor is not None else None
+        cursor = cursor if isinstance(cursor, dict) else {}
+        checkpoints = cursor.get("delivery_checkpoints")
+        checkpoints = dict(checkpoints) if isinstance(checkpoints, dict) else {}
+        checkpoints[key] = state
+        self._save_cursor({**cursor, "delivery_checkpoints": checkpoints})
+
+    def load_checkpoint(self, key: str) -> dict[str, Any] | None:
+        if self._load_cursor is None:
+            return None
+        cursor = self._load_cursor()
+        if not isinstance(cursor, dict):
+            return None
+        checkpoints = cursor.get("delivery_checkpoints")
+        if not isinstance(checkpoints, dict):
+            return None
+        return checkpoints.get(key)
 
 
 def deliver_named_export(
@@ -20,6 +70,8 @@ def deliver_named_export(
     dry_run: bool = False,
     on_progress: Any = None,
     is_cancel_requested: Any = None,
+    save_cursor: Any = None,
+    load_cursor: Any = None,
 ) -> dict[str, Any]:
     """Send a completed source job's saved payload through its export plugin.
 
@@ -28,14 +80,20 @@ def deliver_named_export(
     """
     if on_progress is not None:
         on_progress(0, 1, "Delivering export")
+    context = JobDeliveryContext(
+        on_progress=on_progress,
+        is_cancel_requested=is_cancel_requested,
+        save_cursor=save_cursor,
+        load_cursor=load_cursor,
+    )
     with lease_export_input(export_id, job_id) as verified:
-        report = _deliver(verified, export_id, dry_run)
+        report = _deliver(verified, export_id, dry_run, context)
     if on_progress is not None:
         on_progress(1, 1, "Delivery complete")
     return report.model_dump(mode="json")
 
 
-def _deliver(verified: VerifiedExport, export_id: str, dry_run: bool) -> ExportReport:
+def _deliver(verified: VerifiedExport, export_id: str, dry_run: bool, context: DeliveryContext) -> ExportReport:
     from open_climate_service.exports.service import resolve_named_export
 
     resolved = resolve_named_export(verified.manifest.plugin.format, {"export": export_id})
@@ -44,7 +102,7 @@ def _deliver(verified: VerifiedExport, export_id: str, dry_run: bool) -> ExportR
     target = verified.manifest.target.connection_id if verified.manifest.target else None
     if target is None:
         raise ValueError("Export was rendered without a delivery target")
-    report = resolved.plugin.send(verified.content, target, dry_run=dry_run)
+    report = resolved.plugin.send(verified.content, target, dry_run=dry_run, context=context)
     # External Python plugins are not necessarily type-checked.
     if not isinstance(report, ExportReport):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError("Export plugin send() must return ExportReport")

--- a/open_climate_service/exports/delivery.py
+++ b/open_climate_service/exports/delivery.py
@@ -113,7 +113,7 @@ def deliver_named_export(
     if report.outcome == ExportOutcome.CANCELLED:
         from open_climate_service.jobs.models import JobCancelledError
 
-        raise JobCancelledError("Export delivery was cancelled")
+        raise JobCancelledError("Export delivery was cancelled", result=report.model_dump(mode="json"))
     return report.model_dump(mode="json")
 
 

--- a/open_climate_service/exports/delivery_input.py
+++ b/open_climate_service/exports/delivery_input.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,7 +26,7 @@ class VerifiedExport:
 
 
 @contextmanager
-def lease_export_input(export_id: str, job_id: str) -> Iterator[VerifiedExport]:
+def lease_export_input(export_id: str, job_id: str) -> Generator[VerifiedExport]:
     """Check job status, integrity, mapping, renderer, and target under a lease.
 
     This is not authorization or delivery. The future operator endpoint must apply

--- a/open_climate_service/exports/delivery_input.py
+++ b/open_climate_service/exports/delivery_input.py
@@ -1,0 +1,97 @@
+"""Validate and lease immutable input for a future delivery worker; never send it."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from open_climate_service.exports.manifest import ExportManifest, plugin_identity, target_binding
+from open_climate_service.exports.retention import result_lease
+from open_climate_service.exports.service import read_export_metadata, resolve_named_export
+from open_climate_service.shared.provenance import json_digest
+
+
+@dataclass(frozen=True)
+class VerifiedExport:
+    """Exact saved bytes and their manifest, valid while the source lease is held."""
+
+    content: bytes
+    manifest: ExportManifest
+
+
+@contextmanager
+def lease_export_input(export_id: str, job_id: str) -> Iterator[VerifiedExport]:
+    """Check job status, integrity, mapping, renderer, and target under a lease.
+
+    This is not authorization or delivery. The future operator endpoint must apply
+    access/read-only policy before invoking it and hold the lease through sending.
+    """
+    with result_lease(job_id):
+        yield _verify(export_id, job_id)
+
+
+def _verify(export_id: str, job_id: str) -> VerifiedExport:
+    from open_climate_service.openeo.jobs import _JOBS_DIR, store_get_job
+    from open_climate_service.openeo.schemas import OpenEOJobStatus
+
+    record = store_get_job(job_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Source job not found")
+    if record.status != OpenEOJobStatus.FINISHED:
+        raise HTTPException(status_code=409, detail="Export requires a successfully completed source job")
+    directory = (_JOBS_DIR / job_id / "results").resolve()
+    try:
+        output = (record.usage or {}).get("output_path")
+        if not isinstance(output, str):
+            raise ValueError("Source job has no saved output")
+        path = Path(output)
+        if path.is_symlink() or path.resolve().parent != directory or not path.is_file():
+            raise ValueError("Source payload is missing or outside its job results")
+        metadata = read_export_metadata(path)
+        if metadata is None or "manifest" not in metadata:
+            raise ValueError("This result predates delivery manifests; create a new named export")
+        manifest_path = directory / metadata["manifest"]
+        if manifest_path.is_symlink() or manifest_path.resolve().parent != directory:
+            raise ValueError("Invalid manifest path")
+        raw = manifest_path.read_bytes()
+        if hashlib.sha256(raw).hexdigest() != metadata.get("manifest_sha256"):
+            raise ValueError("Saved export manifest has changed")
+        manifest = ExportManifest.model_validate_json(raw)
+        if manifest.source_job_id != job_id or manifest.export_id != export_id or manifest.filename != path.name:
+            raise ValueError("Saved payload does not belong to this job and export")
+        if (
+            metadata.get("filename") != manifest.filename
+            or metadata.get("format") != manifest.plugin.format
+            or metadata.get("media_type") != manifest.plugin.media_type
+            or metadata.get("record_count") != manifest.record_count
+            or metadata.get("skipped_count") != manifest.skipped_count
+        ):
+            raise ValueError("Saved export metadata does not match its manifest")
+        content = path.read_bytes()
+        if len(content) != manifest.payload_size or hashlib.sha256(content).hexdigest() != manifest.payload_sha256:
+            raise ValueError("Saved export payload has changed")
+        if json_digest(manifest.mapping) != manifest.mapping_sha256:
+            raise ValueError("Saved mapping digest does not match its contents")
+        resolved = resolve_named_export(manifest.plugin.format, {"export": export_id})
+        if json_digest(resolved.mapping) != manifest.mapping_sha256 or resolved.references != manifest.references:
+            raise ValueError("Export mapping or references changed; create a new named export")
+        if not manifest.plugin.version or plugin_identity(resolved.plugin) != manifest.plugin:
+            raise ValueError("Export renderer changed or is unversioned; create a new named export")
+        if manifest.target is None:
+            raise ValueError("Export was rendered without a delivery target; create a new bound export")
+        if target_binding(resolved.plugin.id, resolved.references) != manifest.target:
+            raise ValueError("DHIS2 target changed; create a new named export")
+        graph_digest = manifest.provenance.get("process_sha256")
+        if graph_digest is not None and json_digest(record.process) != graph_digest:
+            raise ValueError("Source job process changed after rendering")
+    except (OSError, ValueError, TypeError, KeyError, ValidationError) as exc:
+        # ValidationError includes arbitrary input; never expose its rendered dump.
+        detail = "Invalid export manifest" if isinstance(exc, ValidationError) else str(exc)
+        raise HTTPException(status_code=409, detail=detail) from None
+    return VerifiedExport(content, manifest)

--- a/open_climate_service/exports/dhis2.py
+++ b/open_climate_service/exports/dhis2.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 
 from open_climate_service import config
 from open_climate_service.exports.dhis2_config import Dhis2ConnectionConfig, parse_connections
+from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin
 
 if TYPE_CHECKING:
     from dhis2_client import DHIS2Client
 
-__all__ = ["Dhis2ConnectionConfig", "get_connection", "get_connection_config"]
+__all__ = ["Dhis2ConnectionConfig", "Dhis2ExportPlugin", "get_connection", "get_connection_config"]
 
 
 def get_connection_config(connection_id: str) -> Dhis2ConnectionConfig:

--- a/open_climate_service/exports/dhis2.py
+++ b/open_climate_service/exports/dhis2.py
@@ -1,0 +1,57 @@
+"""Public named DHIS2 clients shared by exporters and external feature providers."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from open_climate_service import config
+from open_climate_service.exports.dhis2_config import Dhis2ConnectionConfig, parse_connections
+
+if TYPE_CHECKING:
+    from dhis2_client import DHIS2Client
+
+__all__ = ["Dhis2ConnectionConfig", "get_connection", "get_connection_config"]
+
+
+def get_connection_config(connection_id: str) -> Dhis2ConnectionConfig:
+    """Resolve non-secret configuration without importing the optional client."""
+    connections = parse_connections(config.get_config().get("dhis2_connections", []))
+    try:
+        return connections[connection_id]
+    except KeyError:
+        raise ValueError("Unknown DHIS2 connection; configure its ID in dhis2_connections") from None
+
+
+def get_connection(connection_id: str) -> DHIS2Client:
+    """Create a configured client, resolving its token at use time.
+
+    The caller owns the returned client and must call ``close()`` in a ``finally``
+    block (or use ``contextlib.closing``). Each call creates a fresh client so token
+    rotation takes effect without resetting configuration. Construction sends no
+    network requests. Access control for operations belongs to their callers.
+    """
+    connection = get_connection_config(connection_id)
+    token = os.environ.get(connection.token_env)
+    if not token or not token.strip():
+        raise ValueError("The DHIS2 connection's token environment variable is unset or empty")
+    if any(not 33 <= ord(character) <= 126 for character in token):
+        raise ValueError("The DHIS2 token must be a raw ASCII token without whitespace or an authentication prefix")
+    try:
+        from dhis2_client import DHIS2Client
+    except ModuleNotFoundError as exc:
+        if exc.name != "dhis2_client":
+            raise
+        raise RuntimeError(
+            "Named DHIS2 connections require the optional dhis2-client package. "
+            "See docs/importing_to_dhis2.md for the tested installation command."
+        ) from None
+
+    return DHIS2Client(
+        base_url=connection.url,
+        token=token,
+        timeout=connection.timeout,
+        connect_timeout=connection.connect_timeout,
+        retries=connection.retries,
+        verify_ssl=True,
+    )

--- a/open_climate_service/exports/dhis2_config.py
+++ b/open_climate_service/exports/dhis2_config.py
@@ -1,0 +1,93 @@
+"""Validate named DHIS2 connections without resolving credentials or opening clients."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+
+@dataclass(frozen=True)
+class Dhis2ConnectionConfig:
+    """Non-secret configuration for one DHIS2 instance."""
+
+    id: str
+    url: str
+    token_env: str
+    timeout: float = 30.0
+    connect_timeout: float = 10.0
+    retries: int = 3
+
+
+def parse_connections(raw: object) -> dict[str, Dhis2ConnectionConfig]:
+    """Validate a list of connection definitions, without including input values in errors."""
+    if not isinstance(raw, list):
+        raise ValueError("dhis2_connections must be a list")
+    connections: dict[str, Dhis2ConnectionConfig] = {}
+    allowed = {"id", "url", "token_env", "timeout", "connect_timeout", "retries"}
+    for index, item in enumerate(raw):
+        prefix = f"dhis2_connections[{index}]"
+        if not isinstance(item, dict) or set(item) - allowed:
+            raise ValueError(f"{prefix} must be a mapping containing only supported connection fields")
+        identifier = _string(item.get("id"), f"{prefix}.id")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", identifier):
+            raise ValueError(f"{prefix}.id must contain only letters, digits, underscores, or hyphens")
+        if identifier in connections:
+            raise ValueError(f"{prefix}.id duplicates an earlier connection")
+        url = _string(item.get("url"), f"{prefix}.url").rstrip("/")
+        if not _valid_url(url):
+            raise ValueError(f"{prefix}.url must be an HTTP(S) instance URL without credentials, query, or fragment")
+        token_env = _string(item.get("token_env"), f"{prefix}.token_env")
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token_env):
+            raise ValueError(f"{prefix}.token_env must be a literal environment variable name")
+        retries = item.get("retries", 3)
+        if type(retries) is not int or not 0 <= retries <= 10:
+            raise ValueError(f"{prefix}.retries must be an integer between 0 and 10")
+        connections[identifier] = Dhis2ConnectionConfig(
+            id=identifier,
+            url=url,
+            token_env=token_env,
+            timeout=_timeout(item.get("timeout", 30.0), f"{prefix}.timeout"),
+            connect_timeout=_timeout(item.get("connect_timeout", 10.0), f"{prefix}.connect_timeout"),
+            retries=retries,
+        )
+    return connections
+
+
+def _string(raw: object, field: str) -> str:
+    if not isinstance(raw, str) or not raw.strip() or "${" in raw:
+        raise ValueError(f"{field} must be a non-empty literal string (no environment interpolation)")
+    return raw.strip()
+
+
+def _timeout(raw: object, field: str) -> float:
+    if isinstance(raw, bool) or not isinstance(raw, (float, int)) or raw <= 0:
+        raise ValueError(f"{field} must be a finite positive number of seconds")
+    try:
+        value = float(raw)
+    except OverflowError:
+        raise ValueError(f"{field} must be a finite positive number of seconds") from None
+    if not math.isfinite(value):
+        raise ValueError(f"{field} must be a finite positive number of seconds")
+    return value
+
+
+def _valid_url(url: str) -> bool:
+    if any(character.isspace() for character in url) or "\\" in url:
+        return False
+    try:
+        parts = urlsplit(url)
+        port = parts.port
+        return bool(
+            parts.scheme in {"http", "https"}
+            and parts.hostname
+            and not parts.username
+            and not parts.password
+            and "@" not in parts.netloc
+            and "?" not in url
+            and "#" not in url
+            and (port is None or port > 0)
+        )
+    except ValueError:
+        return False

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -1,0 +1,153 @@
+"""Strict single-series DHIS2 rendering for named export mappings."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import re
+from decimal import Decimal
+from typing import Any
+
+from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
+from open_climate_service.exports.tabular import (
+    _build_dhis2_json_payload,
+    _is_nullish,
+    _normalise_period_type,
+    _select_dhis2_value_field,
+    _to_dhis2_period_string,
+)
+
+
+class Dhis2ExportPlugin(BaseExportPlugin):
+    """Map one prepared aggregate series to one DHIS2 data element."""
+
+    id = "dhis2"
+    format = "DHIS2JSON"
+    extension = ".json"
+    media_type = "application/json"
+
+    def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
+        allowed = {"series", "period_type", "org_unit_field", "period_field", "aggregation"}
+        if set(mapping) - allowed:
+            raise ValueError("Unsupported DHIS2 mapping fields")
+        period_type = mapping.get("period_type")
+        if not isinstance(period_type, str) or not period_type.strip():
+            raise ValueError("DHIS2 mapping requires period_type; temporal aggregation must happen upstream")
+        kind = _normalise_period_type(period_type)
+        series = mapping.get("series")
+        if not isinstance(series, list) or len(series) != 1 or not isinstance(series[0], dict):
+            raise ValueError("This phase supports exactly one DHIS2 series per export")
+        entry = series[0]
+        if set(entry) - {"select", "data_element", "category_option_combo", "attribute_option_combo"}:
+            raise ValueError("Unsupported DHIS2 series fields")
+        select = entry.get("select", {})
+        if not isinstance(select, dict) or set(select) - {"variable"}:
+            raise ValueError("Single-series select supports only an optional 'variable' name")
+        if "variable" in select and (not isinstance(select["variable"], str) or not select["variable"].strip()):
+            raise ValueError("select.variable must be a non-empty variable name")
+        _uid(entry.get("data_element"), "series.data_element")
+        for field in ("category_option_combo", "attribute_option_combo"):
+            if field in entry:
+                _uid(entry[field], f"series.{field}")
+        for field, default in (("org_unit_field", "geometry"), ("period_field", "t")):
+            value = mapping.get(field, default)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field} must be a non-empty field name")
+        if mapping.get("org_unit_field", "geometry") == mapping.get("period_field", "t"):
+            raise ValueError("Organisation unit and period fields must be distinct")
+        if "aggregation" in mapping and mapping["aggregation"] not in ("mean", "sum", "min", "max"):
+            raise ValueError("aggregation must be mean, sum, min, or max; it declares upstream computation")
+        return {**mapping, "period_type": kind, "series": [{**entry, "select": select}]}
+
+    def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
+        import numpy as np
+        import pandas as pd
+        import xarray as xr
+
+        entry = mapping["series"][0]
+        org_field = mapping.get("org_unit_field", "geometry")
+        period_field = mapping.get("period_field", "t")
+        kind = mapping["period_type"]
+        variable = entry["select"].get("variable")
+        if isinstance(data, xr.DataArray):
+            data = data.to_dataset(name=data.name or "result")
+        if isinstance(data, xr.Dataset):
+            if variable is not None:
+                if variable not in data.data_vars:
+                    raise ValueError(f"Selected variable '{variable}' is not present in the result")
+                data = data[[variable]]
+            if set(data.dims) - {org_field, period_field}:
+                raise ValueError("DHIS2 export requires aggregates with only organisation-unit and period dimensions")
+            declared_period = data.attrs.get("period_type")
+            if declared_period is not None and _normalise_period_type(str(declared_period)) != kind:
+                raise ValueError("Result period_type differs from the mapping; aggregate temporally before exporting")
+            frame = data.to_dataframe().reset_index()
+        elif isinstance(data, pd.DataFrame):
+            frame = pd.DataFrame(data).copy()
+            if variable is not None:
+                required = [org_field, period_field, variable]
+                if not all(field in frame.columns for field in required):
+                    raise ValueError("Selected variable or identity fields are missing from the result")
+                frame = frame[required]
+        else:
+            raise ValueError("DHIS2 export requires an xarray aggregate or a pandas/GeoPandas table")
+        if org_field not in frame or period_field not in frame:
+            raise ValueError("DHIS2 result is missing organisation-unit or period fields")
+        if not frame.columns.is_unique:
+            raise ValueError("DHIS2 result contains duplicate column names")
+        value_field = _select_dhis2_value_field(frame, org_field, period_field)
+        keys: set[tuple[str, str]] = set()
+        for index, record in enumerate(frame.to_dict(orient="records")):
+            org = _uid(record[org_field], f"row {index} organisation unit (feature.id)")
+            period = _to_dhis2_period_string(record[period_field], kind)
+            _validate_period(period, kind)
+            key = (org, period)
+            if key in keys:
+                raise ValueError(f"Duplicate DHIS2 value for organisation unit '{org}' and period '{period}'")
+            keys.add(key)
+            value = record[value_field]
+            if not _is_nullish(value) and (
+                not isinstance(value, (int, float, Decimal, np.integer, np.floating, bool, np.bool_))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"Row {index} must contain a finite scalar numeric value")
+        options = {
+            "data_element_id": entry["data_element"],
+            "org_unit_field": org_field,
+            "period_field": period_field,
+            "period_type": kind,
+        }
+        if "category_option_combo" in entry:
+            options["category_option_combo"] = entry["category_option_combo"]
+        payload = _build_dhis2_json_payload(frame, options)
+        values = payload["dataValues"]
+        if "attribute_option_combo" in entry:
+            for value in values:
+                value["attributeOptionCombo"] = entry["attribute_option_combo"]
+        return RenderedExport(
+            content=json.dumps(payload, allow_nan=False).encode(),
+            record_count=len(values),
+            skipped_count=len(frame) - len(values),
+        )
+
+
+def _uid(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z][A-Za-z0-9]{10}", value):
+        raise ValueError(f"{field} must be a DHIS2 UID; supply real feature IDs instead of positional labels")
+    return value
+
+
+def _validate_period(period: str, kind: str) -> None:
+    try:
+        if kind == "weekly":
+            year, week = period.split("W")
+            dt.date.fromisocalendar(int(year), int(week), 1)
+        elif kind == "quarterly":
+            year, quarter = period.split("Q")
+            dt.date(int(year), (int(quarter) - 1) * 3 + 1, 1)
+        else:
+            pattern = {"daily": "%Y%m%d", "monthly": "%Y%m", "yearly": "%Y"}[kind]
+            dt.datetime.strptime(period, pattern)
+    except ValueError:
+        raise ValueError(f"Invalid DHIS2 {kind} period '{period}'") from None

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -80,6 +80,16 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             raise ValueError("Organisation unit and period fields must be distinct")
         if "aggregation" in mapping and mapping["aggregation"] not in ("mean", "sum", "min", "max"):
             raise ValueError("aggregation must be mean, sum, min, or max; it declares upstream computation")
+        # Default combo UIDs belong to target metadata, which pure rendering does
+        # not fetch. Avoid treating an omitted combo as distinct from an explicit
+        # one when several series target the same data element.
+        for element in {entry["data_element"] for entry in validated_series}:
+            group = [entry for entry in validated_series if entry["data_element"] == element]
+            for field in ("category_option_combo", "attribute_option_combo"):
+                if any(field in entry for entry in group) and not all(field in entry for entry in group):
+                    raise ValueError(
+                        f"Specify {field} on every series for data element '{element}' to resolve defaults"
+                    )
         return {**mapping, "period_type": kind, "series": validated_series}
 
     def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
@@ -222,7 +232,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         if variable is not None:
             if not isinstance(variable, str):
                 raise ValueError("select.variable must be a string")
-            if variable not in frame.columns:
+            if variable not in self._candidate_value_fields(frame, value_columns, org_field, period_field):
                 raise ValueError(f"Selected variable '{variable}' is not present in the result")
             return variable
         fields = self._candidate_value_fields(frame, value_columns, org_field, period_field)
@@ -240,6 +250,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         if value_columns is not None:
             return [column for column in value_columns if column in frame.columns]
         excluded = {org_field, period_field, "geometry", "spatial_ref", "index", "band", "bands"}
+        excluded.add("quantile")
         return [
             str(column) for column in frame.columns if column not in excluded and not str(column).startswith("level_")
         ]
@@ -286,7 +297,6 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         if not isinstance(body, dict) or not isinstance(body.get("dataValues"), list):
             raise ValueError("DHIS2 delivery payload must be a dataValueSet")
         values = body["dataValues"]
-        submitted = len(values)
         chunks = self._chunk_values(values)
 
         reports: list[ExportReport] = []
@@ -326,7 +336,6 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             payload_sha256=payload_sha256,
             created_at=created_at,
             finished_at=finished_at,
-            submitted=submitted,
             cancelled_early=cancelled_early,
             message=message,
         )
@@ -353,9 +362,47 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         digest = hashlib.sha256(chunk_payload).hexdigest()
         checkpoint = self._load_chunk_checkpoint(context, index, digest)
         if checkpoint is not None:
+            if checkpoint.connection_id != target or checkpoint.dry_run != dry_run:
+                raise ValueError("Delivery checkpoint target or mode changed")
+            if checkpoint.outcome == ExportOutcome.UNKNOWN and checkpoint.remote_task_ids:
+                checkpoint = self._poll_task(
+                    client,
+                    checkpoint.remote_task_ids[0],
+                    target=target,
+                    dry_run=dry_run,
+                    submitted=len(chunk_values),
+                    payload_sha256=digest,
+                    created_at=checkpoint.created_at,
+                    context=context,
+                )
+                self._save_chunk_checkpoint(context, index, digest, checkpoint)
             return checkpoint
+        # Commit intent before POST. A process death at any later point must not
+        # turn an uncertain remote write into a fresh chunk on recovery.
+        self._save_chunk_checkpoint(
+            context,
+            index,
+            digest,
+            ExportReport(
+                plugin_id=self.id,
+                connection_id=target,
+                dry_run=dry_run,
+                outcome=ExportOutcome.UNKNOWN,
+                payload_sha256=digest,
+                submitted=len(chunk_values),
+                created_at=created_at,
+                finished_at=created_at,
+            ),
+        )
         report = self._submit_chunk(
-            client, target, chunk_values, dry_run=dry_run, created_at=created_at, chunk_sha256=digest
+            client,
+            target,
+            chunk_values,
+            dry_run=dry_run,
+            created_at=created_at,
+            chunk_sha256=digest,
+            context=context,
+            index=index,
         )
         self._save_chunk_checkpoint(context, index, digest, report)
         return report
@@ -365,13 +412,16 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         if context is None:
             return None
         state = context.load_checkpoint(self._chunk_checkpoint_key(index))
-        if not isinstance(state, dict) or state.get("digest") != digest:
+        if state is None:
             return None
-        if state.get("status") == "completed" and isinstance(state.get("report"), dict):
-            try:
-                return ExportReport.model_validate(state["report"])
-            except Exception:
-                return None
+        # Checkpoint providers can be external plugins without runtime type checks.
+        if not isinstance(state, dict) or state.get("digest") != digest:  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError("Delivery checkpoint is corrupt or chunk boundaries changed; refusing to resend")
+        if state.get("status") == "completed":
+            report = ExportReport.model_validate(state.get("report"))
+            if report.payload_sha256 != digest or report.plugin_id != self.id:
+                raise ValueError("Delivery checkpoint report does not match the chunk")
+            return report
         if state.get("status") == "submitted_unknown":
             # A previous POST timed out without a reconcilable remote task ID.
             # Do not replay; record the uncertainty so the overall report is honest.
@@ -389,7 +439,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 created_at=str(state.get("created_at") or utc_now().isoformat()),
                 finished_at=str(state.get("finished_at") or utc_now().isoformat()),
             )
-        return None
+        raise ValueError("Unrecognized delivery checkpoint state; refusing to resend")
 
     def _save_chunk_checkpoint(
         self, context: DeliveryContext | None, index: int, digest: str, report: ExportReport
@@ -425,6 +475,8 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         dry_run: bool,
         created_at: str,
         chunk_sha256: str,
+        context: DeliveryContext | None = None,
+        index: int = 0,
     ) -> ExportReport:
         """POST one bounded chunk and reconcile its response, polling async tasks."""
         from open_climate_service.shared.time import utc_now
@@ -437,6 +489,19 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         try:
             response = client.post("/api/dataValueSets", json=chunk_body, params=params)
         except Exception as exc:
+            status_code = getattr(exc, "status_code", None)
+            error_payload = getattr(exc, "payload", None)
+            if isinstance(status_code, int) and 400 <= status_code < 500 and isinstance(error_payload, dict):
+                return build_dhis2_report(
+                    status_code,
+                    error_payload,
+                    plugin_id=self.id,
+                    connection_id=target,
+                    dry_run=dry_run,
+                    payload_sha256=chunk_sha256,
+                    submitted=submitted,
+                    created_at=created_at,
+                )
             # The POST may have reached DHIS2 before failing (e.g. timeout).
             # Record an unknown outcome rather than fabricating a rejection, and
             # never auto-replay this chunk.
@@ -468,6 +533,22 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                     created_at=created_at,
                     finished_at=utc_now().isoformat(),
                 )
+            self._save_chunk_checkpoint(
+                context,
+                index,
+                chunk_sha256,
+                ExportReport(
+                    plugin_id=self.id,
+                    connection_id=target,
+                    dry_run=dry_run,
+                    outcome=ExportOutcome.UNKNOWN,
+                    payload_sha256=chunk_sha256,
+                    submitted=submitted,
+                    remote_task_ids=[task_id],
+                    created_at=created_at,
+                    finished_at=utc_now().isoformat(),
+                ),
+            )
             return self._poll_task(
                 client,
                 task_id,
@@ -476,6 +557,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 submitted=submitted,
                 payload_sha256=chunk_sha256,
                 created_at=created_at,
+                context=context,
             )
 
         return build_dhis2_report(
@@ -499,6 +581,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         submitted: int,
         payload_sha256: str,
         created_at: str,
+        context: DeliveryContext | None = None,
     ) -> ExportReport:
         """Poll a submitted async import task with bounded backoff."""
         import time
@@ -507,9 +590,11 @@ class Dhis2ExportPlugin(BaseExportPlugin):
 
         summary: dict[str, Any] = {}
         for attempt in range(max(0, self.max_poll_attempts)):
+            if context is not None and context.is_cancel_requested():
+                break
             time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
             try:
-                response = client.get(f"/api/system/tasks/{task_id}")
+                response = client.get(f"/api/system/taskSummaries/DATAVALUE_IMPORT/{task_id}")
             except Exception:
                 continue
             summary = _response_json(response)
@@ -544,11 +629,16 @@ class Dhis2ExportPlugin(BaseExportPlugin):
 
     @staticmethod
     def _remote_task_id(summary: dict[str, Any]) -> str | None:
-        value = summary.get("id") or summary.get("taskId")
-        return value if isinstance(value, str) and value else None
+        nested = summary.get("response")
+        task = nested if isinstance(nested, dict) else summary
+        value = task.get("id") or task.get("taskId")
+        return value if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_-]+", value) else None
 
     @staticmethod
     def _is_async_acceptance(status_code: int, summary: dict[str, Any]) -> bool:
+        nested = summary.get("response")
+        if isinstance(nested, dict) and nested.get("jobType") == "DATAVALUE_IMPORT":
+            return 200 <= status_code < 300
         if status_code == 202:
             return True
         status = summary.get("status")
@@ -578,6 +668,7 @@ def build_dhis2_report(
     from open_climate_service.shared.time import utc_now
 
     finished_at = utc_now().isoformat()
+    summary = _extract_import_summary(summary)
     status = summary.get("status")
     message = summary.get("message") or summary.get("httpStatus")
     import_count = summary.get("importCount") or {}
@@ -611,20 +702,16 @@ def build_dhis2_report(
         finished_at=finished_at,
     )
 
-    if dry_run:
-        # A dry run reached DHIS2 validation; the summary describes what would
-        # happen, not persisted writes.
-        return ExportReport(outcome=ExportOutcome.DRY_RUN, message=message, **base)
-
     if not 200 <= status_code < 300:
         return ExportReport(outcome=ExportOutcome.REJECTED, message=message or f"HTTP {status_code}", **base)
 
-    if status == "ERROR":
+    if status in {"ERROR", "FAILED"}:
         return ExportReport(outcome=ExportOutcome.REJECTED, message=message, **base)
     if status == "WARNING" or conflicts:
         return ExportReport(outcome=ExportOutcome.PARTIAL, message=message, **base)
     if status == "SUCCESS":
-        return ExportReport(outcome=ExportOutcome.SUCCESS, message=message, **base)
+        outcome = ExportOutcome.DRY_RUN if dry_run else ExportOutcome.SUCCESS
+        return ExportReport(outcome=outcome, message=message, **base)
     # A 2xx without a recognizable import summary cannot be trusted as success.
     return ExportReport(outcome=ExportOutcome.UNKNOWN, message="Unrecognized import summary", **base)
 
@@ -636,7 +723,7 @@ def _extract_import_summary(summary: dict[str, Any]) -> dict[str, Any]:
     or ``taskSummary`` in different DHIS2 versions; a synchronous summary may be
     returned directly. Keep the remote task ID visible on whichever shape wins.
     """
-    for key in ("importSummary", "summary", "taskSummary"):
+    for key in ("importSummary", "summary", "taskSummary", "response"):
         nested = summary.get(key)
         if isinstance(nested, dict):
             result = dict(nested)
@@ -649,10 +736,16 @@ def _extract_import_summary(summary: dict[str, Any]) -> dict[str, Any]:
 
 
 def _response_status(response: Any) -> int:
+    # The supported DHIS2 client returns decoded JSON after checking HTTP status.
+    if isinstance(response, dict):
+        status = response.get("httpStatusCode", 200)
+        return status if isinstance(status, int) else 200
     return response.status_code if isinstance(getattr(response, "status_code", None), int) else 0
 
 
 def _response_json(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict):
+        return response
     try:
         payload = response.json()
     except Exception:

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -219,6 +219,13 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             value_columns = [str(name) for name in data.data_vars]
             if not value_columns:
                 raise ValueError("DHIS2 result contains no data variables")
+            scalar_coordinates = [
+                name
+                for name, coordinate in data.coords.items()
+                if not coordinate.dims and name not in {org_field, period_field}
+            ]
+            if scalar_coordinates:
+                data = data.drop_vars(scalar_coordinates)
             frame = data.to_dataframe().reset_index()
             if "__cubes__" in frame.columns:
                 if len(value_columns) != 1:
@@ -440,6 +447,8 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 created_at=created_at,
                 finished_at=utc_now().isoformat(),
             )
+            self._save_chunk_checkpoint(context, index, digest, report, status="retryable_failed")
+            return report
         self._save_chunk_checkpoint(context, index, digest, report)
         return report
 
@@ -475,14 +484,24 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 created_at=str(state.get("created_at") or utc_now().isoformat()),
                 finished_at=str(state.get("finished_at") or utc_now().isoformat()),
             )
+        if state.get("status") == "retryable_failed":
+            # The preceding attempt failed before submission. Retain its report
+            # for observability, but retry because DHIS2 received nothing.
+            return None
         raise ValueError("Unrecognized delivery checkpoint state; refusing to resend")
 
     def _save_chunk_checkpoint(
-        self, context: DeliveryContext | None, index: int, digest: str, report: ExportReport
+        self,
+        context: DeliveryContext | None,
+        index: int,
+        digest: str,
+        report: ExportReport,
+        *,
+        status: str | None = None,
     ) -> None:
         if context is None:
             return
-        status = "submitted_unknown" if report.outcome == ExportOutcome.UNKNOWN else "completed"
+        status = status or ("submitted_unknown" if report.outcome == ExportOutcome.UNKNOWN else "completed")
         context.save_checkpoint(
             self._chunk_checkpoint_key(index),
             {
@@ -657,7 +676,8 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 if report.remote_task_ids == []:
                     report = report.model_copy(update={"remote_task_ids": [task_id]})
                 return report
-            time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
+            if attempt + 1 < self.max_poll_attempts:
+                time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
 
         # The task never reached a terminal state within the poll budget.
         return ExportReport(
@@ -723,6 +743,7 @@ def build_dhis2_report(
     conflicts = summary.get("conflicts") or []
     if not isinstance(conflicts, list):
         conflicts = []
+    conflicts = [entry for entry in conflicts if isinstance(entry, dict)]
     remote_task_ids: list[str] = []
     task_id = summary.get("id") or summary.get("taskId")
     if isinstance(task_id, str) and task_id:

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -9,8 +9,8 @@ import re
 from decimal import Decimal
 from typing import Any
 
-from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
-from open_climate_service.exports.report import ExportOutcome, ExportReport
+from open_climate_service.exports.base import BaseExportPlugin, DeliveryContext, RenderedExport
+from open_climate_service.exports.report import ExportOutcome, ExportReport, merge_chunk_reports
 from open_climate_service.exports.tabular import (
     _build_dhis2_json_payload,
     _is_nullish,
@@ -29,6 +29,12 @@ class Dhis2ExportPlugin(BaseExportPlugin):
     media_type = "application/json"
     version = "1"
     supports_delivery = True
+    # Upper bound for one dataValueSets POST; larger payloads are split into
+    # deterministic chunks. Tune against the supported DHIS2 versions.
+    max_chunk_size: int = 1000
+    # Bounded backoff for reconciling an async import task after submission.
+    max_poll_attempts: int = 10
+    poll_backoff_base: float = 1.0
 
     def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
         allowed = {"series", "period_type", "org_unit_field", "period_field", "aggregation"}
@@ -135,8 +141,21 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             periods=tuple(sorted({value["period"] for value in values})),
         )
 
-    def send(self, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
-        """POST the rendered dataValueSet and summarize the import result."""
+    def send(
+        self,
+        payload: bytes,
+        target: Any,
+        *,
+        dry_run: bool = False,
+        context: DeliveryContext | None = None,
+    ) -> ExportReport:
+        """POST the rendered dataValueSet in resumable chunks and reconcile each.
+
+        Chunking, checkpointing, and response interpretation stay inside the
+        plugin. A timeout after POST cannot be reconciled, so it is recorded as
+        ``unknown`` and never replayed automatically; a completed chunk is
+        check pointed and skipped on restart.
+        """
         import hashlib
         from contextlib import closing
 
@@ -153,38 +172,282 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             raise ValueError("DHIS2 delivery payload is not valid JSON") from exc
         if not isinstance(body, dict) or not isinstance(body.get("dataValues"), list):
             raise ValueError("DHIS2 delivery payload must be a dataValueSet")
-        submitted = len(body["dataValues"])
+        values = body["dataValues"]
+        submitted = len(values)
+        chunks = self._chunk_values(values)
 
+        reports: list[ExportReport] = []
+        cancelled_early = False
         with closing(get_connection(target)) as client:
-            params: dict[str, str] = {"importStrategy": "CREATE_AND_UPDATE"}
-            if dry_run:
-                params["dryRun"] = "true"
+            for index, chunk_values in enumerate(chunks):
+                if context is not None and context.is_cancel_requested():
+                    cancelled_early = True
+                    break
+                chunk_report = self._deliver_chunk(
+                    client,
+                    target,
+                    chunk_values,
+                    index=index,
+                    dry_run=dry_run,
+                    created_at=created_at,
+                    context=context,
+                )
+                reports.append(chunk_report)
+                if context is not None:
+                    context.report_progress(index + 1, len(chunks), "Delivering export chunks")
+                # A rejected chunk is a hard stop: later chunks would fail for the
+                # same reason, and it must remain visible in the merged report.
+                if chunk_report.outcome == ExportOutcome.REJECTED:
+                    break
+
+        finished_at = utc_now().isoformat()
+        if cancelled_early:
+            message = f"Cancelled after {len(reports)} of {len(chunks)} chunks"
+        else:
+            message = None
+        return merge_chunk_reports(
+            reports,
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            payload_sha256=payload_sha256,
+            created_at=created_at,
+            finished_at=finished_at,
+            submitted=submitted,
+            cancelled_early=cancelled_early,
+            message=message,
+        )
+
+    def _chunk_values(self, values: list[Any]) -> list[list[Any]]:
+        """Split a dataValues list into deterministic, bounded chunks."""
+        size = max(1, self.max_chunk_size)
+        return [values[offset : offset + size] for offset in range(0, len(values), size)] or [[]]
+
+    def _deliver_chunk(
+        self,
+        client: Any,
+        target: str,
+        chunk_values: list[Any],
+        *,
+        index: int,
+        dry_run: bool,
+        created_at: str,
+        context: DeliveryContext | None,
+    ) -> ExportReport:
+        import hashlib
+
+        chunk_payload = json.dumps({"dataValues": chunk_values}, allow_nan=False, separators=(",", ":")).encode()
+        digest = hashlib.sha256(chunk_payload).hexdigest()
+        checkpoint = self._load_chunk_checkpoint(context, index, digest)
+        if checkpoint is not None:
+            return checkpoint
+        report = self._submit_chunk(
+            client, target, chunk_values, dry_run=dry_run, created_at=created_at, chunk_sha256=digest
+        )
+        self._save_chunk_checkpoint(context, index, digest, report)
+        return report
+
+    def _load_chunk_checkpoint(self, context: DeliveryContext | None, index: int, digest: str) -> ExportReport | None:
+        """Restore a chunk from its checkpoint, or None to send it fresh."""
+        if context is None:
+            return None
+        state = context.load_checkpoint(self._chunk_checkpoint_key(index))
+        if not isinstance(state, dict) or state.get("digest") != digest:
+            return None
+        if state.get("status") == "completed" and isinstance(state.get("report"), dict):
             try:
-                response = client.post("/api/dataValueSets", json=body, params=params)
-            except Exception as exc:
-                # The POST may have reached DHIS2 before failing (e.g. timeout).
-                # Record an unknown outcome rather than fabricating a rejection.
+                return ExportReport.model_validate(state["report"])
+            except Exception:
+                return None
+        if state.get("status") == "submitted_unknown":
+            # A previous POST timed out without a reconcilable remote task ID.
+            # Do not replay; record the uncertainty so the overall report is honest.
+            from open_climate_service.shared.time import utc_now
+
+            return ExportReport(
+                plugin_id=self.id,
+                connection_id=state.get("connection_id"),
+                dry_run=bool(state.get("dry_run")),
+                outcome=ExportOutcome.UNKNOWN,
+                message="Previously submitted; the import result could not be reconciled",
+                payload_sha256=digest,
+                submitted=int(state.get("submitted") or 0),
+                remote_task_ids=list(state.get("remote_task_ids") or []),
+                created_at=str(state.get("created_at") or utc_now().isoformat()),
+                finished_at=str(state.get("finished_at") or utc_now().isoformat()),
+            )
+        return None
+
+    def _save_chunk_checkpoint(
+        self, context: DeliveryContext | None, index: int, digest: str, report: ExportReport
+    ) -> None:
+        if context is None:
+            return
+        status = "submitted_unknown" if report.outcome == ExportOutcome.UNKNOWN else "completed"
+        context.save_checkpoint(
+            self._chunk_checkpoint_key(index),
+            {
+                "digest": digest,
+                "status": status,
+                "report": report.model_dump(mode="json"),
+                "connection_id": report.connection_id,
+                "dry_run": report.dry_run,
+                "submitted": report.submitted,
+                "remote_task_ids": report.remote_task_ids,
+                "created_at": report.created_at,
+                "finished_at": report.finished_at,
+            },
+        )
+
+    @staticmethod
+    def _chunk_checkpoint_key(index: int) -> str:
+        return f"chunk:{index}"
+
+    def _submit_chunk(
+        self,
+        client: Any,
+        target: str,
+        chunk_values: list[Any],
+        *,
+        dry_run: bool,
+        created_at: str,
+        chunk_sha256: str,
+    ) -> ExportReport:
+        """POST one bounded chunk and reconcile its response, polling async tasks."""
+        from open_climate_service.shared.time import utc_now
+
+        chunk_body = {"dataValues": chunk_values}
+        submitted = len(chunk_values)
+        params: dict[str, str] = {"importStrategy": "CREATE_AND_UPDATE"}
+        if dry_run:
+            params["dryRun"] = "true"
+        try:
+            response = client.post("/api/dataValueSets", json=chunk_body, params=params)
+        except Exception as exc:
+            # The POST may have reached DHIS2 before failing (e.g. timeout).
+            # Record an unknown outcome rather than fabricating a rejection, and
+            # never auto-replay this chunk.
+            return ExportReport(
+                plugin_id=self.id,
+                connection_id=target,
+                dry_run=dry_run,
+                outcome=ExportOutcome.UNKNOWN,
+                message=f"Transport error before the import result could be read: {type(exc).__name__}",
+                payload_sha256=chunk_sha256,
+                submitted=submitted,
+                created_at=created_at,
+                finished_at=utc_now().isoformat(),
+            )
+
+        status_code = _response_status(response)
+        summary = _response_json(response)
+        task_id = self._remote_task_id(summary)
+        if self._is_async_acceptance(status_code, summary):
+            if task_id is None:
                 return ExportReport(
                     plugin_id=self.id,
                     connection_id=target,
                     dry_run=dry_run,
                     outcome=ExportOutcome.UNKNOWN,
-                    message=f"Transport error before the import result could be read: {type(exc).__name__}",
-                    payload_sha256=payload_sha256,
+                    message="Async import accepted without a reconcilable remote task ID",
+                    payload_sha256=chunk_sha256,
                     submitted=submitted,
                     created_at=created_at,
                     finished_at=utc_now().isoformat(),
                 )
+            return self._poll_task(
+                client,
+                task_id,
+                target=target,
+                dry_run=dry_run,
+                submitted=submitted,
+                payload_sha256=chunk_sha256,
+                created_at=created_at,
+            )
+
         return build_dhis2_report(
-            _response_status(response),
-            _response_json(response),
+            status_code,
+            summary,
             plugin_id=self.id,
             connection_id=target,
             dry_run=dry_run,
-            payload_sha256=payload_sha256,
+            payload_sha256=chunk_sha256,
             submitted=submitted,
             created_at=created_at,
         )
+
+    def _poll_task(
+        self,
+        client: Any,
+        task_id: str,
+        *,
+        target: str,
+        dry_run: bool,
+        submitted: int,
+        payload_sha256: str,
+        created_at: str,
+    ) -> ExportReport:
+        """Poll a submitted async import task with bounded backoff."""
+        import time
+
+        from open_climate_service.shared.time import utc_now
+
+        summary: dict[str, Any] = {}
+        for attempt in range(max(0, self.max_poll_attempts)):
+            time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
+            try:
+                response = client.get(f"/api/system/tasks/{task_id}")
+            except Exception:
+                continue
+            summary = _response_json(response)
+            if self._task_is_terminal(summary):
+                report = build_dhis2_report(
+                    _response_status(response),
+                    _extract_import_summary(summary),
+                    plugin_id=self.id,
+                    connection_id=target,
+                    dry_run=dry_run,
+                    payload_sha256=payload_sha256,
+                    submitted=submitted,
+                    created_at=created_at,
+                )
+                if report.remote_task_ids == []:
+                    report = report.model_copy(update={"remote_task_ids": [task_id]})
+                return report
+
+        # The task never reached a terminal state within the poll budget.
+        return ExportReport(
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            outcome=ExportOutcome.UNKNOWN,
+            message=f"Async import task '{task_id}' did not reach a terminal state",
+            payload_sha256=payload_sha256,
+            submitted=submitted,
+            remote_task_ids=[task_id],
+            created_at=created_at,
+            finished_at=utc_now().isoformat(),
+        )
+
+    @staticmethod
+    def _remote_task_id(summary: dict[str, Any]) -> str | None:
+        value = summary.get("id") or summary.get("taskId")
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _is_async_acceptance(status_code: int, summary: dict[str, Any]) -> bool:
+        if status_code == 202:
+            return True
+        status = summary.get("status")
+        return isinstance(status, str) and status in {"PENDING", "RUNNING", "SCHEDULED"}
+
+    @staticmethod
+    def _task_is_terminal(summary: dict[str, Any]) -> bool:
+        status = summary.get("status") or summary.get("state")
+        if not isinstance(status, str):
+            # Without a recognizable status the summary cannot be trusted as final.
+            return bool(summary.get("importCount") or summary.get("conflicts"))
+        return status.upper() in {"SUCCESS", "ERROR", "WARNING", "FAILED", "COMPLETED", "COMPLETE"}
 
 
 def build_dhis2_report(
@@ -251,6 +514,25 @@ def build_dhis2_report(
         return ExportReport(outcome=ExportOutcome.SUCCESS, message=message, **base)
     # A 2xx without a recognizable import summary cannot be trusted as success.
     return ExportReport(outcome=ExportOutcome.UNKNOWN, message="Unrecognized import summary", **base)
+
+
+def _extract_import_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    """Surface an import summary from a DHIS2 async task response shape.
+
+    Task responses nest the import result under ``importSummary``, ``summary``,
+    or ``taskSummary`` in different DHIS2 versions; a synchronous summary may be
+    returned directly. Keep the remote task ID visible on whichever shape wins.
+    """
+    for key in ("importSummary", "summary", "taskSummary"):
+        nested = summary.get(key)
+        if isinstance(nested, dict):
+            result = dict(nested)
+            if "id" not in result and "taskId" not in result:
+                task_id = summary.get("id") or summary.get("taskId")
+                if task_id is not None:
+                    result["taskId"] = task_id
+            return result
+    return summary
 
 
 def _response_status(response: Any) -> int:

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any
 
 from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
+from open_climate_service.exports.report import ExportOutcome, ExportReport
 from open_climate_service.exports.tabular import (
     _build_dhis2_json_payload,
     _is_nullish,
@@ -27,6 +28,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
     extension = ".json"
     media_type = "application/json"
     version = "1"
+    supports_delivery = True
 
     def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
         allowed = {"series", "period_type", "org_unit_field", "period_field", "aggregation"}
@@ -132,6 +134,135 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             skipped_count=len(frame) - len(values),
             periods=tuple(sorted({value["period"] for value in values})),
         )
+
+    def send(self, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
+        """POST the rendered dataValueSet and summarize the import result."""
+        import hashlib
+        from contextlib import closing
+
+        from open_climate_service.exports.dhis2 import get_connection
+        from open_climate_service.shared.time import utc_now
+
+        if not isinstance(target, str) or not target.strip():
+            raise ValueError("DHIS2 delivery requires a named connection")
+        created_at = utc_now().isoformat()
+        payload_sha256 = hashlib.sha256(payload).hexdigest()
+        try:
+            body = json.loads(payload)
+        except (ValueError, TypeError) as exc:
+            raise ValueError("DHIS2 delivery payload is not valid JSON") from exc
+        if not isinstance(body, dict) or not isinstance(body.get("dataValues"), list):
+            raise ValueError("DHIS2 delivery payload must be a dataValueSet")
+        submitted = len(body["dataValues"])
+
+        with closing(get_connection(target)) as client:
+            params: dict[str, str] = {"importStrategy": "CREATE_AND_UPDATE"}
+            if dry_run:
+                params["dryRun"] = "true"
+            try:
+                response = client.post("/api/dataValueSets", json=body, params=params)
+            except Exception as exc:
+                # The POST may have reached DHIS2 before failing (e.g. timeout).
+                # Record an unknown outcome rather than fabricating a rejection.
+                return ExportReport(
+                    plugin_id=self.id,
+                    connection_id=target,
+                    dry_run=dry_run,
+                    outcome=ExportOutcome.UNKNOWN,
+                    message=f"Transport error before the import result could be read: {type(exc).__name__}",
+                    payload_sha256=payload_sha256,
+                    submitted=submitted,
+                    created_at=created_at,
+                    finished_at=utc_now().isoformat(),
+                )
+        return build_dhis2_report(
+            _response_status(response),
+            _response_json(response),
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            payload_sha256=payload_sha256,
+            submitted=submitted,
+            created_at=created_at,
+        )
+
+
+def build_dhis2_report(
+    status_code: int,
+    summary: dict[str, Any],
+    *,
+    plugin_id: str,
+    connection_id: str,
+    dry_run: bool,
+    payload_sha256: str,
+    submitted: int,
+    created_at: str,
+) -> ExportReport:
+    """Translate a DHIS2 dataValueSets import response into an ExportReport."""
+    from open_climate_service.shared.time import utc_now
+
+    finished_at = utc_now().isoformat()
+    status = summary.get("status")
+    message = summary.get("message") or summary.get("httpStatus")
+    import_count = summary.get("importCount") or {}
+    if not isinstance(import_count, dict):
+        import_count = {}
+    conflicts = summary.get("conflicts") or []
+    if not isinstance(conflicts, list):
+        conflicts = []
+    remote_task_ids: list[str] = []
+    task_id = summary.get("id") or summary.get("taskId")
+    if isinstance(task_id, str) and task_id:
+        remote_task_ids.append(task_id)
+
+    def count(key: str) -> int:
+        value = import_count.get(key, 0)
+        return value if isinstance(value, int) else 0
+
+    base: dict[str, Any] = dict(
+        plugin_id=plugin_id,
+        connection_id=connection_id,
+        dry_run=dry_run,
+        payload_sha256=payload_sha256,
+        submitted=submitted,
+        imported=count("imported"),
+        updated=count("updated"),
+        ignored=count("ignored"),
+        deleted=count("deleted"),
+        conflicts=conflicts,
+        remote_task_ids=remote_task_ids,
+        created_at=created_at,
+        finished_at=finished_at,
+    )
+
+    if dry_run:
+        # A dry run reached DHIS2 validation; the summary describes what would
+        # happen, not persisted writes.
+        return ExportReport(outcome=ExportOutcome.DRY_RUN, message=message, **base)
+
+    if not 200 <= status_code < 300:
+        return ExportReport(outcome=ExportOutcome.REJECTED, message=message or f"HTTP {status_code}", **base)
+
+    if status == "ERROR":
+        return ExportReport(outcome=ExportOutcome.REJECTED, message=message, **base)
+    if status == "WARNING" or conflicts:
+        return ExportReport(outcome=ExportOutcome.PARTIAL, message=message, **base)
+    if status == "SUCCESS":
+        return ExportReport(outcome=ExportOutcome.SUCCESS, message=message, **base)
+    # A 2xx without a recognizable import summary cannot be trusted as success.
+    return ExportReport(outcome=ExportOutcome.UNKNOWN, message="Unrecognized import summary", **base)
+
+
+def _response_status(response: Any) -> int:
+    return response.status_code if isinstance(getattr(response, "status_code", None), int) else 0
+
+
+def _response_json(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _uid(value: Any, field: str) -> str:

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -30,53 +30,9 @@ def _is_retryable_transport_error(exc: BaseException) -> bool:
     the chunk can be safely retried. Read/write timeouts happen after the request
     may have reached the server and stay ``unknown``.
     """
-    import importlib
-    from types import ModuleType
+    import httpx
 
-    httpx: ModuleType | None = None
-    try:
-        httpx = importlib.import_module("httpx")
-    except ImportError:
-        pass
-    if httpx is not None and isinstance(exc, (httpx.ConnectError, httpx.PoolTimeout, httpx.UnsupportedProtocol)):
-        return True
-    requests: ModuleType | None = None
-    try:
-        requests = importlib.import_module("requests")
-    except ImportError:
-        pass
-    if requests is not None:
-        # ``ConnectionError`` is intentionally too broad here: requests also
-        # uses it for response-side failures such as a connection reset after a
-        # POST may have been processed. Only its connect-timeout subtype, or a
-        # urllib3 exception explicitly identifying connection establishment,
-        # is safe to replay.
-        if isinstance(exc, requests.exceptions.ConnectTimeout):
-            return True
-        pre_send_types: tuple[Any, ...]
-        try:
-            urllib3_exceptions = importlib.import_module("urllib3.exceptions")
-            pre_send_types = (
-                urllib3_exceptions.NewConnectionError,
-                urllib3_exceptions.NameResolutionError,
-            )
-        except (ImportError, AttributeError):
-            pre_send_types = ()
-        pending: list[BaseException] = [exc]
-        seen: set[int] = set()
-        while pending:
-            candidate = pending.pop()
-            if id(candidate) in seen:
-                continue
-            seen.add(id(candidate))
-            if pre_send_types and isinstance(candidate, pre_send_types):
-                return True
-            pending.extend(item for item in candidate.args if isinstance(item, BaseException))
-            if candidate.__cause__ is not None:
-                pending.append(candidate.__cause__)
-            if candidate.__context__ is not None:
-                pending.append(candidate.__context__)
-    return False
+    return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout, httpx.UnsupportedProtocol))
 
 
 class Dhis2ExportPlugin(BaseExportPlugin):
@@ -361,6 +317,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
 
         reports: list[ExportReport] = []
         cancelled_early = False
+        terminal_message: str | None = None
         with closing(get_connection(target)) as client:
             for index, chunk_values in enumerate(chunks):
                 if context is not None and context.is_cancel_requested():
@@ -381,13 +338,15 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 # A rejected chunk is a hard stop: later chunks would fail for the
                 # same reason, and it must remain visible in the merged report.
                 if chunk_report.outcome == ExportOutcome.REJECTED:
+                    terminal_message = chunk_report.message
                     break
 
         finished_at = utc_now().isoformat()
+        message: str | None
         if cancelled_early:
             message = f"Cancelled after {len(reports)} of {len(chunks)} chunks"
         else:
-            message = None
+            message = terminal_message
         return merge_chunk_reports(
             reports,
             plugin_id=self.id,
@@ -465,11 +424,22 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 context=context,
                 index=index,
             )
-        except _RetryableTransportError:
-            # Nothing reached DHIS2, so drop the intent checkpoint to allow a
-            # retry, then propagate.
-            self._delete_chunk_checkpoint(context, index)
-            raise
+        except _RetryableTransportError as exc:
+            # Nothing reached DHIS2. Record the failed attempt so successful
+            # preceding chunks remain visible in the merged delivery report.
+            from open_climate_service.shared.time import utc_now
+
+            report = ExportReport(
+                plugin_id=self.id,
+                connection_id=target,
+                dry_run=dry_run,
+                outcome=ExportOutcome.REJECTED,
+                message=f"Connection failed before submission: {exc}",
+                payload_sha256=digest,
+                submitted=0,
+                created_at=created_at,
+                finished_at=utc_now().isoformat(),
+            )
         self._save_chunk_checkpoint(context, index, digest, report)
         return report
 
@@ -531,11 +501,6 @@ class Dhis2ExportPlugin(BaseExportPlugin):
     @staticmethod
     def _chunk_checkpoint_key(index: int) -> str:
         return f"chunk:{index}"
-
-    def _delete_chunk_checkpoint(self, context: DeliveryContext | None, index: int) -> None:
-        """Remove a chunk checkpoint so it can be retried after a transport error."""
-        if context is not None:
-            context.delete_checkpoint(self._chunk_checkpoint_key(index))
 
     def _submit_chunk(
         self,

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -1,4 +1,4 @@
-"""Strict single-series DHIS2 rendering for named export mappings."""
+"""DHIS2 rendering for named single- and multi-series export mappings."""
 
 from __future__ import annotations
 
@@ -12,16 +12,15 @@ from typing import Any
 from open_climate_service.exports.base import BaseExportPlugin, DeliveryContext, RenderedExport
 from open_climate_service.exports.report import ExportOutcome, ExportReport, merge_chunk_reports
 from open_climate_service.exports.tabular import (
-    _build_dhis2_json_payload,
     _is_nullish,
     _normalise_period_type,
-    _select_dhis2_value_field,
     _to_dhis2_period_string,
+    _to_dhis2_value_string,
 )
 
 
 class Dhis2ExportPlugin(BaseExportPlugin):
-    """Map one prepared aggregate series to one DHIS2 data element."""
+    """Map prepared aggregate series to DHIS2 data elements."""
 
     id = "dhis2"
     format = "DHIS2JSON"
@@ -45,20 +44,34 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             raise ValueError("DHIS2 mapping requires period_type; temporal aggregation must happen upstream")
         kind = _normalise_period_type(period_type)
         series = mapping.get("series")
-        if not isinstance(series, list) or len(series) != 1 or not isinstance(series[0], dict):
-            raise ValueError("This phase supports exactly one DHIS2 series per export")
-        entry = series[0]
-        if set(entry) - {"select", "data_element", "category_option_combo", "attribute_option_combo"}:
-            raise ValueError("Unsupported DHIS2 series fields")
-        select = entry.get("select", {})
-        if not isinstance(select, dict) or set(select) - {"variable"}:
-            raise ValueError("Single-series select supports only an optional 'variable' name")
-        if "variable" in select and (not isinstance(select["variable"], str) or not select["variable"].strip()):
-            raise ValueError("select.variable must be a non-empty variable name")
-        _uid(entry.get("data_element"), "series.data_element")
-        for field in ("category_option_combo", "attribute_option_combo"):
-            if field in entry:
-                _uid(entry[field], f"series.{field}")
+        if not isinstance(series, list) or not series or not all(isinstance(entry, dict) for entry in series):
+            raise ValueError("DHIS2 mapping requires a non-empty list of series mappings")
+        validated_series: list[dict[str, Any]] = []
+        for index, entry in enumerate(series):
+            prefix = f"series[{index}]"
+            if set(entry) - {"select", "data_element", "category_option_combo", "attribute_option_combo"}:
+                raise ValueError(f"Unsupported {prefix} fields")
+            select = entry.get("select", {})
+            if not isinstance(select, dict) or set(select) - {"variable", "quantile"}:
+                raise ValueError(f"{prefix}.select supports only 'variable' and 'quantile'")
+            variable = select.get("variable")
+            if "variable" in select and (not isinstance(variable, str) or not variable.strip()):
+                raise ValueError(f"{prefix}.select.variable must be a non-empty variable name")
+            quantile = select.get("quantile")
+            if "quantile" in select and (
+                isinstance(quantile, bool)
+                or not isinstance(quantile, (int, float))
+                or not math.isfinite(float(quantile))
+            ):
+                raise ValueError(f"{prefix}.select.quantile must be a finite number")
+            validated: dict[str, Any] = {
+                "data_element": _uid(entry.get("data_element"), f"{prefix}.data_element"),
+                "select": dict(select),
+            }
+            for field in ("category_option_combo", "attribute_option_combo"):
+                if field in entry:
+                    validated[field] = _uid(entry[field], f"{prefix}.{field}")
+            validated_series.append(validated)
         for field, default in (("org_unit_field", "geometry"), ("period_field", "t")):
             value = mapping.get(field, default)
             if not isinstance(value, str) or not value.strip():
@@ -67,79 +80,179 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             raise ValueError("Organisation unit and period fields must be distinct")
         if "aggregation" in mapping and mapping["aggregation"] not in ("mean", "sum", "min", "max"):
             raise ValueError("aggregation must be mean, sum, min, or max; it declares upstream computation")
-        return {**mapping, "period_type": kind, "series": [{**entry, "select": select}]}
+        return {**mapping, "period_type": kind, "series": validated_series}
 
     def render(self, data: Any, mapping: dict[str, Any]) -> RenderedExport:
         import numpy as np
-        import pandas as pd
-        import xarray as xr
 
-        entry = mapping["series"][0]
+        entries = mapping["series"]
         org_field = mapping.get("org_unit_field", "geometry")
         period_field = mapping.get("period_field", "t")
         kind = mapping["period_type"]
-        variable = entry["select"].get("variable")
-        if isinstance(data, xr.DataArray):
-            data = data.to_dataset(name=data.name or "result")
-        if isinstance(data, xr.Dataset):
-            if variable is not None:
-                if variable not in data.data_vars:
-                    raise ValueError(f"Selected variable '{variable}' is not present in the result")
-                data = data[[variable]]
-            if set(data.dims) - {org_field, period_field}:
-                raise ValueError("DHIS2 export requires aggregates with only organisation-unit and period dimensions")
-            declared_period = data.attrs.get("period_type")
-            if declared_period is not None and _normalise_period_type(str(declared_period)) != kind:
-                raise ValueError("Result period_type differs from the mapping; aggregate temporally before exporting")
-            frame = data.to_dataframe().reset_index()
-        elif isinstance(data, pd.DataFrame):
-            frame = pd.DataFrame(data).copy()
-            if variable is not None:
-                required = [org_field, period_field, variable]
-                if not all(field in frame.columns for field in required):
-                    raise ValueError("Selected variable or identity fields are missing from the result")
-                frame = frame[required]
-        else:
-            raise ValueError("DHIS2 export requires an xarray aggregate or a pandas/GeoPandas table")
-        if org_field not in frame or period_field not in frame:
+
+        frame, value_columns = self._to_frame(data, org_field, period_field, kind)
+        if org_field not in frame.columns or period_field not in frame.columns:
             raise ValueError("DHIS2 result is missing organisation-unit or period fields")
         if not frame.columns.is_unique:
             raise ValueError("DHIS2 result contains duplicate column names")
-        value_field = _select_dhis2_value_field(frame, org_field, period_field)
-        keys: set[tuple[str, str]] = set()
-        for index, record in enumerate(frame.to_dict(orient="records")):
-            org = _uid(record[org_field], f"row {index} organisation unit (feature.id)")
-            period = _to_dhis2_period_string(record[period_field], kind)
-            _validate_period(period, kind)
-            key = (org, period)
-            if key in keys:
-                raise ValueError(f"Duplicate DHIS2 value for organisation unit '{org}' and period '{period}'")
-            keys.add(key)
-            value = record[value_field]
-            if not _is_nullish(value) and (
-                not isinstance(value, (int, float, Decimal, np.integer, np.floating, bool, np.bool_))
-                or not math.isfinite(value)
-            ):
-                raise ValueError(f"Row {index} must contain a finite scalar numeric value")
-        options = {
-            "data_element_id": entry["data_element"],
-            "org_unit_field": org_field,
-            "period_field": period_field,
-            "period_type": kind,
-        }
-        if "category_option_combo" in entry:
-            options["category_option_combo"] = entry["category_option_combo"]
-        payload = _build_dhis2_json_payload(frame, options)
-        values = payload["dataValues"]
-        if "attribute_option_combo" in entry:
-            for value in values:
-                value["attributeOptionCombo"] = entry["attribute_option_combo"]
+
+        residual_dims: list[str] = []
+        if value_columns is not None:
+            residual_dims = [
+                str(column)
+                for column in frame.columns
+                if column not in {org_field, period_field}
+                and str(column) not in value_columns
+                and str(column) not in {"geometry", "spatial_ref", "index", "band", "bands"}
+            ]
+
+        data_values: list[dict[str, str]] = []
+        seen_keys: set[tuple[str, str, str, str, str]] = set()
+        periods: set[str] = set()
+        record_count = 0
+        skipped_count = 0
+
+        for entry in entries:
+            select = entry.get("select", {})
+            selected = frame
+            if "quantile" in select:
+                selected = self._select_quantile_rows(selected, select["quantile"])
+            elif "quantile" in residual_dims:
+                raise ValueError(
+                    "DHIS2 export requires aggregates with only organisation-unit and period dimensions; "
+                    "the result contains a 'quantile' dimension — select a quantile or aggregate before exporting"
+                )
+            unhandled = [column for column in residual_dims if column != "quantile"]
+            if unhandled:
+                raise ValueError(
+                    "DHIS2 export requires aggregates with only organisation-unit and period dimensions; "
+                    f"found residual dimensions {unhandled}"
+                )
+            column = self._resolve_series_column(selected, select, value_columns, org_field, period_field)
+            for index, record in enumerate(selected.to_dict(orient="records")):
+                org = _uid(record[org_field], f"row {index} organisation unit (feature.id)")
+                period = _to_dhis2_period_string(record[period_field], kind)
+                _validate_period(period, kind)
+                value = record[column]
+                if _is_nullish(value):
+                    skipped_count += 1
+                    continue
+                if not isinstance(
+                    value, (int, float, Decimal, np.integer, np.floating, bool, np.bool_)
+                ) or not math.isfinite(value):
+                    raise ValueError(f"Row {index} must contain a finite scalar numeric value")
+                category_combo = entry.get("category_option_combo")
+                attribute_combo = entry.get("attribute_option_combo")
+                key = (entry["data_element"], org, period, category_combo or "", attribute_combo or "")
+                if key in seen_keys:
+                    raise ValueError(
+                        f"Duplicate DHIS2 value for data element '{entry['data_element']}', "
+                        f"organisation unit '{org}', and period '{period}'"
+                    )
+                seen_keys.add(key)
+                item: dict[str, str] = {
+                    "dataElement": entry["data_element"],
+                    "orgUnit": org,
+                    "period": period,
+                    "value": _to_dhis2_value_string(value),
+                }
+                if category_combo is not None:
+                    item["categoryOptionCombo"] = category_combo
+                if attribute_combo is not None:
+                    item["attributeOptionCombo"] = attribute_combo
+                data_values.append(item)
+                periods.add(period)
+                record_count += 1
+
         return RenderedExport(
-            content=json.dumps(payload, allow_nan=False).encode(),
-            record_count=len(values),
-            skipped_count=len(frame) - len(values),
-            periods=tuple(sorted({value["period"] for value in values})),
+            content=json.dumps({"dataValues": data_values}, allow_nan=False).encode(),
+            record_count=record_count,
+            skipped_count=skipped_count,
+            periods=tuple(sorted(periods)),
         )
+
+    def _to_frame(self, data: Any, org_field: str, period_field: str, kind: str) -> tuple[Any, list[str] | None]:
+        """Normalize an xarray object or DataFrame to one wide table.
+
+        Returns ``(frame, value_columns)``. ``value_columns`` names the value
+        columns when the input carried xarray data-variable metadata; it is
+        ``None`` for a plain DataFrame, whose value columns are derived later by
+        exclusion. A merged cube's synthetic ``__cubes__`` dimension is pivoted
+        into one column per cube label so selectors address source names rather
+        than the internal dimension name.
+        """
+        import pandas as pd
+        import xarray as xr
+
+        if isinstance(data, xr.DataArray):
+            data = data.to_dataset(name=data.name or "result")
+        if isinstance(data, xr.Dataset):
+            declared_period = data.attrs.get("period_type")
+            if declared_period is not None and _normalise_period_type(str(declared_period)) != kind:
+                raise ValueError("Result period_type differs from the mapping; aggregate temporally before exporting")
+            value_columns = [str(name) for name in data.data_vars]
+            if not value_columns:
+                raise ValueError("DHIS2 result contains no data variables")
+            frame = data.to_dataframe().reset_index()
+            if "__cubes__" in frame.columns:
+                if len(value_columns) != 1:
+                    raise ValueError("Merged-cube results require exactly one value column")
+                value_column = value_columns[0]
+                index_columns = [column for column in frame.columns if column != value_column and column != "__cubes__"]
+                if not index_columns:
+                    raise ValueError("Merged-cube result has no organisation-unit or period columns")
+                frame = frame.pivot(index=index_columns, columns="__cubes__", values=value_column).reset_index()
+                frame.columns.name = None
+                value_columns = [str(column) for column in frame.columns if column not in index_columns]
+            return frame, value_columns
+        if isinstance(data, pd.DataFrame):
+            return pd.DataFrame(data).copy(), None
+        raise ValueError("DHIS2 export requires an xarray aggregate or a pandas/GeoPandas table")
+
+    def _resolve_series_column(
+        self,
+        frame: Any,
+        select: dict[str, Any],
+        value_columns: list[str] | None,
+        org_field: str,
+        period_field: str,
+    ) -> str:
+        """Return the single value column a series selector resolves to."""
+        variable = select.get("variable")
+        if variable is not None:
+            if not isinstance(variable, str):
+                raise ValueError("select.variable must be a string")
+            if variable not in frame.columns:
+                raise ValueError(f"Selected variable '{variable}' is not present in the result")
+            return variable
+        fields = self._candidate_value_fields(frame, value_columns, org_field, period_field)
+        if len(fields) != 1:
+            raise ValueError(
+                "DHIS2 export with an empty series selector requires exactly one value column "
+                f"after excluding '{org_field}' and '{period_field}'; found {fields}"
+            )
+        return fields[0]
+
+    @staticmethod
+    def _candidate_value_fields(
+        frame: Any, value_columns: list[str] | None, org_field: str, period_field: str
+    ) -> list[str]:
+        if value_columns is not None:
+            return [column for column in value_columns if column in frame.columns]
+        excluded = {org_field, period_field, "geometry", "spatial_ref", "index", "band", "bands"}
+        return [
+            str(column) for column in frame.columns if column not in excluded and not str(column).startswith("level_")
+        ]
+
+    @staticmethod
+    def _select_quantile_rows(frame: Any, quantile: Any) -> Any:
+        """Filter a table to one quantile along its ``quantile`` dimension."""
+        if "quantile" not in frame.columns:
+            raise ValueError("select.quantile requires a 'quantile' dimension in the result")
+        mask = frame["quantile"] == quantile
+        if not bool(mask.any()):
+            raise ValueError(f"select.quantile value {quantile!r} is not present in the result")
+        return frame.loc[mask]
 
     def send(
         self,

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -26,6 +26,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
     format = "DHIS2JSON"
     extension = ".json"
     media_type = "application/json"
+    version = "1"
 
     def validate_mapping(self, mapping: dict[str, Any]) -> dict[str, Any]:
         allowed = {"series", "period_type", "org_unit_field", "period_field", "aggregation"}
@@ -129,6 +130,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
             content=json.dumps(payload, allow_nan=False).encode(),
             record_count=len(values),
             skipped_count=len(frame) - len(values),
+            periods=tuple(sorted({value["period"] for value in values})),
         )
 
 

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -19,6 +19,65 @@ from open_climate_service.exports.tabular import (
 )
 
 
+class _RetryableTransportError(Exception):
+    """A connection failure that occurred before the request reached DHIS2."""
+
+
+def _is_retryable_transport_error(exc: BaseException) -> bool:
+    """Return True for failures that occur before the request is sent.
+
+    A refused connection, DNS failure, or connect timeout never reached DHIS2, so
+    the chunk can be safely retried. Read/write timeouts happen after the request
+    may have reached the server and stay ``unknown``.
+    """
+    import importlib
+    from types import ModuleType
+
+    httpx: ModuleType | None = None
+    try:
+        httpx = importlib.import_module("httpx")
+    except ImportError:
+        pass
+    if httpx is not None and isinstance(exc, (httpx.ConnectError, httpx.PoolTimeout, httpx.UnsupportedProtocol)):
+        return True
+    requests: ModuleType | None = None
+    try:
+        requests = importlib.import_module("requests")
+    except ImportError:
+        pass
+    if requests is not None:
+        # ``ConnectionError`` is intentionally too broad here: requests also
+        # uses it for response-side failures such as a connection reset after a
+        # POST may have been processed. Only its connect-timeout subtype, or a
+        # urllib3 exception explicitly identifying connection establishment,
+        # is safe to replay.
+        if isinstance(exc, requests.exceptions.ConnectTimeout):
+            return True
+        try:
+            urllib3_exceptions = importlib.import_module("urllib3.exceptions")
+            pre_send_types = (
+                urllib3_exceptions.NewConnectionError,
+                urllib3_exceptions.NameResolutionError,
+            )
+        except (ImportError, AttributeError):
+            pre_send_types = ()
+        pending: list[BaseException] = [exc]
+        seen: set[int] = set()
+        while pending:
+            candidate = pending.pop()
+            if id(candidate) in seen:
+                continue
+            seen.add(id(candidate))
+            if pre_send_types and isinstance(candidate, pre_send_types):
+                return True
+            pending.extend(item for item in candidate.args if isinstance(item, BaseException))
+            if candidate.__cause__ is not None:
+                pending.append(candidate.__cause__)
+            if candidate.__context__ is not None:
+                pending.append(candidate.__context__)
+    return False
+
+
 class Dhis2ExportPlugin(BaseExportPlugin):
     """Map prepared aggregate series to DHIS2 data elements."""
 
@@ -394,16 +453,22 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 finished_at=created_at,
             ),
         )
-        report = self._submit_chunk(
-            client,
-            target,
-            chunk_values,
-            dry_run=dry_run,
-            created_at=created_at,
-            chunk_sha256=digest,
-            context=context,
-            index=index,
-        )
+        try:
+            report = self._submit_chunk(
+                client,
+                target,
+                chunk_values,
+                dry_run=dry_run,
+                created_at=created_at,
+                chunk_sha256=digest,
+                context=context,
+                index=index,
+            )
+        except _RetryableTransportError:
+            # Nothing reached DHIS2, so drop the intent checkpoint to allow a
+            # retry, then propagate.
+            self._delete_chunk_checkpoint(context, index)
+            raise
         self._save_chunk_checkpoint(context, index, digest, report)
         return report
 
@@ -466,6 +531,11 @@ class Dhis2ExportPlugin(BaseExportPlugin):
     def _chunk_checkpoint_key(index: int) -> str:
         return f"chunk:{index}"
 
+    def _delete_chunk_checkpoint(self, context: DeliveryContext | None, index: int) -> None:
+        """Remove a chunk checkpoint so it can be retried after a transport error."""
+        if context is not None:
+            context.delete_checkpoint(self._chunk_checkpoint_key(index))
+
     def _submit_chunk(
         self,
         client: Any,
@@ -502,6 +572,11 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                     submitted=submitted,
                     created_at=created_at,
                 )
+            if _is_retryable_transport_error(exc):
+                # The request never reached DHIS2 (refused connection, DNS failure,
+                # or connect timeout). Raise so the chunk is not checkpointed as
+                # submitted and the caller can retry.
+                raise _RetryableTransportError(str(exc)) from exc
             # The POST may have reached DHIS2 before failing (e.g. timeout).
             # Record an unknown outcome rather than fabricating a rejection, and
             # never auto-replay this chunk.
@@ -583,24 +658,28 @@ class Dhis2ExportPlugin(BaseExportPlugin):
         created_at: str,
         context: DeliveryContext | None = None,
     ) -> ExportReport:
-        """Poll a submitted async import task with bounded backoff."""
+        """Poll a submitted async import task with bounded backoff.
+
+        The first status check happens immediately after acceptance; the backoff
+        applies between subsequent attempts.
+        """
         import time
 
         from open_climate_service.shared.time import utc_now
 
-        summary: dict[str, Any] = {}
         for attempt in range(max(0, self.max_poll_attempts)):
             if context is not None and context.is_cancel_requested():
                 break
-            time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
             try:
                 response = client.get(f"/api/system/taskSummaries/DATAVALUE_IMPORT/{task_id}")
+                status_code = _response_status(response)
+                summary = _response_json(response)
             except Exception:
-                continue
-            summary = _response_json(response)
-            if self._task_is_terminal(summary):
+                status_code = None
+                summary = {}
+            if status_code is not None and self._task_is_terminal(summary):
                 report = build_dhis2_report(
-                    _response_status(response),
+                    status_code,
                     _extract_import_summary(summary),
                     plugin_id=self.id,
                     connection_id=target,
@@ -612,6 +691,7 @@ class Dhis2ExportPlugin(BaseExportPlugin):
                 if report.remote_task_ids == []:
                     report = report.model_copy(update={"remote_task_ids": [task_id]})
                 return report
+            time.sleep(min(30.0, self.poll_backoff_base * (2**attempt)))
 
         # The task never reached a terminal state within the poll budget.
         return ExportReport(
@@ -702,9 +782,9 @@ def build_dhis2_report(
         finished_at=finished_at,
     )
 
-    if not 200 <= status_code < 300:
-        return ExportReport(outcome=ExportOutcome.REJECTED, message=message or f"HTTP {status_code}", **base)
-
+    # Classify by the import summary first: DHIS2 2.38+ reports a partially
+    # successful import as HTTP 409 with status WARNING and real importCount
+    # figures. Only fall back to the HTTP code when no summary status is present.
     if status in {"ERROR", "FAILED"}:
         return ExportReport(outcome=ExportOutcome.REJECTED, message=message, **base)
     if status == "WARNING" or conflicts:
@@ -712,6 +792,8 @@ def build_dhis2_report(
     if status == "SUCCESS":
         outcome = ExportOutcome.DRY_RUN if dry_run else ExportOutcome.SUCCESS
         return ExportReport(outcome=outcome, message=message, **base)
+    if not 200 <= status_code < 300:
+        return ExportReport(outcome=ExportOutcome.REJECTED, message=message or f"HTTP {status_code}", **base)
     # A 2xx without a recognizable import summary cannot be trusted as success.
     return ExportReport(outcome=ExportOutcome.UNKNOWN, message="Unrecognized import summary", **base)
 

--- a/open_climate_service/exports/dhis2_renderer.py
+++ b/open_climate_service/exports/dhis2_renderer.py
@@ -53,6 +53,7 @@ def _is_retryable_transport_error(exc: BaseException) -> bool:
         # is safe to replay.
         if isinstance(exc, requests.exceptions.ConnectTimeout):
             return True
+        pre_send_types: tuple[Any, ...]
         try:
             urllib3_exceptions = importlib.import_module("urllib3.exceptions")
             pre_send_types = (

--- a/open_climate_service/exports/manifest.py
+++ b/open_climate_service/exports/manifest.py
@@ -102,12 +102,10 @@ def plugin_identity(plugin: BaseExportPlugin) -> PluginIdentity:
 
 
 def target_binding(plugin_id: str, references: dict[str, str]) -> TargetBinding | None:
-    """Resolve only public connection settings, never credentials or a network client."""
+    """Bind a named DHIS2 target for built-in or installed export implementations."""
     connection_id = references.get("connection")
     if connection_id is None:
         return None
-    if plugin_id != "dhis2":
-        raise ValueError("Connection bindings currently support only the DHIS2 plugin")
     from open_climate_service.exports.dhis2 import get_connection_config
 
     parts = urlsplit(get_connection_config(connection_id).url)

--- a/open_climate_service/exports/manifest.py
+++ b/open_climate_service/exports/manifest.py
@@ -1,0 +1,172 @@
+"""Versioned export manifests and atomic publication of file generations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from open_climate_service.exports.base import BaseExportPlugin
+from open_climate_service.shared.provenance import json_digest
+
+
+class _Model(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class PluginIdentity(_Model):
+    """Renderer identity whose version is owned by the plugin author."""
+
+    id: str
+    version: str | None
+    implementation: str
+    format: str
+    media_type: str
+    extension: str
+
+
+class TargetBinding(_Model):
+    """Target identity without its URL, token, or environment-variable value."""
+
+    connection_id: str
+    url_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class ExportManifest(_Model):
+    """A saved payload bound to its source job, mapping, and optional target."""
+
+    schema_version: Literal[1] = 1
+    source_job_id: str
+    export_id: str
+    created_at: str
+    filename: str = Field(pattern=r"^export-[0-9a-f]{32}\.[a-z0-9]+$")
+    payload_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    payload_size: int = Field(ge=0)
+    record_count: int = Field(ge=0)
+    skipped_count: int = Field(ge=0)
+    periods: list[str] | None
+    plugin: PluginIdentity
+    mapping: dict[str, Any]
+    mapping_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    references: dict[str, str]
+    target: TargetBinding | None
+    provenance: dict[str, Any]
+
+
+def validate_public_mapping(value: Any) -> None:
+    """Require JSON-compatible, non-secret literal configuration for export metadata."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError("Export mapping keys must be strings")
+            if key.lower().replace("-", "_") in {
+                "token",
+                "password",
+                "secret",
+                "authorization",
+                "credentials",
+                "api_key",
+                "access_token",
+            }:
+                raise ValueError("Export mappings must not contain credentials; use connection references")
+            validate_public_mapping(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            validate_public_mapping(child)
+    elif isinstance(value, str) and "${" in value:
+        raise ValueError("Export mappings must be literal; environment interpolation is not supported")
+    # Canonical serialization also rejects unsupported types and NaN/Infinity.
+    try:
+        json_digest(value)
+    except (ValueError, TypeError):
+        raise ValueError("Export mappings must contain finite JSON values") from None
+
+
+def plugin_identity(plugin: BaseExportPlugin) -> PluginIdentity:
+    """Capture the renderer descriptor before calling its implementation."""
+    cls = type(plugin)
+    return PluginIdentity(
+        id=plugin.id,
+        version=plugin.version,
+        implementation=f"{cls.__module__}.{cls.__qualname__}",
+        format=plugin.format,
+        media_type=plugin.media_type,
+        extension=plugin.extension,
+    )
+
+
+def target_binding(plugin_id: str, references: dict[str, str]) -> TargetBinding | None:
+    """Resolve only public connection settings, never credentials or a network client."""
+    connection_id = references.get("connection")
+    if connection_id is None:
+        return None
+    if plugin_id != "dhis2":
+        raise ValueError("Connection bindings currently support only the DHIS2 plugin")
+    from open_climate_service.exports.dhis2 import get_connection_config
+
+    parts = urlsplit(get_connection_config(connection_id).url)
+    hostname = parts.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    port = parts.port
+    if port is not None and (parts.scheme, port) not in {("https", 443), ("http", 80)}:
+        hostname += f":{port}"
+    canonical = urlunsplit((parts.scheme, hostname, parts.path.rstrip("/"), "", ""))
+    return TargetBinding(connection_id=connection_id, url_sha256=hashlib.sha256(canonical.encode()).hexdigest())
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    """Publish one file by replacement after flushing its complete contents."""
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=".export-", delete=False) as handle:
+            temporary = handle.name
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            Path(temporary).unlink(missing_ok=True)
+
+
+def publish_manifest(directory: Path, manifest: ExportManifest, payload: bytes) -> str:
+    """Commit a fresh generation by replacing the metadata pointer last.
+
+    Failed generations may leave unreferenced files, but never overwrite a
+    previously committed payload or advertise a partially written generation.
+    """
+    path = directory / manifest.filename
+    manifest_name = f"{path.stem}.manifest.json"
+    manifest_bytes = manifest.model_dump_json().encode()
+    atomic_write(path, payload)
+    atomic_write(directory / manifest_name, manifest_bytes)
+    metadata = {
+        "filename": path.name,
+        "format": manifest.plugin.format,
+        "media_type": manifest.plugin.media_type,
+        "record_count": manifest.record_count,
+        "skipped_count": manifest.skipped_count,
+        "manifest": manifest_name,
+        "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+    }
+    # Ensure generation entries precede the pointer in the filesystem journal.
+    if os.name == "nt":
+        # Windows does not expose POSIX directory fsync; replacement remains atomic.
+        atomic_write(directory / ".export.json", json.dumps(metadata).encode())
+        return str(path)
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+        atomic_write(directory / ".export.json", json.dumps(metadata).encode())
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return str(path)

--- a/open_climate_service/exports/registry.py
+++ b/open_climate_service/exports/registry.py
@@ -1,0 +1,66 @@
+"""Discover built-in, installed, and instance export plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from open_climate_service import config, plugin_discovery
+from open_climate_service.exports.base import BaseExportPlugin
+
+
+def load_export_plugins() -> dict[str, BaseExportPlugin]:
+    """Load renderers in precedence order, failing explicitly on broken plugins."""
+    from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin
+
+    builtin = Dhis2ExportPlugin()
+    found: dict[str, BaseExportPlugin] = {builtin.id: builtin}
+    for _, package, resource in sorted(plugin_discovery.iter_plugin_subdirs("exports"), key=lambda item: item[:2]):
+        for file in sorted(resource.iterdir(), key=lambda item: item.name):
+            if file.name.endswith(".py") and not file.name.startswith("_"):
+                _register(found, f"{package}.exports.{file.name[:-3]}")
+
+    raw = config.get_config().get("plugins_dir")
+    if raw:
+        if not isinstance(raw, str):
+            raise ValueError("plugins_dir must be a path string")
+        config_path = config.get_config_path()
+        directory = ((config_path.parent if config_path else Path.cwd()) / raw / "exports").resolve()
+        if directory.is_dir():
+            # Unique namespace per instance prevents collisions with installed
+            # 'exports' packages and supports relative helper imports.
+            namespace = "_ocs_exports_" + hashlib.sha256(str(directory).encode()).hexdigest()[:16]
+            if namespace not in sys.modules:
+                module = ModuleType(namespace)
+                module.__path__ = [str(directory)]
+                sys.modules[namespace] = module
+            for path in sorted(directory.glob("*.py")):
+                if not path.name.startswith("_"):
+                    _register(found, f"{namespace}.{path.stem}")
+    return found
+
+
+def _register(found: dict[str, BaseExportPlugin], name: str) -> None:
+    try:
+        module = importlib.import_module(name)
+    except Exception as exc:
+        raise ValueError(f"Could not load export plugin module '{name}'") from exc
+    plugin = getattr(module, "plugin", None)
+    if not isinstance(plugin, BaseExportPlugin):
+        raise ValueError(f"Export module '{name}' must expose a BaseExportPlugin instance as 'plugin'")
+    for field, pattern in (
+        ("id", r"[A-Za-z0-9][A-Za-z0-9_-]*"),
+        ("format", r"[A-Z][A-Z0-9_]*"),
+        ("extension", r"\.[a-z0-9]+"),
+        ("media_type", r"[a-zA-Z0-9.+-]+/[a-zA-Z0-9.+-]+"),
+    ):
+        value = getattr(plugin, field, None)
+        if not isinstance(value, str) or not re.fullmatch(pattern, value):
+            raise ValueError(f"Export plugin '{name}' has an invalid {field}")
+    if plugin.extension == ".zarr":
+        raise ValueError("Export renderers produce files, not Zarr directories")
+    found[plugin.id] = plugin

--- a/open_climate_service/exports/registry.py
+++ b/open_climate_service/exports/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import logging
 import re
 import sys
 from pathlib import Path
@@ -12,9 +13,11 @@ from types import ModuleType
 from open_climate_service import config, plugin_discovery
 from open_climate_service.exports.base import BaseExportPlugin
 
+logger = logging.getLogger(__name__)
+
 
 def load_export_plugins() -> dict[str, BaseExportPlugin]:
-    """Load renderers in precedence order, failing explicitly on broken plugins."""
+    """Load renderers in precedence order, skipping broken plugins."""
     from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin
 
     builtin = Dhis2ExportPlugin()
@@ -45,13 +48,21 @@ def load_export_plugins() -> dict[str, BaseExportPlugin]:
 
 
 def _register(found: dict[str, BaseExportPlugin], name: str) -> None:
+    """Register one plugin module, skipping broken or invalid plugins.
+
+    A malformed third-party export plugin must not take down discovery endpoints
+    such as ``GET /file_formats`` that every openEO client hits on connect. Log
+    the problem and skip, like the process plugin loader does.
+    """
     try:
         module = importlib.import_module(name)
     except Exception as exc:
-        raise ValueError(f"Could not load export plugin module '{name}'") from exc
+        logger.warning("Skipping export plugin module '%s': %s", name, exc)
+        return
     plugin = getattr(module, "plugin", None)
     if not isinstance(plugin, BaseExportPlugin):
-        raise ValueError(f"Export module '{name}' must expose a BaseExportPlugin instance as 'plugin'")
+        logger.warning("Skipping export module '%s': missing 'plugin' BaseExportPlugin instance", name)
+        return
     for field, pattern in (
         ("id", r"[A-Za-z0-9][A-Za-z0-9_-]*"),
         ("format", r"[A-Z][A-Z0-9_]*"),
@@ -60,7 +71,9 @@ def _register(found: dict[str, BaseExportPlugin], name: str) -> None:
     ):
         value = getattr(plugin, field, None)
         if not isinstance(value, str) or not re.fullmatch(pattern, value):
-            raise ValueError(f"Export plugin '{name}' has an invalid {field}")
+            logger.warning("Skipping export plugin '%s': invalid %s", name, field)
+            return
     if plugin.extension == ".zarr":
-        raise ValueError("Export renderers produce files, not Zarr directories")
+        logger.warning("Skipping export plugin '%s': renderers produce files, not Zarr directories", name)
+        return
     found[plugin.id] = plugin

--- a/open_climate_service/exports/report.py
+++ b/open_climate_service/exports/report.py
@@ -52,3 +52,83 @@ class ExportReport(BaseModel):
     remote_task_ids: list[str] = Field(default_factory=list)
     created_at: str
     finished_at: str
+
+
+# Ordered by severity; a merged report takes the first matching outcome.
+_OUTCOME_PRECEDENCE: tuple[ExportOutcome, ...] = (
+    ExportOutcome.REJECTED,
+    ExportOutcome.UNKNOWN,
+    ExportOutcome.CANCELLED,
+    ExportOutcome.PARTIAL,
+)
+
+
+def merge_chunk_reports(
+    reports: list[ExportReport],
+    *,
+    plugin_id: str,
+    connection_id: str | None,
+    dry_run: bool,
+    payload_sha256: str,
+    created_at: str,
+    finished_at: str,
+    submitted: int | None = None,
+    cancelled_early: bool = False,
+    message: str | None = None,
+) -> ExportReport:
+    """Combine per-chunk reports into one authoritative delivery report.
+
+    Counts, conflicts, remote task IDs, and attempts are summed. The aggregate
+    outcome is the most severe chunk outcome; a dry run that fully validated
+    reports ``dry_run``, otherwise a clean run reports ``success``. An early
+    cancellation is recorded as ``cancelled`` unless a chunk was rejected or its
+    outcome is unknown.
+    """
+    outcomes: set[ExportOutcome]
+    if reports:
+        attempts = sum(report.attempts for report in reports)
+        imported = sum(report.imported for report in reports)
+        updated = sum(report.updated for report in reports)
+        ignored = sum(report.ignored for report in reports)
+        deleted = sum(report.deleted for report in reports)
+        conflicts = [conflict for report in reports for conflict in report.conflicts]
+        remote_task_ids = [task_id for report in reports for task_id in report.remote_task_ids]
+        chunks = len(reports)
+        total_submitted = submitted if submitted is not None else sum(report.submitted for report in reports)
+        outcomes = {report.outcome for report in reports}
+    else:
+        attempts = 0
+        imported = updated = ignored = deleted = 0
+        conflicts = []
+        remote_task_ids = []
+        chunks = 0
+        total_submitted = submitted if submitted is not None else 0
+        outcomes = set()
+
+    outcome = ExportOutcome.SUCCESS
+    for candidate in _OUTCOME_PRECEDENCE:
+        if candidate in outcomes or (candidate == ExportOutcome.CANCELLED and cancelled_early):
+            outcome = candidate
+            break
+    if outcome == ExportOutcome.SUCCESS:
+        outcome = ExportOutcome.DRY_RUN if dry_run else ExportOutcome.SUCCESS
+
+    return ExportReport(
+        plugin_id=plugin_id,
+        connection_id=connection_id,
+        dry_run=dry_run,
+        outcome=outcome,
+        message=message,
+        payload_sha256=payload_sha256,
+        attempts=attempts,
+        chunks=chunks,
+        submitted=total_submitted,
+        imported=imported,
+        updated=updated,
+        ignored=ignored,
+        deleted=deleted,
+        conflicts=conflicts,
+        remote_task_ids=remote_task_ids,
+        created_at=created_at,
+        finished_at=finished_at,
+    )

--- a/open_climate_service/exports/report.py
+++ b/open_climate_service/exports/report.py
@@ -1,0 +1,54 @@
+"""Structured outcome of one export delivery attempt."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ExportOutcome(StrEnum):
+    """Distinct terminal states a delivery attempt can reach."""
+
+    SUCCESS = "success"
+    """The target accepted the payload and reported no conflicts or errors."""
+
+    PARTIAL = "partial"
+    """The target reported a mixed import summary with conflicts or failures."""
+
+    REJECTED = "rejected"
+    """The target rejected the payload outright (validation or import errors)."""
+
+    DRY_RUN = "dry_run"
+    """A dry-run validation completed; nothing was written."""
+
+    CANCELLED = "cancelled"
+    """Delivery was cancelled before or during submission."""
+
+    UNKNOWN = "unknown"
+    """The remote outcome could not be reconciled (e.g. timeout after POST)."""
+
+
+class ExportReport(BaseModel):
+    """Authoritative summary of a delivery attempt, persisted on the delivery job."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    plugin_id: str
+    connection_id: str | None = None
+    dry_run: bool = False
+    outcome: ExportOutcome
+    message: str | None = None
+    payload_sha256: str
+    attempts: int = 1
+    chunks: int = 1
+    submitted: int = 0
+    imported: int = 0
+    updated: int = 0
+    ignored: int = 0
+    deleted: int = 0
+    conflicts: list[dict[str, Any]] = Field(default_factory=list)
+    remote_task_ids: list[str] = Field(default_factory=list)
+    created_at: str
+    finished_at: str

--- a/open_climate_service/exports/reservations.py
+++ b/open_climate_service/exports/reservations.py
@@ -1,42 +1,35 @@
-"""Idempotency reservations for delivery submissions.
-
-Slice-4 persistence: a JSON index guarded by an exclusive lock. Crash-safe
-atomic reservation across a send operation is deferred to CLIM-927 (see the
-CLIM-840 approach doc); this store prevents duplicate submission within a
-running process and across processes via ``portalocker``, but a crash between
-enqueue and reservation can still leave a delivery without a reservation entry.
-"""
+"""Durable idempotency reservations, written before a delivery is enqueued."""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
-import portalocker
-
 from open_climate_service import config as api_config
+from open_climate_service.shared.persistence import atomic_json, index_lock
 
 
 def _reservations_path() -> Path:
     return api_config.get_data_root() / "exports" / "delivery_reservations.json"
 
 
-def _ensure_store() -> None:
-    path = _reservations_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        path.write_text("{}\n", encoding="utf-8")
-
-
 def _load() -> dict[str, dict[str, object]]:
-    _ensure_store()
-    with open(_reservations_path(), encoding="utf-8") as handle:
-        portalocker.lock(handle, portalocker.LOCK_SH)
-        try:
-            payload = json.load(handle)
-        finally:
-            portalocker.unlock(handle)
-    return payload if isinstance(payload, dict) else {}
+    path = _reservations_path()
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not all(isinstance(value, dict) for value in payload.values()):
+        raise ValueError("Invalid delivery reservation index")
+    return payload
+
+
+@contextmanager
+def submission_lock() -> Iterator[None]:
+    """Serialize reservation, job creation and enqueue across all API workers."""
+    with index_lock(_reservations_path()):
+        yield
 
 
 def find_delivery(idempotency_key: str) -> dict[str, object] | None:
@@ -54,24 +47,16 @@ def reserve_delivery(
     fingerprint: str,
 ) -> None:
     """Persist one delivery reservation, refusing a duplicate key."""
-    _ensure_store()
-    with open(_reservations_path(), "r+", encoding="utf-8") as handle:
-        portalocker.lock(handle, portalocker.LOCK_EX)
-        try:
-            payload = json.load(handle)
-            records = payload if isinstance(payload, dict) else {}
-            if idempotency_key in records:
-                raise ValueError(f"Delivery reservation '{idempotency_key}' already exists")
-            records[idempotency_key] = {
-                "delivery_job_id": delivery_job_id,
-                "export_id": export_id,
-                "source_job_id": source_job_id,
-                "dry_run": dry_run,
-                "fingerprint": fingerprint,
-            }
-            handle.seek(0)
-            json.dump(records, handle, indent=2)
-            handle.write("\n")
-            handle.truncate()
-        finally:
-            portalocker.unlock(handle)
+    # Caller holds submission_lock through enqueue; a retry can recreate a job
+    # missing after a crash using this already reserved ID.
+    records = _load()
+    if idempotency_key in records:
+        raise ValueError("Delivery reservation already exists")
+    records[idempotency_key] = {
+        "delivery_job_id": delivery_job_id,
+        "export_id": export_id,
+        "source_job_id": source_job_id,
+        "dry_run": dry_run,
+        "fingerprint": fingerprint,
+    }
+    atomic_json(_reservations_path(), records)

--- a/open_climate_service/exports/reservations.py
+++ b/open_climate_service/exports/reservations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -26,7 +26,7 @@ def _load() -> dict[str, dict[str, object]]:
 
 
 @contextmanager
-def submission_lock() -> Iterator[None]:
+def submission_lock() -> Generator[None]:
     """Serialize reservation, job creation and enqueue across all API workers."""
     with index_lock(_reservations_path()):
         yield

--- a/open_climate_service/exports/reservations.py
+++ b/open_climate_service/exports/reservations.py
@@ -1,0 +1,77 @@
+"""Idempotency reservations for delivery submissions.
+
+Slice-4 persistence: a JSON index guarded by an exclusive lock. Crash-safe
+atomic reservation across a send operation is deferred to CLIM-927 (see the
+CLIM-840 approach doc); this store prevents duplicate submission within a
+running process and across processes via ``portalocker``, but a crash between
+enqueue and reservation can still leave a delivery without a reservation entry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import portalocker
+
+from open_climate_service import config as api_config
+
+
+def _reservations_path() -> Path:
+    return api_config.get_data_root() / "exports" / "delivery_reservations.json"
+
+
+def _ensure_store() -> None:
+    path = _reservations_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("{}\n", encoding="utf-8")
+
+
+def _load() -> dict[str, dict[str, object]]:
+    _ensure_store()
+    with open(_reservations_path(), encoding="utf-8") as handle:
+        portalocker.lock(handle, portalocker.LOCK_SH)
+        try:
+            payload = json.load(handle)
+        finally:
+            portalocker.unlock(handle)
+    return payload if isinstance(payload, dict) else {}
+
+
+def find_delivery(idempotency_key: str) -> dict[str, object] | None:
+    """Return the reservation for one idempotency key, or None."""
+    return _load().get(idempotency_key)
+
+
+def reserve_delivery(
+    idempotency_key: str,
+    *,
+    delivery_job_id: str,
+    export_id: str,
+    source_job_id: str,
+    dry_run: bool,
+    fingerprint: str,
+) -> None:
+    """Persist one delivery reservation, refusing a duplicate key."""
+    _ensure_store()
+    with open(_reservations_path(), "r+", encoding="utf-8") as handle:
+        portalocker.lock(handle, portalocker.LOCK_EX)
+        try:
+            payload = json.load(handle)
+            records = payload if isinstance(payload, dict) else {}
+            if idempotency_key in records:
+                raise ValueError(f"Delivery reservation '{idempotency_key}' already exists")
+            records[idempotency_key] = {
+                "delivery_job_id": delivery_job_id,
+                "export_id": export_id,
+                "source_job_id": source_job_id,
+                "dry_run": dry_run,
+                "fingerprint": fingerprint,
+            }
+            handle.seek(0)
+            json.dump(records, handle, indent=2)
+            handle.write("\n")
+            handle.truncate()
+        finally:
+            portalocker.unlock(handle)

--- a/open_climate_service/exports/retention.py
+++ b/open_climate_service/exports/retention.py
@@ -1,0 +1,32 @@
+"""Cross-process leases protecting job results during consumption."""
+
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import portalocker
+from fastapi import HTTPException
+
+
+@contextmanager
+def result_lease(job_id: str) -> Iterator[None]:
+    """Exclude deletion, updates, reruns, and other consumers until release.
+
+    The lock file lives outside the job directory so deletion cannot unlink the
+    lock inode while another process holds it. Process exit releases the OS lock.
+    """
+    from open_climate_service.openeo.jobs import _JOBS_DIR
+
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", job_id):
+        raise HTTPException(status_code=400, detail="Invalid source job ID")
+    directory = _JOBS_DIR / ".export-locks"
+    directory.mkdir(parents=True, exist_ok=True)
+    lock = portalocker.Lock(directory / f"{job_id}.lock", timeout=0, flags=portalocker.LOCK_EX | portalocker.LOCK_NB)
+    try:
+        lock.acquire()
+    except portalocker.exceptions.LockException:
+        raise HTTPException(status_code=409, detail="Source job results are currently in use") from None
+    try:
+        yield
+    finally:
+        lock.release()

--- a/open_climate_service/exports/retention.py
+++ b/open_climate_service/exports/retention.py
@@ -1,7 +1,7 @@
 """Cross-process leases protecting job results during consumption."""
 
 import re
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 
 import portalocker
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 
 
 @contextmanager
-def result_lease(job_id: str) -> Iterator[None]:
+def result_lease(job_id: str) -> Generator[None]:
     """Exclude deletion, updates, reruns, and other consumers until release.
 
     The lock file lives outside the job directory so deletion cannot unlink the

--- a/open_climate_service/exports/routes.py
+++ b/open_climate_service/exports/routes.py
@@ -67,6 +67,8 @@ def deliver_export(
 def get_delivery_job(export_id: str, delivery_job_id: str) -> dict[str, Any]:
     """Return one delivery job's status and, when finished, its export report."""
     record = get_job_service().get_job_or_404(delivery_job_id)
+    if record.process_id != f"export:{export_id}" or record.request.get("export_id") != export_id:
+        raise HTTPException(status_code=404, detail="Delivery job not found for this export")
     report: ExportReport | None = None
     if isinstance(record.result, dict):
         try:

--- a/open_climate_service/exports/routes.py
+++ b/open_climate_service/exports/routes.py
@@ -1,0 +1,84 @@
+"""Operator delivery routes for named exports.
+
+These routes are deliberately closed in read-only mode (see ``read_only.py``):
+delivery exposes server-held credentials to an operation with external effects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from open_climate_service.exports.delivery import submit_delivery
+from open_climate_service.exports.report import ExportReport
+from open_climate_service.jobs.service import get_job_service
+
+router = APIRouter(tags=["Exports"])
+
+
+class DeliveryRequest(BaseModel):
+    """Request body for POST /exports/{export_id}."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_id: str
+    dry_run: bool = False
+
+
+class DeliveryAccepted(BaseModel):
+    """Accepted delivery job plus links to its status and report."""
+
+    delivery_job_id: str
+    export_id: str
+    dry_run: bool
+    reused: bool
+    status_url: str
+    report_url: str
+
+
+@router.post("/{export_id}", status_code=202, response_model=DeliveryAccepted)
+def deliver_export(
+    export_id: str,
+    body: DeliveryRequest,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> DeliveryAccepted:
+    """Queue delivery of a completed source job's saved export payload.
+
+    Reusing an idempotency key with identical content returns the existing
+    delivery; different content is a conflict.
+    """
+    if not idempotency_key or not idempotency_key.strip():
+        raise HTTPException(status_code=400, detail="An Idempotency-Key header is required")
+    delivery_job_id, reused = submit_delivery(export_id, body.job_id, body.dry_run, idempotency_key.strip())
+    status_url = f"/exports/{export_id}/jobs/{delivery_job_id}"
+    return DeliveryAccepted(
+        delivery_job_id=delivery_job_id,
+        export_id=export_id,
+        dry_run=body.dry_run,
+        reused=reused,
+        status_url=status_url,
+        report_url=status_url,
+    )
+
+
+@router.get("/{export_id}/jobs/{delivery_job_id}")
+def get_delivery_job(export_id: str, delivery_job_id: str) -> dict[str, Any]:
+    """Return one delivery job's status and, when finished, its export report."""
+    record = get_job_service().get_job_or_404(delivery_job_id)
+    report: ExportReport | None = None
+    if isinstance(record.result, dict):
+        try:
+            report = ExportReport.model_validate(record.result)
+        except Exception:
+            report = None
+    return {
+        "delivery_job_id": record.job_id,
+        "export_id": export_id,
+        "status": record.status,
+        "created_at": record.created_at.isoformat(),
+        "finished_at": record.finished_at.isoformat() if record.finished_at else None,
+        "error": record.error.model_dump(mode="json") if record.error else None,
+        "report": report.model_dump(mode="json") if report else None,
+    }

--- a/open_climate_service/exports/service.py
+++ b/open_climate_service/exports/service.py
@@ -5,16 +5,28 @@ from __future__ import annotations
 import json
 import re
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from uuid import uuid4
 
 from open_climate_service import config
 from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
 from open_climate_service.exports.registry import load_export_plugins
 
 
-def render_named_export(data: Any, fmt: str, options: dict[str, Any]) -> tuple[BaseExportPlugin, RenderedExport]:
-    """Render a declared export; per-request mapping overrides are not accepted."""
+@dataclass(frozen=True)
+class ResolvedExport:
+    """Invocation-local mapping and source/target references."""
+
+    export_id: str
+    plugin: BaseExportPlugin
+    mapping: dict[str, Any]
+    references: dict[str, str]
+
+
+def resolve_named_export(fmt: str, options: dict[str, Any]) -> ResolvedExport:
+    """Resolve and validate a mapping without rendering or resolving a target."""
     export_id = options.get("export")
     if not isinstance(export_id, str) or not export_id.strip() or set(options) != {"export"}:
         raise ValueError("Named exports require options containing only a non-empty 'export' ID")
@@ -43,38 +55,101 @@ def render_named_export(data: Any, fmt: str, options: dict[str, Any]) -> tuple[B
         raise ValueError(f"Unknown export plugin '{plugin_id}'")
     if plugin.format != fmt:
         raise ValueError(f"Export '{export_id}' requires format '{plugin.format}', received '{fmt}'")
-    # Source references are declarations only in this slice. Execution provenance
-    # and binding to a delivery target are part of the subsequent manifest phase.
+    references: dict[str, str] = {}
     for field in ("dataset", "org_units", "connection"):
         value = definition.pop(field, None)
         if value is not None and (not isinstance(value, str) or not value.strip()):
             raise ValueError(f"Export {field} must be a non-empty reference string")
+        if value is not None:
+            references[field] = value.strip()
+    from open_climate_service.exports.manifest import validate_public_mapping
+
+    validate_public_mapping(definition)
     mapping = plugin.validate_mapping(definition)
-    rendered = plugin.render(data, mapping)
+    validate_public_mapping(mapping)
+    return ResolvedExport(export_id, plugin, deepcopy(mapping), references)
+
+
+def render_named_export(data: Any, fmt: str, options: dict[str, Any]) -> tuple[BaseExportPlugin, RenderedExport]:
+    """Render a declared export without resolving a connection or credential."""
+    resolved = resolve_named_export(fmt, options)
+    return resolved.plugin, _render(data, resolved)
+
+
+def _render(data: Any, resolved: ResolvedExport) -> RenderedExport:
+    rendered = resolved.plugin.render(data, deepcopy(resolved.mapping))
     # External Python plugins are not necessarily type-checked.
     if not isinstance(rendered, RenderedExport):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError("Export plugin render() must return RenderedExport")
-    return plugin, rendered
+    return rendered
 
 
-def write_named_export(data: Any, directory: Path, fmt: str, options: dict[str, Any]) -> str:
-    """Write the payload and file metadata after rendering succeeds.
+def write_named_export(
+    data: Any,
+    directory: Path,
+    fmt: str,
+    options: dict[str, Any],
+    *,
+    job_id: str,
+    provenance: dict[str, Any] | None = None,
+) -> str:
+    """Freeze a resolved invocation and publish its payload and versioned manifest."""
+    import hashlib
 
-    This metadata describes a downloadable file, not a delivery manifest. It does
-    not establish source provenance, freeze a target, or authorize later delivery.
-    """
-    plugin, rendered = render_named_export(data, fmt, options)
-    path = directory / f"export{plugin.extension}"
-    path.write_bytes(rendered.content)
-    metadata = {
-        "filename": path.name,
-        "media_type": plugin.media_type,
-        "format": plugin.format,
-        "record_count": rendered.record_count,
-        "skipped_count": rendered.skipped_count,
-    }
-    (directory / ".export.json").write_text(json.dumps(metadata), encoding="utf-8")
-    return str(path)
+    from open_climate_service.exports.manifest import (
+        ExportManifest,
+        plugin_identity,
+        publish_manifest,
+        target_binding,
+        validate_public_mapping,
+    )
+    from open_climate_service.shared.provenance import json_digest
+    from open_climate_service.shared.time import utc_now
+
+    resolved = resolve_named_export(fmt, options)
+    identity = plugin_identity(resolved.plugin)
+    target = target_binding(resolved.plugin.id, resolved.references)
+    evidence = (
+        deepcopy(provenance)
+        if provenance is not None
+        else {
+            "scope": "unavailable",
+            "sources": [],
+            "features": [],
+            "missing": ["execution_provenance"],
+        }
+    )
+    validate_public_mapping(evidence)
+    declared = resolved.references.get("dataset")
+    sources_value = evidence.get("sources", [])
+    if not isinstance(sources_value, list) or not all(isinstance(source, dict) for source in sources_value):
+        raise ValueError("Export provenance sources must be a list of mappings")
+    sources = cast(list[dict[str, Any]], sources_value)
+    if (
+        declared is not None
+        and sources
+        and not any(declared in (source.get("collection_id"), source.get("source_dataset_id")) for source in sources)
+    ):
+        raise ValueError("Declared export dataset was not observed during execution")
+    rendered = _render(data, resolved)
+    manifest = ExportManifest(
+        source_job_id=job_id,
+        export_id=resolved.export_id,
+        created_at=utc_now().isoformat(),
+        filename=f"export-{uuid4().hex}{identity.extension}",
+        payload_sha256=hashlib.sha256(rendered.content).hexdigest(),
+        payload_size=len(rendered.content),
+        record_count=rendered.record_count,
+        skipped_count=rendered.skipped_count,
+        periods=sorted(set(rendered.periods)) if rendered.periods is not None else None,
+        plugin=identity,
+        mapping=resolved.mapping,
+        mapping_sha256=json_digest(resolved.mapping),
+        references=resolved.references,
+        target=target,
+        provenance=evidence,
+    )
+    return publish_manifest(directory, manifest, rendered.content)
 
 
 def read_export_metadata(path: Path) -> dict[str, Any] | None:

--- a/open_climate_service/exports/service.py
+++ b/open_climate_service/exports/service.py
@@ -1,0 +1,88 @@
+"""Resolve named mappings and persist pure export results."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from open_climate_service import config
+from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
+from open_climate_service.exports.registry import load_export_plugins
+
+
+def render_named_export(data: Any, fmt: str, options: dict[str, Any]) -> tuple[BaseExportPlugin, RenderedExport]:
+    """Render a declared export; per-request mapping overrides are not accepted."""
+    export_id = options.get("export")
+    if not isinstance(export_id, str) or not export_id.strip() or set(options) != {"export"}:
+        raise ValueError("Named exports require options containing only a non-empty 'export' ID")
+    definitions = config.get_config().get("exports", [])
+    if not isinstance(definitions, list):
+        raise ValueError("exports must be a list of named mappings")
+    by_id: dict[str, dict[str, Any]] = {}
+    for definition in definitions:
+        if not isinstance(definition, dict):
+            raise ValueError("Each export definition must be a mapping")
+        identifier = definition.get("id")
+        if not isinstance(identifier, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", identifier):
+            raise ValueError("Each export requires an ID containing letters, digits, underscores, or hyphens")
+        if identifier in by_id:
+            raise ValueError(f"Duplicate export ID '{identifier}'")
+        by_id[identifier] = definition
+    if export_id not in by_id:
+        raise ValueError(f"Unknown export '{export_id}'")
+    definition = deepcopy(by_id[export_id])
+    definition.pop("id")
+    plugin_id = definition.pop("plugin", None)
+    if not isinstance(plugin_id, str):
+        raise ValueError("Export definition requires a plugin ID")
+    plugin = load_export_plugins().get(plugin_id)
+    if plugin is None:
+        raise ValueError(f"Unknown export plugin '{plugin_id}'")
+    if plugin.format != fmt:
+        raise ValueError(f"Export '{export_id}' requires format '{plugin.format}', received '{fmt}'")
+    # Source references are declarations only in this slice. Execution provenance
+    # and binding to a delivery target are part of the subsequent manifest phase.
+    for field in ("dataset", "org_units", "connection"):
+        value = definition.pop(field, None)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise ValueError(f"Export {field} must be a non-empty reference string")
+    mapping = plugin.validate_mapping(definition)
+    rendered = plugin.render(data, mapping)
+    # External Python plugins are not necessarily type-checked.
+    if not isinstance(rendered, RenderedExport):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise TypeError("Export plugin render() must return RenderedExport")
+    return plugin, rendered
+
+
+def write_named_export(data: Any, directory: Path, fmt: str, options: dict[str, Any]) -> str:
+    """Write the payload and file metadata after rendering succeeds.
+
+    This metadata describes a downloadable file, not a delivery manifest. It does
+    not establish source provenance, freeze a target, or authorize later delivery.
+    """
+    plugin, rendered = render_named_export(data, fmt, options)
+    path = directory / f"export{plugin.extension}"
+    path.write_bytes(rendered.content)
+    metadata = {
+        "filename": path.name,
+        "media_type": plugin.media_type,
+        "format": plugin.format,
+        "record_count": rendered.record_count,
+        "skipped_count": rendered.skipped_count,
+    }
+    (directory / ".export.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return str(path)
+
+
+def read_export_metadata(path: Path) -> dict[str, Any] | None:
+    """Return saved file metadata only for the matching result asset."""
+    metadata_path = path.parent / ".export.json"
+    if not metadata_path.is_file():
+        return None
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if not isinstance(metadata, dict) or metadata.get("filename") != path.name:
+        return None
+    return metadata

--- a/open_climate_service/exports/service.py
+++ b/open_climate_service/exports/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from copy import deepcopy
 from dataclasses import dataclass
@@ -13,6 +14,8 @@ from uuid import uuid4
 from open_climate_service import config
 from open_climate_service.exports.base import BaseExportPlugin, RenderedExport
 from open_climate_service.exports.registry import load_export_plugins
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -153,11 +156,35 @@ def write_named_export(
 
 
 def read_export_metadata(path: Path) -> dict[str, Any] | None:
-    """Return saved file metadata only for the matching result asset."""
+    """Return usable display metadata; delivery separately validates its manifest."""
     metadata_path = path.parent / ".export.json"
-    if not metadata_path.is_file():
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
         return None
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    if not isinstance(metadata, dict) or metadata.get("filename") != path.name:
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        logger.warning("Could not read export metadata '%s'; using result-file defaults", metadata_path)
+        return None
+    if not isinstance(metadata, dict) or any(
+        not isinstance(metadata.get(field), str) or not metadata[field].strip()
+        for field in ("filename", "format", "media_type")
+    ):
+        logger.warning("Invalid export metadata fields in '%s'; using result-file defaults", metadata_path)
+        return None
+    media_type = metadata["media_type"]
+    manifest = metadata.get("manifest")
+    if any(ord(character) < 32 or ord(character) > 126 for character in media_type) or (
+        "manifest" in metadata
+        and (
+            not isinstance(manifest, str)
+            or not manifest.strip()
+            or manifest in {".", ".."}
+            or "/" in manifest
+            or "\\" in manifest
+        )
+    ):
+        logger.warning("Invalid export metadata fields in '%s'; using result-file defaults", metadata_path)
+        return None
+    if metadata["filename"] != path.name:
         return None
     return metadata

--- a/open_climate_service/exports/tabular.py
+++ b/open_climate_service/exports/tabular.py
@@ -1,0 +1,227 @@
+"""Shared tabular serialization used by legacy writers and export plugins."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from typing import Any
+
+
+def _build_dhis2_json_payload(df: Any, options: dict[str, Any]) -> dict[str, list[dict[str, str]]]:
+    import pandas as pd
+
+    data_element_id = _required_str_option(options, "data_element_id")
+    org_unit_field = _required_str_option(options, "org_unit_field")
+    period_field = _optional_str_option(options, "period_field") or "t"
+    period_type = _optional_str_option(options, "period_type")
+    category_option_combo = _optional_str_option(options, "category_option_combo")
+
+    frame = pd.DataFrame(df).copy()
+    if org_unit_field not in frame.columns:
+        raise ValueError(f"Missing org unit field '{org_unit_field}' in aggregated result")
+    if period_field not in frame.columns:
+        raise ValueError(f"Missing period field '{period_field}' in aggregated result")
+
+    value_field = _select_dhis2_value_field(frame, org_unit_field, period_field)
+
+    data_values: list[dict[str, str]] = []
+    for record in frame.to_dict(orient="records"):
+        value = record.get(value_field)
+        if _is_nullish(value):
+            continue
+
+        org_unit = record.get(org_unit_field)
+        if _is_nullish(org_unit):
+            raise ValueError(f"Null org unit value in field '{org_unit_field}'")
+
+        period_value = record.get(period_field)
+        if _is_nullish(period_value):
+            raise ValueError(f"Null period value in field '{period_field}'")
+
+        item = {
+            "dataElement": data_element_id,
+            "orgUnit": str(org_unit),
+            "period": _to_dhis2_period_string(period_value, period_type),
+            "value": _to_dhis2_value_string(value),
+        }
+        if category_option_combo is not None:
+            item["categoryOptionCombo"] = category_option_combo
+        data_values.append(item)
+
+    return {"dataValues": data_values}
+
+
+def _required_str_option(options: dict[str, Any], key: str) -> str:
+    value = _optional_str_option(options, key)
+    if value is None:
+        raise ValueError(f"Missing required export option '{key}'")
+    return value
+
+
+def _optional_str_option(options: dict[str, Any], key: str) -> str | None:
+    raw = options.get(key)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def _select_dhis2_value_field(frame: Any, org_unit_field: str, period_field: str) -> str:
+    excluded = {
+        org_unit_field,
+        period_field,
+        "geometry",
+        "spatial_ref",
+        "index",
+        "band",
+        "bands",
+    }
+    candidates = [str(c) for c in frame.columns if c not in excluded and not str(c).startswith("level_")]
+    if len(candidates) != 1:
+        raise ValueError(
+            "DHIS2JSON export requires exactly one value column after excluding "
+            f"'{org_unit_field}' and '{period_field}', found {candidates}"
+        )
+    return candidates[0]
+
+
+def _is_nullish(value: Any) -> bool:
+    import numpy as np
+    import pandas as pd
+
+    result = pd.isna(value)
+    if isinstance(result, (bool, np.bool_)):
+        return bool(result)
+    if isinstance(result, np.ndarray):
+        if result.ndim == 0:
+            return bool(result.item())
+        raise ValueError("Array-like values are not supported in tabular export cells")
+    if hasattr(result, "shape") and getattr(result, "shape", ()) not in [(), None]:
+        raise ValueError("Array-like values are not supported in tabular export cells")
+    if hasattr(result, "item"):
+        return bool(result.item())
+    return bool(result)
+
+
+def _normalise_period_type(period_type: str | None) -> str | None:
+    if period_type is None:
+        return None
+    value = period_type.strip().lower()
+    aliases = {
+        "day": "daily",
+        "daily": "daily",
+        "week": "weekly",
+        "weekly": "weekly",
+        "month": "monthly",
+        "monthly": "monthly",
+        "quarter": "quarterly",
+        "quarterly": "quarterly",
+        "year": "yearly",
+        "yearly": "yearly",
+    }
+    kind = aliases.get(value)
+    if kind is None:
+        raise ValueError(f"Unsupported period_type '{period_type}'")
+    return kind
+
+
+def _direct_dhis2_period_string(value: str) -> str | None:
+    patterns = (
+        re.compile(r"^\d{8}$"),
+        re.compile(r"^\d{6}$"),
+        re.compile(r"^\d{4}$"),
+        re.compile(r"^\d{4}W\d{2}$"),
+        re.compile(r"^\d{4}Q[1-4]$"),
+    )
+    if any(pattern.fullmatch(value) for pattern in patterns):
+        return value
+    return None
+
+
+def _to_dhis2_period_string(value: Any, period_type: str | None = None) -> str:
+    import pandas as pd
+
+    if _is_nullish(value):
+        raise ValueError("Cannot serialize null period value")
+
+    kind = _normalise_period_type(period_type)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Cannot serialize blank period value")
+        direct = _direct_dhis2_period_string(stripped)
+        if direct is not None:
+            if kind is None:
+                return direct
+            pattern_map = {
+                "daily": re.compile(r"^\d{8}$"),
+                "weekly": re.compile(r"^\d{4}W\d{2}$"),
+                "monthly": re.compile(r"^\d{6}$"),
+                "quarterly": re.compile(r"^\d{4}Q[1-4]$"),
+                "yearly": re.compile(r"^\d{4}$"),
+            }
+            if pattern_map[kind].fullmatch(stripped):
+                return direct
+            for known_type, pattern in pattern_map.items():
+                if known_type != kind and pattern.fullmatch(stripped):
+                    raise ValueError(f"Period value appears to be {known_type}, but period_type={kind}")
+        if kind is None:
+            raise ValueError(
+                "Ambiguous period value; provide save_result option 'period_type' "
+                "for date-like values that are not already in DHIS2 format"
+            )
+        try:
+            timestamp = pd.Timestamp(stripped)
+        except Exception as exc:
+            raise ValueError(f"Could not parse period value {stripped!r} for period_type={kind}") from exc
+        return _format_dhis2_timestamp(timestamp, kind)
+
+    if kind is None:
+        raise ValueError(
+            "Ambiguous period value; provide save_result option 'period_type' "
+            "for date-like values that are not already in DHIS2 format"
+        )
+
+    try:
+        timestamp = pd.Timestamp(value)
+    except Exception as exc:
+        raise ValueError(f"Could not parse period value {value!r} for period_type={kind}") from exc
+    return _format_dhis2_timestamp(timestamp, kind)
+
+
+def _format_dhis2_timestamp(timestamp: Any, period_type: str) -> str:
+    if period_type == "daily":
+        return str(timestamp.strftime("%Y%m%d"))
+    if period_type == "weekly":
+        iso = timestamp.isocalendar()
+        return f"{iso.year}W{iso.week:02d}"
+    if period_type == "monthly":
+        return str(timestamp.strftime("%Y%m"))
+    if period_type == "quarterly":
+        return f"{timestamp.year}Q{timestamp.quarter}"
+    if period_type == "yearly":
+        return str(timestamp.strftime("%Y"))
+    raise ValueError(f"Unsupported period_type '{period_type}'")
+
+
+def _to_dhis2_value_string(value: Any) -> str:
+    import numpy as np
+
+    if _is_nullish(value):
+        raise ValueError("Cannot serialize null value")
+    if isinstance(value, (bool, np.bool_)):
+        return "true" if bool(value) else "false"
+    if isinstance(value, (int, np.integer)) and not isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)):
+        as_float = float(value)
+        as_float32 = float(np.float32(as_float))
+        if as_float == as_float32:
+            return np.format_float_positional(np.float32(as_float), trim="-")
+        return np.format_float_positional(as_float, trim="-")
+    if isinstance(value, Decimal):
+        normalized = format(value, "f")
+        if "." in normalized:
+            normalized = normalized.rstrip("0").rstrip(".")
+        return normalized or "0"
+    return str(value)

--- a/open_climate_service/jobs/models.py
+++ b/open_climate_service/jobs/models.py
@@ -15,6 +15,10 @@ DATASET_UPDATED_EVENT_TYPE = "dataset.updated"
 class JobCancelledError(Exception):
     """Raised by a job implementation when cooperative cancellation is honored."""
 
+    def __init__(self, message: str, *, result: Any | None = None) -> None:
+        super().__init__(message)
+        self.result = result
+
 
 class JobStatus(StrEnum):
     """Persisted lifecycle states for native jobs."""

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -391,13 +391,15 @@ class JobService:
                     except Exception:
                         logger.exception("Failed to consume events for completed job %s", job_id)
                 return
-            except JobCancelledError:
+            except JobCancelledError as exc:
+                cancelled_result = exc.result
                 store.mutate_job_record(
                     job_id,
                     lambda current: current.model_copy(
                         update={
                             "status": JobStatus.CANCELLED,
                             "finished_at": utc_now(),
+                            "result": cancelled_result,
                             "progress": JobProgress(
                                 done=current.progress.done,
                                 total=current.progress.total,

--- a/open_climate_service/jobs/service.py
+++ b/open_climate_service/jobs/service.py
@@ -151,6 +151,7 @@ class JobService:
         request: dict[str, Any],
         max_attempts: int = 1,
         job_href_base: str = "/jobs",
+        job_id: str | None = None,
     ) -> JobRecord:
         """Submit a callable directly as a background job — no YAML registry needed.
 
@@ -171,6 +172,7 @@ class JobService:
             request=safe_request,
             max_attempts=max_attempts,
             job_href_base=job_href_base,
+            job_id=job_id,
         )
 
     def _create_and_enqueue(
@@ -180,8 +182,9 @@ class JobService:
         request: dict[str, Any],
         max_attempts: int,
         job_href_base: str,
+        job_id: str | None = None,
     ) -> JobRecord:
-        job_id = str(uuid4())
+        job_id = job_id or str(uuid4())
         record = JobRecord(
             job_id=job_id,
             process_id=process_id,

--- a/open_climate_service/jobs/store.py
+++ b/open_climate_service/jobs/store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
@@ -112,10 +114,31 @@ def _mutate_records(mutation: Callable[[list[dict[str, object]]], JobRecord]) ->
                 raise ValueError("jobs.json must contain a list")
             records = payload
             result = mutation(records)
-            handle.seek(0)
-            json.dump(records, handle, indent=2)
-            handle.write("\n")
-            handle.truncate()
+            _atomic_write_records(records)
             return result
         finally:
             portalocker.unlock(handle)
+
+
+def _atomic_write_records(records: list[dict[str, object]]) -> None:
+    """Replace jobs.json by first flushing a complete temporary copy.
+
+    The in-place rewrite used before could leave a truncated index if the process
+    crashed mid-write. Writing a sibling file and replacing the index atomically
+    keeps delivery checkpoints and idempotency state durable across a crash.
+    """
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=JOBS_DIR, prefix=".jobs-", suffix=".json.tmp", mode="w", delete=False, encoding="utf-8"
+        ) as handle:
+            temporary = handle.name
+            json.dump(records, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, JOBS_INDEX_PATH)
+        temporary = None
+    finally:
+        if temporary is not None:
+            Path(temporary).unlink(missing_ok=True)

--- a/open_climate_service/jobs/store.py
+++ b/open_climate_service/jobs/store.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-import portalocker
-
 from open_climate_service import config as api_config
 from open_climate_service.jobs.models import JobRecord
+from open_climate_service.shared.persistence import atomic_json, index_lock
 
 
 def _resolve_jobs_dir() -> Path:
@@ -24,9 +21,9 @@ JOBS_INDEX_PATH = JOBS_DIR / "jobs.json"
 
 def ensure_store() -> None:
     """Create the jobs metadata store if it does not exist."""
-    JOBS_DIR.mkdir(parents=True, exist_ok=True)
-    if not JOBS_INDEX_PATH.exists():
-        JOBS_INDEX_PATH.write_text("[]\n", encoding="utf-8")
+    with index_lock(JOBS_INDEX_PATH):
+        if not JOBS_INDEX_PATH.exists():
+            atomic_json(JOBS_INDEX_PATH, [])
 
 
 def list_job_records() -> list[JobRecord]:
@@ -91,12 +88,9 @@ def _load_records() -> list[dict[str, object]]:
 
 
 def _read_records_from_disk() -> list[dict[str, object]]:
-    with open(JOBS_INDEX_PATH, encoding="utf-8") as handle:
-        portalocker.lock(handle, portalocker.LOCK_SH)
-        try:
+    with index_lock(JOBS_INDEX_PATH):
+        with open(JOBS_INDEX_PATH, encoding="utf-8") as handle:
             payload = json.load(handle)
-        finally:
-            portalocker.unlock(handle)
     if not isinstance(payload, list):
         raise ValueError("jobs.json must contain a list")
     if not all(isinstance(item, dict) for item in payload):
@@ -106,18 +100,15 @@ def _read_records_from_disk() -> list[dict[str, object]]:
 
 def _mutate_records(mutation: Callable[[list[dict[str, object]]], JobRecord]) -> JobRecord:
     ensure_store()
-    with open(JOBS_INDEX_PATH, "r+", encoding="utf-8") as handle:
-        portalocker.lock(handle, portalocker.LOCK_EX)
-        try:
+    with index_lock(JOBS_INDEX_PATH):
+        with open(JOBS_INDEX_PATH, encoding="utf-8") as handle:
             payload = json.load(handle)
-            if not isinstance(payload, list):
-                raise ValueError("jobs.json must contain a list")
-            records = payload
-            result = mutation(records)
-            _atomic_write_records(records)
-            return result
-        finally:
-            portalocker.unlock(handle)
+        if not isinstance(payload, list):
+            raise ValueError("jobs.json must contain a list")
+        records = payload
+        result = mutation(records)
+        _atomic_write_records(records)
+        return result
 
 
 def _atomic_write_records(records: list[dict[str, object]]) -> None:
@@ -127,18 +118,4 @@ def _atomic_write_records(records: list[dict[str, object]]) -> None:
     crashed mid-write. Writing a sibling file and replacing the index atomically
     keeps delivery checkpoints and idempotency state durable across a crash.
     """
-    temporary: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            dir=JOBS_DIR, prefix=".jobs-", suffix=".json.tmp", mode="w", delete=False, encoding="utf-8"
-        ) as handle:
-            temporary = handle.name
-            json.dump(records, handle, indent=2)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary, JOBS_INDEX_PATH)
-        temporary = None
-    finally:
-        if temporary is not None:
-            Path(temporary).unlink(missing_ok=True)
+    atomic_json(JOBS_INDEX_PATH, records)

--- a/open_climate_service/main.py
+++ b/open_climate_service/main.py
@@ -12,6 +12,7 @@ from starlette.responses import Response
 import open_climate_service.startup  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from open_climate_service.automation.service import get_workflow_automation_service
 from open_climate_service.data_registry import routes as dataset_template_routes
+from open_climate_service.exports import routes as exports_routes
 from open_climate_service.extents import routes as extent_routes
 from open_climate_service.ingestions import routes as ingestion_routes
 from open_climate_service.jobs.service import get_job_service
@@ -199,6 +200,7 @@ def create_app() -> FastAPI:
     _app.include_router(ingestion_routes.sync_router, prefix="/sync", tags=["Sync"])
     _app.include_router(scheduler_routes.router, prefix="/schedules", tags=["Schedules"])
     _app.include_router(openeo_routes.processes_router, prefix="/processes", tags=["openEO"])
+    _app.include_router(exports_routes.router, prefix="/exports", tags=["Exports"])
 
     return _app
 

--- a/open_climate_service/openeo/execution.py
+++ b/open_climate_service/openeo/execution.py
@@ -324,6 +324,9 @@ def _load_collection_impl(
     """Load a published dataset as an openEO data cube (xr.DataArray)."""
     artifact = _get_published_artifact(id)
     ds = _ensure_crs(_open_artifact(artifact))
+    from open_climate_service.shared.provenance import record_source
+
+    record_source(id, artifact)
 
     bbox = _bbox_to_dict(spatial_extent)
     t_extent = _temporal_to_list(temporal_extent)
@@ -402,6 +405,7 @@ class SaveResultEnvelope:
         self.data = data
         self.format = format.upper()
         self.options: dict[str, Any] = options or {}
+        self.provenance: dict[str, Any] | None = None
 
 
 def _save_result_impl(data: Any, format: str = "Zarr", options: dict[str, Any] | None = None) -> Any:
@@ -606,7 +610,13 @@ def run_process_graph(
     registry = _augment_with_workflows(_build_process_registry())
     try:
         graph = OpenEOProcessGraph(process_graph)
-        return graph.to_callable(registry)()
+        from open_climate_service.shared.provenance import capture_execution
+
+        with capture_execution(process) as evidence:
+            result = graph.to_callable(registry)()
+            if isinstance(result, SaveResultEnvelope):
+                result.provenance = evidence.describe()
+            return result
     except HTTPException:
         raise
     except (TypeError, ValueError, KeyError) as exc:

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -17,6 +17,7 @@ import portalocker
 from fastapi import HTTPException
 
 from open_climate_service import config as api_config
+from open_climate_service.exports.retention import result_lease
 from open_climate_service.exports.tabular import (
     _build_dhis2_json_payload as _build_dhis2_json_payload,
 )
@@ -324,50 +325,53 @@ class OpenEOJobService:
         return record
 
     def update_job(self, job_id: str, body: OpenEOJobUpdate) -> OpenEOJobRecord:
-        record = self.get_job_or_404(job_id)
-        if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
-            raise HTTPException(status_code=400, detail="Cannot update a job that is queued or running")
-        updates: dict[str, Any] = {}
-        if body.title is not None:
-            updates["title"] = body.title
-        if body.description is not None:
-            updates["description"] = body.description
-        if body.process is not None:
-            if not isinstance(body.process.get("process_graph"), dict):
-                raise HTTPException(status_code=422, detail="process.process_graph must be an object")
-            updates["process"] = body.process
-        if body.plan is not None:
-            updates["plan"] = body.plan
-        if body.budget is not None:
-            updates["budget"] = body.budget
-        if updates:
-            updates["updated"] = utc_now()
-            return store_update_job(job_id, lambda r: r.model_copy(update=updates))
-        return record
+        with result_lease(job_id):
+            record = self.get_job_or_404(job_id)
+            if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
+                raise HTTPException(status_code=400, detail="Cannot update a job that is queued or running")
+            updates: dict[str, Any] = {}
+            if body.title is not None:
+                updates["title"] = body.title
+            if body.description is not None:
+                updates["description"] = body.description
+            if body.process is not None:
+                if not isinstance(body.process.get("process_graph"), dict):
+                    raise HTTPException(status_code=422, detail="process.process_graph must be an object")
+                updates["process"] = body.process
+            if body.plan is not None:
+                updates["plan"] = body.plan
+            if body.budget is not None:
+                updates["budget"] = body.budget
+            if updates:
+                updates["updated"] = utc_now()
+                return store_update_job(job_id, lambda r: r.model_copy(update=updates))
+            return record
 
     def delete_job(self, job_id: str) -> None:
-        record = self.get_job_or_404(job_id)
-        if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
-            raise HTTPException(status_code=400, detail="Cannot delete a running job; cancel it first")
-        store_delete_job(job_id)
-        import shutil
+        with result_lease(job_id):
+            record = self.get_job_or_404(job_id)
+            if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
+                raise HTTPException(status_code=400, detail="Cannot delete a running job; cancel it first")
+            store_delete_job(job_id)
+            import shutil
 
-        job_dir = _JOBS_DIR / job_id
-        if job_dir.exists():
-            shutil.rmtree(job_dir, ignore_errors=True)
+            job_dir = _JOBS_DIR / job_id
+            if job_dir.exists():
+                shutil.rmtree(job_dir, ignore_errors=True)
 
     def start_job(self, job_id: str) -> None:
         """Queue a job for processing (POST /jobs/{id}/results)."""
-        record = self.get_job_or_404(job_id)
-        if record.status == OpenEOJobStatus.RUNNING:
-            raise HTTPException(status_code=400, detail="Job is already running")
-        if record.status == OpenEOJobStatus.QUEUED:
-            return
-        store_update_job(
-            job_id,
-            lambda r: r.model_copy(update={"status": OpenEOJobStatus.QUEUED, "updated": utc_now()}),
-        )
-        self._enqueue(job_id)
+        with result_lease(job_id):
+            record = self.get_job_or_404(job_id)
+            if record.status == OpenEOJobStatus.RUNNING:
+                raise HTTPException(status_code=400, detail="Job is already running")
+            if record.status == OpenEOJobStatus.QUEUED:
+                return
+            store_update_job(
+                job_id,
+                lambda r: r.model_copy(update={"status": OpenEOJobStatus.QUEUED, "updated": utc_now()}),
+            )
+            self._enqueue(job_id)
 
     def cancel_job(self, job_id: str) -> None:
         """Request cancellation (DELETE /jobs/{id}/results)."""
@@ -506,15 +510,17 @@ class OpenEOJobService:
         # Unwrap format envelope from save_result
         fmt = "ZARR"
         options: dict[str, Any] = {}
+        provenance: dict[str, Any] | None = None
         if isinstance(result, SaveResultEnvelope):
             fmt = result.format
             options = result.options
+            provenance = result.provenance
             result = result.data
 
         if "export" in options:
             from open_climate_service.exports.service import write_named_export
 
-            return write_named_export(result, results_dir, fmt, options)
+            return write_named_export(result, results_dir, fmt, options, job_id=job_id, provenance=provenance)
 
         # Resolve DataArray → Dataset for raster formats
         if isinstance(result, xr.DataArray):
@@ -1235,7 +1241,7 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
 
         metadata = read_export_metadata(Path(output_path))
         if metadata is not None:
-            return {
+            export_assets = {
                 "result": {
                     "href": f"/jobs/{record.id}/results/{metadata['filename']}",
                     "type": metadata["media_type"],
@@ -1243,6 +1249,14 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
                     "roles": ["data"],
                 }
             }
+            if "manifest" in metadata:
+                export_assets["manifest"] = {
+                    "href": f"/jobs/{record.id}/results/{metadata['manifest']}",
+                    "type": "application/json",
+                    "title": "Export manifest",
+                    "roles": ["metadata"],
+                }
+            return export_assets
     if output_path.startswith("managed://"):
         dataset_id = output_path[len("managed://") :]
         assets: dict[str, Any] = {

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -325,6 +325,8 @@ class OpenEOJobService:
         return record
 
     def update_job(self, job_id: str, body: OpenEOJobUpdate) -> OpenEOJobRecord:
+        # 404 first so an arbitrary or malformed ID never creates a lease file.
+        self.get_job_or_404(job_id)
         with result_lease(job_id):
             record = self.get_job_or_404(job_id)
             if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
@@ -348,6 +350,10 @@ class OpenEOJobService:
             return record
 
     def delete_job(self, job_id: str) -> None:
+        # 404 first so an arbitrary or malformed ID never creates a lease file.
+        record = self.get_job_or_404(job_id)
+        if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
+            raise HTTPException(status_code=400, detail="Cannot delete a running job; cancel it first")
         with result_lease(job_id):
             record = self.get_job_or_404(job_id)
             if record.status in {OpenEOJobStatus.QUEUED, OpenEOJobStatus.RUNNING}:
@@ -358,9 +364,13 @@ class OpenEOJobService:
             job_dir = _JOBS_DIR / job_id
             if job_dir.exists():
                 shutil.rmtree(job_dir, ignore_errors=True)
+        # The lease file lives outside the job directory; remove it now the job is gone.
+        (_JOBS_DIR / ".export-locks" / f"{job_id}.lock").unlink(missing_ok=True)
 
     def start_job(self, job_id: str) -> None:
         """Queue a job for processing (POST /jobs/{id}/results)."""
+        # 404 first so an arbitrary or malformed ID never creates a lease file.
+        self.get_job_or_404(job_id)
         with result_lease(job_id):
             record = self.get_job_or_404(job_id)
             if record.status == OpenEOJobStatus.RUNNING:
@@ -517,6 +527,16 @@ class OpenEOJobService:
             provenance = result.provenance
             result = result.data
 
+        # Resolve a lazy dask_geopandas GeoDataFrame before any tabular path,
+        # including named exports, so a lazy frame never reaches a renderer.
+        try:
+            import dask_geopandas
+
+            if isinstance(result, dask_geopandas.GeoDataFrame):
+                result = result.compute()
+        except ImportError:
+            pass
+
         if "export" in options:
             from open_climate_service.exports.service import write_named_export
 
@@ -537,15 +557,6 @@ class OpenEOJobService:
             if fmt in _TABULAR_EXPORT_FORMATS:
                 return _write_dataset_tabular_export(result, results_dir, fmt, options)
             return _write_raster(result, results_dir, fmt)
-
-        # Tabular: resolve dask_geopandas → GeoDataFrame
-        try:
-            import dask_geopandas
-
-            if isinstance(result, dask_geopandas.GeoDataFrame):
-                result = result.compute()
-        except ImportError:
-            pass
 
         try:
             import geopandas as gpd

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -9,7 +9,6 @@ import re
 import threading
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from decimal import Decimal
 from pathlib import Path
 from typing import Any, TypeVar
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -18,6 +17,24 @@ import portalocker
 from fastapi import HTTPException
 
 from open_climate_service import config as api_config
+from open_climate_service.exports.tabular import (
+    _build_dhis2_json_payload as _build_dhis2_json_payload,
+)
+from open_climate_service.exports.tabular import (
+    _format_dhis2_timestamp as _format_dhis2_timestamp,
+)
+from open_climate_service.exports.tabular import (
+    _is_nullish as _is_nullish,
+)
+from open_climate_service.exports.tabular import (
+    _optional_str_option as _optional_str_option,
+)
+from open_climate_service.exports.tabular import (
+    _to_dhis2_period_string as _to_dhis2_period_string,
+)
+from open_climate_service.exports.tabular import (
+    _to_dhis2_value_string as _to_dhis2_value_string,
+)
 from open_climate_service.openeo.schemas import (
     OpenEOJobCreate,
     OpenEOJobListResponse,
@@ -493,6 +510,11 @@ class OpenEOJobService:
             fmt = result.format
             options = result.options
             result = result.data
+
+        if "export" in options:
+            from open_climate_service.exports.service import write_named_export
+
+            return write_named_export(result, results_dir, fmt, options)
 
         # Resolve DataArray → Dataset for raster formats
         if isinstance(result, xr.DataArray):
@@ -1208,6 +1230,19 @@ def _result_assets(record: OpenEOJobRecord) -> dict[str, Any]:
     output_path = usage.get("output_path")
     if not output_path or not isinstance(output_path, str):
         return {}
+    if not output_path.startswith("managed://"):
+        from open_climate_service.exports.service import read_export_metadata
+
+        metadata = read_export_metadata(Path(output_path))
+        if metadata is not None:
+            return {
+                "result": {
+                    "href": f"/jobs/{record.id}/results/{metadata['filename']}",
+                    "type": metadata["media_type"],
+                    "title": f"{metadata['format']} export",
+                    "roles": ["data"],
+                }
+            }
     if output_path.startswith("managed://"):
         dataset_id = output_path[len("managed://") :]
         assets: dict[str, Any] = {
@@ -1566,226 +1601,6 @@ def _write_dhis2_json(df: Any, results_dir: Any, options: dict[str, Any]) -> str
     path = str(results_dir / "result.json")
     Path(path).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     return path
-
-
-def _build_dhis2_json_payload(df: Any, options: dict[str, Any]) -> dict[str, list[dict[str, str]]]:
-    import pandas as pd
-
-    data_element_id = _required_str_option(options, "data_element_id")
-    org_unit_field = _required_str_option(options, "org_unit_field")
-    period_field = _optional_str_option(options, "period_field") or "t"
-    period_type = _optional_str_option(options, "period_type")
-    category_option_combo = _optional_str_option(options, "category_option_combo")
-
-    frame = pd.DataFrame(df).copy()
-    if org_unit_field not in frame.columns:
-        raise ValueError(f"Missing org unit field '{org_unit_field}' in aggregated result")
-    if period_field not in frame.columns:
-        raise ValueError(f"Missing period field '{period_field}' in aggregated result")
-
-    value_field = _select_dhis2_value_field(frame, org_unit_field, period_field)
-
-    data_values: list[dict[str, str]] = []
-    for record in frame.to_dict(orient="records"):
-        value = record.get(value_field)
-        if _is_nullish(value):
-            continue
-
-        org_unit = record.get(org_unit_field)
-        if _is_nullish(org_unit):
-            raise ValueError(f"Null org unit value in field '{org_unit_field}'")
-
-        period_value = record.get(period_field)
-        if _is_nullish(period_value):
-            raise ValueError(f"Null period value in field '{period_field}'")
-
-        item = {
-            "dataElement": data_element_id,
-            "orgUnit": str(org_unit),
-            "period": _to_dhis2_period_string(period_value, period_type),
-            "value": _to_dhis2_value_string(value),
-        }
-        if category_option_combo is not None:
-            item["categoryOptionCombo"] = category_option_combo
-        data_values.append(item)
-
-    return {"dataValues": data_values}
-
-
-def _required_str_option(options: dict[str, Any], key: str) -> str:
-    value = _optional_str_option(options, key)
-    if value is None:
-        raise ValueError(f"Missing required export option '{key}'")
-    return value
-
-
-def _optional_str_option(options: dict[str, Any], key: str) -> str | None:
-    raw = options.get(key)
-    if raw is None:
-        return None
-    value = str(raw).strip()
-    return value or None
-
-
-def _select_dhis2_value_field(frame: Any, org_unit_field: str, period_field: str) -> str:
-    excluded = {
-        org_unit_field,
-        period_field,
-        "geometry",
-        "spatial_ref",
-        "index",
-        "band",
-        "bands",
-    }
-    candidates = [str(c) for c in frame.columns if c not in excluded and not str(c).startswith("level_")]
-    if len(candidates) != 1:
-        raise ValueError(
-            "DHIS2JSON export requires exactly one value column after excluding "
-            f"'{org_unit_field}' and '{period_field}', found {candidates}"
-        )
-    return candidates[0]
-
-
-def _is_nullish(value: Any) -> bool:
-    import numpy as np
-    import pandas as pd
-
-    result = pd.isna(value)
-    if isinstance(result, (bool, np.bool_)):
-        return bool(result)
-    if isinstance(result, np.ndarray):
-        if result.ndim == 0:
-            return bool(result.item())
-        raise ValueError("Array-like values are not supported in tabular export cells")
-    if hasattr(result, "shape") and getattr(result, "shape", ()) not in [(), None]:
-        raise ValueError("Array-like values are not supported in tabular export cells")
-    if hasattr(result, "item"):
-        return bool(result.item())
-    return bool(result)
-
-
-def _normalise_period_type(period_type: str | None) -> str | None:
-    if period_type is None:
-        return None
-    value = period_type.strip().lower()
-    aliases = {
-        "day": "daily",
-        "daily": "daily",
-        "week": "weekly",
-        "weekly": "weekly",
-        "month": "monthly",
-        "monthly": "monthly",
-        "quarter": "quarterly",
-        "quarterly": "quarterly",
-        "year": "yearly",
-        "yearly": "yearly",
-    }
-    kind = aliases.get(value)
-    if kind is None:
-        raise ValueError(f"Unsupported period_type '{period_type}'")
-    return kind
-
-
-def _direct_dhis2_period_string(value: str) -> str | None:
-    patterns = (
-        re.compile(r"^\d{8}$"),
-        re.compile(r"^\d{6}$"),
-        re.compile(r"^\d{4}$"),
-        re.compile(r"^\d{4}W\d{2}$"),
-        re.compile(r"^\d{4}Q[1-4]$"),
-    )
-    if any(pattern.fullmatch(value) for pattern in patterns):
-        return value
-    return None
-
-
-def _to_dhis2_period_string(value: Any, period_type: str | None = None) -> str:
-    import pandas as pd
-
-    if _is_nullish(value):
-        raise ValueError("Cannot serialize null period value")
-
-    kind = _normalise_period_type(period_type)
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped:
-            raise ValueError("Cannot serialize blank period value")
-        direct = _direct_dhis2_period_string(stripped)
-        if direct is not None:
-            if kind is None:
-                return direct
-            pattern_map = {
-                "daily": re.compile(r"^\d{8}$"),
-                "weekly": re.compile(r"^\d{4}W\d{2}$"),
-                "monthly": re.compile(r"^\d{6}$"),
-                "quarterly": re.compile(r"^\d{4}Q[1-4]$"),
-                "yearly": re.compile(r"^\d{4}$"),
-            }
-            if pattern_map[kind].fullmatch(stripped):
-                return direct
-            for known_type, pattern in pattern_map.items():
-                if known_type != kind and pattern.fullmatch(stripped):
-                    raise ValueError(f"Period value appears to be {known_type}, but period_type={kind}")
-        if kind is None:
-            raise ValueError(
-                "Ambiguous period value; provide save_result option 'period_type' "
-                "for date-like values that are not already in DHIS2 format"
-            )
-        try:
-            timestamp = pd.Timestamp(stripped)
-        except Exception as exc:
-            raise ValueError(f"Could not parse period value {stripped!r} for period_type={kind}") from exc
-        return _format_dhis2_timestamp(timestamp, kind)
-
-    if kind is None:
-        raise ValueError(
-            "Ambiguous period value; provide save_result option 'period_type' "
-            "for date-like values that are not already in DHIS2 format"
-        )
-
-    try:
-        timestamp = pd.Timestamp(value)
-    except Exception as exc:
-        raise ValueError(f"Could not parse period value {value!r} for period_type={kind}") from exc
-    return _format_dhis2_timestamp(timestamp, kind)
-
-
-def _format_dhis2_timestamp(timestamp: Any, period_type: str) -> str:
-    if period_type == "daily":
-        return str(timestamp.strftime("%Y%m%d"))
-    if period_type == "weekly":
-        iso = timestamp.isocalendar()
-        return f"{iso.year}W{iso.week:02d}"
-    if period_type == "monthly":
-        return str(timestamp.strftime("%Y%m"))
-    if period_type == "quarterly":
-        return f"{timestamp.year}Q{timestamp.quarter}"
-    if period_type == "yearly":
-        return str(timestamp.strftime("%Y"))
-    raise ValueError(f"Unsupported period_type '{period_type}'")
-
-
-def _to_dhis2_value_string(value: Any) -> str:
-    import numpy as np
-
-    if _is_nullish(value):
-        raise ValueError("Cannot serialize null value")
-    if isinstance(value, (bool, np.bool_)):
-        return "true" if bool(value) else "false"
-    if isinstance(value, (int, np.integer)) and not isinstance(value, bool):
-        return str(int(value))
-    if isinstance(value, (float, np.floating)):
-        as_float = float(value)
-        as_float32 = float(np.float32(as_float))
-        if as_float == as_float32:
-            return np.format_float_positional(np.float32(as_float), trim="-")
-        return np.format_float_positional(as_float, trim="-")
-    if isinstance(value, Decimal):
-        normalized = format(value, "f")
-        if "." in normalized:
-            normalized = normalized.rstrip("0").rstrip(".")
-        return normalized or "0"
-    return str(value)
 
 
 def _write_png(ds: Any, results_dir: Any) -> str | None:

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -433,6 +433,15 @@ def execute_synchronous(
         options = result.options
         result = result.data
 
+    # Named exporters expect an eager frame, matching the batch-job path.
+    try:
+        import dask_geopandas
+
+        if isinstance(result, dask_geopandas.GeoDataFrame):
+            result = result.compute()
+    except ImportError:
+        pass
+
     if "export" in options:
         from open_climate_service.exports.service import render_named_export
 
@@ -468,14 +477,6 @@ def execute_synchronous(
         )
 
     # Try vector
-    try:
-        import dask_geopandas
-
-        if isinstance(result, dask_geopandas.GeoDataFrame):
-            result = result.compute()
-    except ImportError:
-        pass
-
     try:
         import geopandas as gpd
         import pandas as pd

--- a/open_climate_service/openeo/routes.py
+++ b/open_climate_service/openeo/routes.py
@@ -68,7 +68,7 @@ def credentials_oidc() -> dict[str, Any]:
 @capabilities_router.get("/file_formats")
 def file_formats() -> dict[str, Any]:
     """Return supported input and output file formats."""
-    output_formats = {
+    output_formats: dict[str, Any] = {
         "ZARR": {
             "title": "Zarr",
             "description": "Zarr v3 chunked array store — cloud-native format for multi-dimensional data",
@@ -148,6 +148,21 @@ def file_formats() -> dict[str, Any]:
             "links": [],
         },
     }
+    from open_climate_service.exports.registry import load_export_plugins
+
+    for plugin in load_export_plugins().values():
+        if plugin.format not in output_formats:
+            output_formats[plugin.format] = {
+                "title": plugin.format,
+                "description": "Pure export renderer; requires a configured export ID in save_result options.",
+                "gis_data_types": ["table"],
+                "parameters": {},
+                "links": [],
+            }
+        output_formats[plugin.format]["parameters"]["export"] = {
+            "type": "string",
+            "description": "Named export mapping; use this option without per-request mapping overrides.",
+        }
     return {
         "input": {},
         "output": output_formats,
@@ -339,6 +354,11 @@ def download_result_file(job_id: str, filename: str) -> FileResponse:
 
     suffix = path.suffix.lower()
     media_type = _RESULT_MEDIA_TYPES.get(suffix, "application/octet-stream")
+    from open_climate_service.exports.service import read_export_metadata
+
+    metadata = read_export_metadata(path)
+    if metadata is not None:
+        media_type = metadata["media_type"]
     return FileResponse(str(path), media_type=media_type, filename=filename)
 
 
@@ -412,6 +432,15 @@ def execute_synchronous(
         fmt = result.format
         options = result.options
         result = result.data
+
+    if "export" in options:
+        from open_climate_service.exports.service import render_named_export
+
+        try:
+            plugin, rendered = render_named_export(result, fmt, options)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return Response(content=rendered.content, media_type=plugin.media_type)
 
     if isinstance(result, xr.DataArray):
         result = result.to_dataset(name=result.name or "result")

--- a/open_climate_service/plugin_discovery.py
+++ b/open_climate_service/plugin_discovery.py
@@ -2,7 +2,7 @@
 
 A plugin package declares an ``open_climate_service.plugins`` entry point whose value
 is its top-level import package. The framework then loads the package's ``datasets/``,
-``processes/`` and ``workflows/`` folders the same way it reads an instance's
+``processes/``, ``workflows/`` and ``exports/`` folders the same way it reads an instance's
 ``plugins_dir`` — so an installed package contributes the same extension points, with
 no config wiring beyond installing it.
 """
@@ -24,7 +24,7 @@ def iter_plugin_subdirs(subdir: str) -> Iterator[tuple[str, str, Traversable]]:
     """Yield ``(plugin_name, package, <package>/<subdir>)`` for installed plugins.
 
     Only plugins that actually ship the requested ``<subdir>`` (``datasets`` /
-    ``processes`` / ``workflows``) are yielded. ``package`` is the plugin's import
+    ``processes`` / ``workflows`` / ``exports``) are yielded. ``package`` is the plugin's import
     package, so a caller that needs to *import* modules (processes) can build the
     dotted path, while a caller that reads files (datasets, workflows) can iterate
     the returned traversable.

--- a/open_climate_service/plugins/processes/aggregate_spatial.py
+++ b/open_climate_service/plugins/processes/aggregate_spatial.py
@@ -17,6 +17,10 @@ def _parse_geometries(geometries: Any) -> tuple[list[Any], list[str]]:
     """
     from shapely.geometry import shape
 
+    from open_climate_service.shared.provenance import record_features
+
+    record_features(geometries)
+
     if isinstance(geometries, dict):
         gtype = geometries.get("type", "")
         if gtype == "FeatureCollection":

--- a/open_climate_service/read_only.py
+++ b/open_climate_service/read_only.py
@@ -37,8 +37,10 @@ _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 # Mutating paths that remain open. Matched exactly (after stripping a trailing slash).
 _ALLOWED_WRITE_PATHS = frozenset({"/result"})
 
-# Path trees closed to every method, including GET: the admin console and batch jobs.
-_CLOSED_PREFIXES = ("/manage", "/jobs")
+# Path trees closed to every method, including GET: the admin console, batch
+# jobs, and operator export delivery. Delivery exposes server-held credentials
+# to an operation with external effects, so reports and dry runs are closed too.
+_CLOSED_PREFIXES = ("/manage", "/jobs", "/exports")
 
 _MESSAGE = (
     "This instance is read-only: {method} {path} is not available. "

--- a/open_climate_service/shared/features.py
+++ b/open_climate_service/shared/features.py
@@ -1,0 +1,23 @@
+"""Feature identity checks shared by aggregation and feature providers."""
+
+from typing import Any
+
+
+def validate_feature_ids(geometries: Any) -> list[str]:
+    """Require explicit, unique string IDs and identify the offending feature."""
+    if not isinstance(geometries, dict) or geometries.get("type") not in {"Feature", "FeatureCollection"}:
+        raise ValueError("Named DHIS2 export requires GeoJSON features with explicit feature.id values")
+    features: Any = geometries.get("features") if geometries["type"] == "FeatureCollection" else [geometries]
+    if not isinstance(features, list):
+        raise ValueError("FeatureCollection.features must be a list")
+    identifiers: list[str] = []
+    seen: set[str] = set()
+    for index, feature in enumerate(features):
+        identifier = feature.get("id") if isinstance(feature, dict) else None
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise ValueError(f"Feature {index} is missing a non-empty string feature.id")
+        if identifier in seen:
+            raise ValueError(f"Feature {index} repeats feature.id '{identifier}'")
+        seen.add(identifier)
+        identifiers.append(identifier)
+    return identifiers

--- a/open_climate_service/shared/persistence.py
+++ b/open_climate_service/shared/persistence.py
@@ -23,6 +23,29 @@ def index_lock(path: Path) -> Iterator[None]:
             portalocker.unlock(handle)
 
 
+class AlreadyLocked(Exception):
+    """Raised by :func:`try_index_lock` when the lock is already held."""
+
+
+@contextmanager
+def try_index_lock(path: Path) -> Iterator[None]:
+    """Acquire the index lock without blocking; raise ``AlreadyLocked`` if held."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = portalocker.Lock(
+        path.with_suffix(path.suffix + ".lock"),
+        timeout=0,
+        flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
+    )
+    try:
+        lock.acquire()
+    except portalocker.exceptions.LockException as exc:
+        raise AlreadyLocked(str(path)) from exc
+    try:
+        yield
+    finally:
+        lock.release()
+
+
 def atomic_json(path: Path, value: Any) -> None:
     """Flush contents and directory entries before returning to the caller."""
     temporary: str | None = None
@@ -31,7 +54,9 @@ def atomic_json(path: Path, value: Any) -> None:
             dir=path.parent, prefix=".index-", mode="w", encoding="utf-8", delete=False
         ) as handle:
             temporary = handle.name
-            json.dump(value, handle, allow_nan=False)
+            # Keep parity with the previous store: a completed job whose result
+            # carries NaN must still persist rather than failing the write.
+            json.dump(value, handle, allow_nan=True)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, path)

--- a/open_climate_service/shared/persistence.py
+++ b/open_climate_service/shared/persistence.py
@@ -27,7 +27,9 @@ def atomic_json(path: Path, value: Any) -> None:
     """Flush contents and directory entries before returning to the caller."""
     temporary: str | None = None
     try:
-        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=".index-", mode="w", delete=False) as handle:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, prefix=".index-", mode="w", encoding="utf-8", delete=False
+        ) as handle:
             temporary = handle.name
             json.dump(value, handle, allow_nan=False)
             handle.flush()

--- a/open_climate_service/shared/persistence.py
+++ b/open_climate_service/shared/persistence.py
@@ -3,7 +3,7 @@
 import json
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -12,7 +12,7 @@ import portalocker
 
 
 @contextmanager
-def index_lock(path: Path) -> Iterator[None]:
+def index_lock(path: Path) -> Generator[None]:
     """Lock before opening the index; replacement must not replace the lock inode."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path.with_suffix(path.suffix + ".lock"), "a", encoding="utf-8") as handle:
@@ -28,7 +28,7 @@ class AlreadyLocked(Exception):
 
 
 @contextmanager
-def try_index_lock(path: Path) -> Iterator[None]:
+def try_index_lock(path: Path) -> Generator[None]:
     """Acquire the index lock without blocking; raise ``AlreadyLocked`` if held."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lock = portalocker.Lock(

--- a/open_climate_service/shared/persistence.py
+++ b/open_climate_service/shared/persistence.py
@@ -1,0 +1,45 @@
+"""Atomic JSON replacement protected by a stable sibling lock file."""
+
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import portalocker
+
+
+@contextmanager
+def index_lock(path: Path) -> Iterator[None]:
+    """Lock before opening the index; replacement must not replace the lock inode."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path.with_suffix(path.suffix + ".lock"), "a", encoding="utf-8") as handle:
+        portalocker.lock(handle, portalocker.LOCK_EX)
+        try:
+            yield
+        finally:
+            portalocker.unlock(handle)
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    """Flush contents and directory entries before returning to the caller."""
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=".index-", mode="w", delete=False) as handle:
+            temporary = handle.name
+            json.dump(value, handle, allow_nan=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        temporary = None
+        if os.name != "nt":
+            descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        if temporary is not None:
+            Path(temporary).unlink(missing_ok=True)

--- a/open_climate_service/shared/provenance.py
+++ b/open_climate_service/shared/provenance.py
@@ -1,0 +1,114 @@
+"""Execution-scoped observations, independent of mutable xarray attributes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from os import PathLike
+from typing import Any
+
+
+def json_digest(value: Any) -> str:
+    """Hash a canonical JSON value without retaining its contents."""
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+
+
+@dataclass
+class ExecutionEvidence:
+    """Observed inputs; this is not per-output lineage or an aggregation proof."""
+
+    process_sha256: str | None
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    features: list[dict[str, Any]] = field(default_factory=list)
+    snapshots: dict[str, str] = field(default_factory=dict, repr=False)
+
+    def describe(self) -> dict[str, Any]:
+        missing = ["per_output_lineage", "aggregation_semantics"]
+        if not self.sources:
+            missing.append("source_artifacts")
+        if any(source["snapshot_id"] is None for source in self.sources):
+            missing.append("immutable_source_snapshots")
+        if not self.features:
+            missing.append("feature_inputs")
+        # Named feature collection versioning is not implemented in this checkout.
+        missing.append("named_feature_collection_versions")
+        return {
+            "scope": "executed_processes",
+            "process_sha256": self.process_sha256,
+            "sources": list(self.sources),
+            "features": list(self.features),
+            "missing": missing,
+        }
+
+
+_current: ContextVar[ExecutionEvidence | None] = ContextVar("ocs_execution_evidence", default=None)
+
+
+@contextmanager
+def capture_execution(process: dict[str, Any]) -> Iterator[ExecutionEvidence]:
+    """Isolate observations between simultaneous graph executions."""
+    try:
+        digest = json_digest(process)
+    except (ValueError, TypeError):
+        digest = None
+    evidence = ExecutionEvidence(digest)
+    token = _current.set(evidence)
+    try:
+        yield evidence
+    finally:
+        _current.reset(token)
+
+
+def record_snapshot(path: str, snapshot_id: str) -> None:
+    """Record the snapshot belonging to the actual opened readonly session."""
+    evidence = _current.get()
+    if evidence is not None:
+        evidence.snapshots[path] = snapshot_id
+
+
+def record_source(collection_id: str, artifact: Any) -> None:
+    """Record a successfully opened artifact without copying paths or credentials."""
+    evidence = _current.get()
+    if evidence is None:
+        return
+    observation: dict[str, Any] = {"collection_id": collection_id}
+    for key in ("artifact_id", "source_dataset_id"):
+        value = getattr(artifact, key, None)
+        observation[key] = value if isinstance(value, str) else None
+    raw_path = getattr(artifact, "path", None)
+    paths = getattr(artifact, "asset_paths", [])
+    if raw_path is None and isinstance(paths, list) and paths:
+        raw_path = paths[0]
+    path = str(raw_path) if isinstance(raw_path, (str, PathLike)) else None
+    observation["snapshot_id"] = evidence.snapshots.pop(path, None) if path is not None else None
+    evidence.sources.append(observation)
+
+
+def record_features(geometries: Any) -> None:
+    """Fingerprint actual inline feature inputs before positional labels are assigned."""
+    evidence = _current.get()
+    if evidence is None:
+        return
+    if not isinstance(geometries, dict) or geometries.get("type") not in {"Feature", "FeatureCollection"}:
+        evidence.features.append({"input_sha256": None, "ids_valid": False, "reason": "no_feature_ids"})
+        return
+    features = geometries.get("features", []) if geometries.get("type") == "FeatureCollection" else [geometries]
+    if not isinstance(features, list) or not all(isinstance(feature, dict) for feature in features):
+        return
+    # Properties are irrelevant to spatial aggregation and may contain incidental
+    # metadata. Fingerprint only the geometry and identity actually used here.
+    relevant = [{"id": feature.get("id"), "geometry": feature.get("geometry")} for feature in features]
+    identifiers = [feature["id"] for feature in relevant]
+    valid = all(isinstance(identifier, str) and bool(identifier.strip()) for identifier in identifiers)
+    valid = valid and len(set(identifiers)) == len(identifiers)
+    try:
+        digest = json_digest(relevant)
+    except (TypeError, ValueError):
+        digest = None
+    evidence.features.append({"input_sha256": digest, "feature_count": len(features), "ids_valid": valid})

--- a/open_climate_service/shared/provenance.py
+++ b/open_climate_service/shared/provenance.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from os import PathLike
+from pathlib import Path
 from typing import Any
 
 
@@ -24,6 +25,7 @@ class ExecutionEvidence:
     """Observed inputs; this is not per-output lineage or an aggregation proof."""
 
     process_sha256: str | None
+    require_feature_ids: bool = False
     sources: list[dict[str, Any]] = field(default_factory=list)
     features: list[dict[str, Any]] = field(default_factory=list)
     snapshots: dict[str, str] = field(default_factory=dict, repr=False)
@@ -57,7 +59,7 @@ def capture_execution(process: dict[str, Any]) -> Iterator[ExecutionEvidence]:
         digest = json_digest(process)
     except (ValueError, TypeError):
         digest = None
-    evidence = ExecutionEvidence(digest)
+    evidence = ExecutionEvidence(digest, require_feature_ids=_has_named_dhis2_export(process))
     token = _current.set(evidence)
     try:
         yield evidence
@@ -69,7 +71,7 @@ def record_snapshot(path: str, snapshot_id: str) -> None:
     """Record the snapshot belonging to the actual opened readonly session."""
     evidence = _current.get()
     if evidence is not None:
-        evidence.snapshots[path] = snapshot_id
+        evidence.snapshots[str(Path(path).resolve())] = snapshot_id
 
 
 def record_source(collection_id: str, artifact: Any) -> None:
@@ -85,7 +87,7 @@ def record_source(collection_id: str, artifact: Any) -> None:
     paths = getattr(artifact, "asset_paths", [])
     if raw_path is None and isinstance(paths, list) and paths:
         raw_path = paths[0]
-    path = str(raw_path) if isinstance(raw_path, (str, PathLike)) else None
+    path = str(Path(raw_path).resolve()) if isinstance(raw_path, (str, PathLike)) else None
     observation["snapshot_id"] = evidence.snapshots.pop(path, None) if path is not None else None
     evidence.sources.append(observation)
 
@@ -95,6 +97,10 @@ def record_features(geometries: Any) -> None:
     evidence = _current.get()
     if evidence is None:
         return
+    if evidence.require_feature_ids:
+        from open_climate_service.shared.features import validate_feature_ids
+
+        validate_feature_ids(geometries)
     if not isinstance(geometries, dict) or geometries.get("type") not in {"Feature", "FeatureCollection"}:
         evidence.features.append({"input_sha256": None, "ids_valid": False, "reason": "no_feature_ids"})
         return
@@ -112,3 +118,20 @@ def record_features(geometries: Any) -> None:
     except (TypeError, ValueError):
         digest = None
     evidence.features.append({"input_sha256": digest, "feature_count": len(features), "ids_valid": valid})
+
+
+def _has_named_dhis2_export(value: Any) -> bool:
+    if isinstance(value, dict):
+        arguments = value.get("arguments", {})
+        if value.get("process_id") == "save_result" and isinstance(arguments, dict):
+            options = arguments.get("options", {})
+            if (
+                str(arguments.get("format", "")).upper() == "DHIS2JSON"
+                and isinstance(options, dict)
+                and "export" in options
+            ):
+                return True
+        return any(_has_named_dhis2_export(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_has_named_dhis2_export(child) for child in value)
+    return False

--- a/open_climate_service/shared/provenance.py
+++ b/open_climate_service/shared/provenance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -53,7 +53,7 @@ _current: ContextVar[ExecutionEvidence | None] = ContextVar("ocs_execution_evide
 
 
 @contextmanager
-def capture_execution(process: dict[str, Any]) -> Iterator[ExecutionEvidence]:
+def capture_execution(process: dict[str, Any]) -> Generator[ExecutionEvidence]:
     """Isolate observations between simultaneous graph executions."""
     try:
         digest = json_digest(process)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,11 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
+# Optional, supplied by deployments/plugins; not yet published on PyPI.
+module = ["dhis2_client", "dhis2_client.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["apscheduler", "apscheduler.*", "rasterio.*", "pygeofilter.*", "requests.*", "geopandas.*", "earthkit.*", "metpy.*", "matplotlib.*", "yaml", "xproj", "topozarr.*", "geozarr_toolkit", "xstac", "openeo_pg_parser_networkx", "openeo_pg_parser_networkx.*", "openeo_processes_dask", "openeo_processes_dask.*", "dask_geopandas", "dask_geopandas.*", "xclim", "xclim.*"]
 ignore_missing_imports = true
 

--- a/tests/test_dhis2_connections.py
+++ b/tests/test_dhis2_connections.py
@@ -124,6 +124,40 @@ def test_legacy_yaml_fragment_interpolation_without_connections(connection_file:
     assert config.get_config()["extent"]["bbox"] == [-13.5, 6.9, -10.1, 10.0]
 
 
+def test_exports_can_be_added_to_config_with_yaml_fragment_interpolation(
+    connection_file: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("WEST", "-13.5")
+    connection_file.write_text(
+        "extent:\n"
+        "  bbox: [${WEST}, 6.9, -10.1, 10.0]\n"
+        "exports:\n"
+        "  - id: rainfall\n"
+        "    plugin: dhis2\n"
+        "    period_type: monthly\n"
+        "    series:\n"
+        "      - data_element: BXgDHhPdFVU\n"
+        "dhis2_connections:\n"
+        "  - id: hmis\n"
+        "    url: https://hmis.example.org/dhis\n"
+        "    token_env: TEST_DHIS2_TOKEN\n"
+    )
+    loaded = config.get_config()
+    assert loaded["extent"]["bbox"] == [-13.5, 6.9, -10.1, 10.0]
+    assert loaded["exports"][0]["id"] == "rainfall"
+
+
+@pytest.mark.parametrize("block", ["exports", "dhis2_connections"])
+def test_protected_config_block_rejects_inline_interpolation(
+    connection_file: Path, monkeypatch: pytest.MonkeyPatch, block: str
+) -> None:
+    monkeypatch.setenv("PROTECTED_CONFIG", "[]")
+    connection_file.write_text(f"{block}: ${{PROTECTED_CONFIG}}\n")
+
+    with pytest.raises(ValueError, match=rf"{block} does not support environment interpolation"):
+        config.get_config()
+
+
 def test_unknown_connection(connection_file: Path):
     with pytest.raises(ValueError, match="Unknown DHIS2 connection"):
         get_connection("unknown")

--- a/tests/test_dhis2_connections.py
+++ b/tests/test_dhis2_connections.py
@@ -158,6 +158,27 @@ def test_protected_config_block_rejects_inline_interpolation(
         config.get_config()
 
 
+def test_protected_config_block_rejects_interpolation_after_column_zero_comment(
+    connection_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PLUGIN", "dhis2")
+    connection_file.write_text(
+        "exports:\n  - id: rainfall\n# operator note\n    plugin: ${PLUGIN}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exports does not support environment interpolation"):
+        config.get_config()
+
+
+@pytest.mark.parametrize("indicator", ["*connections", "&connections"])
+def test_protected_config_block_rejects_aliases_and_anchors(connection_file: Path, indicator: str) -> None:
+    connection_file.write_text(f"dhis2_connections: {indicator}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="dhis2_connections does not support environment interpolation"):
+        config.get_config()
+
+
 def test_unknown_connection(connection_file: Path):
     with pytest.raises(ValueError, match="Unknown DHIS2 connection"):
         get_connection("unknown")

--- a/tests/test_dhis2_connections.py
+++ b/tests/test_dhis2_connections.py
@@ -1,0 +1,217 @@
+"""Named connections are reusable without copying credentials into plugin inputs."""
+
+import builtins
+import importlib.util
+import json
+import os
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+
+from open_climate_service import config
+from open_climate_service.exports.dhis2 import get_connection, get_connection_config
+
+
+def _write_config(path: Path, value: object) -> None:
+    with path.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(value, stream)
+
+
+@pytest.fixture
+def connection_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "climate-service.yaml"
+    path.write_text(
+        "dhis2_connections:\n"
+        "  - id: national-hmis\n"
+        "    url: https://hmis.example.org/dhis/\n"
+        "    token_env: TEST_DHIS2_TOKEN\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLIMATE_SERVICE_CONFIG", str(path))
+    monkeypatch.delenv("TEST_DHIS2_TOKEN", raising=False)
+    return path
+
+
+def test_config_is_available_without_credentials_or_client(connection_file: Path, monkeypatch: pytest.MonkeyPatch):
+    original = builtins.__import__
+
+    def forbid_client(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "dhis2_client":
+            pytest.fail("Reading configuration must not import the client")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", forbid_client)
+    connection = get_connection_config("national-hmis")
+    assert connection.url == "https://hmis.example.org/dhis"
+    assert connection.token_env == "TEST_DHIS2_TOKEN"
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"id": ""},
+        {"url": "file:///tmp/dhis2"},
+        {"url": "https://user:literal-secret@example.org"},
+        {"url": "https://example.org?token=literal-secret"},
+        {"url": "https://example.org/#literal-secret"},
+        {"url": "https://example.org:99999"},
+        {"url": "https://example.org\\other"},
+        {"url": "https://"},
+        {"token_env": "${TEST_DHIS2_TOKEN}"},
+        {"token_env": ""},
+        {"token": "literal-secret"},
+        {"password": "literal-secret"},
+        {"verify_ssl": False},
+        {"timeout": 0},
+        {"timeout": float("inf")},
+        {"timeout": True},
+        {"connect_timeout": "30"},
+        {"retries": -1},
+        {"retries": True},
+        {"retries": 11},
+    ],
+)
+def test_invalid_config_is_rejected_before_caching(connection_file: Path, patch: dict[str, Any]):
+    item = {"id": "national-hmis", "url": "https://example.org", "token_env": "TEST_DHIS2_TOKEN"} | patch
+    _write_config(connection_file, {"dhis2_connections": [item]})
+    with pytest.raises(ValueError) as error:
+        config.get_config()
+    assert "literal-secret" not in str(error.value)
+    assert config._cache is None
+
+
+@pytest.mark.parametrize("raw", [None, {}, "national-hmis", [None]])
+def test_connections_must_be_a_list_of_mappings(connection_file: Path, raw: object):
+    _write_config(connection_file, {"dhis2_connections": raw})
+    with pytest.raises(ValueError, match="dhis2_connections"):
+        config.get_config()
+
+
+def test_duplicate_ids_are_rejected(connection_file: Path):
+    raw = yaml.safe_load(connection_file.read_text())
+    assert isinstance(raw, dict)
+    raw["dhis2_connections"] *= 2
+    _write_config(connection_file, raw)
+    with pytest.raises(ValueError, match="duplicates"):
+        config.get_config()
+
+
+def test_interpolated_secret_is_never_parsed_or_cached(connection_file: Path, monkeypatch: pytest.MonkeyPatch):
+    secret = "secret: [invalid yaml"
+    monkeypatch.setenv("TEST_DHIS2_TOKEN", secret)
+    connection_file.write_text(
+        connection_file.read_text().replace("token_env: TEST_DHIS2_TOKEN", "token_env: ${TEST_DHIS2_TOKEN}")
+    )
+    with pytest.raises(ValueError, match="literal") as error:
+        config.get_config()
+    assert secret not in str(error.value)
+    assert config._cache is None
+
+
+def test_other_config_interpolation_still_works(connection_file: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("INSTANCE_NAME", "Test instance")
+    connection_file.write_text(connection_file.read_text() + "name: ${INSTANCE_NAME}\n")
+    assert config.get_name() == "Test instance"
+
+
+def test_legacy_yaml_fragment_interpolation_without_connections(connection_file: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WEST", "-13.5")
+    connection_file.write_text("extent:\n  bbox: [${WEST}, 6.9, -10.1, 10.0]\n")
+    assert config.get_config()["extent"]["bbox"] == [-13.5, 6.9, -10.1, 10.0]
+
+
+def test_unknown_connection(connection_file: Path):
+    with pytest.raises(ValueError, match="Unknown DHIS2 connection"):
+        get_connection("unknown")
+
+
+@pytest.mark.parametrize("token", [None, "", " ", "ApiToken secret", "secret\n", "secret\x00", "secret\x7f", "é"])
+def test_missing_or_invalid_token(connection_file: Path, monkeypatch: pytest.MonkeyPatch, token: str | None):
+    if token is not None:
+        if "\x00" in token:
+            # Real process environments cannot contain NUL; exercise header validation directly.
+            monkeypatch.setattr(
+                "open_climate_service.exports.dhis2.os.environ", dict(os.environ) | {"TEST_DHIS2_TOKEN": token}
+            )
+        else:
+            monkeypatch.setenv("TEST_DHIS2_TOKEN", token)
+    with pytest.raises(ValueError, match="token") as error:
+        get_connection("national-hmis")
+    assert "secret" not in str(error.value)
+
+
+def test_missing_optional_dependency_is_actionable(connection_file: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_DHIS2_TOKEN", "test-token")
+    original = builtins.__import__
+
+    def missing_client(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "dhis2_client":
+            raise ModuleNotFoundError("missing", name=name)
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_client)
+    with pytest.raises(RuntimeError, match="optional dhis2-client"):
+        get_connection("national-hmis")
+
+
+@pytest.fixture
+def requests(monkeypatch: pytest.MonkeyPatch) -> list[httpx.Request]:
+    pytest.importorskip("dhis2_client", reason="Install the documented optional DHIS2 client to run transport tests")
+    captured: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"type": "FeatureCollection", "features": []})
+
+    original = httpx.Client
+
+    def client(**kwargs: Any) -> httpx.Client:
+        return original(**kwargs, transport=httpx.MockTransport(handle))
+
+    monkeypatch.setattr(httpx, "Client", client)
+    return captured
+
+
+def test_real_client_auth_rotation_and_config_redaction(
+    connection_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    requests: list[httpx.Request],
+    caplog: pytest.LogCaptureFixture,
+):
+    for token in ["first-test-secret", "rotated-test-secret"]:
+        monkeypatch.setenv("TEST_DHIS2_TOKEN", token)
+        with closing(get_connection("national-hmis")) as client:
+            assert len(requests) == (0 if token.startswith("first") else 1)
+            client.get("/api/me")
+            assert requests[-1].headers["Authorization"] == f"ApiToken {token}"
+            assert str(requests[-1].url) == "https://hmis.example.org/dhis/api/me"
+            assert requests[-1].extensions["timeout"]["connect"] == 10.0
+            assert requests[-1].extensions["timeout"]["read"] == 30.0
+        assert token not in json.dumps(config.get_config())
+        assert token not in repr(get_connection_config("national-hmis"))
+        assert token not in caplog.text
+
+
+def test_external_provider_uses_only_public_accessor(
+    connection_file: Path, monkeypatch: pytest.MonkeyPatch, requests: list[httpx.Request], tmp_path: Path
+):
+    monkeypatch.setenv("TEST_DHIS2_TOKEN", "provider-test-token")
+    module_file = tmp_path / "external_provider.py"
+    module_file.write_text(
+        "from contextlib import closing\n"
+        "from open_climate_service.exports.dhis2 import get_connection\n"
+        "def fetch(connection_id, level):\n"
+        "    with closing(get_connection(connection_id)) as client:\n"
+        "        return client.get_org_units_geojson(level=level)\n"
+    )
+    spec = importlib.util.spec_from_file_location("external_provider", module_file)
+    assert spec is not None and spec.loader is not None
+    provider = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(provider)
+    assert provider.fetch("national-hmis", 2) == {"type": "FeatureCollection", "features": []}
+    assert requests[0].url.path == "/dhis/api/organisationUnits.geojson"
+    assert requests[0].url.params["level"] == "2"

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -118,6 +118,13 @@ def test_build_dhis2_report_outcomes() -> None:
     rejected = build(200, {"status": "ERROR", "message": "no such data element"})
     assert rejected.outcome == ExportOutcome.REJECTED
 
+    partial_http = build(
+        409,
+        {"status": "WARNING", "importCount": {"imported": 999}, "conflicts": [{"object": "value"}]},
+    )
+    assert partial_http.outcome == ExportOutcome.PARTIAL
+    assert partial_http.imported == 999
+
     http_rejected = build(400, {"message": "bad request"})
     assert http_rejected.outcome == ExportOutcome.REJECTED
 
@@ -137,6 +144,35 @@ def test_deliver_named_export_calls_plugin_send(saved: Path, fake_send: list[dic
     assert fake_send[0]["target"] == "hmis"
     assert fake_send[0]["dry_run"] is True
     assert fake_send[0]["payload"] == saved.read_bytes()
+
+
+def test_deliver_named_export_raises_job_cancelled_when_cancelled(saved: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.jobs.models import JobCancelledError
+
+    def send(
+        self: Dhis2ExportPlugin,
+        payload: bytes,
+        target: Any,
+        *,
+        dry_run: bool = False,
+        context: Any = None,
+    ) -> ExportReport:
+        return ExportReport(
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            outcome=ExportOutcome.CANCELLED,
+            payload_sha256=hashlib.sha256(payload).hexdigest(),
+            submitted=len(payload),
+            created_at=utc_now().isoformat(),
+            finished_at=utc_now().isoformat(),
+        )
+
+    monkeypatch.setattr(Dhis2ExportPlugin, "send", send)
+    with lease_export_input("rain", "source") as verified:
+        digest = json_digest(verified.manifest.model_dump(mode="json"))
+    with pytest.raises(JobCancelledError):
+        deliver_named_export("rain", "source", dry_run=False, expected_manifest_sha256=digest)
 
 
 def test_submit_delivery_deduplicates_by_idempotency_key(saved: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from open_climate_service import config
 from open_climate_service.exports import ExportReport
 from open_climate_service.exports.delivery import deliver_named_export, submit_delivery
+from open_climate_service.exports.delivery_input import lease_export_input
 from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin, build_dhis2_report
 from open_climate_service.exports.report import ExportOutcome
 from open_climate_service.exports.service import write_named_export
@@ -24,6 +25,7 @@ from open_climate_service.jobs import store as native_store
 from open_climate_service.jobs.models import JobRecord, JobStatus
 from open_climate_service.openeo import jobs as openeo_jobs
 from open_climate_service.openeo.schemas import OpenEOJobRecord, OpenEOJobStatus
+from open_climate_service.shared.provenance import json_digest
 from open_climate_service.shared.time import utc_now
 
 
@@ -127,7 +129,9 @@ def test_build_dhis2_report_outcomes() -> None:
 
 
 def test_deliver_named_export_calls_plugin_send(saved: Path, fake_send: list[dict[str, Any]]) -> None:
-    report = deliver_named_export("rain", "source", dry_run=True)
+    with lease_export_input("rain", "source") as verified:
+        digest = json_digest(verified.manifest.model_dump(mode="json"))
+    report = deliver_named_export("rain", "source", dry_run=True, expected_manifest_sha256=digest)
     assert report["outcome"] == ExportOutcome.DRY_RUN
     assert len(fake_send) == 1
     assert fake_send[0]["target"] == "hmis"
@@ -139,29 +143,34 @@ def test_submit_delivery_deduplicates_by_idempotency_key(saved: Path, monkeypatc
     submitted: list[dict[str, Any]] = []
 
     class FakeService:
-        def submit_callable_job(self, *, func: Any, label: str, request: dict[str, Any], **_: Any) -> JobRecord:
+        def submit_callable_job(
+            self: Any, *, func: Any, label: str, request: dict[str, Any], job_id: str, **_: Any
+        ) -> JobRecord:
             submitted.append({"func": func, "label": label, "request": request})
-            job_id = f"delivery-{len(submitted)}"
-            return JobRecord(
+            record = JobRecord(
                 job_id=job_id, process_id=label, status=JobStatus.ACCEPTED, created_at=utc_now(), request=request
             )
+            return native_store.create_job_record(record)
 
     monkeypatch.setattr(job_service_module, "get_job_service", lambda: FakeService())
 
     first, reused = submit_delivery("rain", "source", dry_run=False, idempotency_key="key-1")
-    assert (first, reused) == ("delivery-1", False)
+    assert not reused
     second, reused = submit_delivery("rain", "source", dry_run=False, idempotency_key="key-1")
-    assert (second, reused) == ("delivery-1", True)
+    assert (second, reused) == (first, True)
     assert len(submitted) == 1
     assert submitted[0]["label"] == "export:rain"
-    assert submitted[0]["request"] == {"export_id": "rain", "job_id": "source", "dry_run": False}
+    assert submitted[0]["request"]["export_id"] == "rain"
+    assert submitted[0]["request"]["job_id"] == "source"
+    assert submitted[0]["request"]["dry_run"] is False
+    assert submitted[0]["request"]["expected_manifest_sha256"]
 
 
 def test_submit_delivery_conflicts_on_reused_key_with_different_content(
     saved: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class FakeService:
-        def submit_callable_job(self, **kwargs: Any) -> JobRecord:
+        def submit_callable_job(self: Any, **kwargs: Any) -> JobRecord:
             return JobRecord(
                 job_id="delivery-1", process_id="export:rain", status=JobStatus.ACCEPTED, created_at=utc_now()
             )
@@ -243,3 +252,106 @@ def _await_terminal(service: Any, job_id: str, timeout: float = 5.0) -> JobRecor
             return record
         time.sleep(0.05)
     pytest.fail(f"Delivery job '{job_id}' did not finish within {timeout}s")
+
+
+@pytest.mark.parametrize(
+    "status_code,summary,outcome",
+    [
+        (400, {"status": "ERROR"}, ExportOutcome.REJECTED),
+        (200, {"status": "ERROR"}, ExportOutcome.REJECTED),
+        (200, {"status": "WARNING", "conflicts": [{"object": "bad"}]}, ExportOutcome.PARTIAL),
+        (200, {}, ExportOutcome.UNKNOWN),
+    ],
+)
+def test_dry_run_preserves_rejection_and_uncertainty(status_code: int, summary: dict[str, Any], outcome: ExportOutcome):
+    report = build_dhis2_report(
+        status_code,
+        summary,
+        plugin_id="dhis2",
+        connection_id="hmis",
+        dry_run=True,
+        payload_sha256="a" * 64,
+        submitted=1,
+        created_at=utc_now().isoformat(),
+    )
+    assert report.outcome == outcome
+    assert report.dry_run
+
+
+def test_concurrent_submissions_reserve_before_enqueue(
+    saved: Path, fake_send: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from open_climate_service.exports.reservations import find_delivery
+
+    service = job_service_module.get_job_service()
+    original = service.submit_callable_job
+
+    def submit(**kwargs: Any):
+        reservation = find_delivery("concurrent")
+        assert reservation is not None
+        assert reservation["delivery_job_id"] == kwargs["job_id"]
+        return original(**kwargs)
+
+    monkeypatch.setattr(service, "submit_callable_job", submit)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: submit_delivery("rain", "source", False, "concurrent"), range(4)))
+    assert len({job_id for job_id, _ in results}) == 1
+    assert sum(not reused for _, reused in results) == 1
+    _await_terminal(service, results[0][0])
+    assert len(fake_send) == 1
+
+
+def test_retry_repairs_reservation_after_enqueue_failure(
+    saved: Path, fake_send: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+):
+    from open_climate_service.exports.reservations import find_delivery
+
+    service = job_service_module.get_job_service()
+    original = service.submit_callable_job
+
+    def fail(**kwargs: Any):
+        raise RuntimeError("simulated crash before job creation")
+
+    monkeypatch.setattr(service, "submit_callable_job", fail)
+    with pytest.raises(RuntimeError):
+        submit_delivery("rain", "source", False, "recover")
+    reservation = find_delivery("recover")
+    assert reservation
+    monkeypatch.setattr(service, "submit_callable_job", original)
+    job_id, reused = submit_delivery("rain", "source", False, "recover")
+    assert job_id == reservation["delivery_job_id"]
+    assert reused
+    _await_terminal(service, job_id)
+    assert len(fake_send) == 1
+
+
+def test_queued_delivery_rejects_replaced_source(saved: Path, fake_send: list[dict[str, Any]]):
+    from concurrent.futures import Future
+
+    class PausedExecutor:
+        kind = "test"
+
+        def submit(self: Any, *args: Any, **kwargs: Any):
+            return Future()
+
+        def shutdown(self: Any):
+            pass
+
+    service = job_service_module.JobService(executor=PausedExecutor())
+    job_service_module._job_service = service
+    job_id, _ = submit_delivery("rain", "source", False, "frozen")
+    path = write_named_export(_data(), saved.parent, "DHIS2JSON", {"export": "rain"}, job_id="source")
+    openeo_jobs.store_update_job("source", lambda r: r.model_copy(update={"usage": {"output_path": path}}))
+    with pytest.raises(HTTPException, match="different delivery content"):
+        submit_delivery("rain", "source", False, "frozen")
+    service._execute_job(job_id)
+    assert service.get_job_or_404(job_id).status == JobStatus.FAILED
+    assert fake_send == []
+
+
+def test_delivery_report_requires_matching_export(saved: Path, fake_send: list[dict[str, Any]], client: TestClient):
+    job_id, _ = submit_delivery("rain", "source", False, "report-binding")
+    _await_terminal(job_service_module.get_job_service(), job_id)
+    assert client.get(f"/exports/other/jobs/{job_id}").status_code == 404

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -177,6 +177,7 @@ def test_deliver_named_export_raises_job_cancelled_when_cancelled(saved: Path, m
         digest = json_digest(verified.manifest.model_dump(mode="json"))
     with pytest.raises(JobCancelledError) as exc_info:
         deliver_named_export("rain", "source", dry_run=False, expected_manifest_sha256=digest)
+    assert exc_info.value.result is not None
     assert exc_info.value.result["outcome"] == ExportOutcome.CANCELLED
 
 

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -1,0 +1,238 @@
+"""Slice 4: explicit delivery, reports, idempotency, and operator routes."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from open_climate_service import config
+from open_climate_service.exports import ExportReport
+from open_climate_service.exports.delivery import deliver_named_export, submit_delivery
+from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin, build_dhis2_report
+from open_climate_service.exports.report import ExportOutcome
+from open_climate_service.exports.service import write_named_export
+from open_climate_service.jobs import service as job_service_module
+from open_climate_service.jobs import store as native_store
+from open_climate_service.jobs.models import JobRecord, JobStatus
+from open_climate_service.openeo import jobs as openeo_jobs
+from open_climate_service.openeo.schemas import OpenEOJobRecord, OpenEOJobStatus
+from open_climate_service.shared.time import utc_now
+
+
+def _data() -> pd.DataFrame:
+    return pd.DataFrame({"geometry": ["DiszpKrYNg8"] * 2, "t": ["202501", "202502"], "rain": [0.0, float("nan")]})
+
+
+@pytest.fixture
+def saved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
+    monkeypatch.setattr(openeo_jobs, "_JOBS_DIR", tmp_path / "openeo_jobs")
+    monkeypatch.setattr(config, "get_data_root", lambda: tmp_path / "data")
+    monkeypatch.setattr(native_store, "JOBS_DIR", tmp_path / "data" / "jobs")
+    monkeypatch.setattr(native_store, "JOBS_INDEX_PATH", tmp_path / "data" / "jobs" / "jobs.json")
+    monkeypatch.setattr(
+        config,
+        "_cache",
+        {
+            "exports": [
+                {
+                    "id": "rain",
+                    "plugin": "dhis2",
+                    "connection": "hmis",
+                    "period_type": "monthly",
+                    "series": [{"data_element": "BXgDHhPdFVU"}],
+                }
+            ],
+            "dhis2_connections": [{"id": "hmis", "url": "https://hmis.example.org/dhis", "token_env": "TEST_TOKEN"}],
+        },
+    )
+    monkeypatch.delenv("TEST_TOKEN", raising=False)
+    directory = tmp_path / "openeo_jobs" / "source" / "results"
+    directory.mkdir(parents=True)
+    path = write_named_export(_data(), directory, "DHIS2JSON", {"export": "rain"}, job_id="source")
+    openeo_jobs.store_create_job(
+        OpenEOJobRecord(
+            id="source",
+            status=OpenEOJobStatus.FINISHED,
+            created=utc_now(),
+            usage={"output_path": path},
+        )
+    )
+    yield Path(path)
+    job_service_module.reset_job_service()
+
+
+@pytest.fixture
+def fake_send(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def send(self: Dhis2ExportPlugin, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
+        calls.append({"payload": payload, "target": target, "dry_run": dry_run})
+        return ExportReport(
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            outcome=ExportOutcome.DRY_RUN if dry_run else ExportOutcome.SUCCESS,
+            message="accepted",
+            payload_sha256=hashlib.sha256(payload).hexdigest(),
+            submitted=len(payload),
+            imported=1,
+            created_at=utc_now().isoformat(),
+            finished_at=utc_now().isoformat(),
+        )
+
+    monkeypatch.setattr(Dhis2ExportPlugin, "send", send)
+    return calls
+
+
+def test_build_dhis2_report_outcomes() -> None:
+    base: dict[str, Any] = dict(plugin_id="dhis2", connection_id="hmis", payload_sha256="a" * 64, submitted=2)
+    created = "2026-01-01T00:00:00+00:00"
+
+    def build(status_code: int, summary: dict[str, Any]) -> ExportReport:
+        return build_dhis2_report(status_code, summary, dry_run=False, created_at=created, **base)
+
+    success = build(200, {"status": "SUCCESS", "importCount": {"imported": 2}})
+    assert success.outcome == ExportOutcome.SUCCESS
+    assert (success.imported, success.updated, success.ignored, success.deleted) == (2, 0, 0, 0)
+
+    partial = build(200, {"status": "WARNING", "conflicts": [{"object": "value"}]})
+    assert partial.outcome == ExportOutcome.PARTIAL
+
+    rejected = build(200, {"status": "ERROR", "message": "no such data element"})
+    assert rejected.outcome == ExportOutcome.REJECTED
+
+    http_rejected = build(400, {"message": "bad request"})
+    assert http_rejected.outcome == ExportOutcome.REJECTED
+
+    dry = build_dhis2_report(200, {"status": "SUCCESS"}, dry_run=True, created_at=created, **base)
+    assert dry.outcome == ExportOutcome.DRY_RUN
+
+    unknown = build(200, {"unexpected": True})
+    assert unknown.outcome == ExportOutcome.UNKNOWN
+
+
+def test_deliver_named_export_calls_plugin_send(saved: Path, fake_send: list[dict[str, Any]]) -> None:
+    report = deliver_named_export("rain", "source", dry_run=True)
+    assert report["outcome"] == ExportOutcome.DRY_RUN
+    assert len(fake_send) == 1
+    assert fake_send[0]["target"] == "hmis"
+    assert fake_send[0]["dry_run"] is True
+    assert fake_send[0]["payload"] == saved.read_bytes()
+
+
+def test_submit_delivery_deduplicates_by_idempotency_key(saved: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    submitted: list[dict[str, Any]] = []
+
+    class FakeService:
+        def submit_callable_job(self, *, func: Any, label: str, request: dict[str, Any], **_: Any) -> JobRecord:
+            submitted.append({"func": func, "label": label, "request": request})
+            job_id = f"delivery-{len(submitted)}"
+            return JobRecord(
+                job_id=job_id, process_id=label, status=JobStatus.ACCEPTED, created_at=utc_now(), request=request
+            )
+
+    monkeypatch.setattr(job_service_module, "get_job_service", lambda: FakeService())
+
+    first, reused = submit_delivery("rain", "source", dry_run=False, idempotency_key="key-1")
+    assert (first, reused) == ("delivery-1", False)
+    second, reused = submit_delivery("rain", "source", dry_run=False, idempotency_key="key-1")
+    assert (second, reused) == ("delivery-1", True)
+    assert len(submitted) == 1
+    assert submitted[0]["label"] == "export:rain"
+    assert submitted[0]["request"] == {"export_id": "rain", "job_id": "source", "dry_run": False}
+
+
+def test_submit_delivery_conflicts_on_reused_key_with_different_content(
+    saved: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeService:
+        def submit_callable_job(self, **kwargs: Any) -> JobRecord:
+            return JobRecord(
+                job_id="delivery-1", process_id="export:rain", status=JobStatus.ACCEPTED, created_at=utc_now()
+            )
+
+    monkeypatch.setattr(job_service_module, "get_job_service", lambda: FakeService())
+
+    submit_delivery("rain", "source", dry_run=False, idempotency_key="key-1")
+    with pytest.raises(HTTPException) as error:
+        submit_delivery("rain", "source", dry_run=True, idempotency_key="key-1")
+    assert error.value.status_code == 409
+
+
+def test_delivery_route_end_to_end(saved: Path, fake_send: list[dict[str, Any]], client: TestClient) -> None:
+    response = client.post(
+        "/exports/rain",
+        json={"job_id": "source", "dry_run": False},
+        headers={"Idempotency-Key": "e2e-key"},
+    )
+    assert response.status_code == 202
+    body = response.json()
+    assert body["delivery_job_id"]
+    assert body["status_url"] == f"/exports/rain/jobs/{body['delivery_job_id']}"
+    assert body["reused"] is False
+
+    service = job_service_module.get_job_service()
+    record = _await_terminal(service, body["delivery_job_id"])
+    assert record.status == JobStatus.SUCCESSFUL
+    assert isinstance(record.result, dict)
+    assert record.result["outcome"] == ExportOutcome.SUCCESS
+    assert len(fake_send) == 1
+
+    detail = client.get(body["status_url"])
+    assert detail.status_code == 200
+    assert detail.json()["report"]["outcome"] == ExportOutcome.SUCCESS
+
+    # The source openEO job advertises the delivery.
+    linked = openeo_jobs.store_get_job("source")
+    assert linked is not None
+    deliveries = (linked.usage or {}).get("deliveries")
+    assert isinstance(deliveries, list) and deliveries
+    assert deliveries[0]["delivery_job_id"] == body["delivery_job_id"]
+
+    # Reusing the same key returns the existing delivery without a second send.
+    again = client.post(
+        "/exports/rain",
+        json={"job_id": "source", "dry_run": False},
+        headers={"Idempotency-Key": "e2e-key"},
+    )
+    assert again.status_code == 202
+    assert again.json()["delivery_job_id"] == body["delivery_job_id"]
+    assert again.json()["reused"] is True
+    assert len(fake_send) == 1
+
+
+def test_delivery_route_requires_idempotency_key(
+    saved: Path, fake_send: list[dict[str, Any]], client: TestClient
+) -> None:
+    response = client.post("/exports/rain", json={"job_id": "source"})
+    assert response.status_code == 400
+    assert "Idempotency-Key" in response.json()["detail"]
+
+
+def test_delivery_route_refused_in_read_only(saved: Path, fake_send: list[dict[str, Any]], client: TestClient) -> None:
+    config.get_config()["read_only"] = True
+    response = client.post(
+        "/exports/rain",
+        json={"job_id": "source"},
+        headers={"Idempotency-Key": "ro-key"},
+    )
+    assert response.status_code == 403
+    assert response.json()["code"] == "PermissionsInsufficient"
+
+
+def _await_terminal(service: Any, job_id: str, timeout: float = 5.0) -> JobRecord:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = service.get_job_or_404(job_id)
+        if record.status in {JobStatus.SUCCESSFUL, JobStatus.FAILED, JobStatus.CANCELLED}:
+            return record
+        time.sleep(0.05)
+    pytest.fail(f"Delivery job '{job_id}' did not finish within {timeout}s")

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -115,6 +115,10 @@ def test_build_dhis2_report_outcomes() -> None:
     partial = build(200, {"status": "WARNING", "conflicts": [{"object": "value"}]})
     assert partial.outcome == ExportOutcome.PARTIAL
 
+    string_conflict = build(200, {"status": "WARNING", "conflicts": ["data element not found"]})
+    assert string_conflict.outcome == ExportOutcome.PARTIAL
+    assert string_conflict.conflicts == []
+
     rejected = build(200, {"status": "ERROR", "message": "no such data element"})
     assert rejected.outcome == ExportOutcome.REJECTED
 
@@ -171,8 +175,9 @@ def test_deliver_named_export_raises_job_cancelled_when_cancelled(saved: Path, m
     monkeypatch.setattr(Dhis2ExportPlugin, "send", send)
     with lease_export_input("rain", "source") as verified:
         digest = json_digest(verified.manifest.model_dump(mode="json"))
-    with pytest.raises(JobCancelledError):
+    with pytest.raises(JobCancelledError) as exc_info:
         deliver_named_export("rain", "source", dry_run=False, expected_manifest_sha256=digest)
+    assert exc_info.value.result["outcome"] == ExportOutcome.CANCELLED
 
 
 def test_submit_delivery_deduplicates_by_idempotency_key(saved: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_export_delivery.py
+++ b/tests/test_export_delivery.py
@@ -73,8 +73,15 @@ def saved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
 def fake_send(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
     calls: list[dict[str, Any]] = []
 
-    def send(self: Dhis2ExportPlugin, payload: bytes, target: Any, *, dry_run: bool = False) -> ExportReport:
-        calls.append({"payload": payload, "target": target, "dry_run": dry_run})
+    def send(
+        self: Dhis2ExportPlugin,
+        payload: bytes,
+        target: Any,
+        *,
+        dry_run: bool = False,
+        context: Any = None,
+    ) -> ExportReport:
+        calls.append({"payload": payload, "target": target, "dry_run": dry_run, "context": context})
         return ExportReport(
             plugin_id=self.id,
             connection_id=target,

--- a/tests/test_export_delivery_phase5.py
+++ b/tests/test_export_delivery_phase5.py
@@ -64,9 +64,6 @@ class FakeContext:
     def load_checkpoint(self: Any, key: str) -> dict[str, Any] | None:
         return self.checkpoints.get(key)
 
-    def delete_checkpoint(self: Any, key: str) -> None:
-        self.checkpoints.pop(key, None)
-
 
 def _values(count: int) -> list[dict[str, Any]]:
     return [
@@ -278,27 +275,35 @@ def test_send_records_unknown_on_transport_timeout(monkeypatch: pytest.MonkeyPat
     assert report.submitted == 3
 
 
-def test_send_raises_and_clears_checkpoint_on_connect_error(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("error_type", ["connect_error", "connect_timeout"])
+def test_send_reports_pre_submission_connection_failure(monkeypatch: pytest.MonkeyPatch, error_type: str) -> None:
     import httpx
 
     from open_climate_service.exports import dhis2 as dhis2_module
 
     plugin = _plugin(max_chunk_size=1000)
-    values = _values(3)
+    values = _values(1001)
     client = FakeClient()
 
     def post(path: str, json: Any, params: Any) -> FakeResponse:
+        if len(client.posts) == 1:
+            return FakeResponse(200, {"status": "SUCCESS", "importCount": {"imported": len(json["dataValues"])}})
+        if error_type == "connect_timeout":
+            raise httpx.ConnectTimeout("connection timed out")
         raise httpx.ConnectError("connection refused")
 
     client.post_handler = post
     monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
 
     context = FakeContext()
-    with pytest.raises(Exception, match="connection refused"):
-        plugin.send(_payload(values), "hmis", context=context)
+    report = plugin.send(_payload(values), "hmis", context=context)
 
-    # Nothing reached DHIS2, so the intent checkpoint must be cleared for a retry.
-    assert context.checkpoints.get("chunk:0") is None
+    assert report.outcome == ExportOutcome.REJECTED
+    assert report.chunks == 2
+    assert report.submitted == 1000
+    assert report.imported == 1000
+    assert "Connection failed before submission" in str(report.message)
+    assert context.checkpoints["chunk:1"]["report"]["outcome"] == ExportOutcome.REJECTED
 
 
 def test_send_keeps_unknown_checkpoint_on_ambiguous_requests_connection_error(

--- a/tests/test_export_delivery_phase5.py
+++ b/tests/test_export_delivery_phase5.py
@@ -1,0 +1,437 @@
+"""Slice 5: chunking, checkpoints, async polling, and third-party delivery plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from open_climate_service.exports import ExportOutcome, ExportReport, merge_chunk_reports
+from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.gets: list[str] = []
+        self.post_handler: Any = None
+        self.get_handler: Any = None
+
+    def close(self) -> None:
+        pass
+
+    def post(self, path: str, json: Any = None, params: Any = None) -> FakeResponse:
+        self.posts.append({"path": path, "json": json, "params": params})
+        if self.post_handler is None:
+            raise AssertionError("Unexpected POST")
+        return self.post_handler(path, json, params)
+
+    def get(self, path: str) -> FakeResponse:
+        self.gets.append(path)
+        if self.get_handler is None:
+            raise AssertionError("Unexpected GET")
+        return self.get_handler(path)
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.checkpoints: dict[str, Any] = {}
+        self.progress: list[tuple[Any, Any, Any]] = []
+        self.cancelled = False
+
+    def report_progress(self, done: Any = None, total: Any = None, message: Any = None) -> None:
+        self.progress.append((done, total, message))
+
+    def is_cancel_requested(self) -> bool:
+        return self.cancelled
+
+    def save_checkpoint(self, key: str, state: dict[str, Any]) -> None:
+        self.checkpoints[key] = state
+
+    def load_checkpoint(self, key: str) -> dict[str, Any] | None:
+        return self.checkpoints.get(key)
+
+
+def _values(count: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "dataElement": "BXgDHhPdFVU",
+            "period": f"2025{(index % 12) + 1:02d}",
+            "orgUnit": "DiszpKrYNg8",
+            "value": str(index),
+        }
+        for index in range(count)
+    ]
+
+
+def _payload(values: list[dict[str, Any]]) -> bytes:
+    return json.dumps({"dataValues": values}).encode()
+
+
+def _plugin(**attrs: Any) -> Dhis2ExportPlugin:
+    plugin = Dhis2ExportPlugin()
+    for key, value in attrs.items():
+        setattr(plugin, key, value)
+    return plugin
+
+
+def _chunk_digest(chunk_values: list[dict[str, Any]]) -> str:
+    raw = json.dumps({"dataValues": chunk_values}, allow_nan=False, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _success_report(
+    plugin: Dhis2ExportPlugin, *, submitted: int, imported: int, payload_sha256: str, created_at: str
+) -> ExportReport:
+    return ExportReport(
+        plugin_id=plugin.id,
+        connection_id="hmis",
+        dry_run=False,
+        outcome=ExportOutcome.SUCCESS,
+        payload_sha256=payload_sha256,
+        submitted=submitted,
+        imported=imported,
+        created_at=created_at,
+        finished_at=created_at,
+    )
+
+
+def test_merge_chunk_reports_precedence() -> None:
+    now = "2026-01-01T00:00:00+00:00"
+
+    def report(outcome: ExportOutcome) -> ExportReport:
+        return ExportReport(
+            plugin_id="dhis2",
+            connection_id="hmis",
+            dry_run=False,
+            outcome=outcome,
+            payload_sha256="a" * 64,
+            submitted=1,
+            created_at=now,
+            finished_at=now,
+        )
+
+    merged = merge_chunk_reports(
+        [report(ExportOutcome.SUCCESS), report(ExportOutcome.PARTIAL), report(ExportOutcome.UNKNOWN)],
+        plugin_id="dhis2",
+        connection_id="hmis",
+        dry_run=False,
+        payload_sha256="a" * 64,
+        created_at=now,
+        finished_at=now,
+        submitted=3,
+    )
+    assert merged.outcome == ExportOutcome.UNKNOWN
+    assert merged.chunks == 3
+    assert merged.attempts == 3
+    assert merged.submitted == 3
+
+    cancelled = merge_chunk_reports(
+        [report(ExportOutcome.SUCCESS)],
+        plugin_id="dhis2",
+        connection_id="hmis",
+        dry_run=False,
+        payload_sha256="a" * 64,
+        created_at=now,
+        finished_at=now,
+        submitted=5,
+        cancelled_early=True,
+    )
+    assert cancelled.outcome == ExportOutcome.CANCELLED
+
+    dry = merge_chunk_reports(
+        [],
+        plugin_id="dhis2",
+        connection_id="hmis",
+        dry_run=True,
+        payload_sha256="a" * 64,
+        created_at=now,
+        finished_at=now,
+    )
+    assert dry.outcome == ExportOutcome.DRY_RUN
+
+
+def test_send_splits_large_payload_into_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=2, poll_backoff_base=0.0, max_poll_attempts=1)
+    values = _values(5)
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        return FakeResponse(200, {"status": "SUCCESS", "importCount": {"imported": len(json["dataValues"])}})
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis")
+
+    assert len(client.posts) == 3
+    assert report.outcome == ExportOutcome.SUCCESS
+    assert report.chunks == 3
+    assert report.submitted == 5
+    assert report.imported == 5
+
+
+def test_send_reuses_completed_checkpoint_and_skips_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=2, poll_backoff_base=0.0, max_poll_attempts=1)
+    values = _values(5)
+    now = "2026-01-01T00:00:00+00:00"
+
+    context = FakeContext()
+    context.checkpoints["chunk:0"] = {
+        "digest": _chunk_digest(values[0:2]),
+        "status": "completed",
+        "report": _success_report(
+            plugin, submitted=2, imported=2, payload_sha256=_chunk_digest(values[0:2]), created_at=now
+        ).model_dump(mode="json"),
+    }
+    context.checkpoints["chunk:1"] = {
+        "digest": _chunk_digest(values[2:4]),
+        "status": "submitted_unknown",
+        "connection_id": "hmis",
+        "dry_run": False,
+        "submitted": 2,
+        "remote_task_ids": [],
+        "created_at": now,
+        "finished_at": now,
+    }
+
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        return FakeResponse(200, {"status": "SUCCESS", "importCount": {"imported": len(json["dataValues"])}})
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis", context=context)
+
+    # Chunk 0 was reused, chunk 1 was not re-sent (unknown), only chunk 2 went out.
+    assert len(client.posts) == 1
+    assert client.posts[0]["json"]["dataValues"] == values[4:5]
+    assert report.outcome == ExportOutcome.UNKNOWN
+    assert report.chunks == 3
+    assert report.imported == 3  # chunk 0 (2) + chunk 2 (1)
+    assert report.submitted == 5
+
+
+def test_send_stops_when_cancellation_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=2, poll_backoff_base=0.0, max_poll_attempts=1)
+    values = _values(5)
+    context = FakeContext()
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        if len(client.posts) == 1:
+            context.cancelled = True
+        return FakeResponse(200, {"status": "SUCCESS", "importCount": {"imported": len(json["dataValues"])}})
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis", context=context)
+
+    assert report.outcome == ExportOutcome.CANCELLED
+    assert len(client.posts) == 1
+    assert report.submitted == 5
+    assert report.imported == 2
+
+
+def test_send_records_unknown_on_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=1000)
+    values = _values(3)
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        raise TimeoutError("read timed out")
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis")
+
+    assert report.outcome == ExportOutcome.UNKNOWN
+    assert report.remote_task_ids == []
+    assert report.submitted == 3
+
+
+def test_send_polls_async_import_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=1000, poll_backoff_base=0.0, max_poll_attempts=5)
+    values = _values(2)
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        return FakeResponse(202, {"id": "task-1", "status": "PENDING"})
+
+    client.post_handler = post
+
+    def get(path: str) -> FakeResponse:
+        if len(client.gets) == 1:
+            return FakeResponse(200, {"status": "RUNNING"})
+        return FakeResponse(200, {"status": "SUCCESS", "importCount": {"imported": 2}})
+
+    client.get_handler = get
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis")
+
+    assert report.outcome == ExportOutcome.SUCCESS
+    assert report.remote_task_ids == ["task-1"]
+    assert len(client.posts) == 1
+    assert len(client.gets) >= 2
+
+
+def test_send_poll_budget_exhaustion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=1000, poll_backoff_base=0.0, max_poll_attempts=3)
+    values = _values(1)
+    client = FakeClient()
+
+    client.post_handler = lambda path, json, params: FakeResponse(202, {"id": "task-1", "status": "PENDING"})
+    client.get_handler = lambda path: FakeResponse(200, {"status": "RUNNING"})
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    report = plugin.send(_payload(values), "hmis")
+
+    assert report.outcome == ExportOutcome.UNKNOWN
+    assert report.remote_task_ids == ["task-1"]
+
+
+def _install_delivery_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    name = "chunky_export_" + uuid4().hex
+    package = tmp_path / name
+    (package / "exports").mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "exports" / "__init__.py").write_text("", encoding="utf-8")
+    (package / "exports" / "chunky.py").write_text(_EXTERNAL_DELIVERY_SOURCE, encoding="utf-8")
+    metadata = tmp_path / f"{name}-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n", encoding="utf-8")
+    (metadata / "entry_points.txt").write_text(f"[open_climate_service.plugins]\n{name} = {name}\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return name
+
+
+_EXTERNAL_DELIVERY_SOURCE = """
+import datetime as dt
+import hashlib
+
+from open_climate_service.exports import (
+    BaseExportPlugin,
+    RenderedExport,
+    ExportOutcome,
+    ExportReport,
+    merge_chunk_reports,
+)
+
+
+class ChunkedDelivery(BaseExportPlugin):
+    id = "chunky"
+    format = "CHUNKY"
+    extension = ".chunky"
+    media_type = "application/x-chunky"
+    version = "1"
+    supports_delivery = True
+
+    def validate_mapping(self, mapping):
+        return mapping
+
+    def render(self, data, mapping):
+        return RenderedExport(data.encode() if isinstance(data, str) else b"rendered", 1)
+
+    def send(self, payload, target, *, dry_run=False, context=None):
+        chunk_size = 3
+        chunks = [payload[i:i + chunk_size] for i in range(0, len(payload), chunk_size)] or [b""]
+        reports = []
+        for index, chunk in enumerate(chunks):
+            if context is not None and context.is_cancel_requested():
+                break
+            key = "chunk:" + str(index)
+            digest = hashlib.sha256(chunk).hexdigest()
+            checkpoint = context.load_checkpoint(key) if context is not None else None
+            if isinstance(checkpoint, dict) and checkpoint.get("digest") == digest and checkpoint.get("report"):
+                reports.append(ExportReport.model_validate(checkpoint["report"]))
+                continue
+            now = dt.datetime.now(dt.timezone.utc).isoformat()
+            reports.append(ExportReport(
+                plugin_id=self.id,
+                connection_id=target,
+                dry_run=dry_run,
+                outcome=ExportOutcome.DRY_RUN if dry_run else ExportOutcome.SUCCESS,
+                payload_sha256=digest,
+                submitted=len(chunk),
+                imported=len(chunk),
+                created_at=now,
+                finished_at=now,
+            ))
+            if context is not None:
+                context.save_checkpoint(key, {"digest": digest, "report": reports[-1].model_dump(mode="json")})
+                context.report_progress(index + 1, len(chunks), "delivering")
+        now = dt.datetime.now(dt.timezone.utc).isoformat()
+        return merge_chunk_reports(
+            reports,
+            plugin_id=self.id,
+            connection_id=target,
+            dry_run=dry_run,
+            payload_sha256=hashlib.sha256(payload).hexdigest(),
+            created_at=now,
+            finished_at=now,
+            submitted=len(payload),
+        )
+
+
+plugin = ChunkedDelivery()
+"""
+
+
+def test_third_party_delivery_plugin_uses_only_public_apis(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from open_climate_service import config
+    from open_climate_service.exports.registry import load_export_plugins
+    from open_climate_service.exports.service import render_named_export
+
+    _install_delivery_fixture(tmp_path, monkeypatch)
+    config.get_config()["exports"] = [{"id": "chunky", "plugin": "chunky"}]
+    plugin = load_export_plugins()["chunky"]
+    assert plugin.supports_delivery is True
+
+    _, rendered = render_named_export("hello world", "CHUNKY", {"export": "chunky"})
+
+    context = FakeContext()
+    report = plugin.send(rendered.content, "some-target", context=context)
+
+    assert isinstance(report, ExportReport)
+    assert report.outcome == ExportOutcome.SUCCESS
+    assert report.chunks == 4  # "hello world" (11 bytes) in chunks of 3
+    assert report.imported == 11
+    assert report.submitted == 11
+    assert len(context.progress) == 4
+    assert all(key.startswith("chunk:") for key in context.checkpoints)
+
+    # A second run over the same context resumes from checkpoints without work.
+    context.progress.clear()
+    again = plugin.send(rendered.content, "some-target", context=context)
+    assert again.outcome == ExportOutcome.SUCCESS
+    assert again.imported == 11

--- a/tests/test_export_delivery_phase5.py
+++ b/tests/test_export_delivery_phase5.py
@@ -304,6 +304,16 @@ def test_send_reports_pre_submission_connection_failure(monkeypatch: pytest.Monk
     assert report.imported == 1000
     assert "Connection failed before submission" in str(report.message)
     assert context.checkpoints["chunk:1"]["report"]["outcome"] == ExportOutcome.REJECTED
+    assert context.checkpoints["chunk:1"]["status"] == "retryable_failed"
+
+    client.post_handler = lambda path, json, params: FakeResponse(
+        200, {"status": "SUCCESS", "importCount": {"imported": len(json["dataValues"])}}
+    )
+    resumed = plugin.send(_payload(values), "hmis", context=context)
+
+    assert resumed.outcome == ExportOutcome.SUCCESS
+    assert resumed.imported == 1001
+    assert len(client.posts) == 3
 
 
 def test_send_keeps_unknown_checkpoint_on_ambiguous_requests_connection_error(

--- a/tests/test_export_delivery_phase5.py
+++ b/tests/test_export_delivery_phase5.py
@@ -15,31 +15,31 @@ from open_climate_service.exports.dhis2_renderer import Dhis2ExportPlugin
 
 
 class FakeResponse:
-    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+    def __init__(self: Any, status_code: int, payload: dict[str, Any]) -> None:
         self.status_code = status_code
         self._payload = payload
 
-    def json(self) -> dict[str, Any]:
+    def json(self: Any) -> dict[str, Any]:
         return self._payload
 
 
 class FakeClient:
-    def __init__(self) -> None:
+    def __init__(self: Any) -> None:
         self.posts: list[dict[str, Any]] = []
         self.gets: list[str] = []
         self.post_handler: Any = None
         self.get_handler: Any = None
 
-    def close(self) -> None:
+    def close(self: Any) -> None:
         pass
 
-    def post(self, path: str, json: Any = None, params: Any = None) -> FakeResponse:
+    def post(self: Any, path: str, json: Any = None, params: Any = None) -> FakeResponse:
         self.posts.append({"path": path, "json": json, "params": params})
         if self.post_handler is None:
             raise AssertionError("Unexpected POST")
         return self.post_handler(path, json, params)
 
-    def get(self, path: str) -> FakeResponse:
+    def get(self: Any, path: str) -> FakeResponse:
         self.gets.append(path)
         if self.get_handler is None:
             raise AssertionError("Unexpected GET")
@@ -47,21 +47,21 @@ class FakeClient:
 
 
 class FakeContext:
-    def __init__(self) -> None:
+    def __init__(self: Any) -> None:
         self.checkpoints: dict[str, Any] = {}
         self.progress: list[tuple[Any, Any, Any]] = []
         self.cancelled = False
 
-    def report_progress(self, done: Any = None, total: Any = None, message: Any = None) -> None:
+    def report_progress(self: Any, done: Any = None, total: Any = None, message: Any = None) -> None:
         self.progress.append((done, total, message))
 
-    def is_cancel_requested(self) -> bool:
+    def is_cancel_requested(self: Any) -> bool:
         return self.cancelled
 
-    def save_checkpoint(self, key: str, state: dict[str, Any]) -> None:
+    def save_checkpoint(self: Any, key: str, state: dict[str, Any]) -> None:
         self.checkpoints[key] = state
 
-    def load_checkpoint(self, key: str) -> dict[str, Any] | None:
+    def load_checkpoint(self: Any, key: str) -> dict[str, Any] | None:
         return self.checkpoints.get(key)
 
 
@@ -251,7 +251,7 @@ def test_send_stops_when_cancellation_requested(monkeypatch: pytest.MonkeyPatch)
 
     assert report.outcome == ExportOutcome.CANCELLED
     assert len(client.posts) == 1
-    assert report.submitted == 5
+    assert report.submitted == 2
     assert report.imported == 2
 
 
@@ -435,3 +435,140 @@ def test_third_party_delivery_plugin_uses_only_public_apis(monkeypatch: pytest.M
     again = plugin.send(rendered.content, "some-target", context=context)
     assert again.outcome == ExportOutcome.SUCCESS
     assert again.imported == 11
+
+
+def test_restart_after_remote_acceptance_does_not_resend(monkeypatch: pytest.MonkeyPatch):
+    from open_climate_service.exports import dhis2
+
+    plugin = _plugin(poll_backoff_base=0)
+    client = FakeClient()
+    context = FakeContext()
+    payload = _payload(_values(1))
+    monkeypatch.setattr(dhis2, "get_connection", lambda _: client)
+
+    def crash_after_acceptance(path: Any, json: Any, params: Any):
+        raise SystemExit("process died after the remote write")
+
+    client.post_handler = crash_after_acceptance
+    with pytest.raises(SystemExit):
+        plugin.send(payload, "hmis", context=context)
+    client.post_handler = lambda *args: pytest.fail("Uncertain chunk must not be resent")
+    report = plugin.send(payload, "hmis", context=context)
+    assert report.outcome == ExportOutcome.UNKNOWN
+    assert len(client.posts) == 1
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"status": "completed", "report": {}},
+        {"status": "unrecognized"},
+        {"status": "completed", "digest": "changed", "report": {}},
+    ],
+)
+def test_corrupt_checkpoint_refuses_resubmission(monkeypatch: pytest.MonkeyPatch, state: dict[str, Any]):
+    from open_climate_service.exports import dhis2
+
+    values = _values(1)
+    client = FakeClient()
+    context = FakeContext()
+    context.checkpoints["chunk:0"] = {"digest": _chunk_digest(values), **state}
+    monkeypatch.setattr(dhis2, "get_connection", lambda _: client)
+    with pytest.raises(ValueError):
+        _plugin().send(_payload(values), "hmis", context=context)
+    assert client.posts == []
+
+
+def test_nested_async_task_is_checkpointed_and_polled_on_restart(monkeypatch: pytest.MonkeyPatch):
+    from open_climate_service.exports import dhis2
+
+    plugin = _plugin(max_poll_attempts=1, poll_backoff_base=0)
+    client = FakeClient()
+    client.post_handler = lambda *args, **kwargs: {
+        "httpStatusCode": 200,
+        "status": "OK",
+        "response": {"jobType": "DATAVALUE_IMPORT", "id": "task1"},
+    }
+    client.get_handler = lambda _: {}
+    context = FakeContext()
+    monkeypatch.setattr(dhis2, "get_connection", lambda _: client)
+    payload = _payload(_values(1))
+    first = plugin.send(payload, "hmis", context=context)
+    assert first.outcome == ExportOutcome.UNKNOWN
+    assert context.checkpoints["chunk:0"]["remote_task_ids"] == ["task1"]
+    client.get_handler = lambda _: {"status": "SUCCESS", "importCount": {"imported": 1}}
+    second = plugin.send(payload, "hmis", context=context)
+    assert second.outcome == ExportOutcome.SUCCESS
+    assert len(client.posts) == 1
+    assert client.gets == ["/api/system/taskSummaries/DATAVALUE_IMPORT/task1"] * 2
+
+
+@pytest.mark.parametrize("status_code,outcome", [(200, ExportOutcome.SUCCESS), (409, ExportOutcome.REJECTED)])
+def test_pinned_client_response_contract(monkeypatch: pytest.MonkeyPatch, status_code: int, outcome: ExportOutcome):
+    import httpx
+
+    from open_climate_service import config
+
+    pytest.importorskip("dhis2_client")
+    monkeypatch.setattr(
+        config,
+        "_cache",
+        {
+            "dhis2_connections": [
+                {"id": "hmis", "url": "https://hmis.example.org/dhis", "token_env": "REVIEW_TEST_TOKEN"},
+            ]
+        },
+    )
+    monkeypatch.setenv("REVIEW_TEST_TOKEN", "test-token")
+    requests = []
+
+    def handler(request: httpx.Request):
+        requests.append(request)
+        assert request.url.path == "/dhis/api/dataValueSets"
+        return httpx.Response(
+            status_code,
+            json={
+                "response": {"status": "SUCCESS" if status_code == 200 else "ERROR", "importCount": {"imported": 1}},
+            },
+        )
+
+    original = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: original(**kwargs, transport=httpx.MockTransport(handler)))
+    report = _plugin().send(_payload(_values(1)), "hmis")
+    assert report.outcome == outcome
+    assert len(requests) == 1
+
+
+def test_installed_plugin_can_deliver_through_framework(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    from open_climate_service import config
+    from open_climate_service.exports.delivery import deliver_named_export
+    from open_climate_service.exports.delivery_input import lease_export_input
+    from open_climate_service.exports.service import write_named_export
+    from open_climate_service.openeo import jobs
+    from open_climate_service.openeo.schemas import OpenEOJobRecord, OpenEOJobStatus
+    from open_climate_service.shared.provenance import json_digest
+    from open_climate_service.shared.time import utc_now
+
+    _install_delivery_fixture(tmp_path, monkeypatch)
+    monkeypatch.setattr(jobs, "_JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "get_data_root", lambda: tmp_path)
+    config.get_config()["exports"] = [{"id": "chunky", "plugin": "chunky", "connection": "hmis"}]
+    config.get_config()["dhis2_connections"] = [
+        {"id": "hmis", "url": "https://example.org", "token_env": "UNSET_TEST_TOKEN"},
+    ]
+    directory = tmp_path / "jobs" / "source" / "results"
+    directory.mkdir(parents=True)
+    path = write_named_export("hello", directory, "CHUNKY", {"export": "chunky"}, job_id="source")
+    jobs.store_create_job(
+        OpenEOJobRecord(
+            id="source",
+            status=OpenEOJobStatus.FINISHED,
+            created=utc_now(),
+            usage={"output_path": path},
+        )
+    )
+    with lease_export_input("chunky", "source") as verified:
+        digest = json_digest(verified.manifest.model_dump(mode="json"))
+    report = deliver_named_export("chunky", "source", expected_manifest_sha256=digest)
+    assert report["outcome"] == "success"
+    assert report["imported"] == 5

--- a/tests/test_export_delivery_phase5.py
+++ b/tests/test_export_delivery_phase5.py
@@ -64,6 +64,9 @@ class FakeContext:
     def load_checkpoint(self: Any, key: str) -> dict[str, Any] | None:
         return self.checkpoints.get(key)
 
+    def delete_checkpoint(self: Any, key: str) -> None:
+        self.checkpoints.pop(key, None)
+
 
 def _values(count: int) -> list[dict[str, Any]]:
     return [
@@ -273,6 +276,52 @@ def test_send_records_unknown_on_transport_timeout(monkeypatch: pytest.MonkeyPat
     assert report.outcome == ExportOutcome.UNKNOWN
     assert report.remote_task_ids == []
     assert report.submitted == 3
+
+
+def test_send_raises_and_clears_checkpoint_on_connect_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=1000)
+    values = _values(3)
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        raise httpx.ConnectError("connection refused")
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    context = FakeContext()
+    with pytest.raises(Exception, match="connection refused"):
+        plugin.send(_payload(values), "hmis", context=context)
+
+    # Nothing reached DHIS2, so the intent checkpoint must be cleared for a retry.
+    assert context.checkpoints.get("chunk:0") is None
+
+
+def test_send_keeps_unknown_checkpoint_on_ambiguous_requests_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import requests
+
+    from open_climate_service.exports import dhis2 as dhis2_module
+
+    plugin = _plugin(max_chunk_size=1000)
+    client = FakeClient()
+
+    def post(path: str, json: Any, params: Any) -> FakeResponse:
+        raise requests.exceptions.ConnectionError("connection reset while reading response")
+
+    client.post_handler = post
+    monkeypatch.setattr(dhis2_module, "get_connection", lambda target: client)
+
+    context = FakeContext()
+    report = plugin.send(_payload(_values(3)), "hmis", context=context)
+
+    assert report.outcome == ExportOutcome.UNKNOWN
+    assert context.checkpoints["chunk:0"]["report"]["outcome"] == ExportOutcome.UNKNOWN
 
 
 def test_send_polls_async_import_task(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -537,6 +586,42 @@ def test_pinned_client_response_contract(monkeypatch: pytest.MonkeyPatch, status
     report = _plugin().send(_payload(_values(1)), "hmis")
     assert report.outcome == outcome
     assert len(requests) == 1
+
+
+def test_warning_summary_is_partial_not_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from open_climate_service import config
+
+    pytest.importorskip("dhis2_client")
+    monkeypatch.setattr(
+        config,
+        "_cache",
+        {
+            "dhis2_connections": [
+                {"id": "hmis", "url": "https://hmis.example.org/dhis", "token_env": "REVIEW_TEST_TOKEN"},
+            ]
+        },
+    )
+    monkeypatch.setenv("REVIEW_TEST_TOKEN", "test-token")
+
+    def handler(request: httpx.Request):
+        return httpx.Response(
+            409,
+            json={
+                "response": {
+                    "status": "WARNING",
+                    "importCount": {"imported": 999},
+                    "conflicts": [{"object": "value"}],
+                }
+            },
+        )
+
+    original = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: original(**kwargs, transport=httpx.MockTransport(handler)))
+    report = _plugin(max_chunk_size=1000).send(_payload(_values(1)), "hmis")
+    assert report.outcome == ExportOutcome.PARTIAL
+    assert report.imported == 999
 
 
 def test_installed_plugin_can_deliver_through_framework(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):

--- a/tests/test_export_manifests.py
+++ b/tests/test_export_manifests.py
@@ -1,0 +1,294 @@
+"""Payload integrity, frozen bindings, observed provenance, and result retention."""
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi import HTTPException
+
+from open_climate_service import config
+from open_climate_service.exports.delivery_input import lease_export_input
+from open_climate_service.exports.manifest import ExportManifest
+from open_climate_service.exports.service import write_named_export
+from open_climate_service.openeo import jobs
+from open_climate_service.openeo.schemas import OpenEOJobRecord, OpenEOJobStatus, OpenEOJobUpdate
+from open_climate_service.shared.provenance import (
+    capture_execution,
+    json_digest,
+    record_features,
+    record_snapshot,
+    record_source,
+)
+from open_climate_service.shared.time import utc_now
+
+
+def _data() -> pd.DataFrame:
+    return pd.DataFrame({"geometry": ["DiszpKrYNg8"] * 2, "t": ["202501", "202502"], "rain": [0.0, float("nan")]})
+
+
+@pytest.fixture
+def saved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(jobs, "_JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(
+        config,
+        "_cache",
+        {
+            "exports": [
+                {
+                    "id": "rain",
+                    "plugin": "dhis2",
+                    "connection": "hmis",
+                    "period_type": "monthly",
+                    "series": [{"data_element": "BXgDHhPdFVU"}],
+                }
+            ],
+            "dhis2_connections": [{"id": "hmis", "url": "https://hmis.example.org/dhis", "token_env": "TEST_TOKEN"}],
+        },
+    )
+    monkeypatch.delenv("TEST_TOKEN", raising=False)
+    directory = tmp_path / "jobs" / "source" / "results"
+    directory.mkdir(parents=True)
+    path = write_named_export(_data(), directory, "DHIS2JSON", {"export": "rain"}, job_id="source")
+    jobs.store_create_job(
+        OpenEOJobRecord(
+            id="source",
+            status=OpenEOJobStatus.FINISHED,
+            created=utc_now(),
+            usage={"output_path": path},
+        )
+    )
+    return Path(path)
+
+
+def _manifest(path: Path) -> ExportManifest:
+    metadata = json.loads((path.parent / ".export.json").read_text())
+    return ExportManifest.model_validate_json((path.parent / metadata["manifest"]).read_bytes())
+
+
+def test_manifest_records_exact_bytes_counts_and_missing_evidence(saved: Path):
+    manifest = _manifest(saved)
+    assert manifest.source_job_id == "source"
+    assert manifest.payload_sha256 == hashlib.sha256(saved.read_bytes()).hexdigest()
+    assert manifest.payload_size == saved.stat().st_size
+    assert (manifest.record_count, manifest.skipped_count) == (1, 1)
+    assert manifest.periods == ["202501"]
+    assert manifest.provenance["missing"] == ["execution_provenance"]
+    assert manifest.plugin.version == "1"
+    with lease_export_input("rain", "source") as verified:
+        assert verified.content == saved.read_bytes()
+        assert verified.manifest == manifest
+
+
+def test_rotation_and_url_normalization_do_not_invalidate_binding(saved: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_TOKEN", "rotated-secret")
+    config.get_config()["dhis2_connections"][0]["url"] = "https://HMIS.EXAMPLE.ORG:443/dhis/"
+    with lease_export_input("rain", "source") as verified:
+        serialized = verified.manifest.model_dump_json()
+        assert "rotated-secret" not in serialized
+        assert "TEST_TOKEN" not in serialized
+        assert "https://" not in serialized
+
+
+@pytest.mark.parametrize("change", ["mapping", "target", "connection", "version", "reference", "process"])
+def test_changed_bindings_are_conflicts(saved: Path, monkeypatch: pytest.MonkeyPatch, change: str):
+    definition = config.get_config()["exports"][0]
+    if change == "mapping":
+        definition["series"][0]["data_element"] = "Ix2HsbDMLea"
+    elif change == "target":
+        config.get_config()["dhis2_connections"][0]["url"] = "https://another.example.org"
+    elif change == "connection":
+        definition["connection"] = "other"
+    elif change == "reference":
+        definition["dataset"] = "other"
+    elif change == "version":
+        monkeypatch.setattr("open_climate_service.exports.dhis2_renderer.Dhis2ExportPlugin.version", "2")
+    else:
+        # Construct a fresh manifest with the original graph digest, then change the job graph.
+        path = write_named_export(
+            _data(),
+            saved.parent,
+            "DHIS2JSON",
+            {"export": "rain"},
+            job_id="source",
+            provenance={"process_sha256": json_digest({}), "sources": []},
+        )
+        jobs.store_update_job(
+            "source",
+            lambda record: record.model_copy(
+                update={
+                    "usage": {"output_path": path},
+                    "process": {"process_graph": {}},
+                }
+            ),
+        )
+    with pytest.raises(HTTPException) as error:
+        with lease_export_input("rain", "source"):
+            pytest.fail("Changed export must not be accepted")
+    assert error.value.status_code == 409
+
+
+@pytest.mark.parametrize("change", ["payload", "manifest", "metadata", "missing", "legacy", "path", "version"])
+def test_corrupt_missing_and_legacy_assets_are_rejected(saved: Path, change: str):
+    metadata_path = saved.parent / ".export.json"
+    metadata = json.loads(metadata_path.read_text())
+    if change == "payload":
+        saved.write_bytes(saved.read_bytes() + b" ")
+    elif change == "missing":
+        saved.unlink()
+    elif change == "legacy":
+        del metadata["manifest"]
+        metadata_path.write_text(json.dumps(metadata))
+    elif change == "path":
+        metadata["manifest"] = "../../outside.json"
+        metadata_path.write_text(json.dumps(metadata))
+    elif change == "metadata":
+        metadata["record_count"] += 1
+        metadata_path.write_text(json.dumps(metadata))
+    else:
+        path = saved.parent / metadata["manifest"]
+        if change == "manifest":
+            path.write_bytes(path.read_bytes() + b" ")
+        else:
+            value = json.loads(path.read_text())
+            value["schema_version"] = 99
+            path.write_text(json.dumps(value))
+            metadata["manifest_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+            metadata_path.write_text(json.dumps(metadata))
+    with pytest.raises(HTTPException) as error:
+        with lease_export_input("rain", "source"):
+            pytest.fail("Invalid export must not be accepted")
+    assert error.value.status_code == 409
+
+
+@pytest.mark.parametrize("status", [OpenEOJobStatus.RUNNING, OpenEOJobStatus.ERROR, OpenEOJobStatus.CANCELED])
+def test_only_finished_jobs_are_eligible(saved: Path, status: OpenEOJobStatus):
+    jobs.store_update_job("source", lambda record: record.model_copy(update={"status": status}))
+    with pytest.raises(HTTPException, match="409"):
+        with lease_export_input("rain", "source"):
+            pytest.fail("Incomplete job must not be accepted")
+
+
+def test_wrong_export_and_missing_job(saved: Path):
+    for export, job_id, status in [("other", "source", 409), ("rain", "missing", 404)]:
+        with pytest.raises(HTTPException) as error:
+            with lease_export_input(export, job_id):
+                pytest.fail("Wrong source binding must not be accepted")
+        assert error.value.status_code == status
+
+
+def test_lease_blocks_mutation_and_releases_after_exception(saved: Path):
+    service = jobs.OpenEOJobService()
+    try:
+        with pytest.raises(RuntimeError, match="consumer failed"):
+            with lease_export_input("rain", "source"):
+                for operation in (
+                    lambda: service.delete_job("source"),
+                    lambda: service.start_job("source"),
+                    lambda: service.update_job("source", OpenEOJobUpdate(title="changed")),
+                ):
+                    with pytest.raises(HTTPException) as error:
+                        operation()
+                    assert error.value.status_code == 409
+                raise RuntimeError("consumer failed")
+        service.delete_job("source")
+        assert not saved.exists()
+    finally:
+        service.shutdown()
+
+
+def test_failed_publication_keeps_previous_generation(saved: Path, monkeypatch: pytest.MonkeyPatch):
+    from open_climate_service.exports import manifest as module
+
+    original = module.atomic_write
+    old_metadata = (saved.parent / ".export.json").read_bytes()
+
+    def fail_manifest(path: Path, content: bytes) -> None:
+        if path.name.endswith(".manifest.json"):
+            raise OSError("simulated write failure")
+        original(path, content)
+
+    monkeypatch.setattr(module, "atomic_write", fail_manifest)
+    with pytest.raises(OSError, match="simulated"):
+        write_named_export(_data(), saved.parent, "DHIS2JSON", {"export": "rain"}, job_id="source")
+    assert (saved.parent / ".export.json").read_bytes() == old_metadata
+    with lease_export_input("rain", "source") as verified:
+        assert verified.content == saved.read_bytes()
+
+
+def test_unbound_export_remains_downloadable_but_cannot_be_delivered(saved: Path):
+    del config.get_config()["exports"][0]["connection"]
+    path = write_named_export(_data(), saved.parent, "DHIS2JSON", {"export": "rain"}, job_id="source")
+    jobs.store_update_job("source", lambda record: record.model_copy(update={"usage": {"output_path": path}}))
+    assert _manifest(Path(path)).target is None
+    with pytest.raises(HTTPException, match="without a delivery target"):
+        with lease_export_input("rain", "source"):
+            pytest.fail("Unbound export must not be accepted")
+
+
+def test_feature_and_snapshot_evidence_is_execution_scoped():
+    feature = {
+        "type": "Feature",
+        "id": "DiszpKrYNg8",
+        "geometry": {"type": "Point", "coordinates": [0, 0]},
+        "properties": {"secret": "never copied"},
+    }
+    artifact = SimpleNamespace(path="/private/path", artifact_id="artifact-1", source_dataset_id="rain")
+    with capture_execution({"process_graph": {}}) as outer:
+        record_snapshot(artifact.path, "actual-readonly-snapshot")
+        record_source("managed-rain", artifact)
+        record_features(feature)
+        with capture_execution({}) as inner:
+            record_features({**feature, "id": None})
+        assert inner.describe()["sources"] == []
+        assert inner.describe()["features"][0]["ids_valid"] is False
+        evidence = outer.describe()
+    assert evidence["sources"][0]["snapshot_id"] == "actual-readonly-snapshot"
+    assert evidence["features"][0]["ids_valid"] is True
+    assert "/private/path" not in json.dumps(evidence)
+    assert "never copied" not in json.dumps(evidence)
+
+
+def test_run_graph_attaches_native_observations(monkeypatch: pytest.MonkeyPatch):
+    from open_climate_service.openeo import execution
+    from open_climate_service.plugins.processes.aggregate_spatial import _parse_geometries
+
+    artifact = SimpleNamespace(path="/source", artifact_id="artifact-1", source_dataset_id="rain")
+    monkeypatch.setattr(execution, "_get_published_artifact", lambda _: artifact)
+    monkeypatch.setattr(execution, "_open_artifact", lambda _: xr.Dataset({"rain": ("t", [1])}))
+    monkeypatch.setattr(execution, "_ensure_crs", lambda data: data)
+    monkeypatch.setattr(execution, "_build_process_registry", lambda: {})
+    monkeypatch.setattr(execution, "_augment_with_workflows", lambda registry: registry)
+
+    class Graph:
+        def __init__(self, graph: Any):
+            pass
+
+        def to_callable(self, registry: Any):
+            def execute():
+                execution._load_collection_impl("managed-rain")
+                _parse_geometries(
+                    {"type": "Feature", "id": "DiszpKrYNg8", "geometry": {"type": "Point", "coordinates": [0, 0]}}
+                )
+                return execution.SaveResultEnvelope(_data(), "DHIS2JSON", {"export": "rain"})
+
+            return execute
+
+    monkeypatch.setattr("openeo_pg_parser_networkx.OpenEOProcessGraph", Graph)
+    result = execution.run_process_graph({"process_graph": {}})
+    assert result.provenance["sources"][0]["artifact_id"] == "artifact-1"
+    assert result.provenance["features"][0]["input_sha256"]
+
+
+def test_export_environment_interpolation_rejected_before_caching(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    path.write_text("exports:\n  - id: rain\n    plugin: dhis2\n    data_element: ${SECRET}\n")
+    monkeypatch.setenv("CLIMATE_SERVICE_CONFIG", str(path))
+    monkeypatch.setenv("SECRET", "secret: [invalid yaml")
+    with pytest.raises(ValueError, match="literal"):
+        config.get_config()
+    assert config._cache is None

--- a/tests/test_export_manifests.py
+++ b/tests/test_export_manifests.py
@@ -132,12 +132,14 @@ def test_changed_bindings_are_conflicts(saved: Path, monkeypatch: pytest.MonkeyP
     assert error.value.status_code == 409
 
 
-@pytest.mark.parametrize("change", ["payload", "manifest", "metadata", "missing", "legacy", "path", "version"])
+@pytest.mark.parametrize("change", ["payload", "manifest", "metadata", "missing", "legacy", "path", "version", "corrupt"])
 def test_corrupt_missing_and_legacy_assets_are_rejected(saved: Path, change: str):
     metadata_path = saved.parent / ".export.json"
     metadata = json.loads(metadata_path.read_text())
     if change == "payload":
         saved.write_bytes(saved.read_bytes() + b" ")
+    elif change == "corrupt":
+        metadata_path.write_text("{ this is not valid json", encoding="utf-8")
     elif change == "missing":
         saved.unlink()
     elif change == "legacy":

--- a/tests/test_export_manifests.py
+++ b/tests/test_export_manifests.py
@@ -265,10 +265,10 @@ def test_run_graph_attaches_native_observations(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(execution, "_augment_with_workflows", lambda registry: registry)
 
     class Graph:
-        def __init__(self, graph: Any):
+        def __init__(self: Any, graph: Any):
             pass
 
-        def to_callable(self, registry: Any):
+        def to_callable(self: Any, registry: Any):
             def execute():
                 execution._load_collection_impl("managed-rain")
                 _parse_geometries(
@@ -292,3 +292,36 @@ def test_export_environment_interpolation_rejected_before_caching(monkeypatch: p
     with pytest.raises(ValueError, match="literal"):
         config.get_config()
     assert config._cache is None
+
+
+def test_snapshot_paths_are_normalized(tmp_path: Path):
+    artifact = SimpleNamespace(path=str(tmp_path) + "/./store/", artifact_id="a", source_dataset_id="rain")
+    with capture_execution({}) as evidence:
+        record_snapshot(str(tmp_path / "store"), "snapshot")
+        record_source("rain", artifact)
+    assert evidence.describe()["sources"][0]["snapshot_id"] == "snapshot"
+
+
+@pytest.mark.parametrize("ids", [[None], ["same", "same"]])
+def test_named_dhis2_graph_validates_original_feature_ids(ids: list[str | None]):
+    from open_climate_service.plugins.processes.aggregate_spatial import _parse_geometries
+
+    process = {
+        "process_graph": {
+            "save": {
+                "process_id": "save_result",
+                "arguments": {
+                    "format": "DHIS2JSON",
+                    "options": {"export": "rain"},
+                },
+            }
+        }
+    }
+    features = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "id": value, "geometry": {"type": "Point", "coordinates": [0, 0]}} for value in ids
+        ],
+    }
+    with capture_execution(process), pytest.raises(ValueError, match="Feature .*feature.id"):
+        _parse_geometries(features)

--- a/tests/test_export_manifests.py
+++ b/tests/test_export_manifests.py
@@ -132,7 +132,10 @@ def test_changed_bindings_are_conflicts(saved: Path, monkeypatch: pytest.MonkeyP
     assert error.value.status_code == 409
 
 
-@pytest.mark.parametrize("change", ["payload", "manifest", "metadata", "missing", "legacy", "path", "version", "corrupt"])
+@pytest.mark.parametrize(
+    "change",
+    ["payload", "manifest", "metadata", "missing", "legacy", "path", "version", "corrupt"],
+)
 def test_corrupt_missing_and_legacy_assets_are_rejected(saved: Path, change: str):
     metadata_path = saved.parent / ".export.json"
     metadata = json.loads(metadata_path.read_text())

--- a/tests/test_export_multiseries.py
+++ b/tests/test_export_multiseries.py
@@ -103,6 +103,18 @@ def test_multi_series_merged_cube_pivots_away_internal_dimension(definition: dic
     assert by_element["POPU0000001"] == "45000"
 
 
+def test_scalar_coordinate_is_not_treated_as_residual_dimension(definition: dict[str, Any]):
+    definition["series"] = definition["series"][:1]
+    data = xr.Dataset(
+        {"temperature": (("t", "geometry"), [[26.4]])},
+        coords={"t": ["202501"], "geometry": ["DiszpKrYNg8"], "height": 2.0},
+    )
+
+    values = json.loads(_render(data, definition).content)["dataValues"]
+
+    assert values[0]["value"] == "26.4"
+
+
 def test_multi_series_quantile_selection(definition: dict[str, Any]):
     definition["series"] = [
         {"select": {"variable": "precip", "quantile": 0.1}, "data_element": "PREC0000001"},

--- a/tests/test_export_multiseries.py
+++ b/tests/test_export_multiseries.py
@@ -1,0 +1,166 @@
+"""Slice 6: multi-series rendering to multiple DHIS2 data elements."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from open_climate_service import config
+from open_climate_service.exports.service import render_named_export
+
+
+@pytest.fixture
+def definition(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    definition: dict[str, Any] = {
+        "id": "three",
+        "plugin": "dhis2",
+        "period_type": "monthly",
+        "series": [
+            {"select": {"variable": "temperature"}, "data_element": "TEMP0000001"},
+            {"select": {"variable": "precipitation"}, "data_element": "PREC0000001"},
+            {"select": {"variable": "population"}, "data_element": "POPU0000001"},
+        ],
+    }
+    monkeypatch.setattr(config, "_cache", {"exports": [definition]})
+    return definition
+
+
+def _render(data: Any, definition: dict[str, Any]) -> Any:
+    return render_named_export(data, "DHIS2JSON", {"export": definition["id"]})[1]
+
+
+def test_multi_series_wide_frame(definition: dict[str, Any]):
+    frame = pd.DataFrame(
+        {
+            "geometry": ["DiszpKrYNg8", "DiszpKrYNg8"],
+            "t": ["202501", "202502"],
+            "temperature": [26.4, 27.0],
+            "precipitation": [112.0, 100.0],
+            "population": [45000, 45100],
+        }
+    )
+    rendered = _render(frame, definition)
+    values = json.loads(rendered.content)["dataValues"]
+    assert len(values) == 6
+    assert rendered.record_count == 6
+    assert rendered.skipped_count == 0
+    assert rendered.periods == ("202501", "202502")
+
+    by_key = {(value["dataElement"], value["orgUnit"], value["period"]): value["value"] for value in values}
+    assert by_key[("TEMP0000001", "DiszpKrYNg8", "202501")] == "26.4"
+    assert by_key[("PREC0000001", "DiszpKrYNg8", "202502")] == "100"
+    assert by_key[("POPU0000001", "DiszpKrYNg8", "202501")] == "45000"
+
+
+def test_multi_series_merged_cube_pivots_away_internal_dimension(definition: dict[str, Any]):
+    # merge_cubes yields one value array stacked on a synthetic "__cubes__" dim.
+    merged = xr.DataArray(
+        [[[26.4, 112.0, 45000.0]]],
+        dims=("t", "geometry", "__cubes__"),
+        coords={
+            "t": ["202501"],
+            "geometry": ["DiszpKrYNg8"],
+            "__cubes__": ["temperature", "precipitation", "population"],
+        },
+        name="result",
+    )
+    rendered = _render(merged, definition)
+    values = json.loads(rendered.content)["dataValues"]
+    assert rendered.record_count == 3
+    assert {value["dataElement"] for value in values} == {"TEMP0000001", "PREC0000001", "POPU0000001"}
+    by_element = {value["dataElement"]: value["value"] for value in values}
+    assert by_element["TEMP0000001"] == "26.4"
+    assert by_element["PREC0000001"] == "112"
+    assert by_element["POPU0000001"] == "45000"
+
+
+def test_multi_series_quantile_selection(definition: dict[str, Any]):
+    definition["series"] = [
+        {"select": {"variable": "precip", "quantile": 0.1}, "data_element": "PREC0000001"},
+        {"select": {"variable": "precip", "quantile": 0.9}, "data_element": "PREC0000002"},
+    ]
+    ds = xr.Dataset(
+        {"precip": (("t", "geometry", "quantile"), [[[1.0, 9.0]]])},
+        coords={"t": ["202501"], "geometry": ["DiszpKrYNg8"], "quantile": [0.1, 0.9]},
+    )
+    rendered = _render(ds, definition)
+    values = json.loads(rendered.content)["dataValues"]
+    assert {(value["dataElement"], value["value"]) for value in values} == {
+        ("PREC0000001", "1"),
+        ("PREC0000002", "9"),
+    }
+
+
+def test_multi_series_skips_missing_values_per_series(definition: dict[str, Any]):
+    definition["series"] = definition["series"][:2]
+    frame = pd.DataFrame(
+        {
+            "geometry": ["DiszpKrYNg8", "DiszpKrYNg8"],
+            "t": ["202501", "202502"],
+            "temperature": [26.4, np.nan],
+            "precipitation": [np.nan, 100.0],
+        }
+    )
+    rendered = _render(frame, definition)
+    assert rendered.record_count == 2
+    assert rendered.skipped_count == 2
+
+
+def test_multi_series_duplicate_destination_key_rejected(definition: dict[str, Any]):
+    definition["series"] = [
+        {"select": {"variable": "temperature"}, "data_element": "TEMP0000001"},
+        {"select": {"variable": "temperature"}, "data_element": "TEMP0000001"},
+    ]
+    frame = pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "temperature": [26.4]})
+    with pytest.raises(ValueError, match="Duplicate DHIS2 value"):
+        _render(frame, definition)
+
+
+def test_multi_series_unresolved_variable_rejected(definition: dict[str, Any]):
+    frame = pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "temperature": [26.4]})
+    with pytest.raises(ValueError, match="not present in the result"):
+        _render(frame, definition)
+
+
+def test_multi_series_ambiguous_empty_selector_rejected(definition: dict[str, Any]):
+    definition["series"] = [{"select": {}, "data_element": "TEMP0000001"}]
+    frame = pd.DataFrame(
+        {"geometry": ["DiszpKrYNg8"], "t": ["202501"], "temperature": [26.4], "precipitation": [112.0]}
+    )
+    with pytest.raises(ValueError, match="exactly one value column"):
+        _render(frame, definition)
+
+
+def test_multi_series_captures_all_contributing_sources(definition: dict[str, Any], tmp_path: Path):
+    import hashlib
+
+    from open_climate_service.exports.manifest import ExportManifest
+    from open_climate_service.exports.service import write_named_export
+
+    definition["series"] = [
+        {"select": {"variable": "temperature"}, "data_element": "TEMP0000001"},
+        {"select": {"variable": "population"}, "data_element": "POPU0000001"},
+    ]
+    frame = pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "temperature": [26.4], "population": [45000]})
+    directory = tmp_path / "results"
+    directory.mkdir()
+    provenance = {
+        "process_sha256": hashlib.sha256(b"{}").hexdigest(),
+        "sources": [
+            {"collection_id": "era5-temperature", "artifact_id": "a1", "source_dataset_id": None, "snapshot_id": "s1"},
+            {"collection_id": "worldpop", "artifact_id": "a2", "source_dataset_id": None, "snapshot_id": "s2"},
+        ],
+        "features": [],
+        "missing": [],
+    }
+    path = write_named_export(frame, directory, "DHIS2JSON", {"export": "three"}, job_id="j", provenance=provenance)
+    metadata = json.loads((Path(path).parent / ".export.json").read_text())
+    manifest = ExportManifest.model_validate_json((Path(path).parent / metadata["manifest"]).read_bytes())
+    collections = {source["collection_id"] for source in manifest.provenance["sources"]}
+    assert collections == {"era5-temperature", "worldpop"}

--- a/tests/test_export_multiseries.py
+++ b/tests/test_export_multiseries.py
@@ -15,6 +15,29 @@ from open_climate_service import config
 from open_climate_service.exports.service import render_named_export
 
 
+@pytest.mark.parametrize("field", ["category_option_combo", "attribute_option_combo"])
+def test_implicit_and_explicit_defaults_cannot_evade_duplicates(definition: dict[str, Any], field: str):
+    definition["series"] = [
+        {"select": {"variable": "temperature"}, "data_element": "TEMP0000001"},
+        {"select": {"variable": "temperature"}, "data_element": "TEMP0000001", field: "HllvX50cXC0"},
+    ]
+    with pytest.raises(ValueError, match="resolve defaults"):
+        _render(pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "temperature": [1]}), definition)
+
+
+def test_quantile_selector_does_not_treat_coordinate_as_value(definition: dict[str, Any]):
+    series: dict[str, Any] = {"select": {"quantile": 0.1}, "data_element": "TEMP0000001"}
+    definition["series"] = [series]
+    frame = pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "quantile": [0.1], "temperature": [3]})
+    assert json.loads(_render(frame, definition).content)["dataValues"][0]["value"] == "3"
+    series["select"] = {"variable": "quantile", "quantile": 0.1}
+    with pytest.raises(ValueError, match="Selected variable"):
+        _render(frame, definition)
+    series["select"] = {"quantile": 0.9}
+    with pytest.raises(ValueError, match="not present"):
+        _render(frame, definition)
+
+
 @pytest.fixture
 def definition(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     definition: dict[str, Any] = {

--- a/tests/test_export_plugins.py
+++ b/tests/test_export_plugins.py
@@ -1,0 +1,245 @@
+"""Named export rendering, plugin discovery, and openEO integration."""
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from open_climate_service import config
+from open_climate_service.exports import RenderedExport
+from open_climate_service.exports.registry import load_export_plugins
+from open_climate_service.exports.service import render_named_export
+from open_climate_service.openeo.execution import SaveResultEnvelope
+from open_climate_service.openeo.jobs import OpenEOJobService, _build_dhis2_json_payload, _result_assets
+from open_climate_service.openeo.schemas import OpenEOJobRecord, OpenEOJobStatus
+from open_climate_service.shared.time import utc_now
+
+
+@pytest.fixture
+def definition(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    definition: dict[str, Any] = {
+        "id": "rainfall",
+        "plugin": "dhis2",
+        "period_type": "monthly",
+        "series": [{"select": {}, "data_element": "BXgDHhPdFVU"}],
+    }
+    monkeypatch.setattr(config, "_cache", {"exports": [definition]})
+    return definition
+
+
+def _frame(**overrides: Any) -> pd.DataFrame:
+    return pd.DataFrame({"geometry": ["DiszpKrYNg8"], "t": ["202501"], "precip": [0.0]} | overrides)
+
+
+def _render(data: Any) -> RenderedExport:
+    return render_named_export(data, "DHIS2JSON", {"export": "rainfall"})[1]
+
+
+def test_single_series_matches_legacy_without_resolving_credentials(definition: dict[str, Any]):
+    definition["connection"] = "national-hmis"
+    frame = _frame(t=["202501", "202502"], geometry=["DiszpKrYNg8"] * 2, precip=[0, np.nan])
+    rendered = _render(frame)
+    assert json.loads(rendered.content) == _build_dhis2_json_payload(
+        frame,
+        {"data_element_id": "BXgDHhPdFVU", "org_unit_field": "geometry", "period_type": "monthly"},
+    )
+    assert rendered.record_count == 1
+    assert rendered.skipped_count == 1
+    assert "token" not in json.dumps(config.get_config())
+
+
+@pytest.mark.parametrize("value", [None, "0", "OU_1", 7, ""])
+def test_missing_or_fallback_org_units_fail(definition: dict[str, Any], value: Any):
+    with pytest.raises(ValueError, match="feature.id"):
+        _render(_frame(geometry=[value]))
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), "23.4", [1, 2]])
+def test_invalid_values_fail(definition: dict[str, Any], value: Any):
+    with pytest.raises(ValueError):
+        _render(_frame(precip=[value]))
+
+
+@pytest.mark.parametrize("period", ["202413", "202400", None])
+def test_invalid_periods_fail(definition: dict[str, Any], period: Any):
+    with pytest.raises(ValueError):
+        _render(_frame(t=[period]))
+
+
+def test_dekads_cannot_be_collapsed_by_formatting(definition: dict[str, Any]):
+    with pytest.raises(ValueError, match="Duplicate DHIS2 value"):
+        _render(_frame(t=["2025-01-01", "2025-01-11"], geometry=["DiszpKrYNg8"] * 2, precip=[1, 2]))
+
+
+@pytest.mark.parametrize(
+    ("kind", "period"),
+    [("daily", "20250228"), ("weekly", "2025W01"), ("quarterly", "2025Q1"), ("yearly", "2025")],
+)
+def test_supported_periods(definition: dict[str, Any], kind: str, period: str):
+    definition["period_type"] = kind
+    assert json.loads(_render(_frame(t=[period])).content)["dataValues"][0]["period"] == period
+
+
+def test_variable_selection_and_option_combinations(definition: dict[str, Any]):
+    definition["series"][0].update(
+        select={"variable": "precip"}, category_option_combo="bRowv6yZOF2", attribute_option_combo="HllvX50cXC0"
+    )
+    frame = _frame(temperature=[25.0])
+    ds = frame.set_index(["geometry", "t"]).to_xarray()
+    rendered = _render(ds)
+    value = json.loads(rendered.content)["dataValues"][0]
+    assert value["value"] == "0"
+    assert value["categoryOptionCombo"] == "bRowv6yZOF2"
+    assert value["attributeOptionCombo"] == "HllvX50cXC0"
+    assert len(ds.data_vars) == 2
+
+
+def test_unresolved_dimensions_fail(definition: dict[str, Any]):
+    ds = xr.Dataset({"precip": (("t", "geometry", "quantile"), np.zeros((1, 1, 2)))})
+    with pytest.raises(ValueError, match="only organisation-unit and period dimensions"):
+        _render(ds)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"series": []},
+        {"series": [{"data_element": "BXgDHhPdFVU"}] * 2},
+        {"series": [{"data_element": "bad"}]},
+        {"series": [{"data_element": "BXgDHhPdFVU", "select": {"quantile": 0.1}}]},
+        {"period_type": "dekadal"},
+        {"period_type": None},
+        {"token": "invalid-secret"},
+        {"plugin": "missing"},
+    ],
+)
+def test_bad_mappings_fail(definition: dict[str, Any], change: dict[str, Any]):
+    definition.update(change)
+    with pytest.raises(ValueError):
+        _render(_frame())
+
+
+def test_mapping_is_not_mutated_and_request_cannot_override_it(definition: dict[str, Any]):
+    original = json.dumps(definition)
+    _render(_frame())
+    assert json.dumps(definition) == original
+    with pytest.raises(ValueError, match="only"):
+        render_named_export(_frame(), "DHIS2JSON", {"export": "rainfall", "data_element_id": "OtherElemen"})
+    with pytest.raises(ValueError, match="requires format"):
+        render_named_export(_frame(), "CHAPCSV", {"export": "rainfall"})
+
+
+def test_duplicate_export_ids_fail(definition: dict[str, Any]):
+    config.get_config()["exports"].append(definition.copy())
+    with pytest.raises(ValueError, match="Duplicate export ID"):
+        _render(_frame())
+
+
+def _plugin_source(marker: str) -> str:
+    return (
+        "from open_climate_service.exports import BaseExportPlugin, RenderedExport\n"
+        "class ExampleExport(BaseExportPlugin):\n"
+        "    id = 'example'\n"
+        "    format = 'EXAMPLE'\n"
+        "    extension = '.example'\n"
+        "    media_type = 'application/x-example'\n"
+        "    def validate_mapping(self, mapping):\n"
+        "        return mapping\n"
+        "    def render(self, data, mapping):\n"
+        f"        return RenderedExport({marker!r}.encode(), 1)\n"
+        "plugin = ExampleExport()\n"
+    )
+
+
+def _install_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    name = "example_export_" + uuid4().hex
+    package = tmp_path / name
+    (package / "exports").mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    (package / "exports" / "__init__.py").write_text("")
+    (package / "exports" / "example.py").write_text(_plugin_source("installed"))
+    metadata = tmp_path / f"{name}-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n")
+    (metadata / "entry_points.txt").write_text(f"[open_climate_service.plugins]\n{name} = {name}\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return name
+
+
+def test_installed_plugin_discovery_and_instance_precedence(
+    definition: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _install_fixture(tmp_path, monkeypatch)
+    plugin = load_export_plugins()["example"]
+    assert plugin.render(None, {}).content == b"installed"
+    local = tmp_path / "instance" / "exports"
+    local.mkdir(parents=True)
+    (local / "_helper.py").write_text("MARKER = 'local'\n")
+    (local / "example.py").write_text(
+        "from ._helper import MARKER\n" + _plugin_source("local").replace("'local'.encode()", "MARKER.encode()")
+    )
+    config.get_config()["plugins_dir"] = str(local.parent)
+    assert load_export_plugins()["example"].render(None, {}).content == b"local"
+
+
+def test_broken_plugin_is_not_silently_ignored(definition: dict[str, Any], tmp_path: Path):
+    local = tmp_path / "exports"
+    local.mkdir()
+    (local / "broken.py").write_text("plugin = object()\n")
+    config.get_config()["plugins_dir"] = str(tmp_path)
+    with pytest.raises(ValueError, match="BaseExportPlugin"):
+        load_export_plugins()
+
+
+def test_sync_and_batch_external_export(
+    definition: dict[str, Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path, client: TestClient
+):
+    _install_fixture(tmp_path, monkeypatch)
+    definition.clear()
+    definition.update(id="rainfall", plugin="example")
+    envelope = SaveResultEnvelope(_frame(), "EXAMPLE", {"export": "rainfall"})
+    monkeypatch.setattr("open_climate_service.openeo.execution.run_process_graph", lambda *args: envelope)
+    formats = client.get("/file_formats").json()["output"]
+    assert "export" in formats["EXAMPLE"]["parameters"]
+    response = client.post("/result", json={"process_graph": {}})
+    assert response.status_code == 200
+    assert response.content == b"installed"
+    assert response.headers["content-type"] == "application/x-example"
+
+    monkeypatch.setattr("open_climate_service.openeo.jobs._JOBS_DIR", tmp_path / "jobs")
+    service = OpenEOJobService()
+    try:
+        path = service._persist_result("job-example", envelope)
+    finally:
+        service.shutdown()
+    assert path is not None
+    record = OpenEOJobRecord(
+        id="job-example", status=OpenEOJobStatus.FINISHED, created=utc_now(), usage={"output_path": path}
+    )
+    asset = _result_assets(record)["result"]
+    assert asset["type"] == "application/x-example"
+    response = client.get(asset["href"])
+    assert response.content == b"installed"
+    assert response.headers["content-type"] == "application/x-example"
+    # Historical asset metadata does not depend on the current plugin definition.
+    config.get_config()["exports"] = []
+    assert _result_assets(record) == {"result": asset}
+
+
+def test_sync_named_dhis2_in_read_only_mode(
+    definition: dict[str, Any], monkeypatch: pytest.MonkeyPatch, client: TestClient
+):
+    config.get_config()["read_only"] = True
+    envelope = SaveResultEnvelope(_frame(), "DHIS2JSON", {"export": "rainfall"})
+    monkeypatch.setattr("open_climate_service.openeo.execution.run_process_graph", lambda *args: envelope)
+    response = client.post("/result", json={"process_graph": {}})
+    assert response.status_code == 200
+    assert response.json()["dataValues"][0]["value"] == "0"
+    definition["series"][0]["data_element"] = "invalid"
+    assert client.post("/result", json={"process_graph": {}}).status_code == 400

--- a/tests/test_export_plugins.py
+++ b/tests/test_export_plugins.py
@@ -188,13 +188,13 @@ def test_installed_plugin_discovery_and_instance_precedence(
     assert load_export_plugins()["example"].render(None, {}).content == b"local"
 
 
-def test_broken_plugin_is_not_silently_ignored(definition: dict[str, Any], tmp_path: Path):
+def test_broken_plugin_is_skipped(definition: dict[str, Any], tmp_path: Path):
     local = tmp_path / "exports"
     local.mkdir()
     (local / "broken.py").write_text("plugin = object()\n")
     config.get_config()["plugins_dir"] = str(tmp_path)
-    with pytest.raises(ValueError, match="BaseExportPlugin"):
-        load_export_plugins()
+    plugins = load_export_plugins()
+    assert set(plugins) == {"dhis2"}
 
 
 def test_sync_and_batch_external_export(

--- a/tests/test_export_plugins.py
+++ b/tests/test_export_plugins.py
@@ -228,8 +228,10 @@ def test_sync_and_batch_external_export(
     assert response.content == b"installed"
     assert response.headers["content-type"] == "application/x-example"
     # Historical asset metadata does not depend on the current plugin definition.
+    assets = _result_assets(record)
+    assert "manifest" in assets
     config.get_config()["exports"] = []
-    assert _result_assets(record) == {"result": asset}
+    assert _result_assets(record) == assets
 
 
 def test_sync_named_dhis2_in_read_only_mode(

--- a/tests/test_native_job_persistence.py
+++ b/tests/test_native_job_persistence.py
@@ -1,0 +1,82 @@
+"""Concurrent writers and interrupted replacement must retain committed job state."""
+
+import multiprocessing
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from open_climate_service.jobs import store
+from open_climate_service.jobs.models import JobRecord, JobStatus
+from open_climate_service.shared.time import utc_now
+
+
+def _increment(directory: str, ready: Any, start: Any):
+    store.JOBS_DIR = Path(directory)
+    store.JOBS_INDEX_PATH = store.JOBS_DIR / "jobs.json"
+    ready.put(True)
+    start.wait(10)
+    for _ in range(10):
+
+        def mutate(record: JobRecord):
+            time.sleep(0.002)
+            return record.model_copy(update={"request": {"count": record.request["count"] + 1}})
+
+        store.mutate_job_record("counter", mutate)
+
+
+def test_processes_do_not_lose_updates_across_atomic_replacement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(store, "JOBS_DIR", tmp_path)
+    monkeypatch.setattr(store, "JOBS_INDEX_PATH", tmp_path / "jobs.json")
+    store.create_job_record(
+        JobRecord(
+            job_id="counter",
+            process_id="test",
+            status=JobStatus.ACCEPTED,
+            created_at=utc_now(),
+            request={"count": 0},
+        )
+    )
+    ctx = multiprocessing.get_context("spawn")
+    ready, start = ctx.Queue(), ctx.Event()
+    workers = [ctx.Process(target=_increment, args=(str(tmp_path), ready, start)) for _ in range(4)]
+    try:
+        for worker in workers:
+            worker.start()
+        for _ in workers:
+            assert ready.get(timeout=20)
+        start.set()
+        for worker in workers:
+            worker.join(20)
+            assert worker.exitcode == 0
+    finally:
+        for worker in workers:
+            if worker.is_alive():
+                worker.terminate()
+                worker.join()
+        ready.close()
+    record = store.get_job_record("counter")
+    assert record is not None and record.request["count"] == 40
+
+
+def test_failed_replace_preserves_reservations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from open_climate_service import config
+    from open_climate_service.exports.reservations import find_delivery, reserve_delivery, submission_lock
+    from open_climate_service.shared import persistence
+
+    monkeypatch.setattr(config, "get_data_root", lambda: tmp_path)
+    arguments: dict[str, Any] = dict(
+        delivery_job_id="job", export_id="rain", source_job_id="source", dry_run=False, fingerprint="a"
+    )
+    with submission_lock():
+        reserve_delivery("first", **arguments)
+
+    def fail(*args: Any):
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr(persistence.os, "replace", fail)
+    with submission_lock(), pytest.raises(OSError):
+        reserve_delivery("second", **arguments)
+    assert find_delivery("first") is not None
+    assert find_delivery("second") is None

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -18,6 +18,7 @@ from open_climate_service.read_only import is_blocked
 _MUTATING_ROUTES = [
     ("POST", "/ingestions"),
     ("DELETE", "/ingestions/jobs/{job_id}"),
+    ("POST", "/exports/{export_id}"),
     ("POST", "/jobs"),
     ("PATCH", "/jobs/{job_id}"),
     ("DELETE", "/jobs/{job_id}"),
@@ -101,6 +102,12 @@ def test_policy_closes_batch_jobs_for_reads_too() -> None:
     assert is_blocked("GET", "/jobs/abc")
     assert is_blocked("GET", "/jobs/abc/results")
     assert is_blocked("GET", "/jobs/abc/results/result.zarr/zarr.json")
+
+
+def test_policy_closes_export_delivery_for_reads_too() -> None:
+    """Delivery exposes server credentials, so status and reports are closed too."""
+    assert is_blocked("GET", "/exports")
+    assert is_blocked("GET", "/exports/rainfall-monthly/jobs/abc")
 
 
 @pytest.mark.parametrize("path", _PUBLIC_READS)


### PR DESCRIPTION
## Summary

Implements [CLIM-840](https://dhis2.atlassian.net/browse/CLIM-840) end to end: a first-class **named export** framework that renders computed results through installable plugins and delivers them to DHIS2 with durable idempotency, resumable chunked imports, and provenance binding. Rendering and delivery are kept strictly separate — rendering never resolves credentials or contacts DHIS2.

## What's included

### Named DHIS2 connections
- `dhis2_connections` block in `CLIMATE_SERVICE_CONFIG` (`id`, `url`, `token_env`, optional `timeout`/`connect_timeout`/`retries`).
- Tokens read from environment variables at use time; embedded credentials, query strings, and fragments are rejected.

### Installable export plugins
- `BaseExportPlugin` protocol for pure renderers, auto-discovered from built-ins, installed packages (via the `open_climate_service.plugins` entry point), and the instance `plugins_dir`, with deterministic precedence.
- Ships a built-in `dhis2` (DHIS2JSON) renderer.

### Named exports and multi-series rendering
- `exports` block maps an export ID to a plugin and series mapping; `save_result` selects one with `options: {"export": "..."}`.
- Single- and multi-series rendering with `select`, `data_element`, `category_option_combo`, and `attribute_option_combo`; per-request mapping overrides are rejected.
- Existing `DHIS2JSON` calls using `data_element_id` / `org_unit_field` / `period_type` keep working.

### Provenance manifests
- Versioned `ExportManifest` bound to the source job, mapping digest, plugin identity/version, and a target binding that stores only the URL hash (no credentials).
- Execution-scoped provenance records observed sources, feature inputs, and the process digest, with explicit `missing` entries.

### Delivery and import reporting
- `POST /exports/{export_id}` (202) with an `Idempotency-Key` header; `GET /exports/{export_id}/jobs/{delivery_job_id}` for status and report.
- Durable reservations, cross-process result leases, frozen queued inputs, resumable per-chunk checkpoints, and async import polling.
- Structured `ExportReport` (`success` / `partial` / `rejected` / `dry_run` / `cancelled` / `unknown`) with submitted/imported/updated/ignored/deleted counts, conflicts, and remote task IDs.

## Design guarantees

- Rendering never contacts DHIS2 or resolves credentials; delivery is a separate operator action.
- Idempotency keys reuse identical deliveries and reject conflicting content.
- Imports with uncertain outcomes are reported as `unknown` and never automatically replayed.
- Read-only mode closes all `/exports` routes, including status and report reads.
- Job index persistence uses atomic JSON replacement under a stable sibling lock.

## Validation

- Full regression suite (`make test`) and `make lint` pass.
- DHIS2 transport exercised against the pinned client with mocked HTTP; live deployment validation remains outstanding.

## Out of scope / follow-ups

- Live DHIS2 deployment validation.
- Named feature collection versioning (reported as `missing` in provenance).

[CLIM-840]: https://dhis2.atlassian.net/browse/CLIM-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ