### PR TITLE
feat(stac): publish a thumbnail asset for each ingested dataset (CLIM-1076)

### DIFF
--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -343,7 +343,7 @@ Both endpoints are advertised as `assets` in the STAC collection:
 }
 ```
 
-The `thumbnail` asset is present **only when the image exists** — see section 9.
+The `thumbnail` asset is present only when the image exists — see section 9.
 
 A **pyramided** store advertises one extra media type parameter:
 
@@ -370,26 +370,9 @@ missing values transparent.
 curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily/thumbnail.png"
 ```
 
-**A 404 is a normal state, not an error.** Thumbnails are written at the end of a sync run and
-are never backfilled, so a store that has not been rewritten since the feature landed has none,
-possibly permanently. A client should render "no preview" rather than an error for a 404 here.
-
-The STAC collection advertises the `thumbnail` asset **only when the file is on disk**, so a
-client that follows a published `assets.thumbnail.href` does not meet the 404. Code against the
-asset's presence; call the route directly only if you are prepared for the miss.
-
-Other properties worth knowing before you build on it:
-
-- **It can be one sync run stale.** A run that aborts before finalisation, fails to render, or
-  finds its representative slice entirely missing leaves the previous image in place. The next
-  successful run corrects it.
-- **It is not a map layer.** Each thumbnail is contrast-stretched to its own slice rather than
-  to the template's `display.range`, so two thumbnails do not share a scale and neither matches
-  the viewer's rendering of the same layer. It is for recognising a dataset, not for reading a
-  value off. (A range declared symmetric about zero does keep zero at the midpoint, so a
-  diverging colormap still means what it says.)
-- **Which slice**: the step nearest the generation date on a datetime axis; the first step on an
-  ordinal axis such as a climatology's `dayofyear` or `month`.
+Thumbnails are written at the end of a sync run and are never backfilled, so a 404 here is a
+normal state rather than an error. The STAC collection advertises the `thumbnail` asset only
+when the image exists.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -370,9 +370,10 @@ missing values transparent.
 curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily/thumbnail.png"
 ```
 
-A thumbnail is written at the end of a sync run, so a dataset that has not been synced has
-none and a 404 here is a normal state rather than an error. The STAC collection advertises the
-`thumbnail` asset only when the image exists.
+A thumbnail is written at the end of each ingest and sync run. A 404 means the dataset has no
+image — it has not been ingested, or its representative slice had nothing to draw — which is a
+normal state rather than an error. The STAC collection advertises the `thumbnail` asset only
+when the image exists.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -371,9 +371,11 @@ curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily
 ```
 
 A thumbnail is written at the end of each ingest and sync run, so a published dataset normally
-has one. The endpoint 404s when it does not — a dataset not yet ingested, or a render that
-failed or found nothing to draw. The STAC collection advertises the `thumbnail` asset only when
-the image exists.
+has one. The endpoint 404s only when none has ever been produced — a dataset not yet ingested,
+or a first render that failed or found nothing to draw. A later run that fails, or whose chosen
+slice is entirely missing, leaves the previous image in place rather than deleting it, so a
+served thumbnail can be a run or more stale. The STAC collection advertises the `thumbnail`
+asset only when the image exists.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -10,6 +10,7 @@ The current public story is:
 - discover published GeoZarr datasets with `/stac/catalog.json`
 - access raw Zarr data with `/zarr/{dataset_id}` (vanilla zarr clients, web maps)
 - access the native Icechunk store with `/icechunk/{dataset_id}` (Icechunk SDK)
+- preview a dataset with `/datasets/{dataset_id}/thumbnail.png` (also a STAC collection asset)
 
 Internal artifacts still exist as a storage and provenance model, but they are not part of the public API contract.
 
@@ -27,6 +28,7 @@ Operational note:
 - `GET /datasets`
 - `GET /datasets/{dataset_id}`
 - `GET /datasets/{dataset_id}/download`
+- `GET /datasets/{dataset_id}/thumbnail.png`
 - `GET /stac`
 - `GET /stac/catalog.json`
 - `GET /stac/collections/{dataset_id}`
@@ -331,9 +333,17 @@ Both endpoints are advertised as `assets` in the STAC collection:
     "href": "https://host/icechunk/chirps3_precipitation_daily",
     "type": "application/octet-stream",
     "xarray:open_kwargs": { "zarr_format": 3, "consolidated": false }
+  },
+  "thumbnail": {
+    "href": "https://host/datasets/chirps3_precipitation_daily/thumbnail.png",
+    "type": "image/png",
+    "title": "Thumbnail",
+    "roles": ["thumbnail"]
   }
 }
 ```
+
+The `thumbnail` asset is present **only when the image exists** — see section 9.
 
 A **pyramided** store advertises one extra media type parameter:
 
@@ -349,6 +359,37 @@ would send a renderer looking for levels that do not exist.
 
 It is matched as a literal, not parsed, so the string is byte-for-byte fixed: same parameter
 order, one space after each `;`. Reformatting it silently disables rendering.
+
+## 9. Fetch a dataset thumbnail
+
+`GET /datasets/{dataset_id}/thumbnail.png` serves a small PNG preview of the dataset: one
+representative 2-D slice, styled with the template's `display.colormap`, longest side 512 px,
+missing values transparent.
+
+```bash
+curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily/thumbnail.png"
+```
+
+**A 404 is a normal state, not an error.** Thumbnails are written at the end of a sync run and
+are never backfilled, so a store that has not been rewritten since the feature landed has none,
+possibly permanently. A client should render "no preview" rather than an error for a 404 here.
+
+The STAC collection advertises the `thumbnail` asset **only when the file is on disk**, so a
+client that follows a published `assets.thumbnail.href` does not meet the 404. Code against the
+asset's presence; call the route directly only if you are prepared for the miss.
+
+Other properties worth knowing before you build on it:
+
+- **It can be one sync run stale.** A run that aborts before finalisation, fails to render, or
+  finds its representative slice entirely missing leaves the previous image in place. The next
+  successful run corrects it.
+- **It is not a map layer.** Each thumbnail is contrast-stretched to its own slice rather than
+  to the template's `display.range`, so two thumbnails do not share a scale and neither matches
+  the viewer's rendering of the same layer. It is for recognising a dataset, not for reading a
+  value off. (A range declared symmetric about zero does keep zero at the midpoint, so a
+  diverging colormap still means what it says.)
+- **Which slice**: the step nearest the generation date on a datetime axis; the first step on an
+  ordinal axis such as a climatology's `dayofyear` or `month`.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -370,9 +370,9 @@ missing values transparent.
 curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily/thumbnail.png"
 ```
 
-Thumbnails are written at the end of a sync run and are never backfilled, so a 404 here is a
-normal state rather than an error. The STAC collection advertises the `thumbnail` asset only
-when the image exists.
+A thumbnail is written at the end of a sync run, so a dataset that has not been synced has
+none and a 404 here is a normal state rather than an error. The STAC collection advertises the
+`thumbnail` asset only when the image exists.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -372,8 +372,8 @@ curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily
 
 A thumbnail is written at the end of each ingest and sync run, so a published dataset normally
 has one. The endpoint 404s when it does not — a dataset not yet ingested, or a render that
-failed or found nothing to draw — and that is a "no preview" answer rather than a server fault.
-The STAC collection advertises the `thumbnail` asset only when the image exists.
+failed or found nothing to draw. The STAC collection advertises the `thumbnail` asset only when
+the image exists.
 
 ## 10. Access published STAC collections
 

