### PR TITLE
fix(urls): warn once explicitly, not as a side effect of the parse cache

### DIFF
--- a/open_climate_service/shared/urls.py
+++ b/open_climate_service/shared/urls.py
@@ -44,35 +44,51 @@ class ConfiguredBase(NamedTuple):
     path: str
 
 
+_UNUSABLE = (
+    "%s=%r is not a usable absolute URL (needs a scheme and a host); "
+    "falling back to the request origin, so absolute URLs will name the internal address"
+)
+_HAS_QUERY = "%s=%r carries a query string or fragment; ignoring them, since a path is appended to this value"
+
+_warned_base_urls: set[str] = set()
+
+
+def _forget_base_url_warnings() -> None:
+    """Forget which values have been warned about, so a test starts from silence."""
+    _warned_base_urls.clear()
+
+
 @functools.lru_cache(maxsize=8)
+def _split_configured_base(raw: str) -> tuple[ConfiguredBase, str]:
+    """Split the raw value, and name the problem with it rather than reporting it.
+
+    Pure and cached, so it is only ever memoisation. Reporting lives in
+    `_parse_configured_base`, because a warning emitted from inside a cache appears or not
+    depending on whether the entry survived, which is not something a caller can reason about.
+    """
+    value = raw.strip()
+    if not value:
+        return ConfiguredBase("", ""), ""
+    split = urllib.parse.urlsplit(value)
+    if not split.scheme or not split.netloc:
+        return ConfiguredBase("", ""), _UNUSABLE
+    base = ConfiguredBase(f"{split.scheme}://{split.netloc}", split.path.rstrip("/"))
+    return base, (_HAS_QUERY if split.query or split.fragment else "")
+
+
 def _parse_configured_base(raw: str) -> ConfiguredBase:
     """Parse `CLIMATE_SERVICE_BASE_URL`, refusing a value with no scheme or no host.
 
     Parsed rather than trimmed so that every consumer reads the value the same way and a query
     string or fragment cannot end up in the middle of a link. A schemeless value would give
     links a browser resolves as relative paths, so it is refused and the request origin is
-    used instead, with a warning. Cached on the raw string so the warning appears once per
-    distinct value.
+    used instead, with a warning, once per distinct value.
     """
-    value = raw.strip()
-    if not value:
-        return ConfiguredBase("", "")
-    split = urllib.parse.urlsplit(value)
-    if not split.scheme or not split.netloc:
-        logger.warning(
-            "%s=%r is not a usable absolute URL (needs a scheme and a host); "
-            "falling back to the request origin, so absolute URLs will name the internal address",
-            BASE_URL_ENV,
-            value,
-        )
-        return ConfiguredBase("", "")
-    if split.query or split.fragment:
-        logger.warning(
-            "%s=%r carries a query string or fragment; ignoring them, since a path is appended to this value",
-            BASE_URL_ENV,
-            value,
-        )
-    return ConfiguredBase(f"{split.scheme}://{split.netloc}", split.path.rstrip("/"))
+    base, problem = _split_configured_base(raw)
+    if problem and raw not in _warned_base_urls:
+        _warned_base_urls.add(raw)
+        logger.warning(problem, BASE_URL_ENV, raw.strip())
+    return base
 
 
 def configured_base() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from open_climate_service import config as api_config
 from open_climate_service.main import app
 from open_climate_service.openeo import earthkit_processes, xclim_processes
