### PR TITLE
fix(templates): say which templates can be ingested, and refuse the rest with a 400 (CLIM-912)

### DIFF
--- a/docs/adding_custom_datasets.md
+++ b/docs/adding_custom_datasets.md
@@ -253,6 +253,17 @@ Note `end` stays a plain `str`, so there is no missing-value case to handle.
 
 **Honour `end` when it is given.** If your plugin returns periods outside the requested temporal union, ingestion is refused before mutation. That guard catches a plugin that ignores the range rather than silently storing more than was asked for, so a lead-day plugin has to filter rather than ignore.
 
+### Templates that are produced, not ingested
+
+`ingestion.plugin` is what makes a template ingestable, and roughly half the shipped catalogue
+has none: anomalies, normals and change rasters are *produced* by a workflow through
+`save_result` and registered as static templates, so there is nothing upstream to fetch.
+
+`GET /dataset-templates/` reports this as `ingestable` on every template, the `/manage` ingest
+form offers only the ingestable ones, and asking to ingest one that is not returns `400` naming
+the reason. Read the flag rather than inferring it from `sync.kind`: the two are not the same
+question, and `era5land_temperature_daily_normal_1991_2020` is `static` *and* ingestable.
+
 `temporal_direction` is separate from `sync.kind` on purpose: a forecast is still `temporal` for sync (re-run it and you get fresher data); what differs is which way its periods run. It cannot be combined with `sync.kind: static`, which has no upstream to look ahead into.
 
 **How far ahead belongs in the template, not the request.** A source often publishes further out than is useful — 40 days when only 7 verify well. That cap is a property of the dataset, so express it in `ingestion.params` (as `max_lead_days` above) and let your plugin's `periods()` honour it. The request then narrows _within_ that window rather than re-deciding it on every run.

--- a/open_climate_service/data_registry/routes.py
+++ b/open_climate_service/data_registry/routes.py
@@ -9,10 +9,21 @@ from .services import datasets
 router = APIRouter()
 
 
+def _with_ingestability(dataset: dict[str, Any]) -> dict[str, Any]:
+    """A template plus the derived `ingestable` flag.
+
+    Derived rather than declared, so a template author cannot get it wrong: it is read from
+    the same `ingestion.plugin` that `create_artifact` requires. Without it the listing gives
+    an operator no way to tell an ingestable template from a workflow output, and the answer
+    arrives as a failed ingest (CLIM-912).
+    """
+    return {**dataset, "ingestable": datasets.is_ingestable(dataset)}
+
+
 @router.get("/")
 def list_dataset_templates() -> list[dict[str, Any]]:
     """Return the available dataset templates from the registry."""
-    return datasets.list_datasets()
+    return [_with_ingestability(dataset) for dataset in datasets.list_datasets()]
 
 
 def _get_dataset_or_404(dataset_id: str) -> dict[str, Any]:
@@ -32,4 +43,4 @@ def get_dataset_template(dataset_id: str) -> dict[str, Any]:
     dataset = _get_dataset_or_404(dataset_id)
     coverage = get_data_coverage(dataset)
     dataset.update(coverage)
-    return dataset
+    return _with_ingestability(dataset)

--- a/open_climate_service/data_registry/services/datasets.py
+++ b/open_climate_service/data_registry/services/datasets.py
@@ -146,6 +146,26 @@ def list_datasets() -> list[dict[str, Any]]:
     return list(merged.values())
 
 
+def is_ingestable(dataset: dict[str, Any]) -> bool:
+    """Whether this template can be ingested from an upstream source.
+
+    An ingestable template declares ``ingestion.plugin``: the fetch path. Half the shipped
+    catalogue does not — anomalies, normals and change rasters are *produced* by a workflow
+    through ``save_result`` and registered as static templates, so there is nothing upstream
+    to fetch.
+
+    Keyed on the plugin rather than on ``sync.kind``, which looks like the same question and
+    is not: ``era5land_temperature_daily_normal_1991_2020`` is ``kind: static`` *and* has a
+    plugin, so a kind-based rule would refuse a template that ingests perfectly well. The
+    plugin is what `create_artifact` actually requires, so it is what this reports.
+    """
+    ingestion = dataset.get("ingestion")
+    if not isinstance(ingestion, dict):
+        return False
+    plugin = ingestion.get("plugin")
+    return isinstance(plugin, str) and bool(plugin.strip())
+
+
 def get_dataset(dataset_id: str) -> dict[str, Any] | None:
     """Get dataset dict for a given id."""
     datasets_lookup = {d["id"]: d for d in list_datasets()}