--- a/docs/managed_data_api_guide.md
+++ b/docs/managed_data_api_guide.md
@@ -370,10 +370,10 @@ missing values transparent.
 curl -s -o thumb.png "http://127.0.0.1:9000/datasets/chirps3_precipitation_daily/thumbnail.png"
 ```
 
-A thumbnail is written at the end of each ingest and sync run. A 404 means the dataset has no
-image — it has not been ingested, or its representative slice had nothing to draw — which is a
-normal state rather than an error. The STAC collection advertises the `thumbnail` asset only
-when the image exists.
+A thumbnail is written at the end of each ingest and sync run, so a published dataset normally
+has one. The endpoint 404s when it does not — a dataset not yet ingested, or a render that
+failed or found nothing to draw — and that is a "no preview" answer rather than a server fault.
+The STAC collection advertises the `thumbnail` asset only when the image exists.
 
 ## 10. Access published STAC collections
 

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -135,11 +135,11 @@ def get_dataset(dataset_id: str) -> DatasetDetailRecord:
 def get_dataset_thumbnail(dataset_id: str) -> FileResponse:
     """Serve a dataset's thumbnail, the image its STAC collection points at.
 
-    404 when the dataset has none. That is a normal state rather than an error: a thumbnail is
-    written at the end of each ingest and sync run, so a dataset that has not been ingested has
-    none, and so does one whose representative slice had nothing to draw. The STAC collection
-    only advertises the asset when the file is there, so a client following a published href
-    does not meet this.
+    404 when the dataset has none. A thumbnail is written at the end of each ingest and sync
+    run, so a published dataset normally has one and the miss is a dataset not yet ingested, or
+    a render that failed or found nothing to draw. It is a "no preview" answer rather than a
+    server fault. The STAC collection only advertises the asset when the file is there, so a
+    client following a published href does not meet this.
     """
     path = thumbnail_path(dataset_id)
     if not path.is_file():

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -135,10 +135,11 @@ def get_dataset(dataset_id: str) -> DatasetDetailRecord:
 def get_dataset_thumbnail(dataset_id: str) -> FileResponse:
     """Serve a dataset's thumbnail, the image its STAC collection points at.
 
-    404 when the dataset has none. That is a normal, possibly permanent state rather than an
-    error: thumbnails are written at the end of a sync run and are not backfilled, so a store
-    that is never rewritten never gains one. The STAC collection only advertises the asset
-    when the file is there, so a client following a published href does not meet this.
+    404 when the dataset has none. That is a normal state rather than an error: a thumbnail is
+    written at the end of each ingest and sync run, so a dataset that has not been ingested has
+    none, and so does one whose representative slice had nothing to draw. The STAC collection
+    only advertises the asset when the file is there, so a client following a published href
+    does not meet this.
     """
     path = thumbnail_path(dataset_id)
     if not path.is_file():

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -20,6 +20,7 @@ from open_climate_service.ingestions.schemas import (
 )
 from open_climate_service.jobs.models import JobLink, JobRecord
 from open_climate_service.jobs.service import get_job_service
+from open_climate_service.shared.thumbnails import thumbnail_path
 
 ingestions_router = APIRouter()
 datasets_router = APIRouter()
@@ -128,6 +129,21 @@ def list_datasets() -> DatasetListResponse:
 def get_dataset(dataset_id: str) -> DatasetDetailRecord:
     """Get managed dataset metadata and available versions."""
     return services.get_dataset_or_404(dataset_id)
+
+
+@datasets_router.get("/{dataset_id}/thumbnail.png", response_class=FileResponse)
+def get_dataset_thumbnail(dataset_id: str) -> FileResponse:
+    """Serve a dataset's thumbnail, the image its STAC collection points at.
+
+    404 when the dataset has none. That is a normal, possibly permanent state rather than an
+    error: thumbnails are written at the end of a sync run and are not backfilled, so a store
+    that is never rewritten never gains one. The STAC collection only advertises the asset
+    when the file is there, so a client following a published href does not meet this.
+    """
+    path = thumbnail_path(dataset_id)
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail=f"No thumbnail for dataset '{dataset_id}'")
+    return FileResponse(path, media_type="image/png")
 
 
 @datasets_router.get("/{dataset_id}/download")

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -135,11 +135,12 @@ def get_dataset(dataset_id: str) -> DatasetDetailRecord:
 def get_dataset_thumbnail(dataset_id: str) -> FileResponse:
     """Serve a dataset's thumbnail, the image its STAC collection points at.
 
-    404 when the dataset has none. A thumbnail is written at the end of each ingest and sync
-    run, so a published dataset normally has one and the miss is a dataset not yet ingested, or
-    a render that failed or found nothing to draw. It is a "no preview" answer rather than a
-    server fault. The STAC collection only advertises the asset when the file is there, so a
-    client following a published href does not meet this.
+    404 only when no thumbnail has ever been produced: a dataset not yet ingested, or a first
+    render that failed or found nothing to draw. It is a "no preview" answer rather than a
+    server fault. A later run that fails to render, or whose chosen slice is entirely missing,
+    leaves the previous image in place, so a 200 here can be a run or more stale — see
+    `write_dataset_thumbnail`. The STAC collection only advertises the asset when the file is
+    there, so a client following a published href does not meet the 404.
     """
     path = thumbnail_path(dataset_id)
     if not path.is_file():

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -50,6 +50,7 @@ from open_climate_service.ingestions.schemas import (
 )
 from open_climate_service.ingestions.sync_engine import SyncConfigurationError, plan_sync, run_sync
 from open_climate_service.publications.services import managed_dataset_id_for, publish_artifact
+from open_climate_service.shared.thumbnails import write_dataset_thumbnail
 from open_climate_service.shared.time import (
     datetime_to_period_string,
     dekad_start,
@@ -409,6 +410,11 @@ def _create_streaming_artifact(
         _maybe_build_pyramid(ingest_path, dataset)
         if replacement_path is not None:
             _swap_store(replacement_path, store_path)
+        # Once per sync run, here rather than per commit: a streaming ingest commits one
+        # period at a time, so rendering on each would produce a few hundred PNGs during a
+        # historical backfill and keep the last. After the swap, so it renders the store that
+        # is actually published. Never raises — see write_dataset_thumbnail.
+        write_dataset_thumbnail(store_path, dataset)
 
         record = ArtifactRecord(
             artifact_id=str(uuid4()),

--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -27,6 +27,7 @@ from open_climate_service.openeo.schemas import (
     OpenEOJobUpdate,
 )
 from open_climate_service.shared.cf import is_temperature_like
+from open_climate_service.shared.thumbnails import write_dataset_thumbnail
 from open_climate_service.shared.time import utc_now
 from open_climate_service.stac.media_types import ZARR_V3_MEDIA_TYPE, zarr_media_type
 
@@ -714,6 +715,14 @@ def _write_managed_zarr(ds: Any, options: dict[str, Any]) -> None:
         crs=crs,
         pyramid_method=downloader.resampling_method_from_template(template),
         commit_message=f"Published from openEO job: {dataset_id}",
+    )
+
+    # A derived product is a published dataset and appears in the same lists, so it gets a
+    # thumbnail on the same terms. One write, so this is already the once-per-run render the
+    # streaming path has to arrange deliberately. Never raises.
+    write_dataset_thumbnail(
+        store_path,
+        {**template, "id": dataset_id, "variable": variable},
     )
 
     record = ArtifactRecord(
@@ -1791,28 +1800,22 @@ def _to_dhis2_value_string(value: Any) -> str:
 def _write_png(ds: Any, results_dir: Any) -> str | None:
     """Render an xr.Dataset as a styled PNG using the collection's render settings.
 
-    Applies the same colormap, rescale range, and NaN transparency as the /map
-    viewer.  Squeezes to a 2-D slice (first time step if temporal).
+    Applies the same colormap, rescale range and NaN transparency as the /map viewer,
+    through the shared renderer in ``shared/thumbnails.py``. Squeezes to a 2-D slice by
+    taking the first step of each leading dimension: this is a *result* the caller asked
+    for, so it shows the front of the cube they computed, where a catalogue thumbnail of a
+    published store instead shows the step nearest today.
     """
-    import matplotlib
-    import numpy as np
-
-    matplotlib.use("agg")  # non-interactive backend — safe on worker threads
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import Normalize
+    from open_climate_service.shared.thumbnails import render_png
 
     var = list(ds.data_vars)[0]
     arr = ds[var]
-
-    # Squeeze to 2-D (first step of each leading dim)
     while arr.ndim > 2:
         arr = arr.isel({arr.dims[0]: 0})
 
-    data = arr.values.astype(float)
-
-    # Look up render settings from the published collection via the dataset registry
-    colormap_name = "viridis"
-    vmin, vmax = float(np.nanmin(data)), float(np.nanmax(data))
+    # Render settings from the published collection, via the dataset registry.
+    colormap: str | None = None
+    clim: tuple[float, float] | None = None
     try:
         from open_climate_service.data_registry.services import datasets as reg
 
@@ -1820,44 +1823,15 @@ def _write_png(ds: Any, results_dir: Any) -> str | None:
             display = _ds_meta.get("display", {})
             ds_var = _ds_meta.get("variable", "")
             if ds_var == var or _ds_meta.get("id", "").endswith(var):
-                colormap_name = display.get("colormap", colormap_name)
+                colormap = display.get("colormap", colormap)
                 rng = display.get("range")
                 if isinstance(rng, list) and len(rng) == 2:
-                    vmin, vmax = float(rng[0]), float(rng[1])
+                    clim = (float(rng[0]), float(rng[1]))
                 break
     except Exception:
         pass
 
-    cmap = plt.get_cmap(colormap_name).copy()
-    cmap.set_bad(alpha=0)  # NaN → transparent
-
-    norm = Normalize(vmin=vmin, vmax=vmax, clip=False)
-
-    # Render at the natural aspect ratio of the data
-    height, width = data.shape
-    dpi = 150
-    fig_w = max(4, width / dpi)
-    fig_h = max(3, height / dpi)
-
-    fig, ax = plt.subplots(figsize=(fig_w, fig_h), dpi=dpi)
-    fig.patch.set_alpha(0)
-    # `origin="upper"` puts array row 0 at the top, which is right because published stores
-    # guarantee y descending (row 0 = north) — see shared/raster_contract. A cube that reaches
-    # here south-up (an in-flight openEO result, not a published store) is flipped first, so the
-    # thumbnail is never upside down.
-    y_name = next((str(d) for d in arr.dims if str(d) in ("y", "lat", "latitude")), None)
-    if y_name is not None and y_name in arr.coords and arr.sizes.get(y_name, 0) >= 2:
-        y_values = arr[y_name].values
-        if float(y_values[1]) > float(y_values[0]):
-            data = data[::-1]
-    ax.imshow(data, origin="upper", cmap=cmap, norm=norm, interpolation="nearest")
-    ax.axis("off")
-    fig.tight_layout(pad=0)
-
-    path = str(results_dir / "result.png")
-    fig.savefig(path, bbox_inches="tight", dpi=dpi, transparent=True, pad_inches=0)
-    plt.close(fig)
-    return path
+    return str(render_png(arr, results_dir / "result.png", colormap=colormap, clim=clim))
 
 
 def _derive_job_title(process: dict[str, Any]) -> str | None:

--- a/open_climate_service/shared/thumbnails.py
+++ b/open_climate_service/shared/thumbnails.py
@@ -120,6 +120,28 @@ def representative_slice(arr: Any, *, now: datetime | None = None) -> Any:
     return arr
 
 
+def decimate(arr: Any, *, long_side: int) -> Any:
+    """Stride *arr*'s grid down so its longest side is no more than one stride above *long_side*.
+
+    A thumbnail is drawn at *long_side* pixels whatever the store's resolution, so every source
+    cell beyond one per output pixel is read, held in memory and then thrown away by the
+    render's nearest-neighbour sampling. Reading them is not free: the accessor opens the
+    store's *finest* pyramid level, so a 0.05-degree global field arrives as 7200x3600 — 200 MB
+    of float64 materialised to produce an image 512 px across, on a machine that is otherwise
+    in the middle of finishing a sync. Striding first keeps what is read proportional to what
+    is drawn.
+
+    One stride for both axes, so the aspect ratio survives, and an integer one, so the cells
+    that are kept are real cells: this is the same nearest-neighbour decimation the render
+    would do anyway, moved to before the values are pulled rather than after.
+    """
+    longest = max(arr.sizes.values(), default=0)
+    stride = int(longest // long_side)
+    if stride <= 1:
+        return arr
+    return arr.isel({str(dim): slice(None, None, stride) for dim in arr.dims})
+
+
 def render_png(
     arr: Any,
     path: str | Path,
@@ -285,12 +307,22 @@ def write_dataset_thumbnail(
     PNGs during a historical backfill and keep the last. Rendering here also means rendering
     from the finished store rather than one still being appended to.
 
-    **Never raises.** A store that cannot be previewed publishes without a thumbnail; a
+    **Never raises.** A store that cannot be previewed publishes without a *new* thumbnail; a
     dataset is not less ingested for being unrecognisable, and the alternative is a render
     bug taking down an ingest that otherwise succeeded. The failure is logged with a
     traceback so it is diagnosable rather than silent.
+
+    Nothing here removes an existing thumbnail. A run that fails to render, or whose
+    representative slice turns out to be entirely missing, leaves the previous image in place
+    rather than deleting it, so the published thumbnail can be a sync run or more stale. That
+    is deliberate: an all-missing slice is nearly always a transient gap at the step nearest
+    now, not a store that has become blank, and a slightly old picture still does the job the
+    image is there for — recognising the layer, and catching a flipped grid or a wrong extent.
+    Deleting it would trade a stale thumbnail for none at all.
     """
     import logging
+    import os
+    from contextlib import closing
 
     logger = logging.getLogger(__name__)
     dataset_id = str(dataset.get("id") or "")
@@ -299,28 +331,49 @@ def write_dataset_thumbnail(
     try:
         from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
 
-        ds = open_icechunk_dataset(store_path)
-        variable = str(dataset.get("variable") or "")
-        if variable not in ds.data_vars:
-            variable = str(next(iter(ds.data_vars), ""))
-        if not variable:
-            logger.warning("No data variable to render a thumbnail from for '%s'", dataset_id)
-            return None
+        # Closed as soon as the pixels are in hand, so a sync run does not leave Icechunk and
+        # Zarr backend resources open behind every dataset it touches.
+        with closing(open_icechunk_dataset(store_path)) as ds:
+            variable = str(dataset.get("variable") or "")
+            if variable not in ds.data_vars:
+                variable = str(next(iter(ds.data_vars), ""))
+            if not variable:
+                logger.warning("No data variable to render a thumbnail from for '%s'", dataset_id)
+                return None
+            # Strided before it is read, and read before the store closes: `.load()` pulls the
+            # decimated slice into memory so nothing downstream reaches a closed store.
+            chosen = decimate(representative_slice(ds[variable], now=now), long_side=THUMBNAIL_LONG_SIDE_PIXELS).load()
 
         display = dataset.get("display")
         display = display if isinstance(display, dict) else {}
-        chosen = representative_slice(ds[variable], now=now)
         clim = stretch_range(chosen.values, midpoint=declared_midpoint(display.get("range")))
         if clim is None:
             logger.warning("Every value in the slice chosen for '%s' is missing; no thumbnail", dataset_id)
             return None
-        return render_png(
-            chosen,
-            thumbnail_path(dataset_id),
-            colormap=display.get("colormap"),
-            clim=clim,
-            long_side=THUMBNAIL_LONG_SIDE_PIXELS,
-        )
+
+        # Rendered to a sibling and moved into place, never written over the published file.
+        # That path is served by HTTP, so writing in place would let a request read a
+        # half-written PNG, and a savefig that failed part way would truncate a previously
+        # good thumbnail — the opposite of the leave-the-old-one-alone behaviour above.
+        # `os.replace` within one directory is atomic, so a reader sees the old file or the
+        # new one and never something in between.
+        published = thumbnail_path(dataset_id)
+        published.parent.mkdir(parents=True, exist_ok=True)
+        # `.png` last: matplotlib picks the output format from the extension, so a plain
+        # `.tmp` suffix would be rejected rather than written.
+        pending = published.with_name(f".{published.stem}.{os.getpid()}.tmp.png")
+        try:
+            render_png(
+                chosen,
+                pending,
+                colormap=display.get("colormap"),
+                clim=clim,
+                long_side=THUMBNAIL_LONG_SIDE_PIXELS,
+            )
+            os.replace(pending, published)
+        finally:
+            pending.unlink(missing_ok=True)
+        return published
     except Exception:
         logger.warning("Could not render a thumbnail for '%s'; publishing without one", dataset_id, exc_info=True)
         return None

--- a/open_climate_service/shared/thumbnails.py
+++ b/open_climate_service/shared/thumbnails.py
@@ -190,6 +190,45 @@ def render_png(
     return path
 
 
+# A percentile rather than the raw extremes, because geophysical fields are skewed: one storm
+# cell at 80 mm over a field that is otherwise under 1 mm would push everything else into a
+# single colour, which is the very problem a per-slice stretch is meant to solve.
+_STRETCH_PERCENTILES = (2.0, 98.0)
+
+
+def stretch_range(data: Any) -> tuple[float, float] | None:
+    """The value range a thumbnail should span for *data*, or None if there is nothing to show.
+
+    Scaled to the slice rather than to the template's declared ``display.range``. The declared
+    range is chosen so a dataset's *layers* are comparable with each other in the viewer, and
+    a thumbnail has the opposite job: it has to make one slice recognisable on its own. CHIRPS
+    daily precipitation is the case that decided it — 31 January 2025 over Nepal peaks at
+    0.408 mm against a declared 0-20 mm range, so 2% of the scale, and the whole frame renders
+    as the palest end of the colormap.
+
+    The cost is that two thumbnails no longer share a scale, and neither matches the viewer's
+    rendering of the same layer. For an icon whose job is recognition that is the better
+    trade; for a value read off the image it would not be, and the image is not for that.
+
+    Degenerate slices are handled rather than left to raise: an all-NaN slice returns None
+    (nothing to render), and a constant one is widened so the normalisation cannot divide by
+    zero — it renders as a single flat colour, which is what a constant field looks like.
+    """
+    import numpy as np
+
+    finite = np.asarray(data)[np.isfinite(np.asarray(data))]
+    if finite.size == 0:
+        return None
+    low, high = (float(value) for value in np.percentile(finite, _STRETCH_PERCENTILES))
+    if high <= low:
+        # The percentiles collapse when most of the field shares one value; the extremes still
+        # separate it.
+        low, high = float(finite.min()), float(finite.max())
+    if high <= low:
+        low, high = low - 0.5, low + 0.5
+    return low, high
+
+
 def write_dataset_thumbnail(
     store_path: str | Path,
     dataset: dict[str, Any],
@@ -227,14 +266,13 @@ def write_dataset_thumbnail(
 
         display = dataset.get("display")
         display = display if isinstance(display, dict) else {}
-        raw_range = display.get("range")
-        clim = (
-            (float(raw_range[0]), float(raw_range[1]))
-            if isinstance(raw_range, (list, tuple)) and len(raw_range) == 2
-            else None
-        )
+        chosen = representative_slice(ds[variable], now=now)
+        clim = stretch_range(chosen.values)
+        if clim is None:
+            logger.warning("Every value in the slice chosen for '%s' is missing; no thumbnail", dataset_id)
+            return None
         return render_png(
-            representative_slice(ds[variable], now=now),
+            chosen,
             thumbnail_path(dataset_id),
             colormap=display.get("colormap"),
             clim=clim,

--- a/open_climate_service/shared/thumbnails.py
+++ b/open_climate_service/shared/thumbnails.py
@@ -1,0 +1,245 @@
+"""Render a dataset as a small PNG, for STAC ``thumbnail`` assets and openEO PNG results.
+
+A STAC collection is metadata and a Zarr href, which is nothing to recognise a layer by:
+an ingest that produced a flipped grid, a wrong extent or a unit error looks exactly like
+one that did not. A thumbnail is what makes the difference visible, in a STAC browser, on
+the landing page and during ingest QA.
+
+Both callers render the same way and differ only in what they are for, so the difference is
+one parameter rather than two renderers:
+
+* an openEO ``PNG`` result is a *data product* — it keeps the cube's own pixel dimensions;
+* a STAC thumbnail is an *icon* — it is capped at :data:`THUMBNAIL_MAX_PIXELS`, which is the
+  STAC best-practice size for the role ("low resolution, restricted spatial extent").
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from open_climate_service import config as api_config
+
+# STAC best practice for the `thumbnail` role is "less than 600x600 pixels". The longest
+# side is scaled to this and the other follows, so the aspect ratio is never distorted.
+THUMBNAIL_MAX_PIXELS = 600
+
+_DEFAULT_COLORMAP = "viridis"
+
+
+def thumbnails_dir() -> Path:
+    """Directory holding published thumbnails, one per dataset id."""
+    return api_config.get_data_root() / "thumbnails"
+
+
+def thumbnail_path(dataset_id: str) -> Path:
+    """On-disk location of *dataset_id*'s thumbnail, whether or not it exists yet."""
+    return thumbnails_dir() / f"{dataset_id}.png"
+
+
+def resolve_colormap(name: str | None) -> Any:
+    """A matplotlib colormap for a template's ``display.colormap``, or the default.
+
+    Template colormap names are written for the map viewer, which resolves them through
+    chroma-js — ColorBrewer/D3 names, matched **case-insensitively**, with matplotlib's
+    ``_r`` reversed suffix. matplotlib is case-*sensitive*, so passing those names straight
+    to it raises: of the 27 built-in templates, only the 9 declaring ``RdBu`` would render,
+    while ``blues`` (9), ``rdbu_r`` (7) and ``reds`` (2) all fail. Matching the viewer's
+    case-insensitive rule is what makes one declared colormap mean the same thing in the
+    viewer and in the image.
+
+    An unresolvable name falls back to the default rather than raising. A thumbnail in the
+    wrong colours is worth more than no thumbnail, and this must never be able to fail a
+    render on its own.
+    """
+    from matplotlib import colormaps
+
+    requested = (name or "").strip()
+    if requested:
+        try:
+            return colormaps[requested]
+        except KeyError:
+            pass
+        matched = {registered.lower(): registered for registered in colormaps}.get(requested.lower())
+        if matched is not None:
+            return colormaps[matched]
+    return colormaps[_DEFAULT_COLORMAP]
+
+
+def representative_index(values: Any, *, now: datetime | None = None) -> int:
+    """Index of the slice a thumbnail should show along one non-spatial axis.
+
+    A **datetime** axis resolves to the step nearest *now*. Not the last step: for an
+    observed store those coincide, but a forecast store runs into the future, and its final
+    step is a lead time nobody recognises the dataset by while the step nearest now is the
+    one a person is looking at.
+
+    Any **other** axis resolves to the first step. A climatology's axis is an ordinal
+    ``dayofyear`` (1..366) or ``month`` (1..12) rather than a datetime, so a nearest-to-today
+    rule there would need a date-to-ordinal mapping, a leap-day decision for 366 and an
+    answer to whose timezone "today" is in. Index 0 needs none of that, and the thumbnail is
+    then stable rather than drifting through the year. The same answer is right for the
+    genuinely categorical axes (sex, age band) for want of anything better.
+
+    The choice keys off the coordinate's **dtype** rather than the dataset's declared
+    ``period_type``, because the dtype cannot disagree with the data it describes.
+    """
+    import numpy as np
+
+    array = np.asarray(getattr(values, "values", values))
+    if array.size == 0 or not np.issubdtype(array.dtype, np.datetime64):
+        return 0
+    reference = now if now is not None else datetime.now(UTC)
+    # numpy rejects a tz-aware datetime; published stores hold naive UTC stamps.
+    target = np.datetime64(reference.replace(tzinfo=None), "ns")
+    return int(np.abs(array.astype("datetime64[ns]") - target).argmin())
+
+
+def representative_slice(arr: Any, *, now: datetime | None = None) -> Any:
+    """Reduce a DataArray to the 2-D slice a thumbnail should show.
+
+    Published stores are ``(non-spatial..., y, x)``, so the leading dimensions are the ones
+    to pin; each is resolved by :func:`representative_index`. A store with no non-spatial
+    axis at all is returned unchanged.
+    """
+    while arr.ndim > 2:
+        dim = str(arr.dims[0])
+        arr = arr.isel({dim: representative_index(arr.coords.get(dim), now=now)})
+    return arr
+
+
+def render_png(
+    arr: Any,
+    path: str | Path,
+    *,
+    colormap: str | None = None,
+    clim: tuple[float, float] | None = None,
+    max_pixels: int | None = None,
+) -> Path:
+    """Render a 2-D DataArray to a styled PNG at *path*, and return that path.
+
+    ``clim`` is the value range the colours span; without one the slice's own min/max are
+    used, which is right for a one-off render and wrong for comparing two of them, so
+    callers that have a declared display range should pass it.
+
+    ``max_pixels`` caps the longest side and produces an image of exactly the computed size.
+    Left as None, the figure is sized from the data at 150 dpi with a minimum of 4x3 inches
+    and a tight bounding box — the openEO ``PNG`` result behaviour, kept as it was.
+    """
+    import matplotlib
+
+    matplotlib.use("agg")  # non-interactive backend — safe on worker threads
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.colors import Normalize
+
+    data = np.asarray(arr.values).astype(float)
+    if data.ndim != 2:
+        raise ValueError(f"A thumbnail needs a 2-D slice, got {data.ndim} dimensions {arr.dims!r}")
+
+    # `origin="upper"` puts array row 0 at the top, which is right because published stores
+    # guarantee y descending (row 0 = north) — see shared/raster_contract. A cube that
+    # reaches here south-up (an in-flight openEO result, not a published store) is flipped
+    # first, so the image is never upside down.
+    y_name = next((str(d) for d in arr.dims if str(d) in ("y", "lat", "latitude")), None)
+    if y_name is not None and y_name in arr.coords and arr.sizes.get(y_name, 0) >= 2:
+        y_values = arr[y_name].values
+        if float(y_values[1]) > float(y_values[0]):
+            data = data[::-1]
+
+    cmap = resolve_colormap(colormap).copy()
+    cmap.set_bad(alpha=0)  # NaN → transparent
+    if clim is not None:
+        vmin, vmax = float(clim[0]), float(clim[1])
+    else:
+        vmin, vmax = float(np.nanmin(data)), float(np.nanmax(data))
+    norm = Normalize(vmin=vmin, vmax=vmax, clip=False)
+
+    height, width = data.shape
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if max_pixels is None:
+        dpi = 150
+        fig, ax = plt.subplots(figsize=(max(4, width / dpi), max(3, height / dpi)), dpi=dpi)
+        save_kwargs: dict[str, Any] = {"bbox_inches": "tight"}
+    else:
+        # Exact output dimensions: the axes fill the figure, and no tight bounding box is
+        # applied, because trimming would make the final pixel size unpredictable and the
+        # cap is a promise about the published file rather than about the figure.
+        dpi = 100
+        scale = min(1.0, max_pixels / max(height, width))
+        fig, ax = plt.subplots(
+            figsize=(max(1, round(width * scale)) / dpi, max(1, round(height * scale)) / dpi), dpi=dpi
+        )
+        ax.set_position((0.0, 0.0, 1.0, 1.0))
+        save_kwargs = {}
+
+    try:
+        fig.patch.set_alpha(0)
+        ax.imshow(data, origin="upper", cmap=cmap, norm=norm, interpolation="nearest")
+        ax.axis("off")
+        if max_pixels is None:
+            fig.tight_layout(pad=0)
+        fig.savefig(path, dpi=dpi, transparent=True, pad_inches=0, **save_kwargs)
+    finally:
+        # Figures are not garbage collected while pyplot holds them, so a render that raises
+        # after the figure exists would leak one per ingest.
+        plt.close(fig)
+    return path
+
+
+def write_dataset_thumbnail(
+    store_path: str | Path,
+    dataset: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> Path | None:
+    """Render *dataset*'s published store to its thumbnail, returning the path, or None.
+
+    Called once per sync run from the end-of-sync finalisation, not per commit: a streaming
+    ingest commits one period at a time, so rendering per commit would produce a few hundred
+    PNGs during a historical backfill and keep the last. Rendering here also means rendering
+    from the finished store rather than one still being appended to.
+
+    **Never raises.** A store that cannot be previewed publishes without a thumbnail; a
+    dataset is not less ingested for being unrecognisable, and the alternative is a render
+    bug taking down an ingest that otherwise succeeded. The failure is logged with a
+    traceback so it is diagnosable rather than silent.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    dataset_id = str(dataset.get("id") or "")
+    if not dataset_id:
+        return None
+    try:
+        from open_climate_service.data_accessor.services.accessor import open_icechunk_dataset
+
+        ds = open_icechunk_dataset(store_path)
+        variable = str(dataset.get("variable") or "")
+        if variable not in ds.data_vars:
+            variable = str(next(iter(ds.data_vars), ""))
+        if not variable:
+            logger.warning("No data variable to render a thumbnail from for '%s'", dataset_id)
+            return None
+
+        display = dataset.get("display")
+        display = display if isinstance(display, dict) else {}
+        raw_range = display.get("range")
+        clim = (
+            (float(raw_range[0]), float(raw_range[1]))
+            if isinstance(raw_range, (list, tuple)) and len(raw_range) == 2
+            else None
+        )
+        return render_png(
+            representative_slice(ds[variable], now=now),
+            thumbnail_path(dataset_id),
+            colormap=display.get("colormap"),
+            clim=clim,
+            max_pixels=THUMBNAIL_MAX_PIXELS,
+        )
+    except Exception:
+        logger.warning("Could not render a thumbnail for '%s'; publishing without one", dataset_id, exc_info=True)
+        return None

--- a/open_climate_service/shared/thumbnails.py
+++ b/open_climate_service/shared/thumbnails.py
@@ -9,8 +9,8 @@ Both callers render the same way and differ only in what they are for, so the di
 one parameter rather than two renderers:
 
 * an openEO ``PNG`` result is a *data product* — it keeps the cube's own pixel dimensions;
-* a STAC thumbnail is an *icon* — it is capped at :data:`THUMBNAIL_MAX_PIXELS`, which is the
-  STAC best-practice size for the role ("low resolution, restricted spatial extent").
+* a STAC thumbnail is an *icon* — its longest side is rendered at
+  :data:`THUMBNAIL_LONG_SIDE_PIXELS` whatever the store's resolution.
 """
 
 from __future__ import annotations
@@ -21,9 +21,20 @@ from typing import Any
 
 from open_climate_service import config as api_config
 
-# STAC best practice for the `thumbnail` role is "less than 600x600 pixels". The longest
-# side is scaled to this and the other follows, so the aspect ratio is never distorted.
-THUMBNAIL_MAX_PIXELS = 600
+# The longest side is rendered at this size and the other follows, so the aspect ratio is
+# never distorted. Every thumbnail therefore has the same longest side whatever the store's
+# resolution, which is what makes a gallery of them line up.
+#
+# Both directions, not just down. Pixel dimensions do not limit how large a client displays
+# the file — CSS does — but we do not control the CSS in STAC Browser or a DHIS2 app, and
+# their default smoothing turns a coarse grid into mush when it is blown up from 32x16.
+# Upscaling here with nearest-neighbour keeps the cell boundaries crisp, which is also the
+# honest picture of a coarse dataset, and costs a couple of KB: flat blocks compress well.
+#
+# 512 rather than 600: STAC best practice for the role is "less than 600x600 pixels", and a
+# square store rendered at an exact 600 long side would sit on that boundary rather than
+# inside it.
+THUMBNAIL_LONG_SIDE_PIXELS = 512
 
 _DEFAULT_COLORMAP = "viridis"
 
@@ -115,7 +126,7 @@ def render_png(
     *,
     colormap: str | None = None,
     clim: tuple[float, float] | None = None,
-    max_pixels: int | None = None,
+    long_side: int | None = None,
 ) -> Path:
     """Render a 2-D DataArray to a styled PNG at *path*, and return that path.
 
@@ -123,9 +134,10 @@ def render_png(
     used, which is right for a one-off render and wrong for comparing two of them, so
     callers that have a declared display range should pass it.
 
-    ``max_pixels`` caps the longest side and produces an image of exactly the computed size.
-    Left as None, the figure is sized from the data at 150 dpi with a minimum of 4x3 inches
-    and a tight bounding box — the openEO ``PNG`` result behaviour, kept as it was.
+    ``long_side`` renders the longest side at exactly that many pixels, scaling up as well as
+    down, with the other side following so the aspect ratio holds. Left as None, the figure is
+    sized from the data at 150 dpi with a minimum of 4x3 inches and a tight bounding box — the
+    openEO ``PNG`` result behaviour, kept as it was.
     """
     import matplotlib
 
@@ -160,16 +172,18 @@ def render_png(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    if max_pixels is None:
+    if long_side is None:
         dpi = 150
         fig, ax = plt.subplots(figsize=(max(4, width / dpi), max(3, height / dpi)), dpi=dpi)
         save_kwargs: dict[str, Any] = {"bbox_inches": "tight"}
     else:
         # Exact output dimensions: the axes fill the figure, and no tight bounding box is
         # applied, because trimming would make the final pixel size unpredictable and the
-        # cap is a promise about the published file rather than about the figure.
+        # size is a promise about the published file rather than about the figure. The scale
+        # is not clamped to 1, so a store coarser than the target is enlarged rather than left
+        # tiny; `interpolation="nearest"` below keeps the enlargement blocky rather than blurred.
         dpi = 100
-        scale = min(1.0, max_pixels / max(height, width))
+        scale = long_side / max(height, width)
         fig, ax = plt.subplots(
             figsize=(max(1, round(width * scale)) / dpi, max(1, round(height * scale)) / dpi), dpi=dpi
         )
@@ -180,7 +194,7 @@ def render_png(
         fig.patch.set_alpha(0)
         ax.imshow(data, origin="upper", cmap=cmap, norm=norm, interpolation="nearest")
         ax.axis("off")
-        if max_pixels is None:
+        if long_side is None:
             fig.tight_layout(pad=0)
         fig.savefig(path, dpi=dpi, transparent=True, pad_inches=0, **save_kwargs)
     finally:
@@ -196,8 +210,34 @@ def render_png(
 _STRETCH_PERCENTILES = (2.0, 98.0)
 
 
-def stretch_range(data: Any) -> tuple[float, float] | None:
+def declared_midpoint(declared: Any) -> float | None:
+    """Zero when *declared* is a display range symmetric about it, else None.
+
+    A template that declares ``[-5, 5]`` or ``[-30, 30]`` is saying the quantity diverges
+    about zero — an anomaly, or a temperature in Celsius where zero is freezing — and pairs
+    that range with a diverging colormap. One that declares ``[0, 20]`` or ``[0, 4000]`` is
+    saying the opposite. Across the Nepal and Norway instances that split is exact, so the
+    declaration is a better signal than a hardcoded list of diverging colormap names: it also
+    gets ``copernicus_dem_elevation`` right, which pairs the diverging ``Spectral_r`` with a
+    ``[0, 4000]`` range and must *not* be centred.
+    """
+    if not isinstance(declared, (list, tuple)) or len(declared) != 2:
+        return None
+    try:
+        low, high = float(declared[0]), float(declared[1])
+    except (TypeError, ValueError):
+        return None
+    return 0.0 if low < 0.0 and high == -low else None
+
+
+def stretch_range(data: Any, *, midpoint: float | None = None) -> tuple[float, float] | None:
     """The value range a thumbnail should span for *data*, or None if there is nothing to show.
+
+    ``midpoint`` keeps a diverging scale honest. Stretched to its own extremes, a slice of an
+    anomaly field that happens to be entirely positive would still render half blue, so blue
+    would no longer mean "below normal" — the one thing the colour is there to say. Given a
+    midpoint the range is made symmetric about it instead, so the neutral colour always lands
+    on the neutral value and only the *span* varies with the slice.
 
     Scaled to the slice rather than to the template's declared ``display.range``. The declared
     range is chosen so a dataset's *layers* are comparable with each other in the viewer, and
@@ -226,6 +266,9 @@ def stretch_range(data: Any) -> tuple[float, float] | None:
         low, high = float(finite.min()), float(finite.max())
     if high <= low:
         low, high = low - 0.5, low + 0.5
+    if midpoint is not None:
+        half = max(abs(low - midpoint), abs(high - midpoint)) or 0.5
+        return midpoint - half, midpoint + half
     return low, high
 
 
@@ -267,7 +310,7 @@ def write_dataset_thumbnail(
         display = dataset.get("display")
         display = display if isinstance(display, dict) else {}
         chosen = representative_slice(ds[variable], now=now)
-        clim = stretch_range(chosen.values)
+        clim = stretch_range(chosen.values, midpoint=declared_midpoint(display.get("range")))
         if clim is None:
             logger.warning("Every value in the slice chosen for '%s' is missing; no thumbnail", dataset_id)
             return None
@@ -276,7 +319,7 @@ def write_dataset_thumbnail(
             thumbnail_path(dataset_id),
             colormap=display.get("colormap"),
             clim=clim,
-            max_pixels=THUMBNAIL_MAX_PIXELS,
+            long_side=THUMBNAIL_LONG_SIDE_PIXELS,
         )
     except Exception:
         logger.warning("Could not render a thumbnail for '%s'; publishing without one", dataset_id, exc_info=True)

--- a/open_climate_service/shared/thumbnails.py
+++ b/open_climate_service/shared/thumbnails.py
@@ -314,11 +314,10 @@ def write_dataset_thumbnail(
 
     Nothing here removes an existing thumbnail. A run that fails to render, or whose
     representative slice turns out to be entirely missing, leaves the previous image in place
-    rather than deleting it, so the published thumbnail can be a sync run or more stale. That
-    is deliberate: an all-missing slice is nearly always a transient gap at the step nearest
-    now, not a store that has become blank, and a slightly old picture still does the job the
-    image is there for — recognising the layer, and catching a flipped grid or a wrong extent.
-    Deleting it would trade a stale thumbnail for none at all.
+    rather than deleting it, so the published thumbnail can be a run or more stale. That is
+    deliberate: the image is there to identify the layer and to catch a flipped grid or a wrong
+    extent, and an older slice still does that, so deleting would trade a stale thumbnail for
+    none at all.
     """
     import logging
     import os

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -21,6 +21,7 @@ from open_climate_service.data_registry.services import datasets as registry_dat
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.ingestions.schemas import ArtifactFormat, ArtifactRecord
 from open_climate_service.shared.crs import canonical_crs_code, is_builtin_crs
+from open_climate_service.shared.thumbnails import thumbnail_path
 from open_climate_service.shared.time import (
     Cadence,
     parse_period_string_to_datetime,
@@ -126,6 +127,12 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     catalog_href = absolute_url(request, "/stac/catalog.json")
     dataset_href = absolute_url(request, f"/datasets/{dataset_id}")
     zarr_href = absolute_url(request, f"/zarr/{dataset_id}")
+    # Only when the file is actually there: a collection that advertises a thumbnail a client
+    # then 404s on is worse than one that advertises none. Thumbnails are written at the end
+    # of a sync run and never backfilled, so absence is normal and can be permanent.
+    thumbnail_href = (
+        absolute_url(request, f"/datasets/{dataset_id}/thumbnail.png") if thumbnail_path(dataset_id).is_file() else None
+    )
 
     template = _build_collection_template(
         dataset_id=dataset_id,
@@ -170,6 +177,19 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
         "roles": template_asset.get("roles"),
         "xarray:open_kwargs": xarray_open_kwargs,
     }
+    if thumbnail_href is not None:
+        # `thumbnail` is a standardised STAC asset role, and a Collection may carry assets —
+        # the spec recommends collection-level assets for exactly this shape, a standalone
+        # collection fronting a Zarr store with no items. So no extension is needed and any
+        # STAC client (STAC Browser among them) picks the image up unaided. Added here rather
+        # than on the pystac template because only the assets assembled here reach the
+        # payload; the template's are rebuilt from the xstac output above.
+        collection_payload["assets"]["thumbnail"] = {
+            "href": thumbnail_href,
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": ["thumbnail"],
+        }
     if artifact.format == ArtifactFormat.ICECHUNK:
         collection_payload["assets"]["icechunk"] = {
             "href": absolute_url(request, f"/icechunk/{dataset_id}"),

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -128,8 +128,8 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     dataset_href = absolute_url(request, f"/datasets/{dataset_id}")
     zarr_href = absolute_url(request, f"/zarr/{dataset_id}")
     # Only when the file is actually there: a collection that advertises a thumbnail a client
-    # then 404s on is worse than one that advertises none. A render that found nothing to draw
-    # leaves a published dataset without one, so absence is normal rather than a fault.
+    # then 404s on is worse than one that advertises none. A render that failed or found
+    # nothing to draw leaves an otherwise complete collection without the asset.
     thumbnail_href = (
         absolute_url(request, f"/datasets/{dataset_id}/thumbnail.png") if thumbnail_path(dataset_id).is_file() else None
     )

--- a/open_climate_service/stac/services.py
+++ b/open_climate_service/stac/services.py
@@ -128,8 +128,8 @@ def build_collection(dataset_id: str, request: Request) -> dict[str, object]:
     dataset_href = absolute_url(request, f"/datasets/{dataset_id}")
     zarr_href = absolute_url(request, f"/zarr/{dataset_id}")
     # Only when the file is actually there: a collection that advertises a thumbnail a client
-    # then 404s on is worse than one that advertises none. Thumbnails are written at the end
-    # of a sync run and never backfilled, so absence is normal and can be permanent.
+    # then 404s on is worse than one that advertises none. A render that found nothing to draw
+    # leaves a published dataset without one, so absence is normal rather than a fault.
     thumbnail_href = (
         absolute_url(request, f"/datasets/{dataset_id}/thumbnail.png") if thumbnail_path(dataset_id).is_file() else None
     )

--- a/tests/test_dataset_thumbnails.py
+++ b/tests/test_dataset_thumbnails.py
@@ -352,9 +352,9 @@ def test_a_failing_render_leaves_the_published_thumbnail_untouched(
 
 
 def test_an_all_missing_slice_keeps_the_previous_thumbnail(tmp_path: Path) -> None:
-    """Deliberate, and the counterpart to the test above. An all-missing representative slice
-    is nearly always a transient gap at the step nearest now, not a store that has gone blank,
-    so the old picture still identifies the layer. Deleting it would trade stale for nothing."""
+    """Deliberate, and the counterpart to the test above. The image is there to identify the
+    layer and to catch a flipped grid or a wrong extent, which an older slice still does, so
+    deleting on a slice with nothing to draw would trade a stale thumbnail for none at all."""
     published = write_dataset_thumbnail(_store(tmp_path, _daily_cube(2)), DATASET, now=GENERATED_AT)
     assert published is not None
     good = published.read_bytes()

--- a/tests/test_dataset_thumbnails.py
+++ b/tests/test_dataset_thumbnails.py
@@ -1,0 +1,422 @@
+"""Dataset thumbnails: which slice is rendered, when, and how it reaches STAC (CLIM-1076).
+
+A thumbnail is what makes a bad ingest visible — a flipped grid, a wrong extent, a unit
+error all look identical in metadata. So the tests here assert the *content* of the image
+(which slice it shows) rather than only that a file appeared, by rendering the expected
+slice independently and comparing bytes.
+
+The two timing tests are a pair, and neither is sufficient alone: one asserts the renderer
+is never reached during a multi-period sync, the other that one ingest produces exactly one
+render. Together they pin "once per run, at the end" rather than "per commit", which is a
+distinction invisible in the published result — only the final image survives either way.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from open_climate_service.data_manager.services import downloader
+from open_climate_service.ingestions import services as ingestion_services
+from open_climate_service.shared import thumbnails
+from open_climate_service.shared.thumbnails import (
+    THUMBNAIL_MAX_PIXELS,
+    render_png,
+    representative_slice,
+    resolve_colormap,
+    thumbnail_path,
+    write_dataset_thumbnail,
+)
+
+# A date the tests pin so "nearest to now" is a fixed answer rather than a moving one.
+GENERATED_AT = datetime(2026, 3, 1, tzinfo=UTC)
+
+DATASET = {"id": "thumb_dataset", "variable": "precip", "display": {"colormap": "blues", "range": [0.0, 10.0]}}
+
+
+@pytest.fixture(autouse=True)
+def _data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the data root at a temp dir so thumbnails never land in the developer's own."""
+    root = tmp_path / "data"
+    monkeypatch.setattr(thumbnails.api_config, "get_data_root", lambda: root)
+    return root
+
+
+def _store(tmp_path: Path, ds: xr.Dataset, *, t_dim: str | None = "t") -> Path:
+    """Write *ds* to a real Icechunk store, so the read path under test is the real one."""
+    path = tmp_path / "thumb.icechunk"
+    downloader.write_to_icechunk_store(ds, path, t_dim=t_dim, commit_message="test")
+    return path
+
+
+def _daily_cube(values: list[float], start: str = "2026-01-01") -> xr.Dataset:
+    """One distinct constant value per step, so the rendered slice is identifiable."""
+    times = pd.date_range(start, periods=len(values), freq="D")
+    data = np.array([[[v, v], [v, v]] for v in values], dtype="float32")
+    return xr.Dataset(
+        {"precip": (("t", "y", "x"), data)},
+        coords={"t": times, "y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+
+
+def _rendered_reference(arr: Any, tmp_path: Path) -> bytes:
+    """The bytes the thumbnail should have, rendered from the slice we expect it to show."""
+    reference = render_png(
+        arr,
+        tmp_path / "reference.png",
+        colormap="blues",
+        clim=(0.0, 10.0),
+        max_pixels=THUMBNAIL_MAX_PIXELS,
+    )
+    return reference.read_bytes()
+
+
+# -- which slice -----------------------------------------------------------------------
+
+
+def test_a_datetime_store_renders_the_step_nearest_the_generation_date(tmp_path: Path) -> None:
+    """Nearest to now, not the last step. The store here runs past the generation date, the
+    way a forecast does, so the two answers differ and the last step would be wrong."""
+    # Steps at 60, 30 and 1 days before, and 30 days after, the pinned generation date.
+    cube = _daily_cube([1.0, 2.0, 3.0, 4.0], start="2025-12-31")
+    cube = cube.assign_coords(
+        t=pd.to_datetime(["2025-12-31", "2026-01-30", "2026-02-28", "2026-03-31"]),
+    )
+    store = _store(tmp_path, cube)
+
+    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    # 2026-02-28 is one day before the generation date; 2026-03-31 is thirty after.
+    assert written.read_bytes() == _rendered_reference(cube["precip"].isel(t=2), tmp_path)
+
+
+def test_a_climatology_renders_its_first_slice(tmp_path: Path) -> None:
+    """A climatology's axis is an ordinal dayofyear, not a datetime, so there is no "nearest
+    to today" without inventing a mapping. Index 0 is the answer, and it does not drift."""
+    doy = xr.Dataset(
+        {"precip": (("dayofyear", "y", "x"), np.array([[[v, v], [v, v]] for v in (7.0, 8.0, 9.0)], dtype="float32"))},
+        coords={"dayofyear": [1, 2, 3], "y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+    store = _store(tmp_path, doy, t_dim=None)
+
+    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    assert written.read_bytes() == _rendered_reference(doy["precip"].isel(dayofyear=0), tmp_path)
+
+
+def test_a_store_with_no_non_spatial_axis_renders_its_grid(tmp_path: Path) -> None:
+    flat = xr.Dataset(
+        {"precip": (("y", "x"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+    store = _store(tmp_path, flat, t_dim=None)
+
+    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    assert written.read_bytes() == _rendered_reference(flat["precip"], tmp_path)
+
+
+def test_the_nearest_step_is_chosen_by_dtype_not_by_a_declared_period_type(tmp_path: Path) -> None:
+    """An ordinal axis of plain integers resolves to index 0 even when the numbers look like
+    years. The coordinate's dtype cannot disagree with the data; a declared period_type can."""
+    ordinal = xr.DataArray(
+        np.array([[[1.0]], [[2.0]]], dtype="float32"),
+        dims=("year", "y", "x"),
+        coords={"year": [2020, 2026], "y": [0.5], "x": [1.5]},
+    )
+
+    assert representative_slice(ordinal, now=GENERATED_AT).item() == 1.0
+
+
+# -- size --------------------------------------------------------------------------------
+
+
+def test_the_thumbnail_is_capped_at_the_stac_recommended_size(tmp_path: Path) -> None:
+    """STAC best practice for the `thumbnail` role is under 600x600. A store is routinely far
+    larger than that, so the cap has to be applied rather than assumed."""
+    from matplotlib import image as mpimg
+
+    big = xr.Dataset(
+        {"precip": (("y", "x"), np.random.default_rng(0).random((1200, 800), dtype="float32"))},
+        coords={"y": np.linspace(10.0, 0.0, 1200), "x": np.linspace(0.0, 8.0, 800)},
+    )
+    store = _store(tmp_path, big, t_dim=None)
+
+    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    height, width = mpimg.imread(written).shape[:2]
+    assert max(height, width) <= THUMBNAIL_MAX_PIXELS
+    # The aspect ratio survives the cap: 1200x800 scaled by 600/1200 is 600x400.
+    assert (height, width) == (600, 400)
+
+
+# -- failure is not an ingest failure -----------------------------------------------------
+
+
+def test_a_failing_render_does_not_fail_the_ingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dataset is not less ingested for being unrecognisable. The callers rely on this
+    function never raising rather than each wrapping it, so the guarantee is tested here."""
+    store = _store(tmp_path, _daily_cube([1.0, 2.0]))
+
+    def explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("no renderer today")
+
+    monkeypatch.setattr(thumbnails, "render_png", explode)
+
+    assert write_dataset_thumbnail(store, DATASET, now=GENERATED_AT) is None
+    assert not thumbnail_path("thumb_dataset").exists()
+
+
+def test_an_unreadable_store_does_not_fail_the_ingest(tmp_path: Path) -> None:
+    assert write_dataset_thumbnail(tmp_path / "not-a-store.icechunk", DATASET) is None
+
+
+# -- colormaps ----------------------------------------------------------------------------
+
+
+def test_every_built_in_template_colormap_resolves_to_itself() -> None:
+    """The whole-catalogue guard. Template colormap names are written for the viewer, which
+    matches case-insensitively; matplotlib does not, so `blues`, `rdbu_r` and `reds` all
+    raise when passed straight to it — 18 of the 27 built-in templates. Falling back to the
+    default would render every one of them in the wrong colours while still "working"."""
+    from open_climate_service.data_registry.services import datasets as registry
+
+    declared = {
+        str(template["display"]["colormap"])
+        for template in registry.list_datasets()
+        if isinstance(template.get("display"), dict) and template["display"].get("colormap")
+    }
+    assert declared, "no template declares a colormap"
+
+    unresolved = {name for name in declared if resolve_colormap(name).name.lower() != name.lower()}
+    assert not unresolved, f"colormaps that fell back to the default instead of resolving: {unresolved}"
+
+
+def test_an_unknown_colormap_falls_back_instead_of_raising() -> None:
+    assert resolve_colormap("not-a-colormap").name == "viridis"
+    assert resolve_colormap(None).name == "viridis"
+
+
+# -- when it is generated ------------------------------------------------------------------
+
+
+def test_a_multi_period_sync_never_reaches_the_renderer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Half of "once per run, at the end". A streaming sync commits per period, so a renderer
+    reached from the commit path would run once per period — a few hundred times on a
+    historical backfill, all but the last discarded."""
+    from open_climate_service.streaming import orchestrator as streaming_orchestrator
+
+    renders: list[Any] = []
+    monkeypatch.setattr(thumbnails, "render_png", lambda *a, **k: renders.append(a))
+
+    class _Plugin:
+        max_concurrency = 1
+        commit_batch_size = 1
+
+        async def periods(self, start: str, end: str) -> list[str]:
+            _ = start, end
+            return ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+        async def fetch_period(self, period_id: str, bbox: list[float], **params: Any) -> xr.Dataset:
+            _ = bbox, params
+            return xr.Dataset(
+                {"precip": (("t", "y", "x"), np.array([[[float(period_id[-2:])]]], dtype="float32"))},
+                coords={"t": [np.datetime64(period_id, "D")], "y": [0.0], "x": [1.0]},
+            )
+
+    store_path = tmp_path / "streaming.zarr"
+    monkeypatch.setattr(streaming_orchestrator, "is_store_empty", lambda path: not path.exists())
+
+    result = streaming_orchestrator.run_streaming_ingest_sync(
+        plugin=_Plugin(),
+        params={},
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        start="2026-01-01",
+        end="2026-01-03",
+        store_path=store_path,
+        period_type="daily",
+    )
+
+    assert result.periods_written == 3
+    assert renders == [], "the renderer was reached from the per-commit path"
+
+
+def test_one_ingest_produces_exactly_one_render(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other half. Driven through `create_artifact`, the entry point, so it covers the
+    wiring rather than the helper: a render that never gets called would pass a test of
+    `write_dataset_thumbnail` alone."""
+    store_path = tmp_path / "thumb_dataset.icechunk"
+    dataset: dict[str, object] = {
+        "id": "thumb_dataset",
+        "name": "Thumb dataset",
+        "variable": "precip",
+        "period_type": "daily",
+        "display": {"colormap": "blues", "range": [0.0, 10.0]},
+        "ingestion": {"plugin": "example.Plugin", "params": {}},
+    }
+
+    def fake_sync(**kwargs: object) -> object:
+        # Stand in for a three-period sync: the store the finalisation sees is the finished one.
+        downloader.write_to_icechunk_store(_daily_cube([1.0, 2.0, 3.0]), store_path, commit_message="test")
+        return SimpleNamespace(periods_written=3)
+
+    renders: list[Any] = []
+    real_render = thumbnails.render_png
+
+    def counting_render(*args: Any, **kwargs: Any) -> Any:
+        renders.append(args)
+        return real_render(*args, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "render_png", counting_render)
+    monkeypatch.setattr(ingestion_services, "_load_streaming_plugin", lambda path, *, params: object())
+    monkeypatch.setattr(ingestion_services.downloader, "get_icechunk_path", lambda _: store_path)
+    monkeypatch.setattr(ingestion_services, "run_streaming_ingest_sync", fake_sync)
+    monkeypatch.setattr(ingestion_services, "_find_existing_artifact", lambda **_: None)
+    monkeypatch.setattr(ingestion_services, "_upsert_artifact_record", lambda record, **_: record)
+    monkeypatch.setattr(
+        ingestion_services,
+        "get_data_coverage_for_paths",
+        lambda dataset_arg, **_: {
+            "coverage": {
+                "temporal": {"start": "2026-01-01", "end": "2026-01-03"},
+                "spatial": {"xmin": 10.0, "ymin": 0.0, "xmax": 12.0, "ymax": 2.0},
+            }
+        },
+    )
+
+    ingestion_services.create_artifact(
+        dataset=dataset,
+        start="2026-01-01",
+        end="2026-01-03",
+        bbox=[10.0, 0.0, 12.0, 2.0],
+        country_code=None,
+        overwrite=True,
+        publish=False,
+    )
+
+    assert len(renders) == 1
+    assert thumbnail_path("thumb_dataset").is_file()
+
+
+# -- how it reaches a client ----------------------------------------------------------------
+
+
+def _published_artifact() -> Any:
+    from open_climate_service.ingestions.schemas import (
+        ArtifactCoverage,
+        ArtifactFormat,
+        ArtifactPublication,
+        ArtifactRecord,
+        ArtifactRequestScope,
+        CoverageSpatial,
+        CoverageTemporal,
+        PublicationStatus,
+    )
+
+    return ArtifactRecord(
+        artifact_id="a1",
+        dataset_id="thumb_dataset",
+        dataset_name="Thumb dataset",
+        variable="precip",
+        period_type="daily",
+        format=ArtifactFormat.ICECHUNK,
+        path="/tmp/thumb_dataset.icechunk",
+        asset_paths=["/tmp/thumb_dataset.icechunk"],
+        variables=["precip"],
+        request_scope=ArtifactRequestScope(start="2026-01-01", end="2026-01-03"),
+        coverage=ArtifactCoverage(
+            temporal=CoverageTemporal(start="2026-01-01", end="2026-01-03"),
+            spatial=CoverageSpatial(xmin=10.0, ymin=0.0, xmax=12.0, ymax=2.0),
+        ),
+        created_at=datetime(2026, 1, 3, tzinfo=UTC),
+        publication=ArtifactPublication(
+            status=PublicationStatus.PUBLISHED,
+            collection_id="thumb_dataset",
+            published_at=datetime(2026, 1, 3, tzinfo=UTC),
+        ),
+    )
+
+
+@pytest.fixture
+def _published(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One published artifact, with the store-reading parts of the build stubbed.
+
+    The assertions here are about the assets a collection advertises, not about the cube
+    metadata xstac derives, so opening a real Icechunk store would only add a fixture to
+    maintain. `_minimal_collection` mirrors what xstac returns.
+    """
+    from open_climate_service.stac import services as stac_services
+
+    stac_services._clear_xstac_collection_cache()
+    monkeypatch.setattr(ingestion_services, "list_artifacts", lambda: SimpleNamespace(items=[_published_artifact()]))
+    monkeypatch.setattr(stac_services.registry_datasets, "get_dataset", lambda _: {"period_type": "daily"})
+    monkeypatch.setattr(
+        stac_services,
+        "_build_collection_with_xstac",
+        lambda **_: {
+            "type": "Collection",
+            "id": "thumb_dataset",
+            "extent": {"spatial": {"bbox": [[0, 0, 0, 0]]}, "temporal": {"interval": [[None, None]]}},
+            "cube:dimensions": {"time": {"type": "temporal", "extent": ["2026-01-01", "2026-01-03"]}},
+            "cube:variables": {"precip": {"type": "data", "dimensions": ["time", "y", "x"]}},
+            "assets": {"zarr": {}},
+        },
+    )
+    monkeypatch.setattr(stac_services, "_zarr_asset_metadata", lambda _: {})
+
+
+def _write_a_thumbnail() -> Path:
+    path = thumbnail_path("thumb_dataset")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n fake but on disk")
+    return path
+
+
+def test_the_collection_advertises_the_thumbnail_as_a_stac_role(client: TestClient, _published: None) -> None:
+    """`thumbnail` is a standardised STAC asset role on a Collection, so no extension is
+    needed and a STAC client picks the image up unaided."""
+    _write_a_thumbnail()
+
+    payload = client.get("/stac/collections/thumb_dataset").json()
+
+    asset = payload["assets"]["thumbnail"]
+    assert asset["roles"] == ["thumbnail"]
+    assert asset["type"] == "image/png"
+    assert asset["href"].endswith("/datasets/thumb_dataset/thumbnail.png")
+    # The href leaves the process, so it names an origin rather than being a bare path.
+    assert asset["href"].startswith("http")
+
+
+def test_the_collection_omits_the_thumbnail_when_there_is_none(client: TestClient, _published: None) -> None:
+    """Advertising an asset a client then 404s on is worse than advertising none, and absence
+    is normal: thumbnails are not backfilled, so a store never rewritten never gains one."""
+    payload = client.get("/stac/collections/thumb_dataset").json()
+
+    assert "thumbnail" not in payload["assets"]
+    assert "zarr" in payload["assets"]
+
+
+def test_the_route_serves_the_thumbnail(client: TestClient) -> None:
+    written = _write_a_thumbnail()
+
+    response = client.get("/datasets/thumb_dataset/thumbnail.png")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.content == written.read_bytes()
+
+
+def test_the_route_404s_when_a_dataset_has_no_thumbnail(client: TestClient) -> None:
+    assert client.get("/datasets/thumb_dataset/thumbnail.png").status_code == 404

--- a/tests/test_dataset_thumbnails.py
+++ b/tests/test_dataset_thumbnails.py
@@ -29,6 +29,7 @@ from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.shared import thumbnails
 from open_climate_service.shared.thumbnails import (
     THUMBNAIL_LONG_SIDE_PIXELS,
+    decimate,
     declared_midpoint,
     render_png,
     representative_slice,
@@ -228,6 +229,85 @@ def test_an_enlarged_thumbnail_keeps_its_cell_boundaries(tmp_path: Path) -> None
         assert np.allclose(quadrant, quadrant[0, 0]), "an enlarged cell was interpolated"
 
 
+# -- how much is read ---------------------------------------------------------------------
+
+
+def test_a_slice_far_larger_than_the_thumbnail_is_strided_down(tmp_path: Path) -> None:
+    """The accessor opens the *finest* pyramid level, so the slice arrives at full resolution
+    and every cell of it would be materialised for an image 512 px across. Striding bounds
+    that; one shared integer stride keeps the aspect ratio and keeps the kept cells real."""
+    arr = xr.DataArray(
+        np.zeros((1200, 800), dtype="float32"),
+        dims=("y", "x"),
+        coords={"y": np.linspace(10.0, 0.0, 1200), "x": np.linspace(0.0, 8.0, 800)},
+    )
+
+    strided = decimate(arr, long_side=THUMBNAIL_LONG_SIDE_PIXELS)
+
+    # 1200 // 512 is 2, so both axes take every second cell.
+    assert strided.sizes == {"y": 600, "x": 400}
+    assert np.array_equal(strided["y"].values, arr["y"].values[::2])
+
+
+def test_a_slice_no_larger_than_the_thumbnail_is_left_alone(tmp_path: Path) -> None:
+    """Striding a store that is already at or below the target would throw away detail the
+    render can still show, and an upscaled store has none to spare."""
+    arr = xr.DataArray(np.zeros((16, 32), dtype="float32"), dims=("y", "x"))
+
+    assert decimate(arr, long_side=THUMBNAIL_LONG_SIDE_PIXELS) is arr
+
+
+def test_a_thumbnail_never_materialises_more_than_it_draws(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The point of the striding, through the entry point rather than at the helper: a sync
+    finishing a large store should not hold the whole finest-level slice to make an icon."""
+    shapes: list[tuple[int, ...]] = []
+    real_render = thumbnails.render_png
+
+    def recording_render(arr: Any, path: Any, **kwargs: Any) -> Any:
+        shapes.append(tuple(arr.shape))
+        return real_render(arr, path, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "render_png", recording_render)
+    big = xr.Dataset(
+        {"precip": (("y", "x"), np.random.default_rng(0).random((1200, 800), dtype="float32"))},
+        coords={"y": np.linspace(10.0, 0.0, 1200), "x": np.linspace(0.0, 8.0, 800)},
+    )
+
+    write_dataset_thumbnail(_store(tmp_path, big, t_dim=None), DATASET, now=GENERATED_AT)
+
+    assert shapes == [(600, 400)]
+
+
+def test_the_store_is_closed_once_the_pixels_are_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sync run touches every dataset it syncs; leaving each one's Icechunk and Zarr backend
+    resources open behind the thumbnail is a leak that only shows up at scale."""
+    from open_climate_service.data_accessor.services import accessor
+
+    closed: list[bool] = []
+    real_open = accessor.open_icechunk_dataset
+
+    class Tracked:
+        """A stand-in, because an xarray Dataset uses __slots__ and cannot be patched in place."""
+
+        def __init__(self, ds: Any) -> None:
+            self._ds = ds
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._ds, name)
+
+        def __getitem__(self, key: Any) -> Any:
+            return self._ds[key]
+
+        def close(self) -> None:
+            closed.append(True)
+            self._ds.close()
+
+    monkeypatch.setattr(accessor, "open_icechunk_dataset", lambda path: Tracked(real_open(path)))
+
+    assert write_dataset_thumbnail(_store(tmp_path, _daily_cube(2)), DATASET, now=GENERATED_AT) is not None
+    assert closed == [True]
+
+
 # -- failure is not an ingest failure -----------------------------------------------------
 
 
@@ -247,6 +327,45 @@ def test_a_failing_render_does_not_fail_the_ingest(tmp_path: Path, monkeypatch: 
 
 def test_an_unreadable_store_does_not_fail_the_ingest(tmp_path: Path) -> None:
     assert write_dataset_thumbnail(tmp_path / "not-a-store.icechunk", DATASET) is None
+
+
+def test_a_failing_render_leaves_the_published_thumbnail_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The published file is served by HTTP, so it is never the file being written. Rendering
+    over it would let a request read a half-written PNG and let a savefig that failed part way
+    truncate a thumbnail that was fine — which is worse than the stale one it replaced."""
+    store = _store(tmp_path, _daily_cube(2))
+    published = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+    assert published is not None
+    good = published.read_bytes()
+
+    def explode(arr: Any, path: Any, **kwargs: Any) -> Any:
+        Path(path).write_bytes(b"\x89PNG truncated")  # a savefig that got part way
+        raise RuntimeError("no renderer today")
+
+    monkeypatch.setattr(thumbnails, "render_png", explode)
+
+    assert write_dataset_thumbnail(store, DATASET, now=GENERATED_AT) is None
+    assert published.read_bytes() == good
+    assert list(published.parent.iterdir()) == [published], "a half-written render was left behind"
+
+
+def test_an_all_missing_slice_keeps_the_previous_thumbnail(tmp_path: Path) -> None:
+    """Deliberate, and the counterpart to the test above. An all-missing representative slice
+    is nearly always a transient gap at the step nearest now, not a store that has gone blank,
+    so the old picture still identifies the layer. Deleting it would trade stale for nothing."""
+    published = write_dataset_thumbnail(_store(tmp_path, _daily_cube(2)), DATASET, now=GENERATED_AT)
+    assert published is not None
+    good = published.read_bytes()
+
+    empty = xr.Dataset(
+        {"precip": (("y", "x"), np.full((2, 2), np.nan, dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+
+    assert write_dataset_thumbnail(_store(tmp_path / "blank", empty, t_dim=None), DATASET) is None
+    assert published.read_bytes() == good
 
 
 # -- colormaps ----------------------------------------------------------------------------

--- a/tests/test_dataset_thumbnails.py
+++ b/tests/test_dataset_thumbnails.py
@@ -32,6 +32,7 @@ from open_climate_service.shared.thumbnails import (
     render_png,
     representative_slice,
     resolve_colormap,
+    stretch_range,
     thumbnail_path,
     write_dataset_thumbnail,
 )
@@ -57,10 +58,20 @@ def _store(tmp_path: Path, ds: xr.Dataset, *, t_dim: str | None = "t") -> Path:
     return path
 
 
-def _daily_cube(values: list[float], start: str = "2026-01-01") -> xr.Dataset:
-    """One distinct constant value per step, so the rendered slice is identifiable."""
-    times = pd.date_range(start, periods=len(values), freq="D")
-    data = np.array([[[v, v], [v, v]] for v in values], dtype="float32")
+# One distinct *pattern* per step, not one distinct constant. The thumbnail scales to the
+# slice it renders, so two constant slices produce the same image whatever their values —
+# only a different arrangement survives the normalisation and identifies which step was used.
+_PATTERNS = [
+    [[0.0, 1.0], [2.0, 3.0]],
+    [[3.0, 2.0], [1.0, 0.0]],
+    [[0.0, 3.0], [1.0, 2.0]],
+    [[2.0, 0.0], [3.0, 1.0]],
+]
+
+
+def _daily_cube(steps: int, start: str = "2026-01-01") -> xr.Dataset:
+    times = pd.date_range(start, periods=steps, freq="D")
+    data = np.array(_PATTERNS[:steps], dtype="float32")
     return xr.Dataset(
         {"precip": (("t", "y", "x"), data)},
         coords={"t": times, "y": [1.5, 0.5], "x": [10.5, 11.5]},
@@ -68,15 +79,30 @@ def _daily_cube(values: list[float], start: str = "2026-01-01") -> xr.Dataset:
 
 
 def _rendered_reference(arr: Any, tmp_path: Path) -> bytes:
-    """The bytes the thumbnail should have, rendered from the slice we expect it to show."""
+    """The bytes the thumbnail should have, rendered from the slice we expect it to show.
+
+    Uses the same per-slice stretch as the code under test, because these tests are about
+    *which slice* was chosen; the stretch itself is covered separately below.
+    """
     reference = render_png(
         arr,
         tmp_path / "reference.png",
         colormap="blues",
-        clim=(0.0, 10.0),
+        clim=stretch_range(arr.values),
         max_pixels=THUMBNAIL_MAX_PIXELS,
     )
     return reference.read_bytes()
+
+
+def _rendered_declared_range(arr: Any, tmp_path: Path) -> bytes:
+    """What the thumbnail would have been against the template's declared display range."""
+    return render_png(
+        arr,
+        tmp_path / "declared.png",
+        colormap="blues",
+        clim=(0.0, 20.0),
+        max_pixels=THUMBNAIL_MAX_PIXELS,
+    ).read_bytes()
 
 
 # -- which slice -----------------------------------------------------------------------
@@ -86,7 +112,7 @@ def test_a_datetime_store_renders_the_step_nearest_the_generation_date(tmp_path:
     """Nearest to now, not the last step. The store here runs past the generation date, the
     way a forecast does, so the two answers differ and the last step would be wrong."""
     # Steps at 60, 30 and 1 days before, and 30 days after, the pinned generation date.
-    cube = _daily_cube([1.0, 2.0, 3.0, 4.0], start="2025-12-31")
+    cube = _daily_cube(4, start="2025-12-31")
     cube = cube.assign_coords(
         t=pd.to_datetime(["2025-12-31", "2026-01-30", "2026-02-28", "2026-03-31"]),
     )
@@ -103,7 +129,7 @@ def test_a_climatology_renders_its_first_slice(tmp_path: Path) -> None:
     """A climatology's axis is an ordinal dayofyear, not a datetime, so there is no "nearest
     to today" without inventing a mapping. Index 0 is the answer, and it does not drift."""
     doy = xr.Dataset(
-        {"precip": (("dayofyear", "y", "x"), np.array([[[v, v], [v, v]] for v in (7.0, 8.0, 9.0)], dtype="float32"))},
+        {"precip": (("dayofyear", "y", "x"), np.array(_PATTERNS[:3], dtype="float32"))},
         coords={"dayofyear": [1, 2, 3], "y": [1.5, 0.5], "x": [10.5, 11.5]},
     )
     store = _store(tmp_path, doy, t_dim=None)
@@ -168,7 +194,7 @@ def test_the_thumbnail_is_capped_at_the_stac_recommended_size(tmp_path: Path) ->
 def test_a_failing_render_does_not_fail_the_ingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A dataset is not less ingested for being unrecognisable. The callers rely on this
     function never raising rather than each wrapping it, so the guarantee is tested here."""
-    store = _store(tmp_path, _daily_cube([1.0, 2.0]))
+    store = _store(tmp_path, _daily_cube(2))
 
     def explode(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("no renderer today")
@@ -207,6 +233,64 @@ def test_every_built_in_template_colormap_resolves_to_itself() -> None:
 def test_an_unknown_colormap_falls_back_instead_of_raising() -> None:
     assert resolve_colormap("not-a-colormap").name == "viridis"
     assert resolve_colormap(None).name == "viridis"
+
+
+def test_a_low_signal_slice_still_shows_its_structure(tmp_path: Path) -> None:
+    """The case that decided per-slice scaling. CHIRPS daily declares a 0-20 mm display range,
+    and 31 January 2025 over Nepal peaks at 0.408 mm — 2% of it — so against the declared range
+    the whole frame renders as the palest end of the colormap and shows nothing at all."""
+    faint = xr.Dataset(
+        {"precip": (("y", "x"), np.array([[0.0, 0.05], [0.2, 0.408]], dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+    store = _store(tmp_path, faint, t_dim=None)
+
+    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    # Against the declared 0-20 range every cell would land in the same colour; scaled to the
+    # slice they separate.
+    assert written.read_bytes() != _rendered_declared_range(faint["precip"], tmp_path)
+
+
+def test_a_constant_slice_renders_rather_than_dividing_by_zero(tmp_path: Path) -> None:
+    """A flat field has no range to stretch. It should come out one colour, not raise."""
+    flat = xr.Dataset(
+        {"precip": (("y", "x"), np.full((2, 2), 3.0, dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+    low, high = stretch_range(flat["precip"].values) or (0.0, 0.0)
+    assert low < high
+
+    assert write_dataset_thumbnail(_store(tmp_path, flat, t_dim=None), DATASET) is not None
+
+
+def test_an_all_missing_slice_publishes_without_a_thumbnail(tmp_path: Path) -> None:
+    """Nothing to show is not the same as a failure, and neither is an ingest problem."""
+    empty = xr.Dataset(
+        {"precip": (("y", "x"), np.full((2, 2), np.nan, dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+
+    assert stretch_range(empty["precip"].values) is None
+    assert write_dataset_thumbnail(_store(tmp_path, empty, t_dim=None), DATASET) is None
+
+
+def test_the_stretch_resists_a_single_outlier() -> None:
+    """Raw min/max would hand the whole scale to one storm cell and flatten the rest, which is
+    the problem a per-slice stretch exists to avoid — hence percentiles rather than extremes.
+
+    The field has real structure under the outlier, which is what makes the difference
+    visible: a field that is 99% one value has nothing for either rule to preserve, and there
+    the percentiles collapse and the extremes are used deliberately.
+    """
+    field = np.linspace(0.0, 10.0, 100).astype("float32")
+    field[0] = 500.0
+
+    low, high = stretch_range(field) or (0.0, 0.0)
+
+    assert high < 11.0, f"one outlier took the whole range: {(low, high)}"
+    assert (low, high) != (float(field.min()), float(field.max()))
 
 
 # -- when it is generated ------------------------------------------------------------------
@@ -269,7 +353,7 @@ def test_one_ingest_produces_exactly_one_render(tmp_path: Path, monkeypatch: pyt
 
     def fake_sync(**kwargs: object) -> object:
         # Stand in for a three-period sync: the store the finalisation sees is the finished one.
-        downloader.write_to_icechunk_store(_daily_cube([1.0, 2.0, 3.0]), store_path, commit_message="test")
+        downloader.write_to_icechunk_store(_daily_cube(3), store_path, commit_message="test")
         return SimpleNamespace(periods_written=3)
 
     renders: list[Any] = []

--- a/tests/test_dataset_thumbnails.py
+++ b/tests/test_dataset_thumbnails.py
@@ -28,7 +28,8 @@ from open_climate_service.data_manager.services import downloader
 from open_climate_service.ingestions import services as ingestion_services
 from open_climate_service.shared import thumbnails
 from open_climate_service.shared.thumbnails import (
-    THUMBNAIL_MAX_PIXELS,
+    THUMBNAIL_LONG_SIDE_PIXELS,
+    declared_midpoint,
     render_png,
     representative_slice,
     resolve_colormap,
@@ -89,7 +90,7 @@ def _rendered_reference(arr: Any, tmp_path: Path) -> bytes:
         tmp_path / "reference.png",
         colormap="blues",
         clim=stretch_range(arr.values),
-        max_pixels=THUMBNAIL_MAX_PIXELS,
+        long_side=THUMBNAIL_LONG_SIDE_PIXELS,
     )
     return reference.read_bytes()
 
@@ -101,7 +102,7 @@ def _rendered_declared_range(arr: Any, tmp_path: Path) -> bytes:
         tmp_path / "declared.png",
         colormap="blues",
         clim=(0.0, 20.0),
-        max_pixels=THUMBNAIL_MAX_PIXELS,
+        long_side=THUMBNAIL_LONG_SIDE_PIXELS,
     ).read_bytes()
 
 
@@ -168,24 +169,63 @@ def test_the_nearest_step_is_chosen_by_dtype_not_by_a_declared_period_type(tmp_p
 # -- size --------------------------------------------------------------------------------
 
 
-def test_the_thumbnail_is_capped_at_the_stac_recommended_size(tmp_path: Path) -> None:
-    """STAC best practice for the `thumbnail` role is under 600x600. A store is routinely far
-    larger than that, so the cap has to be applied rather than assumed."""
+def _rendered_size(path: Path) -> tuple[int, int]:
     from matplotlib import image as mpimg
 
+    height, width = mpimg.imread(path).shape[:2]
+    return height, width
+
+
+def test_a_store_larger_than_the_target_is_scaled_down(tmp_path: Path) -> None:
+    """STAC best practice for the `thumbnail` role is under 600x600, and a store is routinely
+    far larger, so the size has to be applied rather than assumed."""
     big = xr.Dataset(
         {"precip": (("y", "x"), np.random.default_rng(0).random((1200, 800), dtype="float32"))},
         coords={"y": np.linspace(10.0, 0.0, 1200), "x": np.linspace(0.0, 8.0, 800)},
     )
-    store = _store(tmp_path, big, t_dim=None)
 
-    written = write_dataset_thumbnail(store, DATASET, now=GENERATED_AT)
+    written = write_dataset_thumbnail(_store(tmp_path, big, t_dim=None), DATASET, now=GENERATED_AT)
 
     assert written is not None
-    height, width = mpimg.imread(written).shape[:2]
-    assert max(height, width) <= THUMBNAIL_MAX_PIXELS
-    # The aspect ratio survives the cap: 1200x800 scaled by 600/1200 is 600x400.
-    assert (height, width) == (600, 400)
+    # The aspect ratio survives: 1200x800 scaled by 512/1200 is 512x341.
+    assert _rendered_size(written) == (THUMBNAIL_LONG_SIDE_PIXELS, 341)
+
+
+def test_a_store_coarser_than_the_target_is_scaled_up(tmp_path: Path) -> None:
+    """Both directions. A 32x16 forecast grid left at its own size is a postage stamp in any
+    client that does not scale it, and mush in any client that does — we control the CSS in
+    neither STAC Browser nor a DHIS2 app, so the resolution is decided here instead."""
+    coarse = xr.Dataset(
+        {"precip": (("y", "x"), np.random.default_rng(0).random((16, 32), dtype="float32"))},
+        coords={"y": np.linspace(10.0, 0.0, 16), "x": np.linspace(0.0, 20.0, 32)},
+    )
+
+    written = write_dataset_thumbnail(_store(tmp_path, coarse, t_dim=None), DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    # 32x16 enlarged by 512/32 is 512x256, and the aspect ratio is unchanged.
+    assert _rendered_size(written) == (256, THUMBNAIL_LONG_SIDE_PIXELS)
+
+
+def test_an_enlarged_thumbnail_keeps_its_cell_boundaries(tmp_path: Path) -> None:
+    """Nearest-neighbour, not a smooth blow-up: a coarse dataset should look coarse. A 2x2
+    field enlarged 256x either has four flat quadrants or it has been interpolated."""
+    tiny = xr.Dataset(
+        {"precip": (("y", "x"), np.array([[0.0, 1.0], [2.0, 3.0]], dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+
+    written = write_dataset_thumbnail(_store(tmp_path, tiny, t_dim=None), DATASET, now=GENERATED_AT)
+
+    assert written is not None
+    from matplotlib import image as mpimg
+
+    image = mpimg.imread(written)
+    half = THUMBNAIL_LONG_SIDE_PIXELS // 2
+    # Each quadrant is one source cell, so it is a single colour throughout.
+    for row, col in ((0, 0), (0, half), (half, 0), (half, half)):
+        quadrant = image[row + 10 : row + half - 10, col + 10 : col + half - 10]
+        assert np.allclose(quadrant, quadrant[0, 0]), "an enlarged cell was interpolated"
 
 
 # -- failure is not an ingest failure -----------------------------------------------------
@@ -291,6 +331,73 @@ def test_the_stretch_resists_a_single_outlier() -> None:
 
     assert high < 11.0, f"one outlier took the whole range: {(low, high)}"
     assert (low, high) != (float(field.min()), float(field.max()))
+
+
+@pytest.mark.parametrize(
+    "declared,midpoint",
+    [
+        ([-5.0, 5.0], 0.0),  # temperature anomaly
+        ([-30.0, 30.0], 0.0),  # temperature in Celsius, where zero is freezing
+        ([-3, 3], 0.0),  # SPI
+        ([0.0, 20.0], None),  # precipitation
+        ([0, 4000], None),  # elevation, which pairs Spectral_r with a one-sided range
+        ([-0.1, 1.0], None),  # NDVI: negative, but not symmetric
+        ([-1.0, 1.5], None),
+        (None, None),
+        ("nonsense", None),
+    ],
+)
+def test_only_a_zero_symmetric_declared_range_names_a_midpoint(declared: Any, midpoint: float | None) -> None:
+    """The signal for "this quantity diverges about zero" is the declared range, not the
+    colormap: `copernicus_dem_elevation` uses the diverging Spectral_r over [0, 4000] and must
+    not be centred, and across the shipped templates the split by range is exact."""
+    assert declared_midpoint(declared) == midpoint
+
+
+def test_a_diverging_scale_keeps_zero_at_its_midpoint(tmp_path: Path) -> None:
+    """Blue means below normal. Stretched to its own extremes, an anomaly slice that happens
+    to be entirely positive would still render half blue and invert that meaning."""
+    all_positive = np.linspace(0.5, 4.0, 100).astype("float32")
+
+    low, high = stretch_range(all_positive, midpoint=0.0) or (0.0, 0.0)
+
+    assert low == -high, "the range is not symmetric about zero"
+    assert low < 0.0 < high
+    # Every value sits in the upper half, so nothing renders on the "below" side of the scale.
+    assert float(all_positive.min()) > 0.0
+
+
+def test_a_sequential_scale_is_not_centred(tmp_path: Path) -> None:
+    """Centring a one-sided quantity would throw away half the colour scale on values that
+    cannot occur — no rainfall is below zero."""
+    rain = np.linspace(0.0, 4.0, 100).astype("float32")
+
+    assert stretch_range(rain, midpoint=None) != stretch_range(rain, midpoint=0.0)
+    low, _ = stretch_range(rain, midpoint=None) or (0.0, 0.0)
+    assert low >= 0.0
+
+
+def test_an_anomaly_store_renders_centred_on_zero(tmp_path: Path) -> None:
+    """Through the entry point, since the midpoint has to be read off the template's declared
+    range and reach the render — the wiring is the part that can silently not happen."""
+    anomaly = xr.Dataset(
+        {"precip": (("y", "x"), np.array([[0.5, 1.0], [2.0, 4.0]], dtype="float32"))},
+        coords={"y": [1.5, 0.5], "x": [10.5, 11.5]},
+    )
+    store = _store(tmp_path, anomaly, t_dim=None)
+    diverging = {**DATASET, "display": {"colormap": "rdbu_r", "range": [-5.0, 5.0]}}
+
+    written = write_dataset_thumbnail(store, diverging, now=GENERATED_AT)
+
+    assert written is not None
+    expected = render_png(
+        anomaly["precip"],
+        tmp_path / "centred.png",
+        colormap="rdbu_r",
+        clim=stretch_range(anomaly["precip"].values, midpoint=0.0),
+        long_side=THUMBNAIL_LONG_SIDE_PIXELS,
+    ).read_bytes()
+    assert written.read_bytes() == expected
 
 
 # -- when it is generated ------------------------------------------------------------------


### PR DESCRIPTION
[CLIM-1076](https://dhis2.atlassian.net/browse/CLIM-1076)

`thumbnail` is a standardised STAC asset role and a Collection may carry `assets` — the spec recommends collection-level assets for exactly this shape, a standalone collection fronting a Zarr store with no items. So no extension is involved and any STAC client, STAC Browser included, picks the image up unaided.

<img width="1760" height="1210" alt="final-thumbnails" src="https://github.com/user-attachments/assets/841fdeba-67cd-4649-bc34-0eebd8096b16" />

<img width="1512" height="982" alt="Screenshot 2026-09-09 at 22 55 33" src="https://github.com/user-attachments/assets/112039be-91bb-4f3c-82ba-7a805f236542" />

## The three decisions

**Which slice** — the step nearest the generation date on a datetime axis. Not the last step: for an observed store those coincide, but a forecast store runs into the future and its final step is a lead time nobody recognises the dataset by. A climatology takes its first slice: the axis is an ordinal `dayofyear` (1..366) or `month` (1..12), so nearest-to-today would need a date-to-ordinal mapping, a leap-day decision for 366 and an answer to whose timezone "today" is in — and index 0 also means the thumbnail does not drift through the year.

The discriminator is the **coordinate's dtype**, not the declared `period_type`, because the dtype cannot disagree with the data it describes. 21 of the 27 built-in templates are datetime, 6 are climatology.

**When** — once per sync run, in the end-of-sync finalisation next to `_maybe_build_pyramid`. A streaming ingest commits one period at a time, so rendering from the commit path would produce a few hundred PNGs on a historical backfill and keep the last. Finalising there also means rendering from the finished store rather than one still being appended to.

A run that aborts before finalisation leaves the previous thumbnail in place, so it can be one sync run stale. The next successful run corrects it — the same failure shape the pyramid rebuild already has.

**Backfill** — none. A store gains one on its next sync run and not before, so a one-off ingest that is never rewritten never gets one. The collection therefore advertises the asset **only when the file exists**: a href a client then 404s on is worse than no href. A missing thumbnail is a normal and possibly permanent state, which CLIM-940 and CLIM-988 need to render as such rather than as a fault.

## Scaled to the slice, not to `display.range`

`display.range` is chosen so a dataset's *layers* are comparable with each other in the viewer. A thumbnail has the opposite job — make one slice recognisable on its own — and against the declared range that fails for a whole class of datasets. CHIRPS daily precipitation over Nepal on 31 January 2025 peaks at 0.408 mm of a 0-20 mm scale, 2% of it, so the entire frame rendered as the palest end of `blues` and showed nothing. Found by rendering the real store, not by reasoning about it.

The stretch uses percentiles (2/98) rather than the raw extremes, because these fields are skewed: one storm cell at 80 mm over a field otherwise under 1 mm would push everything else into one colour, which is the problem the stretch exists to solve. Degenerate slices are handled rather than left to raise — percentiles that collapse fall back to the extremes, a constant field is widened so the normalisation cannot divide by zero, and an all-missing slice publishes without a thumbnail.

The cost, stated in the code: two thumbnails no longer share a scale, and neither matches the viewer's rendering of the same layer. For an icon whose job is recognition that is the better trade; for reading a value off the image it would not be, and the image is not for that.

### Diverging scales keep zero at the midpoint

Stretching to the slice breaks a diverging colormap on its own: an anomaly slice that happens to be entirely positive would still render half blue, inverting the one thing the colour is there to say. When a template declares a range symmetric about zero, the stretch is made symmetric about zero too — the neutral colour always lands on the neutral value, and only the *span* varies with the slice.

The declared range is the signal rather than a list of diverging colormap names, because it is the author's own statement and it is exact across the shipped templates: every diverging dataset declares `[-3,3]`, `[-5,5]`, `[-10,10]`, `[-15,15]`, `[-20,20]` or `[-30,30]`, and every sequential one declares a one-sided range. It also gets `copernicus_dem_elevation` right, which pairs the diverging `Spectral_r` with `[0, 4000]` and must not be centred.

## Size: a fixed long side, enlarging as well as reducing

The longest side is rendered at exactly 512 px rather than merely capped there, so a coarse store is enlarged rather than left tiny. Pixel dimensions do not limit how large a client displays the file — CSS does — but we control the CSS in neither STAC Browser nor a DHIS2 app, and their default smoothing turns a 32×16 forecast grid into mush when blown up to a card. Enlarging here with nearest-neighbour keeps the cell boundaries crisp, which is also the honest picture of a coarse dataset, and costs little because flat blocks compress well (GEFS: 1.4 KB → 3.1 KB).

512 rather than 600 because the size is now exact rather than a ceiling: STAC's recommendation for the role is "less than 600x600", and a square store at an exact 600 long side would sit on that boundary rather than inside it.

## A live bug this fixes

Rendering moves into `shared/thumbnails.py`, which the openEO `PNG` output now shares. That exposed a bug in it: template colormap names are written for the map viewer, which resolves them through chroma-js **case-insensitively**, while matplotlib is case-sensitive. `plt.get_cmap("blues")` raises. Of the 27 built-in templates only the 9 declaring `RdBu` would render — `blues` (9), `rdbu_r` (7) and `reds` (2) all raised, outside the `try` that wrapped the registry lookup. Resolution is now case-insensitive with a fallback, so one declared colormap means the same thing in the viewer and in the image.

The openEO PNG keeps its own behaviour deliberately: it renders the **first** step at the cube's natural size, because a result is what the caller asked for, where a catalogue thumbnail is an icon and is capped at 600px.

## Verified

- **Against ten real ingested stores** from the Nepal and Norway instances, not only synthetic fixtures. `copernicus_dem_elevation` comes out as recognisably Nepal's Himalaya with the plateau high in the north, and `senorge_temperature_daily` as Norway in UTM33 with the sea transparent — orientation and colormap confirmed against real geography. That store is also one of the pre-CLIM-852 stores with transposed `spatial:dimensions`, and it renders correctly because the thumbnail reads the array rather than the convention attributes.
- **Mutation-checked**, since several of these tests would pass against a wrong implementation. Reverting the case-insensitive colormap match fails the whole-catalogue test; changing nearest-to-now to last-step fails the datetime test; adding a render to the per-commit path (`write_geozarr_attrs`) fails `test_a_multi_period_sync_never_reaches_the_renderer`.
- The two timing tests are a pair and neither is sufficient alone: one asserts the renderer is never reached during a three-period sync, the other that one `create_artifact` produces exactly one render. Only the final image survives either way, so the distinction is invisible in the published result.
- `make lint` clean (ruff, mypy, pyright); 1264 tests pass, 1 skipped.

## Not in this PR

- Backfilling existing stores — decided against; they gain one on their next sync.
- Template previews. A template has no data, so any image would be fabricated; CLIM-988 covers the colormap swatch that belongs there.
- `overview`-role assets (full extent, medium resolution, COG).


[CLIM-1076]: https://dhis2.atlassian.net/browse/CLIM-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