+from open_climate_service.shared import urls
 
 _TEST_CONFIG = """\
 extent:
@@ -36,10 +37,15 @@ def _reset_config_cache() -> Generator[None, None, None]:
     api_config._cache = None
     xclim_processes._cache = None
     earthkit_processes._cache = None
+    # Warnings about an unusable base URL are emitted once per distinct value for the life of
+    # the process, so without this a test asserting on one depends on whether an earlier test
+    # happened to use the same value.
+    urls._forget_base_url_warnings()
     yield
     api_config._cache = None
     xclim_processes._cache = None
     earthkit_processes._cache = None
+    urls._forget_base_url_warnings()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -521,19 +521,26 @@ def test_an_unusable_base_url_is_logged_once(monkeypatch: pytest.MonkeyPatch, ca
     """Silence is how this survives: the links are broken but every response is a 200."""
     import logging
 
-    from open_climate_service.shared.urls import _parse_configured_base, absolute_base
+    from open_climate_service.shared.urls import _split_configured_base, absolute_base
 
     # `startup.py` gives the package logger its own handler and stops propagation, so `caplog`
     # sees nothing until it is let through.
     monkeypatch.setattr(logging.getLogger("open_climate_service"), "propagate", True)
-    _parse_configured_base.cache_clear()
     monkeypatch.setenv(BASE_URL_ENV, "ocs-demo-nepal.dhis2.org")
     with caplog.at_level("WARNING"):
         for _ in range(3):
             absolute_base(_fake_request("http://localhost:9000/", "/stac"))
 
-    assert len(caplog.records) == 1, "cached on the raw value, so one warning per distinct value"
+    assert len(caplog.records) == 1, "warned once per distinct value"
     assert BASE_URL_ENV in caplog.text
+
+    # The parse cache is memoisation, not the deduplicator. Losing it must not repeat an
+    # operator-facing warning, which is what made this assertion depend on execution order.
+    _split_configured_base.cache_clear()
+    with caplog.at_level("WARNING"):
+        absolute_base(_fake_request("http://localhost:9000/", "/stac"))
+
+    assert len(caplog.records) == 1, "still once, even with the parse cache cleared"
 
 
 def test_the_asgi_prefix_ignores_the_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_absolute_urls.py
+++ b/tests/test_absolute_urls.py
@@ -517,30 +517,44 @@ def test_a_base_url_is_parsed_rather_than_trimmed(monkeypatch: pytest.MonkeyPatc
     assert mount_prefix(request) == "/ocs"
 
 
-def test_an_unusable_base_url_is_logged_once(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-    """Silence is how this survives: the links are broken but every response is a 200."""
+def test_an_unusable_base_url_is_logged_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence is how this survives: the links are broken but every response is a 200.
+
+    The emissions are counted on the emitting logger with a handler of this test's own, rather
+    than through `caplog`. `caplog` captures at the root, which this package's logger does not
+    propagate to, so asserting through it means monkeypatching `propagate` and then trusting
+    that nothing else in the process has put a second capture in that chain. Counting at the
+    source is the same assertion without that dependency.
+    """
     import logging
 
     from open_climate_service.shared.urls import _split_configured_base, absolute_base
 
-    # `startup.py` gives the package logger its own handler and stops propagation, so `caplog`
-    # sees nothing until it is let through.
-    monkeypatch.setattr(logging.getLogger("open_climate_service"), "propagate", True)
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    emitter = logging.getLogger("open_climate_service.shared.urls")
+    handler = _Collect(level=logging.WARNING)
+    emitter.addHandler(handler)
     monkeypatch.setenv(BASE_URL_ENV, "ocs-demo-nepal.dhis2.org")
-    with caplog.at_level("WARNING"):
+    try:
         for _ in range(3):
             absolute_base(_fake_request("http://localhost:9000/", "/stac"))
 
-    assert len(caplog.records) == 1, "warned once per distinct value"
-    assert BASE_URL_ENV in caplog.text
+        assert len(records) == 1, "warned once per distinct value"
+        assert BASE_URL_ENV in records[0].getMessage()
 
-    # The parse cache is memoisation, not the deduplicator. Losing it must not repeat an
-    # operator-facing warning, which is what made this assertion depend on execution order.
-    _split_configured_base.cache_clear()
-    with caplog.at_level("WARNING"):
+        # The parse cache is memoisation, not the deduplicator. Losing it must not repeat an
+        # operator-facing warning, which is what made this assertion depend on execution order.
+        _split_configured_base.cache_clear()
         absolute_base(_fake_request("http://localhost:9000/", "/stac"))
 
-    assert len(caplog.records) == 1, "still once, even with the parse cache cleared"
+        assert len(records) == 1, "still once, even with the parse cache cleared"
+    finally:
+        emitter.removeHandler(handler)
 
 
 def test_the_asgi_prefix_ignores_the_configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

`main` is red. `test_an_unusable_base_url_is_logged_once` fails on CI, deterministically (a re-run of the same job failed identically), while passing in isolation and in the full suite on macOS.

The cause is that the warning about an unusable `CLIMATE_SERVICE_BASE_URL` was emitted from inside an `lru_cache`'d function, so it was deduplicated by whether the cache entry happened to survive rather than by anything the code states. That leaves the warning count dependent on execution order, and the test compensated by reaching for `_parse_configured_base.cache_clear()`, which is the tell that one construct was doing two jobs.

The autouse `_reset_config_cache` fixture resets three other config caches and never touched this one, so the isolation the rest of the suite relies on did not extend to it.

## What changed

- `_split_configured_base` is pure and cached, and names the problem instead of reporting it. The cache is now only memoisation.
- `_parse_configured_base` does the reporting, deduplicated against an explicit `_warned_base_urls` set. Call sites are unchanged.
- The test fixture clears that set, alongside the three caches it already resets.
- The test drops its private `cache_clear()` call and instead pins the property directly: clear the parse cache mid-test and assert the warning count does not move.

## Verification

The failure mode is gone by construction. Forcing three parses with the cache cleared before each emits one warning.

Full suite 1249 passed, 1 skipped. `ruff`, `ruff format`, `mypy` and `pyright` all clean.