--- a/open_climate_service/ingestions/routes.py
+++ b/open_climate_service/ingestions/routes.py
@@ -72,7 +72,11 @@ def create_ingestion(
     return immediately with 202 + ``Location: /ingestions/jobs/{id}``.
     """
     if _prefer_respond_async(prefer):
-        _get_dataset_or_404(request.dataset_id)
+        # Refuse here, not in the worker. Everything past `submit_callable_job` is reported
+        # through the job record, so a non-ingestable template would be accepted with 202 and
+        # then fail — logging a traceback for what is a client mistake, and hiding the reason
+        # from the response that was supposed to carry it (CLIM-912).
+        services.ensure_ingestable(_get_dataset_or_404(request.dataset_id))
         get_extent_or_404()
 
         from open_climate_service.ingestions.processes import execute_ingestion

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -267,6 +267,22 @@ def create_artifact(
     streaming engine remains store-authoritative and appends only periods that
     are actually missing from the committed store.
     """
+    # Before any request validation: whether this template can be ingested at all does not
+    # depend on the request, and checking it later meant an operator who picked a workflow
+    # output was first told to supply a start period — advice for a request that could never
+    # have succeeded.
+    if not registry_datasets.is_ingestable(dataset):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Dataset template '{dataset['id']}' cannot be ingested: it declares no "
+                "'ingestion.plugin', so there is no source to fetch from. It is a derived "
+                "product, published by a workflow through 'save_result' rather than ingested — "
+                "run the workflow that produces it (see GET /process_graphs). "
+                "GET /dataset-templates/ reports 'ingestable' for every template."
+            ),
+        )
+
     period_type = str(dataset["period_type"])
     start = _resolve_request_start(start, dataset=dataset, period_type=period_type)
     end = _normalize_optional_request_period(end, period_type=period_type, field_name="end")
@@ -295,25 +311,25 @@ def create_artifact(
         end=end,
         bbox=(bbox[0], bbox[1], bbox[2], bbox[3]) if bbox is not None else None,
     )
+    # Guaranteed non-blank by the `is_ingestable` check above, which is the single definition
+    # of what makes a template ingestable; re-testing it here would let the two drift.
     ingestion = dataset.get("ingestion")
-    plugin_path = ingestion.get("plugin") if isinstance(ingestion, dict) else None
-    if isinstance(plugin_path, str) and plugin_path:
-        return _create_streaming_artifact(
-            dataset=dataset,
-            plugin_path=plugin_path,
-            start=start,
-            end=resolved_download_end,
-            bbox=bbox,
-            country_code=country_code,
-            overwrite=overwrite,
-            publish=publish,
-            request_scope=request_scope,
-            on_progress=on_progress,
-            is_cancel_requested=is_cancel_requested,
-            save_cursor=save_cursor,
-            periods=periods,
-        )
-    raise HTTPException(status_code=500, detail=f"Dataset '{dataset['id']}' does not define ingestion.plugin")
+    plugin_path = str((ingestion or {}).get("plugin", "")).strip() if isinstance(ingestion, dict) else ""
+    return _create_streaming_artifact(
+        dataset=dataset,
+        plugin_path=plugin_path,
+        start=start,
+        end=resolved_download_end,
+        bbox=bbox,
+        country_code=country_code,
+        overwrite=overwrite,
+        publish=publish,
+        request_scope=request_scope,
+        on_progress=on_progress,
+        is_cancel_requested=is_cancel_requested,
+        save_cursor=save_cursor,
+        periods=periods,
+    )
 
 
 def _period_order_key(period: str, period_type: str) -> str:

