### PR TITLE
fix(openeo): stop offering save_result units as a recovery

### DIFF
--- a/open_climate_service/openeo/jobs.py
+++ b/open_climate_service/openeo/jobs.py
@@ -948,8 +948,20 @@ def _reject_incompatible_template_units(ds: Any, variable: str, cf_attrs: dict[s
 
     Overwriting a *placeholder* unit remains the point of the call site — a placeholder is not
     a parseable unit, so `_variable_units` reports it as absent and this never fires. What is
-    refused is overwriting a unit the result genuinely carries; `units` in the save_result
-    options is the way to say the relabel is intended.
+    refused is overwriting a unit the result genuinely carries.
+
+    `units` in the save_result options is **not** an escape hatch from that refusal, and the
+    messages below deliberately do not offer it as one (CLIM-918). It is a declaration of what
+    the result already is, never a conversion or an override:
+
+    * With a **pre-registered** template, `cf_attrs` comes from the template and the option is
+      never read, so passing it re-raises this same error.
+    * With an **auto-derived** template, the option becomes the declared unit, so it is checked
+      here like any other declaration — it can only cause this refusal, never avoid it. Omitting
+      it is what lets the produced unit through.
+
+    The two real recoveries are converting the result in the process graph, or targeting a
+    template that declares the units the process produces.
     """
     declared = cf_attrs.get("units")
     produced = _variable_units(ds, variable)
@@ -976,15 +988,13 @@ def _reject_incompatible_template_units(ds: Any, variable: str, cf_attrs: dict[s
             f"({declared_unit.dimensionality or 'dimensionless'} vs "
             f"{produced_unit.dimensionality or 'dimensionless'}). Publishing would relabel the values "
             "rather than convert them. Use a template whose units match the process output (a relative "
-            "anomaly is a percentage, not the observed variable's unit), or pass an explicit "
-            "'units' in the save_result options."
+            "anomaly is a percentage, not the observed variable's unit)."
         )
     raise ValueError(
         f"dataset template declares units '{declared or 'dimensionless'}' but the result carries "
         f"'{produced}'. They measure the same quantity on different scales, so publishing would "
-        "relabel the values without converting them. Convert the result in the process graph, use a "
-        "template declaring the units the process produces, or pass an explicit 'units' in the "
-        "save_result options."
+        "relabel the values without converting them. Convert the result in the process graph, or use "
+        "a template declaring the units the process produces."
     )
 
 

--- a/tests/test_managed_publish_units.py
+++ b/tests/test_managed_publish_units.py
@@ -303,3 +303,75 @@ def test_absolute_anomaly_publishes_with_the_observed_unit_end_to_end(managed_in
 
     assert _published_units("chirps3_precipitation_daily_anomaly") == "mm/d"
     assert float(ds["tp"].isel(t=0, y=0, x=0)) == pytest.approx(2.0)
+
+
+# -- `units` in the save_result options is a declaration, not an escape hatch (CLIM-918) ------
+
+
+def test_save_result_units_does_not_rescue_a_preregistered_mismatch(managed_instance: Path) -> None:
+    """The error used to advise passing `units` in the save_result options. Following that
+    advice changes nothing here: with a pre-registered template the option is never read, so
+    the publish fails identically. Driven through `_write_managed_zarr` rather than the guard,
+    because it is the option plumbing — not the comparison — that makes the advice empty."""
+    registry.write_dataset_template(
+        {
+            "id": "preregistered_declared_mm",
+            "name": "Precipitation anomaly",
+            "short_name": "Anomaly",
+            "variable": "tp",
+            "units": "mm/d",
+            "period_type": "daily",
+            "sync": {"kind": "static"},
+            "display": {"colormap": "rdbu_r", "range": [-20.0, 20.0]},
+        }
+    )
+
+    options: dict[str, Any] = {
+        "dataset_id": "preregistered_declared_mm",
+        "variable": "tp",
+        "source_dataset_id": "chirps3_precipitation_daily",
+        "units": "%",  # the recovery the old message suggested
+    }
+    with pytest.raises(ValueError, match="measures a different quantity"):
+        jobs._write_managed_zarr(_cube("%"), options)
+
+
+def test_save_result_units_can_only_cause_the_refusal_not_avoid_it(managed_instance: Path) -> None:
+    """On the auto-derived path the option *is* read — as the declared unit, so it is checked
+    like any other declaration. Declaring `mm/d` over a result carrying `%` is refused, while
+    omitting the option lets the produced unit through. So the option never rescues a publish
+    in either direction, which is why the message no longer offers it."""
+    refused: dict[str, Any] = {
+        "dataset_id": "auto_declared_mm",
+        "variable": "tp",
+        "source_dataset_id": "chirps3_precipitation_daily",
+        "units": "mm/d",
+    }
+    with pytest.raises(ValueError, match="measures a different quantity"):
+        jobs._write_managed_zarr(_cube("%"), refused)
+
+    jobs._write_managed_zarr(
+        _cube("%"),
+        {
+            "dataset_id": "auto_no_units_option",
+            "variable": "tp",
+            "source_dataset_id": "chirps3_precipitation_daily",
+        },
+    )
+    assert _published_units("auto_no_units_option") == "%"
+
+
+@pytest.mark.parametrize(
+    ("declared", "produced"),
+    [("mm/d", "%"), ("mm/d", "m/d")],  # different quantity, then same quantity different scale
+)
+def test_neither_refusal_offers_the_save_result_units_option(declared: str, produced: str) -> None:
+    """Both messages must stop advertising a recovery that does not exist. Asserted on the
+    text because the advice *is* the defect — a reader who follows it gets the same error."""
+    with pytest.raises(ValueError) as exc_info:
+        jobs._reject_incompatible_template_units(_cube(produced), "tp", {"units": declared})
+
+    message = str(exc_info.value)
+    assert "save_result" not in message
+    # ...and each still names a recovery that works.
+    assert "template" in message


### PR DESCRIPTION
Fixes CLIM-918.

Both unit-mismatch refusals in `_reject_incompatible_template_units` advised passing an explicit `units` in the `save_result` options as a way out. The ticket asked which of three things that option should be. The code has already answered: it is **a declaration**, never a conversion or an override, so the advice cannot work on either path.

- **Pre-registered template** — `cf_attrs = cf_attrs_from_template(template)` (`jobs.py:746`). The option is never read, so following the advice raises the same error again.
- **Auto-derived template** — the option becomes the declared unit (`jobs.py:880-883`) and is then checked like any other declaration. It can only *cause* the refusal, never avoid it; omitting it is what lets the produced unit through.

So the messages now name the two recoveries that do work — convert in the process graph, or target a template declaring what the process produces — and the docstring that motivated the advice says why the option is not an escape hatch. The refusal itself is unchanged; only the advice attached to it was unsupported.

`units` is not documented as a `save_result` option anywhere, so these two messages were the only place it was offered. `docs/workflows.md` already gives the correct advice.

### Tests

- Two publish-path tests pin why the advice was empty, driven through `_write_managed_zarr` rather than the guard, since it is the option plumbing and not the comparison that makes it empty. **These pass on the pre-fix code too** — deliberately: they document the behaviour the old message misdescribed, and they are what stops the option quietly becoming an override later.
- One test asserts neither message mentions `save_result` and that each still names a working recovery. This one fails on pre-fix code, both parametrizations.

### Validation

1693 passed, 6 skipped. Ruff check + format, mypy, pyright and `mkdocs build --strict` clean; `git diff --check` clean. (Pyright's 2 warnings are the pre-existing optional `dhis2_client` import.)
