### PR TITLE
chore(viewer): pin zarr-layer 0.9.1, which carries the selector fix

### DIFF
--- a/open_climate_service/templates/map-viewer.html
+++ b/open_climate_service/templates/map-viewer.html
@@ -275,7 +275,7 @@
       // (carbonplan/zarr-layer#88). CLIM-1006 (CHIRPS3 streaks on the Rwanda instance) was
       // reported against 0.6.1, which never read these attributes, so it is a separate
       // fault and still open.
-      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.9.0";
+      import { ZarrLayer } from "https://esm.sh/@carbonplan/zarr-layer@0.9.1";
       import chroma from "https://esm.sh/chroma-js@3.2.0";
 
       // Suffix _r means the scale is reversed (matplotlib convention).
@@ -376,10 +376,11 @@
       // layer load, then fell through to treating a numeric value as the index. That fallback
       // happened to be what we meant, so this worked by accident (CLIM-1003).
       //
-      // Saying it outright drops the wasted coordinate read and the logged failure, and stops
-      // depending on a fallback the library is actively changing: carbonplan/zarr-layer#87
-      // tightens the same resolver, rejecting unresolvable *string* selectors while keeping
-      // numeric ones. Every write to `selector` goes through here so they cannot drift apart.
+      // Saying it outright drops the wasted coordinate read and the logged failure, and no
+      // longer depends on a fallback that has since been removed: carbonplan/zarr-layer#87,
+      // released in 0.9.1, rejects an unresolvable *string* selector instead of silently
+      // returning index 0, and keeps the direct-index behaviour this relies on. Every write to
+      // `selector` goes through here so they cannot drift apart.
       function indexSelection(index) {
         return { selected: index, type: "index" };
       }


### PR DESCRIPTION
[carbonplan/zarr-layer#87](https://github.com/carbonplan/zarr-layer/pull/87) landed, closing [#86](https://github.com/carbonplan/zarr-layer/issues/86) — the issue this repo reported. An unresolvable selector silently resolved to index 0, so a multi-band composite read the same slice for every band and rendered grey rather than failing: a plausible-looking image of the wrong data.

This pins `0.9.1` in the map viewer.

## Provenance

Checked rather than inferred from the version number, since the published bundle is minified and its identifiers are mangled:

- upstream's default branch is at version `0.9.1`, and `git compare` puts it **1 commit ahead of #87's merge and 0 behind** — so 0.9.1 is that merge plus its version bump;
- esm.sh serves `0.9.1` and still exports `ZarrLayer`.

## Nothing here depended on the old fallback

#87 *tightens* selector resolution, so the question is whether the viewer relied on the behaviour being removed. It does not. CLIM-1003 already routed every write to `selector` through `indexSelection()`, which sends an explicit `{selected, type: "index"}` and skips the coordinate lookup entirely — all three call sites on `main` go through it. The new rejection of unresolvable **string** selectors cannot reach this viewer, and the direct-index behaviour it keeps is exactly what we send.

The comment at `indexSelection` described #87 as something "the library is actively changing"; it now says what the library does.

## Verified

- `make lint` clean (ruff, mypy, pyright); 1689 passed, 6 skipped.
- **Not** visually confirmed in a browser — the Python tests only grep the template, nothing exercises the JS.

## Related

`feat/clim-947-rgb-rendering` (#359) is the branch this actually unblocks: its true-colour code documents this exact bug and resolves band indices itself to avoid it. Worth deciding there whether to keep that resolution — defensive, and works on any version — or lean on 0.9.1 now that it is pinned.