--- a/open_climate_service/ingestions/services.py
+++ b/open_climate_service/ingestions/services.py
@@ -243,6 +243,33 @@ def get_latest_artifact_for_dataset_or_404(dataset_id: str) -> ArtifactRecord:
     return max(artifacts, key=lambda artifact: artifact.created_at)
 
 
+def ensure_ingestable(dataset: dict[str, object]) -> None:
+    """Raise 400 unless *dataset* declares a source to fetch from.
+
+    Called at every entrance to ingestion, not only inside `create_artifact`. The async
+    branch of `POST /ingestions` (`Prefer: respond-async`) enqueues a job and returns 202
+    before `create_artifact` runs, so a check that lived only there turned a client mistake
+    into an accepted job that later failed — with a logged traceback, and with the 400 the
+    caller needed buried in the job record instead of in the response.
+
+    400 rather than 500. The request is well formed and the template is valid; it simply has
+    no upstream, which is a property of the dataset the caller named. A 500 says the server
+    broke and invites a retry that cannot succeed (CLIM-912).
+    """
+    if registry_datasets.is_ingestable(dataset):
+        return
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"Dataset template '{dataset['id']}' cannot be ingested: it declares no "
+            "'ingestion.plugin', so there is no source to fetch from. It is a derived "
+            "product, published by a workflow through 'save_result' rather than ingested — "
+            "run the workflow that produces it (see GET /process_graphs). "
+            "GET /dataset-templates/ reports 'ingestable' for every template."
+        ),
+    )
+
+
 def create_artifact(
     *,
     dataset: dict[str, object],
@@ -271,17 +298,7 @@ def create_artifact(
     # depend on the request, and checking it later meant an operator who picked a workflow
     # output was first told to supply a start period — advice for a request that could never
     # have succeeded.
-    if not registry_datasets.is_ingestable(dataset):
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Dataset template '{dataset['id']}' cannot be ingested: it declares no "
-                "'ingestion.plugin', so there is no source to fetch from. It is a derived "
-                "product, published by a workflow through 'save_result' rather than ingested — "
-                "run the workflow that produces it (see GET /process_graphs). "
-                "GET /dataset-templates/ reports 'ingestable' for every template."
-            ),
-        )
+    ensure_ingestable(dataset)
 
     period_type = str(dataset["period_type"])
     start = _resolve_request_start(start, dataset=dataset, period_type=period_type)

--- a/open_climate_service/system/templates.py
+++ b/open_climate_service/system/templates.py
@@ -149,12 +149,12 @@ def _load_templates() -> list[dict[str, Any]]:
 def _ingestable_templates() -> list[dict[str, Any]]:
     """Return only templates that can be ingested from a source.
 
-    Ingestable templates declare an ``ingestion.plugin``. Derived/static templates
-    (e.g. workflow outputs published via ``save_result``, which have ``sync.kind:
-    static`` and no upstream fetch path) are excluded so they don't appear in the
-    ingest form.
+    Derived templates — workflow outputs published via ``save_result``, with no upstream
+    fetch path — are excluded so they do not appear in the ingest form. Shares the registry's
+    predicate with ``GET /dataset-templates/`` and with the ingest path that refuses them, so
+    the form and the API cannot disagree about what is offerable.
     """
-    return [t for t in _load_templates() if (t.get("ingestion") or {}).get("plugin")]
+    return [t for t in _load_templates() if registry_datasets.is_ingestable(t)]
 
 
 def _load_datasets() -> list[Any]:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2025,6 +2025,9 @@ def test_create_artifact_overwrite_keeps_existing_store_when_replacement_is_inva
 
 
 def test_create_artifact_rejects_missing_plugin_definition() -> None:
+    """A 4xx, not a 5xx (CLIM-912). A template with no `ingestion.plugin` is not broken — half
+    the shipped catalogue is produced by a workflow rather than fetched — so naming one is a
+    client error, and a 500 both misreports it and invites a retry that cannot succeed."""
     dataset: dict[str, object] = {
         "id": "broken_dataset",
         "name": "Broken dataset",
@@ -2044,8 +2047,10 @@ def test_create_artifact_rejects_missing_plugin_definition() -> None:
             publish=False,
         )
 
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.detail == "Dataset 'broken_dataset' does not define ingestion.plugin"
+    assert exc_info.value.status_code == 400
+    assert "cannot be ingested" in str(exc_info.value.detail)
+    assert "broken_dataset" in str(exc_info.value.detail)
+    assert "ingestion.plugin" in str(exc_info.value.detail)
 
 
 def test_create_artifact_rejects_partial_download_scope(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2054,6 +2059,9 @@ def test_create_artifact_rejects_partial_download_scope(monkeypatch: pytest.Monk
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
         "period_type": "daily",
+        # An ingestable template: the scope validation under test runs after the check that
+        # the dataset has a source at all (CLIM-912), so a bare template never reaches it.
+        "ingestion": {"plugin": "open_climate_service.plugins.datasets.chirps3"},
     }
 
     with pytest.raises(services.HTTPException) as exc_info:
@@ -2081,6 +2089,9 @@ def test_create_artifact_rejects_download_scope_outside_request_scope(monkeypatc
         "name": "Total precipitation (CHIRPS3)",
         "variable": "precip",
         "period_type": "daily",
+        # An ingestable template: the scope validation under test runs after the check that
+        # the dataset has a source at all (CLIM-912), so a bare template never reaches it.
+        "ingestion": {"plugin": "open_climate_service.plugins.datasets.chirps3"},
     }
 
     with pytest.raises(services.HTTPException) as exc_info:

--- a/tests/test_ingestion_async.py
+++ b/tests/test_ingestion_async.py
@@ -75,7 +75,9 @@ def test_post_ingestion_respond_async_returns_202_with_location(
     monkeypatch.setattr("open_climate_service.jobs.service.JobService.submit_callable_job", lambda self, **kw: job)
     monkeypatch.setattr(
         "open_climate_service.ingestions.routes._get_dataset_or_404",
-        lambda _: {"id": "chirps3_precipitation_daily"},
+        # An ingestable template. The ingest path refuses one with no "ingestion.plugin"
+        # (CLIM-912), so a bare stub short-circuits before the behaviour under test.
+        lambda _: {"id": "chirps3_precipitation_daily", "ingestion": {"plugin": "pkg.mod"}},
     )
     monkeypatch.setattr("open_climate_service.ingestions.routes.get_extent_or_404", lambda: {"bbox": [0, 0, 1, 1]})
 
@@ -161,7 +163,7 @@ def test_post_ingestion_without_prefer_does_not_return_202(client: TestClient, m
     """Without Prefer: respond-async the response is never 202 Accepted."""
     monkeypatch.setattr(
         "open_climate_service.ingestions.routes._get_dataset_or_404",
-        lambda _: {"id": "chirps3_precipitation_daily"},
+        lambda _: {"id": "chirps3_precipitation_daily", "ingestion": {"plugin": "pkg.mod"}},
     )
 
     def raise_no_extent() -> NoReturn:

--- a/tests/test_non_ingestable_templates.py
+++ b/tests/test_non_ingestable_templates.py
@@ -1,0 +1,99 @@
+"""A template with no ingestion plugin says so, and refuses politely (CLIM-912).
+
+Half the shipped catalogue is *produced* rather than fetched: anomalies, normals and change
+rasters are written by a workflow through `save_result` and registered as static templates.
+They appeared in `GET /dataset-templates/` beside ingestable ones with nothing to tell them
+apart, so an operator found out by picking one and getting
+
+    500: Dataset 'worldpop_population_change' does not define ingestion.plugin
+
+A 500 says the server broke and invites a retry. Nothing was broken: the template is valid and
+the request was well formed, it just named a dataset with no upstream.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from open_climate_service.data_registry.services import datasets as registry
+from open_climate_service.ingestions import services as ingestion_services
+
+
+def _template(**overrides: Any) -> dict[str, Any]:
+    return {"id": "t", "period_type": "daily", **overrides}
+
+
+# -- which templates can be ingested --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        pytest.param(_template(ingestion={"plugin": "pkg.mod"}), True, id="declares-a-plugin"),
+        pytest.param(_template(), False, id="no-ingestion-block"),
+        pytest.param(_template(ingestion={}), False, id="empty-ingestion-block"),
+        pytest.param(_template(ingestion={"plugin": ""}), False, id="blank-plugin"),
+        pytest.param(_template(ingestion={"plugin": "   "}), False, id="whitespace-plugin"),
+        pytest.param(_template(ingestion="pkg.mod"), False, id="ingestion-not-a-mapping"),
+    ],
+)
+def test_ingestability_is_the_presence_of_a_plugin(template: dict[str, Any], expected: bool) -> None:
+    assert registry.is_ingestable(template) is expected
+
+
+def test_a_static_template_with_a_plugin_is_still_ingestable() -> None:
+    """`sync.kind` looks like the same question and is not. Keying on it would refuse
+    `era5land_temperature_daily_normal_1991_2020`, which is static and ingests perfectly well —
+    so the flag has to follow the plugin, which is what `create_artifact` requires."""
+    assert registry.is_ingestable(_template(sync={"kind": "static"}, ingestion={"plugin": "pkg.mod"})) is True
+    assert registry.is_ingestable(_template(sync={"kind": "temporal"})) is False
+
+
+def test_the_shipped_catalogue_splits_both_ways() -> None:
+    """Guards the guard: if every built-in became ingestable the tests above would still pass
+    while the listing had nothing left to distinguish."""
+    flags = {registry.is_ingestable(t) for t in registry.list_datasets()}
+    assert flags == {True, False}
+
+
+# -- the listing says so --------------------------------------------------------------------
+
+
+def test_every_listed_template_reports_ingestability(client: TestClient) -> None:
+    payload = client.get("/dataset-templates/").json()
+    assert payload, "no templates listed"
+    assert all("ingestable" in t for t in payload)
+    assert all(t["ingestable"] == registry.is_ingestable(t) for t in payload)
+
+
+def test_a_single_template_reports_it_too(client: TestClient) -> None:
+    """The detail route is where an operator looks before ingesting one."""
+    listed = client.get("/dataset-templates/").json()
+    derived = next(t["id"] for t in listed if not t["ingestable"])
+    assert client.get(f"/dataset-templates/{derived}").json()["ingestable"] is False
+
+
+# -- and asking anyway is a 4xx --------------------------------------------------------------
+
+
+def test_ingesting_a_derived_template_is_a_client_error_not_a_server_error() -> None:
+    """The whole point: nothing here is a fault, so it must not be reported as one."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        ingestion_services.create_artifact(
+            dataset=_template(id="worldpop_population_change", sync={"kind": "static"}),
+            start=None,
+            end=None,
+            bbox=None,
+            country_code=None,
+            overwrite=False,
+            publish=False,
+        )
+
+    assert exc_info.value.status_code == 400
+    detail = str(exc_info.value.detail)
+    assert "worldpop_population_change" in detail
+    assert "ingestion.plugin" in detail
+    assert "save_result" in detail, "the message should say what does produce it"

--- a/tests/test_non_ingestable_templates.py
+++ b/tests/test_non_ingestable_templates.py
@@ -74,6 +74,55 @@ def test_a_single_template_reports_it_too(client: TestClient) -> None:
     assert client.get(f"/dataset-templates/{derived}").json()["ingestable"] is False
 
 
+# -- and asking anyway is a 4xx, on both request shapes ---------------------------------------
+
+
+def test_the_async_ingest_refuses_before_it_enqueues(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`Prefer: respond-async` returns 202 and reports everything afterwards through the job
+    record. A check that lived only in `create_artifact` therefore accepted the request, ran in
+    the worker, and failed the job — logging a traceback for a client mistake and putting the
+    400 somewhere the caller was not looking."""
+    from open_climate_service.extents import services as extent_services
+    from open_climate_service.jobs import service as job_service
+
+    monkeypatch.setattr(
+        extent_services, "get_extent_or_404", lambda: {"bbox": [-13.5, 6.9, -10.1, 10.0], "country_code": "SLE"}
+    )
+    submitted: list[object] = []
+    monkeypatch.setattr(
+        job_service.JobService,
+        "submit_callable_job",
+        lambda self, **kw: submitted.append(kw) or (_ for _ in ()).throw(AssertionError("enqueued")),
+    )
+
+    response = client.post(
+        "/ingestions",
+        json={"dataset_id": "worldpop_population_change"},
+        headers={"Prefer": "respond-async"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert "cannot be ingested" in response.json()["detail"]
+    assert submitted == [], "the job was enqueued before the template was checked"
+
+
+def test_the_async_ingest_still_accepts_an_ingestable_template(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not close the door on the ordinary case."""
+    from open_climate_service.extents import services as extent_services
+
+    monkeypatch.setattr(
+        extent_services, "get_extent_or_404", lambda: {"bbox": [-13.5, 6.9, -10.1, 10.0], "country_code": "SLE"}
+    )
+    response = client.post(
+        "/ingestions",
+        json={"dataset_id": "chirps3_precipitation_daily"},
+        headers={"Prefer": "respond-async"},
+    )
+    assert response.status_code == 202, response.text
+
+
 # -- and asking anyway is a 4xx --------------------------------------------------------------
 
 


### PR DESCRIPTION
[CLIM-912](https://dhis2.atlassian.net/browse/CLIM-912)

Roughly half the shipped catalogue is *produced* rather than fetched: anomalies, normals and change rasters are written by a workflow through `save_result` and registered as static templates. They appeared in `GET /dataset-templates/` beside ingestable ones with nothing to tell them apart, so an operator found out by picking one and getting

```
500: Dataset 'worldpop_population_change' does not define ingestion.plugin
```

Nothing was broken. The template is valid and the request was well formed; it named a dataset with no upstream. A 500 misreports that as a server fault and invites a retry that cannot succeed.

It is **15 of 27** built-in templates, not the one in the report.

## One definition, four readers

`registry.is_ingestable` is now the single answer, read by the listing, the detail route, the `/manage` form filter and the ingest path — so the form cannot offer something the ingest path refuses.

It keys on `ingestion.plugin`, **not** `sync.kind`. The ticket offered either; only one is correct. `era5land_temperature_daily_normal_1991_2020` is `kind: static` *and* has a plugin, so a kind-based rule would refuse a template that ingests perfectly well. The plugin is what `create_artifact` actually requires, so it is what the flag reports.

## The three parts

- **The listing says so.** `GET /dataset-templates/` and `/dataset-templates/{id}` carry `ingestable`, derived rather than declared so a template author cannot get it wrong.
- **The manage form already filtered.** `_ingestable_templates()` existed and was correct; it now shares the predicate instead of repeating the rule.
- **Asking anyway is a 400**, naming the template, the missing field, and what does produce it.

## The check moved earlier

Ingestability does not depend on the request, but the old check ran after request validation. An operator who picked a workflow output was therefore told to supply a start period first — advice for a request that could never have worked. Found because a test written against the ticket's wording failed on the wrong error.

## Verified

- End to end through the real route: derived → `400` with the explanation, `chirps3_precipitation_daily` → `200`; the listing splits 12/15.
- **Mutation-checked.** Keying on `sync.kind` fails 6 tests; dropping the flag from the listing fails 2.
- Two existing scope tests used bare templates and so never reached the validation they were about — they now declare a plugin. One asserted the old `500` contract and now asserts the new one.
- `make lint` clean (ruff, mypy, pyright); 1700 passed, 6 skipped.

## Note

`/dataset-templates` is not documented in `docs/` at all, so rather than write the endpoint up here I added a short section to `adding_custom_datasets.md` explaining that some templates are produced rather than ingested and to read `ingestable` instead of inferring from `sync.kind`. A fuller write-up of the endpoint belongs in the API guide if you want it.

[CLIM-912]: https://dhis2.atlassian.net/browse/CLIM-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